### PR TITLE
Migrate browser fixtures off lab state global

### DIFF
--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -6,7 +6,7 @@
   "viewRuntimeBridgeConsumers": 0,
   "viewRuntimeBridgeLookups": 0,
   "labStateAppFiles": 1,
-  "labStateTestFiles": 42,
+  "labStateTestFiles": 39,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/playwright/browser-script-runner.js
+++ b/tests/playwright/browser-script-runner.js
@@ -27,7 +27,10 @@ export async function runBrowserScript(page, testPath, options = {}) {
   try {
     if (options.viewport) await page.setViewportSize(options.viewport);
     await page.goto('/app', { waitUntil: 'load' });
-    await page.waitForFunction(() => window._labState && document.getElementById('main-content'), null, {
+    await page.waitForFunction(async () => {
+      const { state } = await import('/js/state.js');
+      return state && document.getElementById('main-content');
+    }, null, {
       timeout: options.readyTimeout ?? 15_000,
     });
 

--- a/tests/test-audit-fixes.js
+++ b/tests/test-audit-fixes.js
@@ -34,7 +34,8 @@ return (async function () {
   console.log('%c Audit-Fix Regression Tests ', 'background:#0891b2;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
 
   // Snapshot global state we'll mutate.
-  const _origImported = window._labState ? window._labState.importedData : null;
+  const { state } = await import('/js/state.js');
+  const _origImported = state.importedData;
   const _origOverflow = document.body.style.overflow;
   const _origAICap = window._aiConcurrencyCap;
   const _origDisable = window.DISABLE_AI_VERDICTS;
@@ -462,7 +463,7 @@ return (async function () {
   }
 
   // ─── Restore mutated globals ───────────────────────────────────────
-  if (window._labState) window._labState.importedData = _origImported;
+  state.importedData = _origImported;
   document.body.style.overflow = _origOverflow;
   if (_origAICap === undefined) delete window._aiConcurrencyCap;
   else window._aiConcurrencyCap = _origAICap;

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -61,7 +61,7 @@ assert('quality guardrail ratchets _labState retirement by file',
     guardrailSrc.includes('labStateAppFiles') &&
     guardrailSrc.includes('labStateTestFiles') &&
     baseline.labStateAppFiles === 1 &&
-    baseline.labStateTestFiles === 42);
+    baseline.labStateTestFiles === 39);
 const forbiddenAppEventWindowGlobals = [
   'closeModal',
   'toggleChatPanel',

--- a/tests/test-ui-flows.js
+++ b/tests/test-ui-flows.js
@@ -24,7 +24,7 @@ return (async function() {
     catch (e) { return false; }
   }
   const main = document.getElementById('main-content');
-  const S = window._labState;
+  const { state: S } = await import('/js/state.js');
   const dataModule = await import('/js/data.js');
   const viewsModule = await import('/js/views.js');
   const supplements = await import('/js/supplements.js');
@@ -807,7 +807,6 @@ return (async function() {
     // Filter with a term taken from an item that is eligible to hide.
     sidebarSearch.value = searchTerm;
     navModule.filterSidebar();
-    await wait(20);
     const hiddenNav = getFilterableNavItems().filter(el => el.style.display === 'none');
     assert('Sidebar search filters items', hiddenNav.length > 0);
     assert('Sidebar search shows matches', hiddenNav.length < totalBefore);
@@ -815,7 +814,6 @@ return (async function() {
     // Clear filter
     sidebarSearch.value = '';
     navModule.filterSidebar();
-    await wait(20);
     const afterClear = getFilterableNavItems().filter(el => el.style.display === 'none');
     assert('Sidebar search clear restores all', afterClear.length === 0);
   } else {


### PR DESCRIPTION
## Summary

- migrate the shared browser-script readiness check and two legacy browser fixtures from `window._labState` to the explicit `state` module export
- stabilize the synchronous sidebar-filter assertions by removing waits that allowed background rendering to race the checks
- ratchet the guarded test-file ceiling from 42 to 39

This is test-only, so no app cache/version bump is required.

## Validation

- `node tests/test-quality-guardrails.js` — 25 passed
- `npm run quality` — 11 passed; 1/1 app files and 39/39 test files within the `_labState` ceilings
- `npx playwright test tests/playwright/ui-regression-browser-flows.spec.js` — 4 passed
- repeated UI-flow fixture under four-worker load — 20/20 passed
- `./run-tests.sh` — 399 Vitest tests, 352 Playwright tests, and 472 responsive-theme assertions passed

## Overall progress

- Before this PR: 15/58 files complete (25.9%)
- This PR: 3 additional test consumers migrated
- After this PR: 18/58 files complete (31.0%)
- Entire work remaining: 40/58 files (69.0%) — the final app export plus 39 test consumers
