### PR TITLE
Migrate light tests off lab state global

### DIFF
--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -6,7 +6,7 @@
   "viewRuntimeBridgeConsumers": 0,
   "viewRuntimeBridgeLookups": 0,
   "labStateAppFiles": 1,
-  "labStateTestFiles": 53,
+  "labStateTestFiles": 50,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/test-light-ai-renders.js
+++ b/tests/test-light-ai-renders.js
@@ -15,8 +15,8 @@ function assert(name, cond, detail) {
 
 console.log('=== Light AI Render Smoke Tests ===\n');
 
-await import('../js/state.js');
-  const origImported = window._labState.importedData;
+const { state } = await import('../js/state.js');
+  const origImported = state.importedData;
   const origProvider = localStorage.getItem('labcharts-ai-provider');
   const origPaused = localStorage.getItem('labcharts-ai-paused');
 
@@ -28,7 +28,7 @@ await import('../js/state.js');
     localStorage.setItem('labcharts-ai-paused', 'true');
   }
   function reset(seed = {}) {
-    window._labState.importedData = Object.assign({
+    state.importedData = Object.assign({
       entries: [],
       sunSessions: [],
       deviceSessions: [],
@@ -170,7 +170,7 @@ await import('../js/state.js');
         screens: [],
       },
     });
-    const ctx = mod.buildRoomContext(window._labState.importedData.lightEnvironment.rooms[0]);
+    const ctx = mod.buildRoomContext(state.importedData.lightEnvironment.rooms[0]);
     // Newlines collapsed to single spaces — no \n[INJECT]\n breakout
     assert('room context collapses newlines in user-supplied name',
       !ctx.includes('Bedroom\n[INJECT]'));
@@ -204,7 +204,7 @@ await import('../js/state.js');
     // not render the green dot.
     reset({ sunSessions: [{ id: 'sx', endedAt: Date.now() - 60000, durationMin: 20 }] });
     const today = new Date().toISOString().slice(0, 10);
-    const verdicts = window._labState.importedData.lightDailyVerdicts = {};
+    const verdicts = state.importedData.lightDailyVerdicts = {};
     const realFp = mod.getDayFingerprint
       ? mod.getDayFingerprint({ key: today, date: new Date(), isLightTodayTarget: true })
       : 'fp';
@@ -291,12 +291,12 @@ await import('../js/state.js');
     assert('burden render shows CTA + heuristic when no AI verdict',
       idle.includes('Get AI verdict') && idle.includes('fallback heuristic text'));
 
-    window._labState.importedData.lightEnvironment.burdenAI = okVerdict('yellow');
+    state.importedData.lightEnvironment.burdenAI = okVerdict('yellow');
     // Fingerprint won't match (different by design), so the render
     // shows stale-CTA. Recompute fingerprint match by setting it
     // explicitly to whatever the module computes.
     const currentFp = mod.getBurdenFingerprint();
-    window._labState.importedData.lightEnvironment.burdenAI.fingerprint = currentFp;
+    state.importedData.lightEnvironment.burdenAI.fingerprint = currentFp;
     const ok = mod.renderBurdenInterp(burden);
     assert('burden render shows yellow verdict on fingerprint match',
       ok.includes('sun-session-ai-dot-yellow') && ok.includes('tip-text'));
@@ -318,9 +318,9 @@ await import('../js/state.js');
     assert('channel-mix render shows CTA + fallback when no verdict',
       idle.includes('Get AI synthesis') && idle.includes('static-fallback'));
 
-    window._labState.importedData.channelMixAI = okVerdict('green');
+    state.importedData.channelMixAI = okVerdict('green');
     const currentFp = mod.getChannelMixFingerprint();
-    window._labState.importedData.channelMixAI.fingerprint = currentFp;
+    state.importedData.channelMixAI.fingerprint = currentFp;
     const ok = mod.renderChannelMixVerdict(fallback);
     assert('channel-mix render shows verdict on fingerprint match',
       ok.includes('sun-session-ai-dot-green'));
@@ -352,7 +352,7 @@ await import('../js/state.js');
       idle.includes('Generate plan'));
 
     // Test the actions[] custom field via parseExtraFields
-    window._labState.importedData.sunDefaults.aiAnalysis = Object.assign(okVerdict('yellow'), {
+    state.importedData.sunDefaults.aiAnalysis = Object.assign(okVerdict('yellow'), {
       actions: ['Walk outside within 10 min of waking', 'Avoid screens past 9 pm', 'Change bedroom bulb to incandescent'],
     });
     const ok = mod.renderOnboardingAIBlock();
@@ -360,8 +360,8 @@ await import('../js/state.js');
       ok.includes('<ul class="light-setup-ai-actions">') && ok.includes('Walk outside'));
 
     // Skip rendering when setup not completed
-    delete window._labState.importedData.sunDefaults.completedAt;
-    delete window._labState.importedData.sunDefaults.aiAnalysis;
+    delete state.importedData.sunDefaults.completedAt;
+    delete state.importedData.sunDefaults.aiAnalysis;
     assert('onboarding render returns "" when setup not completed',
       mod.renderOnboardingAIBlock() === '');
   }
@@ -371,7 +371,7 @@ await import('../js/state.js');
   else localStorage.removeItem('labcharts-ai-provider');
   if (origPaused != null) localStorage.setItem('labcharts-ai-paused', origPaused);
   else localStorage.removeItem('labcharts-ai-paused');
-  window._labState.importedData = origImported;
+  state.importedData = origImported;
 
 console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
 process.exit(fail > 0 ? 1 : 0);

--- a/tests/test-light-device-ai-analysis.js
+++ b/tests/test-light-device-ai-analysis.js
@@ -15,7 +15,7 @@ function assert(name, condition, detail) {
 
 console.log('=== Light Device AI Analysis Tests ===\n');
 
-await import('../js/state.js');
+const { state } = await import('../js/state.js');
 await import('../js/light-devices.js');
 const mod = await import('../js/light-device-ai-analysis.js');
 const {
@@ -26,7 +26,7 @@ const {
   refreshDeviceSessionAIAnalysis,
   maybeAnalyzeDeviceSessionAfterFinish,
 } = mod;
-  const origImported = window._labState.importedData;
+  const origImported = state.importedData;
   const origProvider = localStorage.getItem('labcharts-ai-provider');
   const origPaused = localStorage.getItem('labcharts-ai-paused');
 
@@ -50,7 +50,7 @@ const {
   }
 
   function reset(seed = {}) {
-    window._labState.importedData = Object.assign({
+    state.importedData = Object.assign({
       entries: [],
       deviceSessions: [],
       lightDevices: [],
@@ -351,7 +351,7 @@ const {
 
   // After refresh, the session in state should carry an error verdict —
   // which proves setAIAnalysis was reached (via the catch branch).
-  const after = window._labState.importedData.deviceSessions.find(s => s.id === 'dev-refresh-target');
+  const after = state.importedData.deviceSessions.find(s => s.id === 'dev-refresh-target');
   assert('refresh resolved id via getTarget (target exists in state)',
     !!after);
   assert('refresh reached setAIAnalysis via catch (error sidecar written)',
@@ -369,7 +369,7 @@ const {
   else localStorage.removeItem('labcharts-ai-provider');
   if (origPaused != null) localStorage.setItem('labcharts-ai-paused', origPaused);
   else localStorage.removeItem('labcharts-ai-paused');
-  window._labState.importedData = origImported;
+  state.importedData = origImported;
 
 console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
 process.exit(fail > 0 ? 1 : 0);

--- a/tests/test-light-tools.js
+++ b/tests/test-light-tools.js
@@ -16,7 +16,7 @@ function assert(name, condition, detail) {
 
 console.log('=== Light Tools Tests ===\n');
 
-await import('../js/state.js');
+const { state } = await import('../js/state.js');
 const tools = await import('../js/light-tools.js');
   const {
     computeRowBanding,
@@ -45,9 +45,9 @@ const tools = await import('../js/light-tools.js');
       return a >= 0 && b >= 0 && a < b;
     };
 
-  const orig = window._labState.importedData;
+  const orig = state.importedData;
   function reset(seed = {}) {
-    window._labState.importedData = Object.assign({ entries: [] }, seed);
+    state.importedData = Object.assign({ entries: [] }, seed);
   }
 
   // ─── 1. computeRowBanding shape ──────────────────────────────────────
@@ -140,7 +140,7 @@ const tools = await import('../js/light-tools.js');
     assert('getMeasurements preserves audit walkthrough history during collapse',
       migrated.filter(m => m.tool === 'audit').length === 2);
     assert('getMeasurements tombstones collapsed rows for sync',
-      window._labState.importedData._deleted?.lightMeasurements?.includes('old-lux'));
+      state.importedData._deleted?.lightMeasurements?.includes('old-lux'));
 
     reset();
 
@@ -335,7 +335,7 @@ const tools = await import('../js/light-tools.js');
   configureLightTools({ suggestRoomSourceFromSpectrum: async () => {} });
 
   // Restore
-  window._labState.importedData = orig;
+  state.importedData = orig;
 
 console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
 process.exit(fail > 0 ? 1 : 0);

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -61,7 +61,7 @@ assert('quality guardrail ratchets _labState retirement by file',
     guardrailSrc.includes('labStateAppFiles') &&
     guardrailSrc.includes('labStateTestFiles') &&
     baseline.labStateAppFiles === 1 &&
-    baseline.labStateTestFiles === 53);
+    baseline.labStateTestFiles === 50);
 const forbiddenAppEventWindowGlobals = [
   'closeModal',
   'toggleChatPanel',


### PR DESCRIPTION
## Summary

- import the shared state module directly in the light tools, light AI render, and device AI analysis tests
- remove those tests' dependency on the browser-only `window._labState` export
- ratchet the quality ceiling from 53 to 50 remaining test files

This is test-only, so no app cache-version bump is required.

## Validation

- `./run-tests.sh`
  - 399 Vitest tests passed
  - 352 Playwright tests passed
  - 472 responsive-theme assertions passed
  - typecheck, checkjs, vendor verification, static module verification, and quality guardrails passed

## Overall cleanup progress

The measured `_labState` retirement scope started at 58 files: 2 app files and 56 test files.

- completed before this PR: 4/58 files (6.9%)
- completed by this PR: 3 additional files
- completed after this PR: 7/58 files (12.1%)
- entire work remaining: 51/58 files (87.9%) — 1 app export and 50 test files

The final app export can be removed once the remaining tests no longer consume it.