### PR TITLE
Migrate Sun tests off lab state global

### DIFF
--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -6,7 +6,7 @@
   "viewRuntimeBridgeConsumers": 0,
   "viewRuntimeBridgeLookups": 0,
   "labStateAppFiles": 1,
-  "labStateTestFiles": 50,
+  "labStateTestFiles": 46,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -61,7 +61,7 @@ assert('quality guardrail ratchets _labState retirement by file',
     guardrailSrc.includes('labStateAppFiles') &&
     guardrailSrc.includes('labStateTestFiles') &&
     baseline.labStateAppFiles === 1 &&
-    baseline.labStateTestFiles === 50);
+    baseline.labStateTestFiles === 46);
 const forbiddenAppEventWindowGlobals = [
   'closeModal',
   'toggleChatPanel',

--- a/tests/test-sun-ai-analysis.js
+++ b/tests/test-sun-ai-analysis.js
@@ -15,7 +15,7 @@ function assert(name, condition, detail) {
 
 console.log('=== Sun AI Analysis Tests ===\n');
 
-await import('../js/state.js');
+const { state } = await import('../js/state.js');
 await import('../js/sun.js');
 await import('../js/sun-uvdata.js');
 const mod = await import('../js/sun-ai-analysis.js');
@@ -27,12 +27,12 @@ const {
   maybeAnalyzeSessionAfterFinish,
   refreshSessionAIAnalysis,
 } = mod;
-  const origImported = window._labState.importedData;
+  const origImported = state.importedData;
   const origProvider = localStorage.getItem('labcharts-ai-provider');
   const origPaused = localStorage.getItem('labcharts-ai-paused');
 
   function reset(seed = {}) {
-    window._labState.importedData = Object.assign({
+    state.importedData = Object.assign({
       entries: [],
       sunSessions: [],
       sunDefaults: { fitzpatrick: 'III' },
@@ -321,7 +321,7 @@ const {
   window.fetch = () => Promise.reject(new Error('test stub: provider unreachable'));
   try { await refreshSessionAIAnalysis('sun_refresh_target'); } catch (_) {}
   window.fetch = origFetch;
-  const after = window._labState.importedData.sunSessions.find(s => s.id === 'sun_refresh_target');
+  const after = state.importedData.sunSessions.find(s => s.id === 'sun_refresh_target');
   assert('refresh resolved id via getTarget (target intact)', !!after);
   assert('refresh reached setAIAnalysis via catch (error sidecar written)',
     !!after?.aiAnalysis && (after.aiAnalysis.status === 'error' || !!after.aiAnalysis.lastErrorMessage),
@@ -337,7 +337,7 @@ const {
   else localStorage.removeItem('labcharts-ai-provider');
   if (origPaused != null) localStorage.setItem('labcharts-ai-paused', origPaused);
   else localStorage.removeItem('labcharts-ai-paused');
-  window._labState.importedData = origImported;
+  state.importedData = origImported;
 
 console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
 process.exit(fail > 0 ? 1 : 0);

--- a/tests/test-sun-context.js
+++ b/tests/test-sun-context.js
@@ -15,7 +15,7 @@ function assert(name, condition, detail) {
 
 console.log('=== Sun Context Tests ===\n');
 
-await import('../js/state.js');
+const { state } = await import('../js/state.js');
 const labCtxMod = await import('../js/lab-context.js');
 const ctxMod = await import('../js/sun-context.js');
 const { getSessions } = await import('../js/sun-sessions-store.js');
@@ -23,9 +23,9 @@ await import('../js/sun-context-hooks.js');
 const { buildSunContext, configureSunContext } = ctxMod;
 labCtxMod.setLightSunContextEnabled(true);
 
-  const orig = window._labState.importedData;
+  const orig = state.importedData;
   function reset(seed = {}) {
-    window._labState.importedData = Object.assign({ entries: [], sunSessions: [] }, seed);
+    state.importedData = Object.assign({ entries: [], sunSessions: [] }, seed);
   }
 
   // ─── 1. Empty path ──────────────────────────────────────────────────
@@ -552,7 +552,7 @@ labCtxMod.setLightSunContextEnabled(true);
     populatedStandard.length < 8500, `len=${populatedStandard.length}`);
 
   // Restore
-  window._labState.importedData = orig;
+  state.importedData = orig;
 
 console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
 process.exit(fail > 0 ? 1 : 0);

--- a/tests/test-sun-ui-flow.js
+++ b/tests/test-sun-ui-flow.js
@@ -12,7 +12,7 @@ return (async function() {
   }
   const wait = ms => new Promise(r => setTimeout(r, ms));
   const main = document.getElementById('main-content');
-  const S = window._labState;
+  const { state: S } = await import('/js/state.js');
   const dataModule = await import('/js/data.js');
   const viewsModule = await import('/js/views.js');
   const lightDevices = await import('/js/light-devices.js');

--- a/tests/test-sun.js
+++ b/tests/test-sun.js
@@ -22,7 +22,7 @@ function assert(name, condition, detail) {
 
 console.log('=== Sun Session Tests ===\n');
 
-await import('../js/state.js');
+const { state } = await import('../js/state.js');
 const sun = await import('../js/sun.js');
 const sunChannelMetrics = await import('../js/sun-channel-metrics.js');
 const sunSessionModel = await import('../js/sun-session-model.js');
@@ -43,10 +43,10 @@ const {
 } = sun;
 
   // Stash importedData so we don't pollute the host page.
-  const orig = window._labState.importedData;
+  const orig = state.importedData;
   // Reset to a clean slate per test block.
   function reset(seed = {}) {
-    window._labState.importedData = Object.assign({ entries: [], sunSessions: [] }, seed);
+    state.importedData = Object.assign({ entries: [], sunSessions: [] }, seed);
   }
 
   // ─── 1. Constant shape ───────────────────────────────────────────────
@@ -504,7 +504,7 @@ const {
   assert('_applyAtmOverrides with no sunDefaults returns input unchanged',
     _applyAtmOverrides(baseAtm).uvIndex === 5);
 
-  window._labState.importedData.sunDefaults = {
+  state.importedData.sunDefaults = {
     overrides: { uvIndex: 9, cloudCover: 50, ozoneDU: 250 },
   };
   const overridden = _applyAtmOverrides(baseAtm);
@@ -514,7 +514,7 @@ const {
   assert('Override sets _uvOverridden marker', overridden._uvOverridden === true);
 
   // null/non-finite override is ignored, not blindly applied
-  window._labState.importedData.sunDefaults = {
+  state.importedData.sunDefaults = {
     overrides: { uvIndex: null, cloudCover: 'abc', ozoneDU: NaN },
   };
   const overridden2 = _applyAtmOverrides(baseAtm);
@@ -650,7 +650,7 @@ const {
     swSrc.includes("'/js/light-sun-ai-hooks.js'"));
 
   // Restore
-  window._labState.importedData = orig;
+  state.importedData = orig;
 
 console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
 process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

- import the shared state module directly in the core Sun session, Sun context, and Sun AI analysis tests
- use the same module import in the browser-driven Light & Sun UI fixture
- ratchet the quality ceiling from 50 to 46 remaining test files

This is test-only, so no app cache-version bump is required.

## Validation

- focused Node suites: 232 assertions passed
- focused Light & Sun browser fixture: 3 tests passed
- `./run-tests.sh`
  - 399 Vitest tests passed
  - 352 Playwright tests passed
  - 472 responsive-theme assertions passed
  - typecheck, checkjs, vendor verification, static module verification, and quality guardrails passed

## Overall cleanup progress

The measured `_labState` retirement scope started at 58 files: 2 app files and 56 test files.

- completed before this PR: 7/58 files (12.1%)
- completed by this PR: 4 additional files
- completed after this PR: 11/58 files (19.0%)
- entire work remaining: 47/58 files (81.0%) — 1 app export and 46 test files

The final app export can be removed once the remaining tests no longer consume it.