### PR TITLE
Migrate Node fixtures off lab state global

### DIFF
--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -6,7 +6,7 @@
   "viewRuntimeBridgeConsumers": 0,
   "viewRuntimeBridgeLookups": 0,
   "labStateAppFiles": 1,
-  "labStateTestFiles": 39,
+  "labStateTestFiles": 33,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/test-biometrics.js
+++ b/tests/test-biometrics.js
@@ -13,16 +13,15 @@ function assert(name, condition, detail) {
 
 console.log('=== Biometrics Tests ===\n');
 
-await import('../js/state.js');
+const { state } = await import('../js/state.js');
 const profile = await import('../js/profile.js');
 const labContext = await import('../js/lab-context.js');
 const exportModule = await import('../js/export.js');
 // Initialize profiles so getProfiles() / setProfileHeight() have something
 // to mutate. The Playwright environment runs main.js which seeds this.
-if (!window._labState.profiles) {
-  window._labState.profiles = [{ id: 'default', name: 'Default' }];
+if (!state.profiles) {
+  state.profiles = [{ id: 'default', name: 'Default' }];
 }
-  const state = window._labState;
   const profileId = state.currentProfile;
 
   // Save originals

--- a/tests/test-change-history.js
+++ b/tests/test-change-history.js
@@ -21,7 +21,7 @@ function assert(name, condition, detail) {
 console.log('=== Change History Tests ===\n');
 
 // Change-history recording is a module-only context-cards API.
-await import('../js/state.js');
+const { state } = await import('../js/state.js');
 const contextCards = await import('../js/context-cards.js');
   // ═══════════════════════════════════════
   // 1. recordChange function exists
@@ -37,20 +37,20 @@ const contextCards = await import('../js/context-cards.js');
   console.log('2. Basic Recording');
 
   // Save original state
-  const origHistory = window._labState.importedData.changeHistory;
-  const origDiet = window._labState.importedData.diet;
+  const origHistory = state.importedData.changeHistory;
+  const origDiet = state.importedData.diet;
 
   // Reset for testing
-  window._labState.importedData.changeHistory = [];
-  window._labState.importedData.diet = { type: 'omnivore', restrictions: [], pattern: null, note: '' };
+  state.importedData.changeHistory = [];
+  state.importedData.diet = { type: 'omnivore', restrictions: [], pattern: null, note: '' };
 
   contextCards.recordChange('diet');
-  assert('Records first change', window._labState.importedData.changeHistory.length === 1);
-  assert('Entry has field', window._labState.importedData.changeHistory[0].field === 'diet');
-  assert('Entry has date (ISO)', /^\d{4}-\d{2}-\d{2}$/.test(window._labState.importedData.changeHistory[0].date));
-  assert('Entry has snapshot', window._labState.importedData.changeHistory[0].snapshot != null);
-  assert('Snapshot is deep copy', window._labState.importedData.changeHistory[0].snapshot !== window._labState.importedData.diet);
-  assert('Snapshot matches current data', JSON.stringify(window._labState.importedData.changeHistory[0].snapshot) === JSON.stringify(window._labState.importedData.diet));
+  assert('Records first change', state.importedData.changeHistory.length === 1);
+  assert('Entry has field', state.importedData.changeHistory[0].field === 'diet');
+  assert('Entry has date (ISO)', /^\d{4}-\d{2}-\d{2}$/.test(state.importedData.changeHistory[0].date));
+  assert('Entry has snapshot', state.importedData.changeHistory[0].snapshot != null);
+  assert('Snapshot is deep copy', state.importedData.changeHistory[0].snapshot !== state.importedData.diet);
+  assert('Snapshot matches current data', JSON.stringify(state.importedData.changeHistory[0].snapshot) === JSON.stringify(state.importedData.diet));
 
   // ═══════════════════════════════════════
   // 3. Dedup: identical snapshot skipped
@@ -58,27 +58,27 @@ const contextCards = await import('../js/context-cards.js');
   console.log('3. Dedup — Identical Snapshot');
 
   contextCards.recordChange('diet');
-  assert('Identical snapshot not duplicated', window._labState.importedData.changeHistory.length === 1);
+  assert('Identical snapshot not duplicated', state.importedData.changeHistory.length === 1);
 
   // ═══════════════════════════════════════
   // 4. Dedup: same field + same day overwrites
   // ═══════════════════════════════════════
   console.log('4. Dedup — Same Day Overwrite');
 
-  window._labState.importedData.diet = { type: 'low-carb', restrictions: ['gluten'], pattern: '2 meals', note: '' };
+  state.importedData.diet = { type: 'low-carb', restrictions: ['gluten'], pattern: '2 meals', note: '' };
   contextCards.recordChange('diet');
-  assert('Same-day update overwrites (no new entry)', window._labState.importedData.changeHistory.length === 1);
-  assert('Snapshot updated to new value', window._labState.importedData.changeHistory[0].snapshot.type === 'low-carb');
+  assert('Same-day update overwrites (no new entry)', state.importedData.changeHistory.length === 1);
+  assert('Snapshot updated to new value', state.importedData.changeHistory[0].snapshot.type === 'low-carb');
 
   // ═══════════════════════════════════════
   // 5. Different fields tracked independently
   // ═══════════════════════════════════════
   console.log('5. Multiple Fields');
 
-  window._labState.importedData.exercise = { frequency: '3x/week', types: ['strength'], intensity: 'moderate', note: '' };
+  state.importedData.exercise = { frequency: '3x/week', types: ['strength'], intensity: 'moderate', note: '' };
   contextCards.recordChange('exercise');
-  assert('Different field creates new entry', window._labState.importedData.changeHistory.length === 2);
-  assert('Exercise entry recorded', window._labState.importedData.changeHistory[1].field === 'exercise');
+  assert('Different field creates new entry', state.importedData.changeHistory.length === 2);
+  assert('Exercise entry recorded', state.importedData.changeHistory[1].field === 'exercise');
 
   // ═══════════════════════════════════════
   // 6. Null snapshot for cleared fields
@@ -86,10 +86,10 @@ const contextCards = await import('../js/context-cards.js');
   console.log('6. Null Snapshot');
 
   // Simulate clearing by setting to different date first
-  const h = window._labState.importedData.changeHistory;
+  const h = state.importedData.changeHistory;
   // Force a past date entry so "clear" on today creates a new one
   h[0].date = '2025-01-01';
-  window._labState.importedData.diet = null;
+  state.importedData.diet = null;
   contextCards.recordChange('diet');
   const nullEntry = h.find(e => e.field === 'diet' && e.snapshot === null);
   assert('Null field recorded with null snapshot', nullEntry != null);
@@ -99,40 +99,40 @@ const contextCards = await import('../js/context-cards.js');
   // ═══════════════════════════════════════
   console.log('7. Cap at 200');
 
-  window._labState.importedData.changeHistory = [];
+  state.importedData.changeHistory = [];
   for (let i = 0; i < 210; i++) {
-    window._labState.importedData.changeHistory.push({
+    state.importedData.changeHistory.push({
       field: 'stress', date: `2024-${String(Math.floor(i / 28) + 1).padStart(2, '0')}-${String((i % 28) + 1).padStart(2, '0')}`,
       snapshot: { level: `level-${i}` }
     });
   }
   // Force a new unique entry
-  window._labState.importedData.stress = { level: 'high', sources: ['work'] };
+  state.importedData.stress = { level: 'high', sources: ['work'] };
   contextCards.recordChange('stress');
-  assert('History capped at 200', window._labState.importedData.changeHistory.length <= 200, `length: ${window._labState.importedData.changeHistory.length}`);
+  assert('History capped at 200', state.importedData.changeHistory.length <= 200, `length: ${state.importedData.changeHistory.length}`);
 
   // ═══════════════════════════════════════
   // 8. String fields (interpretiveLens)
   // ═══════════════════════════════════════
   console.log('8. String Fields');
 
-  window._labState.importedData.changeHistory = [];
-  window._labState.importedData.interpretiveLens = 'Functional medicine';
+  state.importedData.changeHistory = [];
+  state.importedData.interpretiveLens = 'Functional medicine';
   contextCards.recordChange('interpretiveLens');
-  assert('String field snapshot is a string', typeof window._labState.importedData.changeHistory[0].snapshot === 'string');
-  assert('String field value correct', window._labState.importedData.changeHistory[0].snapshot === 'Functional medicine');
+  assert('String field snapshot is a string', typeof state.importedData.changeHistory[0].snapshot === 'string');
+  assert('String field value correct', state.importedData.changeHistory[0].snapshot === 'Functional medicine');
 
   // ═══════════════════════════════════════
   // 9. Array fields (healthGoals)
   // ═══════════════════════════════════════
   console.log('9. Array Fields');
 
-  window._labState.importedData.changeHistory = [];
-  window._labState.importedData.healthGoals = [{ text: 'Reduce inflammation', severity: 'major' }];
+  state.importedData.changeHistory = [];
+  state.importedData.healthGoals = [{ text: 'Reduce inflammation', severity: 'major' }];
   contextCards.recordChange('healthGoals');
-  assert('Array field recorded', window._labState.importedData.changeHistory.length === 1);
-  assert('Array snapshot is array', Array.isArray(window._labState.importedData.changeHistory[0].snapshot));
-  assert('Array snapshot deep copy', window._labState.importedData.changeHistory[0].snapshot !== window._labState.importedData.healthGoals);
+  assert('Array field recorded', state.importedData.changeHistory.length === 1);
+  assert('Array snapshot is array', Array.isArray(state.importedData.changeHistory[0].snapshot));
+  assert('Array snapshot deep copy', state.importedData.changeHistory[0].snapshot !== state.importedData.healthGoals);
 
   // ═══════════════════════════════════════
   // 10. Migration guard
@@ -210,8 +210,8 @@ const contextCards = await import('../js/context-cards.js');
     cycleSrc.includes("recordContextCardChangeRuntime('menstrualCycle')"));
 
   // Restore original state
-  window._labState.importedData.changeHistory = origHistory || [];
-  window._labState.importedData.diet = origDiet;
+  state.importedData.changeHistory = origHistory || [];
+  state.importedData.diet = origDiet;
 
   // ═══════════════════════════════════════
 console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);

--- a/tests/test-chat-actions.js
+++ b/tests/test-chat-actions.js
@@ -28,9 +28,8 @@ function assert(name, condition, detail) {
 
 console.log('=== Chat Actions Tests ===\n');
 
-// state.js exposes window._labState; chat actions and context summaries stay
-// on their module surfaces.
-await import('../js/state.js');
+// State, chat actions, and context summaries stay on their module surfaces.
+const { state: S } = await import('../js/state.js');
 const labContext = await import('../js/lab-context.js');
 await import('../js/chat.js');
 const {
@@ -51,9 +50,8 @@ const {
 } = await import('../js/chat-discussion-round-prompts.js');
 const { readDiscussPersonaPickerSelection } = await import('../js/chat-discussion-ui.js');
 
-const S = window._labState;
 const hasState = S && typeof S === 'object';
-assert('window._labState exists', hasState, hasState ? 'found' : 'not found');
+assert('state module export exists', hasState, hasState ? 'found' : 'not found');
 
 // ─── Section 1: Module exports ───
 console.log('Section 1: Module Exports');
@@ -93,7 +91,7 @@ if (hasState) {
   S.chatHistory = origHistory;
   document.getElementById = origGetElementById;
 } else {
-  console.warn('Skipping Discuss button UI tests — _labState not available');
+  console.warn('Skipping Discuss button UI tests — state module not available');
 }
 
 // ─── Section 1b: Discuss Picker Selection ───
@@ -193,7 +191,7 @@ if (hasState) {
   if (origThreadIndex === null) localStorage.removeItem(threadIndexKey);
   else localStorage.setItem(threadIndexKey, origThreadIndex);
 } else {
-  console.warn('Skipping discussion lifecycle state tests — _labState not available');
+  console.warn('Skipping discussion lifecycle state tests — state module not available');
 }
 
 // ─── Section 2: getContextSummary() ───
@@ -256,7 +254,7 @@ if (hasState) {
 
   assert('Second AI msg shows 2 areas', bar3.includes('2 areas'), 'shows 2 areas');
 } else {
-  console.warn('Skipping buildActionBar tests — _labState not available');
+  console.warn('Skipping buildActionBar tests — state module not available');
 }
 
 // Section 4 (renderChatMessages / DOMParser integration) lives in
@@ -275,7 +273,7 @@ if (hasState) {
   assert('Msg without .sources has no sources toggle', !barNoCtx.includes('chat-sources-toggle'), 'no sources toggle');
   assert('Msg without .context still has action bar', barNoCtx.includes('chat-action-bar'), 'has action bar');
 } else {
-  console.warn('Skipping backward compat tests — _labState not available');
+  console.warn('Skipping backward compat tests — state module not available');
 }
 
 // Section 10 (navigator.clipboard) and Section 12 (context-toggle live DOM)
@@ -696,12 +694,12 @@ if (hasState) {
   assert('First AI msg (non-last) has no Regenerate', !bar0.includes('regenerate-last-message'), 'no regenerate');
   assert('Last AI msg has Regenerate', barLast.includes('regenerate-last-message'), 'has regenerate');
 } else {
-  console.warn('Skipping regenerate placement tests — _labState not available');
+  console.warn('Skipping regenerate placement tests — state module not available');
 }
 
 // ─── Section 19: setChatPersonality thread behavior ───
 // Pure source-inspection of chatSrc — `chatSrc` is read unconditionally
-// from the filesystem above, so these run regardless of _labState init
+// from the filesystem above, so these run regardless of state initialization
 // (the original's `if (hasState)` gate was a carry-over from when chatSrc
 // came from a fetch that could be absent before state was ready).
 console.log('Section 19: setChatPersonality thread behavior');
@@ -709,13 +707,6 @@ assert('setChatPersonality is async', chatPersonalitiesSrc.includes('async funct
 assert('setChatPersonality switches in-place', chatPersonalitiesSrc.includes('state.currentChatPersonality = id'), 'found');
 assert('Updates thread personality in-place', chatPersonalitiesSrc.includes('thread.personality = id'), 'found in setChatPersonality');
 assert('Updates thread metadata on switch', chatPersonalitiesSrc.includes('thread.personalityName') && chatPersonalitiesSrc.includes('thread.personalityIcon'), 'found');
-
-// ─── Section 20: state.js exposes _labState ───
-console.log('Section 20: State exposure');
-const stateSrc = read('js/state.js');
-assert('state.js exports _labState through runtime adapter',
-  stateSrc.includes('registerUtilsRuntimeExports') && stateSrc.includes('_labState'),
-  'found');
 
 // ─── Cleanup ───
 if (hasState && origHistory) S.chatHistory = origHistory;

--- a/tests/test-dna-illumina-and-valence.js
+++ b/tests/test-dna-illumina-and-valence.js
@@ -11,7 +11,7 @@
 // Full port — parseDNAFile spins a Blob-backed Worker (synchronous Worker
 // shim in _node-shim.js); renderGeneticsSection returns an HTML string with
 // no DOM dependency. snp-health.json + DNA parser source go through the
-// fs-backed fetch shim; window._labState comes from state.js.
+// fs-backed fetch shim; mutable app data comes from the state module.
 
 import './_node-shim.js';
 
@@ -40,8 +40,7 @@ function assert(name, condition, detail) {
 
 console.log('=== DNA: Illumina + valence + recalibration ===\n');
 
-// state.js sets window._labState; dna.js's Object.assign(window, …) runs on import.
-await import('../js/state.js');
+const { state } = await import('../js/state.js');
 await import('../js/utils.js');
 await import('../js/data.js');
 const dna = await import('../js/dna.js');
@@ -220,10 +219,10 @@ console.log('7. Dot Rendering');
 
 // dotFor is a local fn inside renderGeneticsSection — verify behavior by
 // mocking genetics state for known genotypes and inspecting rendered HTML.
-const origGenetics = window._labState.importedData.genetics;
+const origGenetics = state.importedData.genetics;
 
 function mockAndRender(snps) {
-  window._labState.importedData.genetics = {
+  state.importedData.genetics = {
     source: 'TestSource', importDate: '2026-04-24',
     coverage: { found: Object.keys(snps).length, total: Object.keys(snps).length },
     effects: { significant: 0, moderate: 0, normal: 0 },
@@ -266,7 +265,7 @@ html = mockAndRender({ rs601338: { genotype: 'GG', gene: 'FUT2', variant: 'W154X
 assert('None-effect genotype is collapsed with other SNPs', html.includes('genetics-other-snps') && html.includes('normal') && findingRowDots(html).includes('⚪'));
 
 // Restore genetics state
-window._labState.importedData.genetics = origGenetics;
+state.importedData.genetics = origGenetics;
 
 // ═══════════════════════════════════════
 // 8. Legend block + catLabels coverage
@@ -274,7 +273,7 @@ window._labState.importedData.genetics = origGenetics;
 console.log('8. Legend & Category Labels');
 
 // Legend renders when there's at least one finding
-window._labState.importedData.genetics = {
+state.importedData.genetics = {
   source: 'TestSource', importDate: '2026-04-24',
   coverage: { found: 1, total: 1 }, effects: {},
   snps: { rs1801133: { genotype: 'AA', gene: 'MTHFR', variant: 'C677T' } }
@@ -286,7 +285,7 @@ assert('Legend has "mild risk" label', legendHtml.includes('mild risk'));
 assert('Legend has "beneficial" label', legendHtml.includes('beneficial'));
 assert('Legend has "neutral" label', legendHtml.includes('neutral'));
 assert('Legend has "moderate risk" label', legendHtml.includes('moderate risk'));
-window._labState.importedData.genetics = origGenetics;
+state.importedData.genetics = origGenetics;
 
 // Every category used in snp-health.json must have a display label in SNP_CATEGORY_LABELS
 const catLabelsMatch = dnaSrc.match(/SNP_CATEGORY_LABELS = \{([^}]+)\}/);
@@ -336,12 +335,12 @@ assert('E2E: FUT2 AA matched', e2eResult.matches.rs601338?.genotype === 'AA');
 
 // Now save the parsed result and render the dashboard, asserting all 5 dots
 // are present in the rendered HTML.
-const e2eOrig = window._labState.importedData.genetics;
+const e2eOrig = state.importedData.genetics;
 const e2eState = { source: e2eResult.source, importDate: '2026-04-24', coverage: e2eResult.coverage, effects: {}, snps: {} };
 for (const [rsid, m] of Object.entries(e2eResult.matches)) {
   e2eState.snps[rsid] = { genotype: m.genotype, gene: m.gene, variant: m.variant };
 }
-window._labState.importedData.genetics = e2eState;
+state.importedData.genetics = e2eState;
 const e2eHtml = dna.renderGeneticsSection();
 assert('E2E render: green dot present (PCSK9 protective)', e2eHtml.includes('🟢'));
 assert('E2E render: red dot present (MTHFR significant)', e2eHtml.includes('🔴'));
@@ -350,7 +349,7 @@ assert('E2E render: yellow dot present (MTR mild)', e2eHtml.includes('🟡'));
 assert('E2E render: white circle present (FUT2 neutral)', e2eHtml.includes('⚪'));
 assert('E2E render: legend visible', e2eHtml.includes('genetics-legend'));
 assert('E2E render: source name "Illumina GenomeStudio (DNAEra)" visible', e2eHtml.includes('Illumina GenomeStudio'));
-window._labState.importedData.genetics = e2eOrig;
+state.importedData.genetics = e2eOrig;
 
 // ═══════════════════════════════════════
 // 10. Severity ordering (categories + within-category)
@@ -362,8 +361,8 @@ window._labState.importedData.genetics = e2eOrig;
 // category mild rows must follow moderate rows.
 console.log('10. Severity Ordering');
 
-const sortOrig = window._labState.importedData.genetics;
-window._labState.importedData.genetics = {
+const sortOrig = state.importedData.genetics;
+state.importedData.genetics = {
   source: 'TestSource', importDate: '2026-04-24',
   coverage: { found: 4, total: 4 }, effects: {},
   snps: {
@@ -391,7 +390,7 @@ const mthfrPos = methylationBlock.indexOf('MTHFR');
 const mtrPos   = methylationBlock.indexOf('MTR ');
 assert('Within-category sort: MTHFR (moderate) before MTR (mild) inside methylation', mthfrPos > 0 && mtrPos > mthfrPos);
 
-window._labState.importedData.genetics = sortOrig;
+state.importedData.genetics = sortOrig;
 
 // ═══════════════════════════════════════
 // Results

--- a/tests/test-dna.js
+++ b/tests/test-dna.js
@@ -45,9 +45,8 @@ function assert(name, condition, detail) {
 
 console.log('=== DNA Adapter Tests ===\n');
 
-// Load the app module surface; state.js retains the temporary _labState
-// compatibility hook while DNA actions stay module-only.
-await import('../js/state.js');
+// Load the app module surface while DNA actions stay module-only.
+const { state } = await import('../js/state.js');
 await import('../js/utils.js');
 await import('../js/data.js');
 const dna = await import('../js/dna.js');
@@ -621,7 +620,7 @@ assert('References include Wallace 2015', hapData._meta.references.some(r => r.p
 console.log('16. mtDNA Storage & Context');
 
 // Save original genetics
-const origGenetics = window._labState.importedData.genetics;
+const origGenetics = state.importedData.genetics;
 
 // Simulate mtDNA import
 const testGenetics = origGenetics ? JSON.parse(JSON.stringify(origGenetics)) : { source: null, importDate: null, coverage: { found: 0, total: 0 }, effects: {}, snps: {} };
@@ -631,7 +630,7 @@ testGenetics.mtdna = {
   mutations: ['295T', '4216C', '10398G', '13708A', '16069T', '16126C', '11251G'],
   source: 'mtDNA CSV', importDate: '2026-03-26'
 };
-window._labState.importedData.genetics = testGenetics;
+state.importedData.genetics = testGenetics;
 
 // Test context includes haplogroup
 const ctx = dna.buildGeneticsContext(testGenetics, null);
@@ -653,7 +652,7 @@ delete testGenetics.mtdna;
 assert('mtDNA deletable without affecting snps', testGenetics.snps != null && testGenetics.mtdna == null);
 
 // Restore
-window._labState.importedData.genetics = origGenetics;
+state.importedData.genetics = origGenetics;
 
 // ═══════════════════════════════════════
 // Results

--- a/tests/test-lens-multi-query.js
+++ b/tests/test-lens-multi-query.js
@@ -13,9 +13,8 @@
 //
 // Run: node tests/test-lens-multi-query.js  (or via npm test)
 
-// lens.js transitively pulls in state.js, which does `window._labState
-// = state` at module load. Vitest's setup file handles this globally;
-// for standalone `node` runs we shim inline.
+// lens.js transitively pulls in the state module. For standalone `node` runs,
+// install the browser shims inline.
 import './_node-shim.js';
 
 let pass = 0, fail = 0;

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -61,7 +61,7 @@ assert('quality guardrail ratchets _labState retirement by file',
     guardrailSrc.includes('labStateAppFiles') &&
     guardrailSrc.includes('labStateTestFiles') &&
     baseline.labStateAppFiles === 1 &&
-    baseline.labStateTestFiles === 39);
+    baseline.labStateTestFiles === 33);
 const forbiddenAppEventWindowGlobals = [
   'closeModal',
   'toggleChatPanel',


### PR DESCRIPTION
## Summary

- migrate biometrics, change-history, chat-action, and DNA Node fixtures from `window._labState` to the explicit `state` module export
- remove the chat fixture's obsolete assertion of the compatibility global and clean up the stale Lens compatibility comment
- ratchet the guarded test-file ceiling from 39 to 33

This is test-only, so no app cache/version bump is required.

## Validation

- six targeted Node fixtures — 587 assertions passed
- `node tests/test-quality-guardrails.js` — 25 passed
- `npm run quality` — 11 passed; 1/1 app files and 33/33 test files within the `_labState` ceilings
- `./run-tests.sh` — 399 Vitest tests, 352 Playwright tests, and 472 responsive-theme assertions passed

## Overall progress

- Before this PR: 18/58 files complete (31.0%)
- This PR: 6 additional test files retired from the global-state count
- After this PR: 24/58 files complete (41.4%)
- Entire work remaining: 34/58 files (58.6%) — the final app export plus 33 test consumers
