### PR TITLE
Inject wearable OAuth profile context

### DIFF
--- a/js/wearables-auth-runtime.js
+++ b/js/wearables-auth-runtime.js
@@ -11,10 +11,6 @@ export function getWearableAuthLocation() {
   return getRuntimeWindow()?.location || null;
 }
 
-export function getWearableAuthProfileId() {
-  return getRuntimeWindow()?._labState?.currentProfile || null;
-}
-
 /** @param {string} url */
 export function redirectWearableAuth(url) {
   const location = getWearableAuthLocation();

--- a/js/wearables-connect.js
+++ b/js/wearables-connect.js
@@ -103,6 +103,7 @@ export function beginConnectOAuth(adapterId) {
     clientId: getOAuthClientId(adapter),
     registeredUris: adapter.oauth.redirectUris,
     scopes: adapter.oauth.scopes,
+    profileId: state.currentProfile,
   });
 }
 

--- a/js/wearables-fitbit-auth.js
+++ b/js/wearables-fitbit-auth.js
@@ -14,7 +14,6 @@ import { isDebugMode } from './utils.js';
 import {
   exposeWearableAuthDebug,
   getWearableAuthLocation,
-  getWearableAuthProfileId,
   redirectWearableAuth,
 } from './wearables-auth-runtime.js';
 
