### PR TITLE
Migrate data flow tests off lab state global

### DIFF
--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -6,7 +6,7 @@
   "viewRuntimeBridgeConsumers": 0,
   "viewRuntimeBridgeLookups": 0,
   "labStateAppFiles": 1,
-  "labStateTestFiles": 46,
+  "labStateTestFiles": 42,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/test-calculated-markers.js
+++ b/tests/test-calculated-markers.js
@@ -30,10 +30,8 @@ function assert(name, condition, detail) {
 console.log('=== Calculated Markers Tests ===\n');
 
 // Bring in state.js and the module-only data API.
-await import('../js/state.js');
+const { state } = await import('../js/state.js');
 const dataModule = await import('../js/data.js');
-
-const state = window._labState;
 
   // Save originals
   const origEntries = state.importedData.entries;

--- a/tests/test-data-pipeline.js
+++ b/tests/test-data-pipeline.js
@@ -33,10 +33,8 @@ const wait = ms => new Promise(r => setTimeout(r, ms));
 console.log('=== Data Pipeline Tests ===\n');
 
 // Bring in state.js + the module-only data API.
-await import('../js/state.js');
+const { state: S } = await import('../js/state.js');
 const dataModule = await import('../js/data.js');
-
-const S = window._labState;
 
   // ═══════════════════════════════════════════════
   // SETUP — load demo data into state

--- a/tests/test-export-import.js
+++ b/tests/test-export-import.js
@@ -8,7 +8,7 @@ return (async function() {
     else { fail++; console.error(`  ✗ ${name}${detail ? ' — ' + detail : ''}`); }
   }
   const wait = ms => new Promise(r => setTimeout(r, ms));
-  const S = window._labState;
+  const { state: S } = await import('/js/state.js');
   const backupModule = await import('/js/backup.js');
   const dataModule = await import('/js/data.js');
   const exportModule = await import('/js/export.js');

--- a/tests/test-integration-batch2.js
+++ b/tests/test-integration-batch2.js
@@ -25,6 +25,7 @@ console.log('=== Integration Tests — Batch 2 Fixes ===\n');
   // ═══════════════════════════════════════
   console.log('1. Module imports');
 
+  const { state } = await import('../js/state.js');
   const { UNIT_CONVERSIONS, MARKER_SCHEMA, OPTIMAL_RANGES } = await import('../js/schema.js');
   const contextCards = await import('../js/context-cards.js');
 
@@ -220,7 +221,7 @@ console.log('=== Integration Tests — Batch 2 Fixes ===\n');
   // SKIPPED in Node — needs a real DOM for showDashboard's innerHTML writes;
   // covered end-to-end by Playwright. Gate on `process.versions.node` (only
   // truthy in Node) — clean cross-environment skip.
-  const _rtState = window._labState;
+  const _rtState = state;
   const _isNode = typeof process !== 'undefined' && !!process.versions?.node;
   if (!_isNode && typeof contextCards.saveAndRefresh === 'function' && _rtState) {
     const sv_stress = _rtState.importedData?.stress;

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -61,7 +61,7 @@ assert('quality guardrail ratchets _labState retirement by file',
     guardrailSrc.includes('labStateAppFiles') &&
     guardrailSrc.includes('labStateTestFiles') &&
     baseline.labStateAppFiles === 1 &&
-    baseline.labStateTestFiles === 46);
+    baseline.labStateTestFiles === 42);
 const forbiddenAppEventWindowGlobals = [
   'closeModal',
   'toggleChatPanel',


### PR DESCRIPTION
## Summary

- import the shared state module directly in calculated-marker, data-pipeline, export/import, and integration tests
- remove four remaining test consumers of the browser-only `window._labState` export
- ratchet the quality ceiling from 46 to 42 remaining test files

This is test-only, so no app cache-version bump is required.

## Validation

- focused Node suites: 353 assertions passed
- focused core browser fixtures: 2 tests passed
- `./run-tests.sh`
  - 399 Vitest tests passed
  - 352 Playwright tests passed
  - 472 responsive-theme assertions passed
  - typecheck, checkjs, vendor verification, static module verification, and quality guardrails passed

## Overall cleanup progress

The measured `_labState` retirement scope started at 58 files: 2 app files and 56 test files.

- completed before this PR: 11/58 files (19.0%)
- completed by this PR: 4 additional files
- completed after this PR: 15/58 files (25.9%)
- entire work remaining: 43/58 files (74.1%) — 1 app export and 42 test files

The final app export can be removed once the remaining tests no longer consume it.