### PR TITLE
Inject provider panel runtime dependencies

### DIFF
--- a/js/api-venice.js
+++ b/js/api-venice.js
@@ -23,11 +23,17 @@ import {
  *   _veniceE2EE?: any,
  *   _veniceE2EEKey?: string,
  *   _veniceAttestation?: any,
- *   _veniceLastStreamDiagnostics?: any,
- *   clearE2EESession?: () => void
+ *   _veniceLastStreamDiagnostics?: any
  * }} VeniceApiWindow */
 
 const apiWindow = /** @type {VeniceApiWindow} */ (typeof window !== 'undefined' ? window : {});
+
+export function clearVeniceE2EESession() {
+  const e2ee = apiWindow._veniceE2EE;
+  if (typeof e2ee?.clearSession !== 'function') return false;
+  e2ee.clearSession();
+  return true;
+}
 
 export async function getVeniceBalance() {
   const key = getVeniceKey();
@@ -75,7 +81,6 @@ export async function callVeniceAPI(opts) {
   if (!apiWindow._veniceE2EE || apiWindow._veniceE2EEKey !== key) {
     apiWindow._veniceE2EE = createVeniceE2EE({ apiKey: key });
     apiWindow._veniceE2EEKey = key;
-    apiWindow.clearE2EESession = () => apiWindow._veniceE2EE?.clearSession();
   }
   let session;
   try {

--- a/js/api.js
+++ b/js/api.js
@@ -99,6 +99,7 @@ export {
   callOpenAICompatibleLocalAPI,
 } from './api-local.js';
 export {
+  clearVeniceE2EESession,
   getVeniceBalance,
   callVeniceAPI,
 } from './api-venice.js';

--- a/js/provider-model-controls-runtime.js
+++ b/js/provider-model-controls-runtime.js
@@ -1,7 +1,7 @@
 // @ts-check
 // provider-model-controls-runtime.js - Browser runtime adapters for provider model controls.
 
-import { callClaudeAPI } from './api.js';
+import { callClaudeAPI, clearVeniceE2EESession } from './api.js';
 import {
   refreshChatWebSearchToggleRuntime,
   updateChatHeaderModelRuntime,
@@ -9,34 +9,18 @@ import {
 
 const providerModelControlsRuntimeDeps = {
   callClaudeAPI,
+  clearE2EESession: clearVeniceE2EESession,
 };
 
 export function configureProviderModelControlsRuntimeDeps(deps = {}) {
   const previous = { ...providerModelControlsRuntimeDeps };
   if (typeof deps.callClaudeAPI === 'function') providerModelControlsRuntimeDeps.callClaudeAPI = deps.callClaudeAPI;
+  if (typeof deps.clearE2EESession === 'function') providerModelControlsRuntimeDeps.clearE2EESession = deps.clearE2EESession;
   return previous;
 }
 
-function getProviderModelControlsRuntime() {
-  return typeof window !== 'undefined'
-    ? /** @type {any} */ (window)
-    : null;
-}
-
-/**
- * @param {string} name
- * @returns {Function | null}
- */
-function getRuntimeFunction(name) {
-  const runtime = getProviderModelControlsRuntime();
-  return runtime && typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
-}
-
 export function clearProviderE2EESessionRuntime() {
-  const clearSession = getRuntimeFunction('clearE2EESession');
-  if (!clearSession) return false;
-  clearSession();
-  return true;
+  return providerModelControlsRuntimeDeps.clearE2EESession() !== false;
 }
 
 export function refreshProviderModelUiRuntime() {

--- a/js/provider-panels.js
+++ b/js/provider-panels.js
@@ -8,6 +8,7 @@ import {
   getOpenRouterBalance, getVeniceBalance,
   getRoutstrKey, saveRoutstrKey,
   fetchRoutstrModels, validateRoutstrKey, createRoutstrAccount,
+  clearVeniceE2EESession, hasAIProvider,
   setAIPaused,
   setCustomApiModel, setOllamaMainModel, setPpqModel,
   getVeniceE2EE,
@@ -17,6 +18,7 @@ import {
 } from './api.js';
 import { updateKeyCache, encryptedSetItem } from './crypto.js';
 import { openChatPanel } from './chat-panel.js';
+import { loadFocusCard } from './focus-card.js';
 import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 import { clearRoutstrModelCaches } from './routstr-model-cache.js';
 import { installProviderPanelDelegates } from './provider-panel-delegates.js';
@@ -101,36 +103,36 @@ import {
   doRoutstrWalletRestore,
   walletRuntime
 } from './provider-wallet-panels.js';
-import { getSettingsModuleFunction } from './settings-runtime-bridge.js';
-import { getViewRuntimeFunction } from './views-runtime-bridge.js';
+function openProviderPanelExternal(...args) {
+  const open = /** @type {any} */ (globalThis).open;
+  return typeof open === 'function' ? open.apply(globalThis, args) : null;
+}
+
+function reloadProviderPanelPage() {
+  const location = /** @type {any} */ (globalThis).location;
+  if (typeof location?.reload === 'function') location.reload();
+}
 
 const providerPanelDeps = {
+  clearE2EESession: clearVeniceE2EESession,
+  closeSettingsModal: () => {},
+  hadProviderBeforeSettings: () => false,
+  hasAIProvider,
+  loadFocusCard,
   openChatPanel,
+  openExternal: openProviderPanelExternal,
+  openSettingsModal: () => {},
+  reloadPage: reloadProviderPanelPage,
 };
+
+const providerPanelClipboardTimers = new Map();
 
 export function configureProviderPanelDeps(deps = {}) {
   const previous = { ...providerPanelDeps };
-  if (typeof deps.openChatPanel === 'function') providerPanelDeps.openChatPanel = deps.openChatPanel;
+  for (const name of Object.keys(providerPanelDeps)) {
+    if (typeof deps[name] === 'function') providerPanelDeps[name] = deps[name];
+  }
   return previous;
-}
-
-function providerPanelRuntime() {
-  return /** @type {Record<string, any>} */ (globalThis);
-}
-
-function getProviderPanelRuntimeValue(name) {
-  return providerPanelRuntime()[name];
-}
-
-function callProviderPanelRuntime(name, ...args) {
-  const runtime = providerPanelRuntime();
-  const fn = getSettingsModuleFunction(name) || runtime[name] || getViewRuntimeFunction(name);
-  return typeof fn === 'function' ? fn.apply(runtime, args) : undefined;
-}
-
-function reloadProviderPanelRuntime() {
-  const location = getProviderPanelRuntimeValue('location');
-  if (typeof location?.reload === 'function') location.reload();
 }
 
 export { renderAIProviderPanel } from './provider-panel-renderers.js';
@@ -211,7 +213,7 @@ export function toggleAIPause(enabled) {
   setAIPaused(!enabled);
   showNotification(enabled ? 'AI features enabled' : 'AI features paused', 'info');
   // Refresh focus card — show cached content when paused, fetch new when enabled
-  callProviderPanelRuntime('loadFocusCard');
+  providerPanelDeps.loadFocusCard();
 }
 
 export function switchAIProvider(provider) {
@@ -331,9 +333,9 @@ export function initSettingsModelFetch() {
 // ═══════════════════════════════════════════════
 /** After a successful key save, auto-close settings and return to chat if we came from onboarding. */
 function _returnToChatIfOnboarding() {
-  if (getProviderPanelRuntimeValue('_settingsHadProvider')) return; // already had a provider — user is just reconfiguring
-  if (!callProviderPanelRuntime('hasAIProvider')) return;
-  callProviderPanelRuntime('closeSettingsModal');
+  if (providerPanelDeps.hadProviderBeforeSettings()) return; // already had a provider — user is just reconfiguring
+  if (!providerPanelDeps.hasAIProvider()) return;
+  providerPanelDeps.closeSettingsModal();
   setTimeout(() => providerPanelDeps.openChatPanel(), 300);
 }
 
@@ -355,9 +357,12 @@ async function _copyProviderPanelText(text, actionEl) {
     const timerKey = actionEl?.dataset?.clearTimerKey || '';
     const clearMs = Number(actionEl?.dataset?.clearClipboardAfter || 0);
     if (timerKey && clearMs > 0) {
-      const runtime = providerPanelRuntime();
-      clearTimeout(runtime[timerKey]);
-      runtime[timerKey] = setTimeout(() => navigator.clipboard?.writeText?.(''), clearMs);
+      clearTimeout(providerPanelClipboardTimers.get(timerKey));
+      const timer = setTimeout(() => {
+        providerPanelClipboardTimers.delete(timerKey);
+        navigator.clipboard?.writeText?.('');
+      }, clearMs);
+      providerPanelClipboardTimers.set(timerKey, timer);
     }
   } catch (e) {
     showNotification(`Copy failed: ${e?.message || e}`, 'error');
@@ -385,7 +390,7 @@ async function _recoverPendingToken(actionEl, clearName) {
     await walletRuntime.cashuReceiveToken(token);
     await clearPendingToken();
     showNotification('Recovered!', 'success');
-    reloadProviderPanelRuntime();
+    providerPanelDeps.reloadPage();
   } catch (e) {
     showNotification(e?.message || String(e), 'error');
   }
@@ -465,9 +470,9 @@ export function handleRemoveVeniceKey() {
   localStorage.removeItem('labcharts-venice-e2ee-models');
   localStorage.removeItem('labcharts-venice-model-regular');
   localStorage.removeItem('labcharts-venice-model-e2ee');
-  callProviderPanelRuntime('clearE2EESession');
+  providerPanelDeps.clearE2EESession();
   showNotification('Venice API key removed', 'info');
-  callProviderPanelRuntime('openSettingsModal');
+  providerPanelDeps.openSettingsModal();
 }
 
 
@@ -509,7 +514,7 @@ export function handleRemoveOpenRouterKey() {
   localStorage.removeItem('labcharts-openrouter-model');
   localStorage.removeItem('labcharts-openrouter-pricing');
   showNotification('OpenRouter API key removed', 'info');
-  callProviderPanelRuntime('openSettingsModal');
+  providerPanelDeps.openSettingsModal();
 }
 
 function _orBalanceHtml(remaining) {
@@ -558,7 +563,7 @@ export function showInsufficientBalanceDialog() {
   const close = function() { closeModalOverlay(overlay); };
   document.getElementById('or-add-credits').onclick = function() {
     close();
-    callProviderPanelRuntime('open', 'https://openrouter.ai/settings/credits', '_blank', 'noopener');
+    providerPanelDeps.openExternal('https://openrouter.ai/settings/credits', '_blank', 'noopener');
   };
   document.getElementById('or-nb-cancel').onclick = close;
   overlay.onclick = function(e) { if (e.target === overlay) close(); };
@@ -635,7 +640,7 @@ export function handleRemoveRoutstrKey() {
   updateKeyCache('labcharts-routstr-key', null);
   clearRoutstrModelCaches();
   showNotification('Routstr key removed', 'info');
-  callProviderPanelRuntime('openSettingsModal');
+  providerPanelDeps.openSettingsModal();
 }
 
 // ─── Custom API handlers ───

--- a/js/settings-provider-bridge.js
+++ b/js/settings-provider-bridge.js
@@ -10,9 +10,36 @@ import {
 } from './api.js';
 
 let _providerPanelsLoad = null;
+let settingsHadProvider = false;
+
+const settingsProviderBridgeDeps = {
+  closeSettingsModal: () => {},
+  openSettingsModal: () => {},
+};
+
+export function configureSettingsProviderBridgeDeps(deps = {}) {
+  const previous = { ...settingsProviderBridgeDeps };
+  for (const name of Object.keys(settingsProviderBridgeDeps)) {
+    if (typeof deps[name] === 'function') settingsProviderBridgeDeps[name] = deps[name];
+  }
+  return previous;
+}
+
+export function setSettingsProviderHadProvider(value) {
+  settingsHadProvider = value === true;
+}
 
 function loadProviderPanels() {
-  if (!_providerPanelsLoad) _providerPanelsLoad = import('./provider-panels.js');
+  if (!_providerPanelsLoad) {
+    _providerPanelsLoad = import('./provider-panels.js').then(providerPanels => {
+      providerPanels.configureProviderPanelDeps({
+        closeSettingsModal: () => settingsProviderBridgeDeps.closeSettingsModal(),
+        hadProviderBeforeSettings: () => settingsHadProvider,
+        openSettingsModal: () => settingsProviderBridgeDeps.openSettingsModal(),
+      });
+      return providerPanels;
+    });
+  }
   return _providerPanelsLoad;
 }
 

--- a/js/settings.js
+++ b/js/settings.js
@@ -14,8 +14,10 @@ import { renderWearablesSettingsSection } from './wearables-settings-panel.js';
 import { isProductRecsEnabled, setProductRecsEnabled } from './recommendations.js';
 import { closeModalOverlay, openModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
 import {
+  configureSettingsProviderBridgeDeps,
   initSettingsProviderPanels,
   renderAIProviderPanelBridge,
+  setSettingsProviderHadProvider,
   switchAIProviderBridge,
   testPIIOllamaConnectionBridge,
   toggleAIPauseBridge,
@@ -729,7 +731,7 @@ addSettingsRuntimeEventListener('labcharts-themechange', () => applyAccentOverri
 installSunDataSourceDelegates();
 
 export function openSettingsModal(tab) {
-  settingsWindow._settingsHadProvider = hasAIProvider();
+  setSettingsProviderHadProvider(hasAIProvider());
   const overlay = document.getElementById('settings-modal-overlay');
   const modal = document.getElementById('settings-modal');
   const provider = getAIProvider();
@@ -1067,4 +1069,9 @@ configureSettingsModuleBridge({
   applyAccentOverride,
   updateSettingsUI,
   updateTweaksUI,
+});
+
+configureSettingsProviderBridgeDeps({
+  closeSettingsModal,
+  openSettingsModal,
 });

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -3,8 +3,8 @@
   "windowReferences": 0,
   "windowGlobalAssignments": 0,
   "legacyWindowGlobalAssignments": 0,
-  "viewRuntimeBridgeConsumers": 2,
-  "viewRuntimeBridgeLookups": 3,
+  "viewRuntimeBridgeConsumers": 1,
+  "viewRuntimeBridgeLookups": 2,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/playwright/provider-coverage-batch.spec.js
+++ b/tests/playwright/provider-coverage-batch.spec.js
@@ -132,7 +132,6 @@ test('provider model controls cover dropdowns custom models and delegates', asyn
     for (const key of storageKeys) oldStorage[key] = localStorage.getItem(key);
     const oldGlobals = {
       fetch: window.fetch,
-      clearE2EESession: window.clearE2EESession,
       consoleWarn: console.warn,
     };
     let previousRuntimeDeps = null;
@@ -156,7 +155,6 @@ test('provider model controls cover dropdowns custom models and delegates', asyn
         </section>
       `);
 
-      window.clearE2EESession = () => { clearCount += 1; };
       previousChatRuntime = chatRuntime.configureChatRuntimeCallbacks({
         updateChatHeaderModel: () => { headerRefreshes += 1; },
         refreshWebSearchToggle: () => { searchRefreshes += 1; },
@@ -196,6 +194,7 @@ test('provider model controls cover dropdowns custom models and delegates', asyn
       let fetchedPricing = false;
       previousRuntimeDeps = runtime.configureProviderModelControlsRuntimeDeps({
         callClaudeAPI: async () => ({ content: 'ok' }),
+        clearE2EESession: () => { clearCount += 1; },
       });
       window.fetch = async function(url) {
         const href = typeof url === 'string' ? url : url?.url || '';
@@ -379,7 +378,6 @@ test('provider model controls cover dropdowns custom models and delegates', asyn
       window.fetch = oldGlobals.fetch;
       if (previousRuntimeDeps) runtime.configureProviderModelControlsRuntimeDeps(previousRuntimeDeps);
       if (previousChatRuntime) chatRuntime.configureChatRuntimeCallbacks(previousChatRuntime);
-      window.clearE2EESession = oldGlobals.clearE2EESession;
       console.warn = oldGlobals.consoleWarn;
       for (const key of storageKeys) {
         if (oldStorage[key] == null) localStorage.removeItem(key);
@@ -401,7 +399,6 @@ test('provider panels cover provider switching key saves balances custom API and
   const results = await page.evaluate(async ({ panelsUrl }) => {
     const panels = await import(panelsUrl);
     const cryptoStore = await import('/js/crypto.js');
-    const settingsBridge = await import('/js/settings-runtime-bridge.js');
     const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
     const jsonResponse = (body, status = 200, headers = {}) => new Response(JSON.stringify(body), {
       status,
@@ -444,22 +441,22 @@ test('provider panels cover provider switching key saves balances custom API and
     const oldSessionPrevious = sessionStorage.getItem('or_previous_ai_provider');
     const oldGlobals = {
       fetch: window.fetch,
-      open: window.open,
-      loadFocusCard: window.loadFocusCard,
-      clearE2EESession: window.clearE2EESession,
     };
 
     let openedUrl = '';
     let settingsClosed = 0;
+    let settingsOpened = 0;
     let chatOpened = 0;
     let focusLoads = 0;
     let e2eeClears = 0;
-    const previousSettingsBridge = settingsBridge.configureSettingsModuleBridge({
-      openSettingsModal: () => {},
-      closeSettingsModal: () => { settingsClosed += 1; },
-    });
     const previousProviderPanelDeps = panels.configureProviderPanelDeps({
+      clearE2EESession: () => { e2eeClears += 1; },
+      closeSettingsModal: () => { settingsClosed += 1; },
+      hadProviderBeforeSettings: () => false,
+      loadFocusCard: () => { focusLoads += 1; },
       openChatPanel: () => { chatOpened += 1; },
+      openExternal: url => { openedUrl = String(url); return null; },
+      openSettingsModal: () => { settingsOpened += 1; },
     });
 
     try {
@@ -469,10 +466,6 @@ test('provider panels cover provider switching key saves balances custom API and
       cryptoStore.updateKeyCache('labcharts-routstr-key', '');
       cryptoStore.updateKeyCache('labcharts-ppq-key', '');
       cryptoStore.updateKeyCache('labcharts-custom-key', '');
-      window.open = url => { openedUrl = String(url); return null; };
-      window.loadFocusCard = () => { focusLoads += 1; };
-      window.clearE2EESession = () => { e2eeClears += 1; };
-
       window.fetch = async function(url, opts = {}) {
         const href = typeof url === 'string' ? url : url?.url || '';
         if (href === 'https://openrouter.ai/api/v1/models') {
@@ -657,6 +650,12 @@ test('provider panels cover provider switching key saves balances custom API and
       panels.showInsufficientBalanceDialog();
       document.getElementById('or-nb-cancel').click();
       const cancelBalanceDialog = !document.getElementById('or-no-balance-overlay')?.classList.contains('show');
+      await wait(325);
+      const explicitProviderCallbacksRun = settingsClosed >= 1
+        && settingsOpened >= 3
+        && chatOpened >= 1
+        && focusLoads >= 2
+        && e2eeClears >= 1;
 
       return {
         switchStoresPrevious,
@@ -673,14 +672,11 @@ test('provider panels cover provider switching key saves balances custom API and
         customRemoveRendersDisconnected,
         addCreditsDialog,
         cancelBalanceDialog,
+        explicitProviderCallbacksRun,
       };
     } finally {
       window.fetch = oldGlobals.fetch;
-      window.open = oldGlobals.open;
-      settingsBridge.configureSettingsModuleBridge(previousSettingsBridge);
       panels.configureProviderPanelDeps(previousProviderPanelDeps);
-      window.loadFocusCard = oldGlobals.loadFocusCard;
-      window.clearE2EESession = oldGlobals.clearE2EESession;
       for (const key of storageKeys) {
         if (oldStorage[key] == null) localStorage.removeItem(key);
         else localStorage.setItem(key, oldStorage[key]);

--- a/tests/playwright/provider-model-controls-edge-browser-coverage.spec.js
+++ b/tests/playwright/provider-model-controls-edge-browser-coverage.spec.js
@@ -10,6 +10,7 @@ test('provider model controls edge coverage handles pricing updates guards and m
   const results = await page.evaluate(async ({ controlsUrl }) => {
     const controls = await import(controlsUrl);
     const chatRuntime = await import('/js/chat-runtime.js');
+    const providerRuntime = await import('/js/provider-model-controls-runtime.js');
     const failures = [];
     const check = (name, condition, detail = '') => {
       if (!condition) failures.push(detail ? `${name}: ${detail}` : name);
@@ -31,17 +32,17 @@ test('provider model controls edge coverage handles pricing updates guards and m
     ];
     const oldStorage = {};
     for (const key of storageKeys) oldStorage[key] = localStorage.getItem(key);
-    const oldGlobals = {
-      clearE2EESession: window.clearE2EESession,
-    };
     let clearCount = 0;
     let headerRefreshes = 0;
     let webSearchRefreshes = 0;
     let previousChatRuntime = null;
+    let previousProviderRuntime = null;
 
     try {
       for (const key of storageKeys) localStorage.removeItem(key);
-      window.clearE2EESession = () => { clearCount += 1; };
+      previousProviderRuntime = providerRuntime.configureProviderModelControlsRuntimeDeps({
+        clearE2EESession: () => { clearCount += 1; },
+      });
       previousChatRuntime = chatRuntime.configureChatRuntimeCallbacks({
         updateChatHeaderModel: () => { headerRefreshes += 1; },
         refreshWebSearchToggle: () => { webSearchRefreshes += 1; },
@@ -159,7 +160,7 @@ test('provider model controls edge coverage handles pricing updates guards and m
         customManualTypedAppliesAndPrices,
       };
     } finally {
-      window.clearE2EESession = oldGlobals.clearE2EESession;
+      if (previousProviderRuntime) providerRuntime.configureProviderModelControlsRuntimeDeps(previousProviderRuntime);
       if (previousChatRuntime) chatRuntime.configureChatRuntimeCallbacks(previousChatRuntime);
       for (const key of storageKeys) {
         if (oldStorage[key] == null) localStorage.removeItem(key);

--- a/tests/provider-model-controls-runtime.test.js
+++ b/tests/provider-model-controls-runtime.test.js
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 
 import {
@@ -9,34 +9,17 @@ import {
 } from '../js/provider-model-controls-runtime.js';
 import { configureChatRuntimeCallbacks } from '../js/chat-runtime.js';
 
-const savedWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
-
-function setRuntimeWindow(runtime) {
-  Object.defineProperty(globalThis, 'window', {
-    configurable: true,
-    writable: true,
-    value: runtime,
-  });
-}
-
-afterEach(() => {
-  if (savedWindow) Object.defineProperty(globalThis, 'window', savedWindow);
-  else delete globalThis.window;
-});
-
 describe('provider model controls runtime adapter', () => {
   it('delegates provider model runtime hooks at call time', async () => {
     const clearE2EESession = vi.fn();
     const updateChatHeaderModel = vi.fn();
     const refreshWebSearchToggle = vi.fn();
     const callClaudeAPI = vi.fn(async () => ({ content: 'ok' }));
-    const previousDeps = configureProviderModelControlsRuntimeDeps({ callClaudeAPI });
+    const previousDeps = configureProviderModelControlsRuntimeDeps({ callClaudeAPI, clearE2EESession });
     const previousChatRuntime = configureChatRuntimeCallbacks({
       updateChatHeaderModel,
       refreshWebSearchToggle,
     });
-    setRuntimeWindow({ clearE2EESession });
-
     try {
       expect(clearProviderE2EESessionRuntime()).toBe(true);
       expect(refreshProviderModelUiRuntime()).toBe(true);
@@ -55,17 +38,20 @@ describe('provider model controls runtime adapter', () => {
     });
   });
 
-  it('uses safe no-op fallbacks when browser hooks are missing', () => {
+  it('uses safe no-op fallbacks when optional UI hooks are missing', () => {
+    const previousDeps = configureProviderModelControlsRuntimeDeps({
+      clearE2EESession: () => false,
+    });
     const previousChatRuntime = configureChatRuntimeCallbacks({
       refreshWebSearchToggle: null,
       updateChatHeaderModel: null,
     });
-    delete globalThis.window;
 
     try {
       expect(clearProviderE2EESessionRuntime()).toBe(false);
       expect(refreshProviderModelUiRuntime()).toBe(false);
     } finally {
+      configureProviderModelControlsRuntimeDeps(previousDeps);
       configureChatRuntimeCallbacks(previousChatRuntime);
     }
   });

--- a/tests/test-openrouter.js
+++ b/tests/test-openrouter.js
@@ -137,8 +137,11 @@ assert('settings provider bridge resolves module APIs without publishing globals
     !settingsBridgeSrc.includes('settingsWindow') &&
     !settingsBridgeSrc.includes('PROVIDER_PANEL_BRIDGE_NAMES'));
 assert('settings records existing provider before provider-key onboarding return',
-  settingsSrc.includes('settingsWindow._settingsHadProvider = hasAIProvider();')
-    && ppSrc.includes("if (getProviderPanelRuntimeValue('_settingsHadProvider')) return"));
+  settingsSrc.includes('setSettingsProviderHadProvider(hasAIProvider());')
+    && settingsSrc.includes('configureSettingsProviderBridgeDeps({')
+    && settingsBridgeSrc.includes('hadProviderBeforeSettings: () => settingsHadProvider')
+    && settingsBridgeSrc.includes('providerPanels.configureProviderPanelDeps({')
+    && ppSrc.includes('if (providerPanelDeps.hadProviderBeforeSettings()) return'));
 assert('renderAIProviderPanel handles openrouter', providerRenderSrc.includes("provider === 'openrouter'"));
 assert('handleSaveOpenRouterKey exists', ppSrc.includes('function handleSaveOpenRouterKey()'));
 assert('handleRemoveOpenRouterKey exists', ppSrc.includes('function handleRemoveOpenRouterKey()'));

--- a/tests/test-provider-panel-delegated-actions.js
+++ b/tests/test-provider-panel-delegated-actions.js
@@ -148,20 +148,24 @@ assert('provider panel recovery uses mint-aware receiveToken instead of wallet i
     panelsSrc.includes('await walletRuntime.cashuReceiveToken(token)') &&
     !panelsSrc.includes('await appWindow.cashuImportWallet(token)'));
 assert('provider panel recovery awaits pending-token clear before reload',
-  /await walletRuntime\.cashuReceiveToken\(token\);[\s\S]*await clearPendingToken\(\);[\s\S]*reloadProviderPanelRuntime\(\);/.test(panelsSrc));
-assert('provider panel onboarding return uses module Chat dependency',
-  panelsSrc.includes("getProviderPanelRuntimeValue('_settingsHadProvider')") &&
-    panelsSrc.includes("callProviderPanelRuntime('hasAIProvider')") &&
-    panelsSrc.includes("callProviderPanelRuntime('closeSettingsModal')") &&
+  /await walletRuntime\.cashuReceiveToken\(token\);[\s\S]*await clearPendingToken\(\);[\s\S]*providerPanelDeps\.reloadPage\(\);/.test(panelsSrc));
+assert('provider panel onboarding return uses explicit dependencies',
+  panelsSrc.includes('providerPanelDeps.hadProviderBeforeSettings()') &&
+    panelsSrc.includes('providerPanelDeps.hasAIProvider()') &&
+    panelsSrc.includes('providerPanelDeps.closeSettingsModal()') &&
     panelsSrc.includes('providerPanelDeps.openChatPanel()') &&
-    !panelsSrc.includes("callProviderPanelRuntime('openChatPanel')"));
-assert('provider panel focus-card refresh uses runtime helper call',
-  panelsSrc.includes("callProviderPanelRuntime('loadFocusCard')"));
-assert('provider panel E2EE clear and settings reopen use runtime helper calls',
-  panelsSrc.includes("callProviderPanelRuntime('clearE2EESession')") &&
-    panelsSrc.includes("callProviderPanelRuntime('openSettingsModal')"));
-assert('provider panel OpenRouter credits link uses runtime helper open',
-  panelsSrc.includes("callProviderPanelRuntime('open', 'https://openrouter.ai/settings/credits', '_blank', 'noopener')"));
+    !panelsSrc.includes('callProviderPanelRuntime'));
+assert('provider panel focus-card refresh uses explicit dependency',
+  panelsSrc.includes('providerPanelDeps.loadFocusCard()'));
+assert('provider panel E2EE clear and settings reopen use explicit dependencies',
+  panelsSrc.includes('providerPanelDeps.clearE2EESession()') &&
+    panelsSrc.includes('providerPanelDeps.openSettingsModal()'));
+assert('provider panel OpenRouter credits link uses explicit browser dependency',
+  panelsSrc.includes("providerPanelDeps.openExternal('https://openrouter.ai/settings/credits', '_blank', 'noopener')"));
+assert('provider panels avoid generic settings and view runtime bridges',
+  !panelsSrc.includes("from './settings-runtime-bridge.js'") &&
+    !panelsSrc.includes("from './views-runtime-bridge.js'") &&
+    !panelsSrc.includes('providerPanelRuntime'));
 
 console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
 if (failed > 0) process.exit(1);

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -54,8 +54,8 @@ assert('quality guardrail ratchets view runtime bridge coupling',
   guardrailSrc.includes('VIEW_RUNTIME_LOOKUP_RE') &&
     guardrailSrc.includes('viewRuntimeBridgeConsumers') &&
     guardrailSrc.includes('viewRuntimeBridgeLookups') &&
-    baseline.viewRuntimeBridgeConsumers === 2 &&
-    baseline.viewRuntimeBridgeLookups === 3);
+    baseline.viewRuntimeBridgeConsumers === 1 &&
+    baseline.viewRuntimeBridgeLookups === 2);
 const forbiddenAppEventWindowGlobals = [
   'closeModal',
   'toggleChatPanel',

--- a/tests/test-venice-e2ee.js
+++ b/tests/test-venice-e2ee.js
@@ -50,6 +50,10 @@ assert('Venice GLM E2EE disables hidden reasoning and caps reasoning-only stream
 
 // 2. api.js module exports
 assert('api.isE2EEModel is function', typeof api.isE2EEModel === 'function');
+assert('api.clearVeniceE2EESession is function', typeof api.clearVeniceE2EESession === 'function');
+assert('Venice E2EE clear stays module-scoped',
+  apiVeniceSrc.includes('export function clearVeniceE2EESession()')
+    && !apiVeniceSrc.includes('apiWindow.clearE2EESession'));
 assert('e2ee-llama-3.3-70b is E2EE', api.isE2EEModel('e2ee-llama-3.3-70b'));
 assert('llama-3.3-70b is not E2EE', !api.isE2EEModel('llama-3.3-70b'));
 assert('empty string is not E2EE', !api.isE2EEModel(''));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.290';
+self.APP_VERSION = '1.10.291';


### PR DESCRIPTION
## Summary
- replace provider panel settings/view runtime lookups with explicit lazy-wired dependencies
- keep onboarding state inside the settings provider bridge and clipboard timers module-scoped
- expose Venice E2EE session clearing as a module API instead of a browser global
- ratchet view-runtime bridge coupling from 2 consumers / 3 lookups to 1 / 2
- bump the app cache version to 1.10.291

## Testing
- `./run-tests.sh`
- 352 Playwright tests passed
- 472 theme/responsive assertions passed
- 399 Vitest tests passed
- typecheck, checkjs, quality, vendor, static, and origin-guard checks passed