@@ -92,13 +91,13 @@ export async function buildAuthorizeUrl({ clientId, redirectUri, scopes = DEFAUL
   return `${AUTHORIZE_URL}?${params.toString()}`;
 }
 
-export async function beginOAuth({ clientId, registeredUris, scopes = DEFAULT_FITBIT_SCOPES }) {
+export async function beginOAuth({ clientId, registeredUris, scopes = DEFAULT_FITBIT_SCOPES, profileId = null }) {
   const state = randomUrlSafe(16);
   const codeVerifier = randomUrlSafe(32); // 43 chars after base64url encoding
   const redirectUri = pickRedirectUri(registeredUris);
   sessionStorage.setItem(STATE_KEY, JSON.stringify({
     state, redirectUri, startedAt: Date.now(), clientId, codeVerifier,
-    profileId: getWearableAuthProfileId(),
+    profileId,
   }));
   const url = await buildAuthorizeUrl({ clientId, redirectUri, scopes, state, codeVerifier });
   redirectWearableAuth(url);

--- a/js/wearables-oura-auth.js
+++ b/js/wearables-oura-auth.js
@@ -14,7 +14,6 @@ import { isDebugMode } from './utils.js';
 import {
   exposeWearableAuthDebug,
   getWearableAuthLocation,
-  getWearableAuthProfileId,
   redirectWearableAuth,
 } from './wearables-auth-runtime.js';
 
@@ -76,12 +75,12 @@ export function buildAuthorizeUrl({ clientId, redirectUri, scopes = DEFAULT_OURA
   return `${AUTHORIZE_URL}?${params.toString()}`;
 }
 
-export function beginOAuth({ clientId, registeredUris, scopes = DEFAULT_OURA_SCOPES }) {
+export function beginOAuth({ clientId, registeredUris, scopes = DEFAULT_OURA_SCOPES, profileId = null }) {
   const state = randomState();
   const redirectUri = pickRedirectUri(registeredUris);
   sessionStorage.setItem(STATE_KEY, JSON.stringify({
     state, redirectUri, startedAt: Date.now(), clientId,
-    profileId: getWearableAuthProfileId(),
+    profileId,
   }));
   const url = buildAuthorizeUrl({ clientId, redirectUri, scopes, state });
   redirectWearableAuth(url);

--- a/js/wearables-polar-auth.js
+++ b/js/wearables-polar-auth.js
@@ -19,7 +19,6 @@ import { isDebugMode } from './utils.js';
 import {
   exposeWearableAuthDebug,
   getWearableAuthLocation,
-  getWearableAuthProfileId,
   redirectWearableAuth,
 } from './wearables-auth-runtime.js';
 
@@ -59,12 +58,12 @@ export function buildAuthorizeUrl({ clientId, redirectUri, scopes = DEFAULT_POLA
   return `${AUTHORIZE_URL}?${params.toString()}`;
 }
 
-export function beginOAuth({ clientId, registeredUris, scopes = DEFAULT_POLAR_SCOPES }) {
+export function beginOAuth({ clientId, registeredUris, scopes = DEFAULT_POLAR_SCOPES, profileId = null }) {
   const state = randomState();
   const redirectUri = pickRedirectUri(registeredUris);
   sessionStorage.setItem(STATE_KEY, JSON.stringify({
     state, redirectUri, startedAt: Date.now(), clientId,
-    profileId: getWearableAuthProfileId(),
+    profileId,
   }));
   const url = buildAuthorizeUrl({ clientId, redirectUri, scopes, state });
   redirectWearableAuth(url);

--- a/js/wearables-ultrahuman-auth.js
+++ b/js/wearables-ultrahuman-auth.js
@@ -19,7 +19,6 @@ import { isDebugMode } from './utils.js';
 import {
   exposeWearableAuthDebug,
   getWearableAuthLocation,
-  getWearableAuthProfileId,
   redirectWearableAuth,
 } from './wearables-auth-runtime.js';
 
@@ -59,12 +58,12 @@ export function buildAuthorizeUrl({ clientId, redirectUri, scopes = DEFAULT_ULTR
   return `${AUTHORIZE_URL}?${params.toString()}`;
 }
 
-export function beginOAuth({ clientId, registeredUris, scopes = DEFAULT_ULTRAHUMAN_SCOPES }) {
+export function beginOAuth({ clientId, registeredUris, scopes = DEFAULT_ULTRAHUMAN_SCOPES, profileId = null }) {
   const state = randomState();
   const redirectUri = pickRedirectUri(registeredUris);
   sessionStorage.setItem(STATE_KEY, JSON.stringify({
     state, redirectUri, startedAt: Date.now(), clientId,
-    profileId: getWearableAuthProfileId(),
+    profileId,
   }));
   const url = buildAuthorizeUrl({ clientId, redirectUri, scopes, state });
   redirectWearableAuth(url);

--- a/js/wearables-whoop-auth.js
+++ b/js/wearables-whoop-auth.js
@@ -13,7 +13,6 @@ import { isDebugMode } from './utils.js';
 import {
   exposeWearableAuthDebug,
   getWearableAuthLocation,
-  getWearableAuthProfileId,
   redirectWearableAuth,
 } from './wearables-auth-runtime.js';
 
@@ -82,13 +81,13 @@ export async function buildAuthorizeUrl({ clientId, redirectUri, scopes = DEFAUL
   return `${AUTHORIZE_URL}?${params.toString()}`;
 }
 
-export async function beginOAuth({ clientId, registeredUris, scopes = DEFAULT_WHOOP_SCOPES }) {
+export async function beginOAuth({ clientId, registeredUris, scopes = DEFAULT_WHOOP_SCOPES, profileId = null }) {
   const state = randomUrlSafe(16);
   const codeVerifier = randomUrlSafe(32); // 43-128 chars after base64url — 32 bytes → 43 chars
   const redirectUri = pickRedirectUri(registeredUris);
   sessionStorage.setItem(STATE_KEY, JSON.stringify({
     state, redirectUri, startedAt: Date.now(), clientId, codeVerifier,
-    profileId: getWearableAuthProfileId(), // pin profile so a mid-OAuth switch lands in the initiating profile
+    profileId, // pin profile so a mid-OAuth switch lands in the initiating profile
   }));
   const url = await buildAuthorizeUrl({ clientId, redirectUri, scopes, state, codeVerifier });
   redirectWearableAuth(url);

--- a/js/wearables-withings-auth.js
+++ b/js/wearables-withings-auth.js
@@ -16,7 +16,6 @@ import { isDebugMode } from './utils.js';
 import {
   exposeWearableAuthDebug,
   getWearableAuthLocation,
-  getWearableAuthProfileId,
   redirectWearableAuth,
 } from './wearables-auth-runtime.js';
 
@@ -56,12 +55,12 @@ export function buildAuthorizeUrl({ clientId, redirectUri, scopes = DEFAULT_WITH
   return `${AUTHORIZE_URL}?${params.toString()}`;
 }
 
-export function beginOAuth({ clientId, registeredUris, scopes = DEFAULT_WITHINGS_SCOPES }) {
+export function beginOAuth({ clientId, registeredUris, scopes = DEFAULT_WITHINGS_SCOPES, profileId = null }) {
   const state = randomState();
   const redirectUri = pickRedirectUri(registeredUris);
   sessionStorage.setItem(STATE_KEY, JSON.stringify({
     state, redirectUri, startedAt: Date.now(), clientId,
-    profileId: getWearableAuthProfileId(),
+    profileId,
   }));
   const url = buildAuthorizeUrl({ clientId, redirectUri, scopes, state });
   redirectWearableAuth(url);

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -5,6 +5,8 @@
   "legacyWindowGlobalAssignments": 0,
   "viewRuntimeBridgeConsumers": 0,
   "viewRuntimeBridgeLookups": 0,
+  "labStateAppFiles": 1,
+  "labStateTestFiles": 53,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/scripts/quality-guardrails.mjs
+++ b/scripts/quality-guardrails.mjs
@@ -10,11 +10,14 @@ const BASELINE_PATH = path.join(ROOT, 'scripts', 'quality-baseline.json');
 // tests/ is intentionally omitted; this check covers app JS only, not test helpers.
 const SYNTAX_DIRS = ['js', 'api', 'scripts'];
 const APP_JS_DIR = path.join(ROOT, 'js');
+const TEST_JS_DIR = path.join(ROOT, 'tests');
 const INLINE_EVENT_RE = /\bon(?:click|keydown|change|input|submit)=["']/g;
 const WINDOW_REF_RE = /\bwindow(?:\.|\s*\[)/g;
 const WINDOW_GLOBAL_ASSIGN_RE = /Object\.assign\(\s*window\b/g;
 const VIEW_RUNTIME_LOOKUP_RE = /\bgetViewRuntimeFunction\s*\(/g;
+const LAB_STATE_RE = /\b_labState\b/g;
 const VIEW_RUNTIME_BRIDGE_FILE = 'js/views-runtime-bridge.js';
+const LAB_STATE_GUARDRAIL_TEST_FILE = 'tests/test-quality-guardrails.js';
 // Keep this value in sync with the baseline key name largeJsFilesOver800Lines.
 const LARGE_FILE_LINE_LIMIT = 800;
 
@@ -63,6 +66,7 @@ function collectAppMetrics() {
   let legacyWindowGlobalAssignments = 0;
   let viewRuntimeBridgeConsumers = 0;
   let viewRuntimeBridgeLookups = 0;
+  let labStateAppFiles = 0;
   const largeFiles = [];
   let largestFile = { file: '', lines: 0 };
 
@@ -73,12 +77,14 @@ function collectAppMetrics() {
     const viewRuntimeLookupCount = repoRel(file) === VIEW_RUNTIME_BRIDGE_FILE
       ? 0
       : countMatches(source, VIEW_RUNTIME_LOOKUP_RE);
+    const labStateCount = countMatches(source, LAB_STATE_RE);
     inlineEventAttributes += countMatches(source, INLINE_EVENT_RE);
     windowReferences += countMatches(source, WINDOW_REF_RE);
     windowGlobalAssignments += windowAssignmentCount;
     if (!file.endsWith('-window-bindings.js')) legacyWindowGlobalAssignments += windowAssignmentCount;
     viewRuntimeBridgeLookups += viewRuntimeLookupCount;
     if (viewRuntimeLookupCount > 0) viewRuntimeBridgeConsumers++;
+    if (labStateCount > 0) labStateAppFiles++;
     if (lines >= LARGE_FILE_LINE_LIMIT) largeFiles.push({ file: repoRel(file), lines });
     if (lines > largestFile.lines) largestFile = { file: repoRel(file), lines };
   }
@@ -91,10 +97,22 @@ function collectAppMetrics() {
     legacyWindowGlobalAssignments,
     viewRuntimeBridgeConsumers,
     viewRuntimeBridgeLookups,
+    labStateAppFiles,
     largeJsFilesOver800Lines: largeFiles.length,
     largestFile,
     largeFiles,
   };
+}
+
+function collectTestMetrics() {
+  const files = walkFiles(TEST_JS_DIR, new Set(['.js']));
+  let labStateTestFiles = 0;
+  for (const file of files) {
+    if (repoRel(file) === LAB_STATE_GUARDRAIL_TEST_FILE) continue;
+    const source = fs.readFileSync(file, 'utf8');
+    if (countMatches(source, LAB_STATE_RE) > 0) labStateTestFiles++;
+  }
+  return { labStateTestFiles };
 }
 
 function collectSyntaxFiles() {
@@ -134,6 +152,7 @@ function main() {
   console.log('=== Quality Guardrails ===\n');
   const baseline = readBaseline();
   const metrics = collectAppMetrics();
+  const testMetrics = collectTestMetrics();
 
   compareBudget('inline event attributes in js/', metrics.inlineEventAttributes, baseline.inlineEventAttributes);
   compareBudget('window global references in js/', metrics.windowReferences, baseline.windowReferences);
@@ -141,6 +160,8 @@ function main() {
   compareBudget('legacy window global assignments in js/', metrics.legacyWindowGlobalAssignments, baseline.legacyWindowGlobalAssignments);
   compareBudget('view runtime bridge consumer modules in js/', metrics.viewRuntimeBridgeConsumers, baseline.viewRuntimeBridgeConsumers);
   compareBudget('view runtime bridge lookups in js/', metrics.viewRuntimeBridgeLookups, baseline.viewRuntimeBridgeLookups);
+  compareBudget('_labState files in js/', metrics.labStateAppFiles, baseline.labStateAppFiles);
+  compareBudget('_labState files in tests/', testMetrics.labStateTestFiles, baseline.labStateTestFiles);
   compareBudget('large JS files (>=800 lines)', metrics.largeJsFilesOver800Lines, baseline.largeJsFilesOver800Lines);
 
   if (metrics.largestFile.lines <= baseline.maxJsFileLines) {

--- a/tests/playwright/wearables-auth-browser-coverage.spec.js
+++ b/tests/playwright/wearables-auth-browser-coverage.spec.js
@@ -10,7 +10,6 @@ test('confidential wearable OAuth modules cover callback refresh and token guard
   const results = await page.evaluate(async ({ cases }) => {
     const outcomes = {};
     const originalFetch = window.fetch;
-    const originalProfile = window._labState?.currentProfile;
 
     const makeResponse = ({ body = {}, status = 200 } = {}) => new Response(JSON.stringify(body), {
       status,
@@ -31,7 +30,6 @@ test('confidential wearable OAuth modules cover callback refresh and token guard
       try {
         await loaded;
         const win = frame.contentWindow;
-        win._labState = { currentProfile: 'wearables-auth-profile' };
         win.sessionStorage.removeItem(spec.stateKey);
         sessionStorage.removeItem(spec.stateKey);
         const frameMod = await win.eval(`import(${JSON.stringify(`${spec.url}&beginFrame=1`)})`);
@@ -39,6 +37,7 @@ test('confidential wearable OAuth modules cover callback refresh and token guard
           clientId: 'client-id',
           registeredUris: [`${location.origin}/app`],
           scopes: ['scope:one'],
+          profileId: 'wearables-auth-profile',
         });
         if (maybePromise?.catch) maybePromise.catch(() => {});
         const raw = sessionStorage.getItem(spec.stateKey) || win.sessionStorage.getItem(spec.stateKey);
@@ -50,9 +49,6 @@ test('confidential wearable OAuth modules cover callback refresh and token guard
     };
 
     try {
-      window._labState ||= {};
-      window._labState.currentProfile = 'wearables-auth-profile';
-
       for (const spec of cases) {
         try {
           const mod = await import(spec.url);
@@ -277,7 +273,6 @@ test('confidential wearable OAuth modules cover callback refresh and token guard
       }
     } finally {
       window.fetch = originalFetch;
-      if (window._labState) window._labState.currentProfile = originalProfile;
       for (const spec of cases) sessionStorage.removeItem(spec.stateKey);
     }
 
@@ -405,7 +400,6 @@ test('PKCE wearable OAuth modules cover callback refresh and challenge paths', a
   const results = await page.evaluate(async ({ cases }) => {
     const outcomes = {};
     const originalFetch = window.fetch;
-    const originalProfile = window._labState?.currentProfile;
     const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
     const challenge = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
 
@@ -428,7 +422,6 @@ test('PKCE wearable OAuth modules cover callback refresh and challenge paths', a
       try {
         await loaded;
         const win = frame.contentWindow;
-        win._labState = { currentProfile: 'wearables-auth-profile' };
         win.sessionStorage.removeItem(spec.stateKey);
         sessionStorage.removeItem(spec.stateKey);
         const frameMod = await win.eval(`import(${JSON.stringify(`${spec.url}&beginFrame=1`)})`);
@@ -436,6 +429,7 @@ test('PKCE wearable OAuth modules cover callback refresh and challenge paths', a
           clientId: 'client-id',
           registeredUris: [`${location.origin}/app`],
           scopes: ['scope:one'],
+          profileId: 'wearables-auth-profile',
         });
         if (maybePromise?.catch) maybePromise.catch(() => {});
         const raw = sessionStorage.getItem(spec.stateKey) || win.sessionStorage.getItem(spec.stateKey);
@@ -447,9 +441,6 @@ test('PKCE wearable OAuth modules cover callback refresh and challenge paths', a
     };
 
     try {
-      window._labState ||= {};
-      window._labState.currentProfile = 'wearables-auth-profile';
-
       for (const spec of cases) {
         try {
           const mod = await import(spec.url);
@@ -672,7 +663,6 @@ test('PKCE wearable OAuth modules cover callback refresh and challenge paths', a
       }
     } finally {
       window.fetch = originalFetch;
-      if (window._labState) window._labState.currentProfile = originalProfile;
       for (const spec of cases) sessionStorage.removeItem(spec.stateKey);
     }
 

--- a/tests/playwright/wearables-connect-browser-coverage.spec.js
+++ b/tests/playwright/wearables-connect-browser-coverage.spec.js
@@ -138,16 +138,15 @@ test('wearables connect browser coverage drives OAuth callback, backfill, refres
         document.body.appendChild(frame);
         try {
           await loaded;
-          frame.contentWindow._labState = { currentProfile: profileId };
           frame.contentWindow.sessionStorage.removeItem(stateKeys[id]);
           sessionStorage.removeItem(stateKeys[id]);
           const frameMod = await frame.contentWindow.eval(`import(${JSON.stringify(`${connectUrl}&frame=${id}`)})`);
-          frame.contentWindow._labState.currentProfile = profileId;
           const redirectUri = `${frame.contentWindow.location.origin}${frame.contentWindow.location.pathname}`;
           const maybePromise = frameMod.OAUTH_DISPATCH[id].begin({
             clientId: `client-${id}`,
             registeredUris: [redirectUri],
             scopes: ['scope:one'],
+            profileId,
           });
           if (maybePromise?.catch) maybePromise.catch(() => {});
           const raw = frame.contentWindow.sessionStorage.getItem(stateKeys[id]) || sessionStorage.getItem(stateKeys[id]);

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -56,6 +56,12 @@ assert('quality guardrail ratchets view runtime bridge coupling',
     guardrailSrc.includes('viewRuntimeBridgeLookups') &&
     baseline.viewRuntimeBridgeConsumers === 0 &&
     baseline.viewRuntimeBridgeLookups === 0);
+assert('quality guardrail ratchets _labState retirement by file',
+  guardrailSrc.includes('LAB_STATE_RE') &&
+    guardrailSrc.includes('labStateAppFiles') &&
+    guardrailSrc.includes('labStateTestFiles') &&
+    baseline.labStateAppFiles === 1 &&
+    baseline.labStateTestFiles === 53);
 const forbiddenAppEventWindowGlobals = [
   'closeModal',
   'toggleChatPanel',

--- a/tests/test-wearables-auth-runtime.js
+++ b/tests/test-wearables-auth-runtime.js
@@ -5,7 +5,6 @@ import './_node-shim.js';
 import {
   exposeWearableAuthDebug,
   getWearableAuthLocation,
-  getWearableAuthProfileId,
   redirectWearableAuth,
 } from '../js/wearables-auth-runtime.js';
 
@@ -44,14 +43,11 @@ try {
   const location = { origin: 'https://app.example', pathname: '/app', href: 'https://app.example/app' };
   const runtime = {
     location,
-    _labState: { currentProfile: 'profile-123' },
   };
   setRuntime(runtime);
 
   assert('wearables auth runtime reads browser location',
     getWearableAuthLocation() === location);
-  assert('wearables auth runtime reads active profile id',
-    getWearableAuthProfileId() === 'profile-123');
   assert('wearables auth runtime redirects through location href',
     redirectWearableAuth('https://provider.example/auth') &&
       location.href === 'https://provider.example/auth');
@@ -62,17 +58,14 @@ try {
     exposeWearableAuthDebug('_testAuth', { ok: true }, true) === true &&
       runtime._testAuth.ok === true);
 
-  delete runtime._labState;
   delete runtime.location;
   assert('wearables auth runtime handles missing optional browser globals',
     getWearableAuthLocation() === null &&
-      getWearableAuthProfileId() === null &&
       redirectWearableAuth('https://provider.example/auth') === false);
 
   delete globalThis.window;
   assert('wearables auth runtime no-ops without browser window',
     getWearableAuthLocation() === null &&
-      getWearableAuthProfileId() === null &&
       exposeWearableAuthDebug('_missingWindowAuth', { ok: true }, true) === false);
 } finally {
   restoreWindow();

--- a/tests/test-wearables.js
+++ b/tests/test-wearables.js
@@ -876,13 +876,17 @@ const authModuleSources = await Promise.all(authModuleFiles.map(file => fetch(fi
 assert('Wearable OAuth modules delegate browser globals to auth runtime',
   authModuleSources.every(src =>
     src.includes("from './wearables-auth-runtime.js'") &&
-    src.includes('getWearableAuthProfileId') &&
+    !src.includes('getWearableAuthProfileId') &&
+    src.includes('profileId = null') &&
     src.includes('redirectWearableAuth') &&
     src.includes('exposeWearableAuthDebug') &&
     !/\bwindow(?:\.|\s*\[)/.test(src)) &&
     authRuntimeSrc.includes('export function getWearableAuthLocation') &&
     authRuntimeSrc.includes('export function exposeWearableAuthDebug'),
   authModuleFiles.find((file, index) => /\bwindow(?:\.|\s*\[)/.test(authModuleSources[index])) || 'missing runtime import');
+assert('wearable connector passes the initiating profile into OAuth modules',
+  (await fetch('/js/wearables-connect.js').then(r => r.text()))
+    .includes('profileId: state.currentProfile'));
 // (JSZip functional smoke — needs real browser <script> injection —
 // lives in test-wearables-dom.js. The loadJSZip source-pattern asserts
 // above run in Node.)

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.292';
+self.APP_VERSION = '1.10.293';


### PR DESCRIPTION
## Summary
- pass the initiating profile explicitly from the wearable connector into all six OAuth providers
- remove the wearable auth runtime's dependency on the global `_labState` object
- migrate the focused OAuth and connector tests to module/argument state
- add ratcheting quality metrics for remaining `_labState` files
- bump the app cache version to 1.10.293

## Workstream progress
- prior generic view-runtime bridge phase: **100% complete** (0 consumers / 0 lookups remain)
- `_labState` retirement baseline: **58 files** (2 app + 56 tests)
- completed after this PR: **4 / 58 files (6.9%)**
- remaining after this PR: **54 / 58 files (93.1%)** — 1 app export + 53 test files
- the final app export will be removed after the remaining test consumers are migrated

## Testing
- `./run-tests.sh` (399 Vitest tests, 352 Playwright tests, 472 responsive-theme assertions)
- targeted wearable OAuth and connector Playwright coverage (4 tests)
- wearable regression suite (585 assertions)
- quality guardrails, module verification, and both TypeScript/checkJs suites