### PR TITLE
Migrate wearable fixtures off lab state global

### DIFF
--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -6,7 +6,7 @@
   "viewRuntimeBridgeConsumers": 0,
   "viewRuntimeBridgeLookups": 0,
   "labStateAppFiles": 1,
-  "labStateTestFiles": 33,
+  "labStateTestFiles": 28,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -61,7 +61,7 @@ assert('quality guardrail ratchets _labState retirement by file',
     guardrailSrc.includes('labStateAppFiles') &&
     guardrailSrc.includes('labStateTestFiles') &&
     baseline.labStateAppFiles === 1 &&
-    baseline.labStateTestFiles === 33);
+    baseline.labStateTestFiles === 28);
 const forbiddenAppEventWindowGlobals = [
   'closeModal',
   'toggleChatPanel',

--- a/tests/test-wearables-dom.js
+++ b/tests/test-wearables-dom.js
@@ -33,24 +33,25 @@ return (async function() {
 
   console.log('%c Wearables DOM Tests ', 'background:#6366f1;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
 
+  const { state } = await import('../js/state.js');
   const store = await import('../js/wearables-store.js');
   const ah = await import('../js/wearables-apple-health.js');
   const reg = await import('../js/wearable-adapters.js');
   const wearables = await import('../js/wearables.js');
   const views = await import('../js/views.js');
 
-  window._labState.importedData = window._labState.importedData || {};
-  const TEST_PROFILE = window._labState.currentProfile || ('__test-wearables-dom-' + Math.random().toString(36).slice(2, 8));
+  state.importedData = state.importedData || {};
+  const TEST_PROFILE = state.currentProfile || ('__test-wearables-dom-' + Math.random().toString(36).slice(2, 8));
   localStorage.removeItem('wearable-detail-range');
 
   // ═══════════════════════════════════════
   // 0. Strip empty-card manual log delegate
   // ═══════════════════════════════════════
   console.log('%c 0. Strip Manual Delegate ', 'font-weight:bold;color:#f59e0b');
-  const priorSummary = window._labState.importedData.wearableSummary;
+  const priorSummary = state.importedData.wearableSummary;
   const stripHost = document.createElement('div');
   try {
-    window._labState.importedData.wearableSummary = {
+    state.importedData.wearableSummary = {
       sources: { oura: { connectedSince: '2026-01-01', lastSyncAt: Date.now(), coverageDays: 5 } },
       metrics: {
         hrv_rmssd: { primarySource: 'oura', latest: 42, latestDate: '2026-04-22', baseline: 40, baselineP25: 36, baselineP75: 44, rolling: { d7: 42, d30: 40, d90: 40 }, trend30d: 'rising', weekly: [38, 40, 42] },
@@ -67,7 +68,7 @@ return (async function() {
       !!stripHost.querySelector('#wl-weight-val'));
   } finally {
     stripHost.remove();
-    window._labState.importedData.wearableSummary = priorSummary;
+    state.importedData.wearableSummary = priorSummary;
   }
 
   // ═══════════════════════════════════════
@@ -81,7 +82,7 @@ return (async function() {
       activity_score: { primarySource: 'oura', latest: 0, latestDate: '2026-04-22', baseline: 0, baselineP25: 0, baselineP75: 0, rolling: { d7: 0, d30: 0, d90: 0 }, trend30d: 'flat', weekly: [0,0,0,0,0] },
     },
   };
-  window._labState.importedData.wearableSummary = detailSummary;
+  state.importedData.wearableSummary = detailSummary;
   await store.upsertDailyBatch(TEST_PROFILE, [
     { source: 'oura', date: '2026-04-20', hrv_rmssd: 40, activity_score: 0 },
     { source: 'oura', date: '2026-04-21', hrv_rmssd: 41, activity_score: 0 },
@@ -89,7 +90,7 @@ return (async function() {
   ]);
 
   await wearables.openWearableDetail('hrv_rmssd');
-  await waitFor(() => window._labState?.chartInstances?.modal?.data?.datasets?.[0]?.data?.length === 3);
+  await waitFor(() => state?.chartInstances?.modal?.data?.datasets?.[0]?.data?.length === 3);
   assert('Detail modal opens on a valid metric', document.getElementById('modal-overlay').classList.contains('show'));
   const modalHtml = document.getElementById('detail-modal').innerHTML;
   assert('Detail modal includes metric label HRV', modalHtml.includes('HRV'));
@@ -97,8 +98,8 @@ return (async function() {
   assert('Detail modal shows Baseline (90d) stat', /Baseline/.test(modalHtml));
   assert('Detail modal shows Chart samples stat', /Chart samples/.test(modalHtml));
   assert('Chart canvas mounted on modal', !!document.getElementById('chart-modal'));
-  assert('Chart instance stored under state.chartInstances.modal', !!window._labState.chartInstances?.modal);
-  const modalChart = window._labState.chartInstances?.modal;
+  assert('Chart instance stored under state.chartInstances.modal', !!state.chartInstances?.modal);
+  const modalChart = state.chartInstances?.modal;
   assert('Chart has 3 data points matching L1 row count', modalChart?.data?.datasets?.[0]?.data?.length === 3);
   assert('Chart primary dataset carries 3 dated points',
     modalChart?.data?.datasets?.[0]?.data?.filter(p => p?.x && typeof p?.y === 'number')?.length === 3);
@@ -114,21 +115,21 @@ return (async function() {
     localStorage.getItem('wearable-detail-range') === '6m' &&
     /of last 6 months/.test(document.getElementById('detail-modal')?.textContent || ''));
   views.closeModal();
-  assert('closeModal clears modal chart instance', !window._labState.chartInstances?.modal);
+  assert('closeModal clears modal chart instance', !state.chartInstances?.modal);
 
   await wearables.openWearableDetail('activity_score');
   await new Promise(r => setTimeout(r, 60));
   assert('Rest-mode hint shown on all-zero activity score',
     /Rest Mode/.test(document.getElementById('detail-modal').innerHTML));
   views.closeModal();
-  delete window._labState.importedData.wearableSummary;
+  delete state.importedData.wearableSummary;
 
   // ═══════════════════════════════════════
   // A2. Blood Pressure detail modal pairs systolic + diastolic
   // ═══════════════════════════════════════
   console.log('%c A2. Blood Pressure Modal Pairing ', 'font-weight:bold;color:#f59e0b');
   localStorage.setItem('wearable-detail-range', '90d');
-  window._labState.importedData.wearableSummary = {
+  state.importedData.wearableSummary = {
     sources: { manual: { connectedSince: '2026-04-20', lastSyncAt: Date.now(), coverageDays: 3 } },
     metrics: {
       bp_systolic: { primarySource: 'manual', latest: 120, latestDate: '2026-04-22', baseline: 121, baselineP25: 118, baselineP75: 123, rolling: { d7: 120, d30: 121, d90: 121 }, trend30d: 'flat', weekly: [121, 120] },
@@ -141,9 +142,9 @@ return (async function() {
     { source: 'manual', date: '2026-04-22', bp_systolic: 120, bp_diastolic: 80, note: 'after walk', tags: ['rested'] },
   ]);
   await wearables.openWearableDetail('bp_systolic');
-  await waitFor(() => window._labState?.chartInstances?.modal?.data?.datasets?.some(d => /Diastolic/.test(d?.label || '')));
+  await waitFor(() => state?.chartInstances?.modal?.data?.datasets?.some(d => /Diastolic/.test(d?.label || '')));
   const bpModalText = document.getElementById('detail-modal')?.textContent || '';
-  const bpChart = window._labState.chartInstances?.modal;
+  const bpChart = state.chartInstances?.modal;
   const bpLabels = bpChart?.data?.datasets?.map(d => d.label) || [];
   assert('BP modal latest/stat/manual list shows paired 120/80 value', /120\/80/.test(bpModalText), bpModalText);
   assert('BP modal Typical range shows unit once at the end',
@@ -161,7 +162,7 @@ return (async function() {
 
   await store.clearSource(TEST_PROFILE, 'manual');
   await store.clearSource(TEST_PROFILE, 'withings');
-  window._labState.importedData.wearableSummary = {
+  state.importedData.wearableSummary = {
     sources: {
       withings: { connectedSince: '2026-06-20', lastSyncAt: Date.now(), coverageDays: 2 },
       manual: { connectedSince: '2026-06-20', lastSyncAt: Date.now(), coverageDays: 1 },
@@ -178,9 +179,9 @@ return (async function() {
     { source: 'manual', date: '2026-06-22', bp_diastolic: 78 },
   ]);
   await wearables.openWearableDetail('bp_systolic');
-  await waitFor(() => window._labState?.chartInstances?.modal?.data?.datasets?.some(d => /^Diastolic/.test(d?.label || '')));
+  await waitFor(() => state?.chartInstances?.modal?.data?.datasets?.some(d => /^Diastolic/.test(d?.label || '')));
   const mixedModalText = document.getElementById('detail-modal')?.textContent || '';
-  const mixedChartLabels = window._labState.chartInstances?.modal?.data?.datasets?.map(d => d.label) || [];
+  const mixedChartLabels = state.chartInstances?.modal?.data?.datasets?.map(d => d.label) || [];
   assert('BP modal fetches diastolic rows from paired metric primary source',
     mixedChartLabels.some(l => /^Diastolic \(Manual/.test(l)), mixedChartLabels.join('|'));
   assert('BP mixed-source chart does not duplicate manual-primary diastolic as manual scatter',
@@ -199,7 +200,7 @@ return (async function() {
 
   await store.clearSource(TEST_PROFILE, 'manual');
   await store.clearSource(TEST_PROFILE, 'withings');
-  window._labState.importedData.wearableSummary = {
+  state.importedData.wearableSummary = {
     sources: {
       withings: { connectedSince: '2026-06-20', lastSyncAt: Date.now(), coverageDays: 0 },
       manual: { connectedSince: '2026-06-20', lastSyncAt: Date.now(), coverageDays: 2 },
@@ -216,7 +217,7 @@ return (async function() {
     { source: 'manual', date: '2026-06-22', bp_systolic: 121, bp_diastolic: 79 },
   ]);
   await wearables.openWearableDetail('bp_systolic');
-  await waitFor(() => window._labState?.chartInstances?.modal?.data?.datasets?.some(d => /^Diastolic \(Manual/.test(d?.label || '')));
+  await waitFor(() => state?.chartInstances?.modal?.data?.datasets?.some(d => /^Diastolic \(Manual/.test(d?.label || '')));
   const mixedManualPrimaryText = document.getElementById('detail-modal')?.textContent || '';
   assert('BP mixed manual-diastolic fallback chooses the newest same-date pair across chart and manual candidates',
     /Latest\s+121\/79 mmHg/.test(mixedManualPrimaryText)
@@ -225,15 +226,15 @@ return (async function() {
   views.closeModal();
 
   await wearables.openWearableDetail('bp_diastolic');
-  await waitFor(() => window._labState?.chartInstances?.modal?.data?.datasets?.some(d => /systolic/i.test(d?.label || '')));
+  await waitFor(() => state?.chartInstances?.modal?.data?.datasets?.some(d => /systolic/i.test(d?.label || '')));
   assert('Opening bp_diastolic normalizes to the paired BP detail view',
-    (window._labState.chartInstances?.modal?.data?.datasets?.map(d => d.label) || []).some(l => /systolic/i.test(l)) &&
+    (state.chartInstances?.modal?.data?.datasets?.map(d => d.label) || []).some(l => /systolic/i.test(l)) &&
     /121\/79/.test(document.getElementById('detail-modal')?.textContent || ''));
   views.closeModal();
 
   await store.clearSource(TEST_PROFILE, 'manual');
   await store.clearSource(TEST_PROFILE, 'withings');
-  window._labState.importedData.wearableSummary = {
+  state.importedData.wearableSummary = {
     sources: {
       withings: { connectedSince: '2026-06-20', lastSyncAt: Date.now(), coverageDays: 1 },
       manual: { connectedSince: '2026-06-20', lastSyncAt: Date.now(), coverageDays: 1 },
@@ -254,7 +255,7 @@ return (async function() {
     /Latest\s+—\s+No same-date pair/.test(splitDateText) && !/Latest\s+130\/78 mmHg/.test(splitDateText), splitDateText);
   views.closeModal();
 
-  window._labState.importedData.wearableSummary.metrics.bp_diastolic.latestDate = undefined;
+  state.importedData.wearableSummary.metrics.bp_diastolic.latestDate = undefined;
   await wearables.openWearableDetail('bp_systolic');
   await waitFor(() => /No same-date pair/.test(document.getElementById('detail-modal')?.textContent || ''));
   const missingDateText = document.getElementById('detail-modal')?.textContent || '';
@@ -264,7 +265,7 @@ return (async function() {
 
   await store.clearSource(TEST_PROFILE, 'manual');
   await store.clearSource(TEST_PROFILE, 'withings');
-  window._labState.importedData.wearableSummary = {
+  state.importedData.wearableSummary = {
     sources: {
       withings: { connectedSince: '2026-06-20', lastSyncAt: Date.now(), coverageDays: 0 },
       manual: { connectedSince: '2026-06-20', lastSyncAt: Date.now(), coverageDays: 2 },
@@ -279,16 +280,16 @@ return (async function() {
     { source: 'manual', date: '2026-06-22', bp_systolic: 121, bp_diastolic: 79 },
   ]);
   await wearables.openWearableDetail('bp_systolic');
-  await waitFor(() => window._labState?.chartInstances?.modal?.data?.datasets?.some(d => /^Manual systolic$/.test(d?.label || '')));
+  await waitFor(() => state?.chartInstances?.modal?.data?.datasets?.some(d => /^Manual systolic$/.test(d?.label || '')));
   const manualOnlyText = document.getElementById('detail-modal')?.textContent || '';
   assert('BP modal hides empty chart hint when manual readings are charted',
     !/No chart samples for this metric/.test(manualOnlyText), manualOnlyText);
   assert('BP manual-only latest row prefers latest same-date manual pair over mismatched summary halves',
     /Latest\s+121\/79 mmHg/.test(manualOnlyText) && !/Latest\s+125\/79 mmHg/.test(manualOnlyText), manualOnlyText);
   assert('BP manual-only fallback chart renders manual sys/dia points',
-    (window._labState.chartInstances?.modal?.data?.datasets?.map(d => d.label) || []).some(l => /^Manual diastolic$/.test(l)));
+    (state.chartInstances?.modal?.data?.datasets?.map(d => d.label) || []).some(l => /^Manual diastolic$/.test(l)));
   views.closeModal();
-  delete window._labState.importedData.wearableSummary;
+  delete state.importedData.wearableSummary;
 
   // ═══════════════════════════════════════
   // B. JSZip lazy-loader functional smoke
@@ -320,7 +321,7 @@ return (async function() {
   // here we assert the *modal* renderer matches — catches the v1.22.2
   // divergence where the modal's inline formatV fell through to .toFixed(1).
   console.log('%c C. SpO2 Modal Parity ', 'font-weight:bold;color:#f59e0b');
-  window._labState.importedData.wearableSummary = {
+  state.importedData.wearableSummary = {
     sources: { oura: { connectedSince: '2026-01-01', lastSyncAt: Date.now(), coverageDays: 10 } },
     metrics: {
       spo2_avg: { primarySource: 'oura', latest: 97, latestDate: '2026-04-22', baseline: 96, baselineP25: 95, baselineP75: 98, rolling: { d7: 97, d30: 97, d90: 96 }, trend30d: 'flat', weekly: [96, 96, 97, 97, 97] },
@@ -334,7 +335,7 @@ return (async function() {
   const modalSpo2Html = document.getElementById('detail-modal').innerHTML;
   assert('Modal renders SpO2 97 as integer (no .0)', !/97\.0/.test(modalSpo2Html));
   views.closeModal();
-  delete window._labState.importedData.wearableSummary;
+  delete state.importedData.wearableSummary;
 
   // ═══════════════════════════════════════
   // D. Partial-day cumulative chart marker
@@ -344,7 +345,7 @@ return (async function() {
   const todayISO = reg.isoDay();
   const yesterday = new Date(); yesterday.setDate(yesterday.getDate() - 1);
   const yesterdayISO = reg.isoDay(yesterday);
-  window._labState.importedData.wearableSummary = {
+  state.importedData.wearableSummary = {
     sources: { oura: { connectedSince: yesterdayISO, lastSyncAt: Date.now(), coverageDays: 2 } },
     metrics: {
       steps: {
@@ -365,8 +366,8 @@ return (async function() {
     { source: 'oura', date: todayISO, steps: 1200 },
   ]);
   await wearables.openWearableDetail('steps');
-  await waitFor(() => window._labState?.chartInstances?.modal?.data?.datasets?.[0]?.data?.some(p => p?.x === todayISO));
-  const stepsChart = window._labState.chartInstances?.modal;
+  await waitFor(() => state?.chartInstances?.modal?.data?.datasets?.[0]?.data?.some(p => p?.x === todayISO));
+  const stepsChart = state.chartInstances?.modal;
   const todayIdx = stepsChart?.data?.datasets?.[0]?.data?.findIndex(p => p?.x === todayISO);
   assert('Cumulative detail chart keeps today in the plotted series',
     todayIdx >= 0 && stepsChart.data.datasets[0].data[todayIdx]?.y === 1200);
@@ -386,7 +387,7 @@ return (async function() {
   assert('Detail chart tooltip snaps by x-index, not invisible point intersection',
     stepsChart?.options?.interaction?.mode === 'index' && stepsChart.options.interaction.intersect === false);
   views.closeModal();
-  delete window._labState.importedData.wearableSummary;
+  delete state.importedData.wearableSummary;
 
   // ═══════════════════════════════════════
   // E. Manual overlay tooltip date alignment
@@ -399,7 +400,7 @@ return (async function() {
   const vendorDay3 = reg.daysAgoIso(3);
   const vendorDay2 = reg.daysAgoIso(2);
   const vendorDay1 = reg.daysAgoIso(1);
-  window._labState.importedData.wearableSummary = {
+  state.importedData.wearableSummary = {
     sources: {
       oura: { connectedSince: vendorDay3, lastSyncAt: Date.now(), coverageDays: 3 },
       manual: { connectedSince: todayISO, lastSyncAt: Date.now(), coverageDays: 1 },
@@ -425,8 +426,8 @@ return (async function() {
     { source: 'manual', date: todayISO, rhr: 57 },
   ]);
   await wearables.openWearableDetail('rhr');
-  await waitFor(() => window._labState?.chartInstances?.modal?.data?.datasets?.some(d => d?._kind === 'manual'));
-  const rhrChart = window._labState.chartInstances?.modal;
+  await waitFor(() => state?.chartInstances?.modal?.data?.datasets?.some(d => d?._kind === 'manual'));
+  const rhrChart = state.chartInstances?.modal;
   const manualDs = rhrChart?.data?.datasets?.find(d => d?._kind === 'manual');
   assert('Manual overlay switches interaction mode away from index',
     rhrChart?.options?.interaction?.mode === 'nearest');
@@ -439,7 +440,7 @@ return (async function() {
     manualTitle === new Date(todayISO + 'T00:00:00Z').toLocaleDateString(undefined, { month: 'short', day: 'numeric', timeZone: 'UTC' }),
     `title=${manualTitle}`);
   views.closeModal();
-  delete window._labState.importedData.wearableSummary;
+  delete state.importedData.wearableSummary;
 
   // ═══════════════════════════════════════
   // F. Daytime-empty-state HRV modal
@@ -448,8 +449,8 @@ return (async function() {
   // surface a "Not from {Source} · why?" empty-state row carrying the long
   // explanation in a title attr.
   console.log('%c F. Daytime-Empty-State Modal ', 'font-weight:bold;color:#f59e0b');
-  const _origImported = window._labState.importedData;
-  window._labState.importedData = {
+  const _origImported = state.importedData;
+  state.importedData = {
     entries: [],
     wearableConnections: {
       oura:   { source: 'oura',   connectedAt: new Date().toISOString(), lastSyncAt: Date.now() },
@@ -481,7 +482,7 @@ return (async function() {
   assert('v1.26 P1-2: empty-state row carries the long explanation in title attr',
     !!tooltipCarrier);
   views.closeModal();
-  window._labState.importedData = _origImported;
+  state.importedData = _origImported;
 
   console.log(`\n%c Wearables DOM: ${pass} passed, ${fail} failed `, fail > 0 ? 'background:#ef4444;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px' : 'background:#22c55e;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
   if (typeof window.__TEST_RESULTS === 'undefined') window.__TEST_RESULTS = {};

--- a/tests/test-wearables-manual.js
+++ b/tests/test-wearables-manual.js
@@ -44,8 +44,8 @@ function assert(name, condition, detail) {
 
 console.log('=== Manual-as-wearable-source Tests ===\n');
 
-// state.js exposes the legacy test-state bridge; wearable actions are modules.
-await import('../js/state.js');
+// Mutable app state and wearable actions stay on their module surfaces.
+const { state } = await import('../js/state.js');
 const manual = await import('../js/wearables-manual.js');
 const store = await import('../js/wearables-store.js');
 const adapters = await import('../js/wearable-adapters.js');
@@ -131,10 +131,10 @@ const TEST_PROFILE = 'test-manual-' + Math.random().toString(36).slice(2, 8);
 // Every sub-profile that gets real IDB writes — torn down in the finally
 // so a reused Vitest worker (or a standalone re-run) doesn't accumulate.
 const _idbProfiles = [TEST_PROFILE];
-const origProfile = window._labState.currentProfile;
-const origImported = window._labState.importedData;
-window._labState.currentProfile = TEST_PROFILE;
-window._labState.importedData = { wearableConnections: {} };
+const origProfile = state.currentProfile;
+const origImported = state.importedData;
+state.currentProfile = TEST_PROFILE;
+state.importedData = { wearableConnections: {} };
 
 try {
   await manual.logManualMetric(TEST_PROFILE, 'weight', { date: '2026-04-24', value: 82.1 });
@@ -143,9 +143,9 @@ try {
   assert('weight row has correct date', row?.date === '2026-04-24');
   assert('weight row has correct value', row?.weight === 82.1);
   assert('ensureManualConnection populated wearableConnections.manual',
-    window._labState.importedData.wearableConnections?.manual != null);
+    state.importedData.wearableConnections?.manual != null);
   assert('manual connection has connectedAt',
-    !!window._labState.importedData.wearableConnections.manual.connectedAt);
+    !!state.importedData.wearableConnections.manual.connectedAt);
 
   // ═══════════════════════════════════════
   // 4. logManualBP writes combined row
@@ -192,8 +192,8 @@ try {
 
   const MIGRATE_PROFILE = 'test-mig-' + Math.random().toString(36).slice(2, 8);
   _idbProfiles.push(MIGRATE_PROFILE);
-  window._labState.currentProfile = MIGRATE_PROFILE;
-  window._labState.importedData = { wearableConnections: {} };
+  state.currentProfile = MIGRATE_PROFILE;
+  state.importedData = { wearableConnections: {} };
   const legacyBiometrics = {
     weight: [
       { date: '2026-04-20', value: 82.5, unit: 'kg', source: 'manual' },
@@ -236,8 +236,8 @@ try {
 
   const DEL_PROFILE = 'test-del-' + Math.random().toString(36).slice(2, 8);
   _idbProfiles.push(DEL_PROFILE);
-  window._labState.currentProfile = DEL_PROFILE;
-  window._labState.importedData = { wearableConnections: {} };
+  state.currentProfile = DEL_PROFILE;
+  state.importedData = { wearableConnections: {} };
   await manual.logManualMetric(DEL_PROFILE, 'weight', { date: '2026-04-24', value: 82 });
   await manual.logManualBP(DEL_PROFILE, { date: '2026-04-24', systolic: 118, diastolic: 76, pulse: 64 });
 
@@ -267,8 +267,8 @@ try {
 
   const TAG_PROFILE = 'test-tags-' + Math.random().toString(36).slice(2, 8);
   _idbProfiles.push(TAG_PROFILE);
-  window._labState.currentProfile = TAG_PROFILE;
-  window._labState.importedData = { wearableConnections: {} };
+  state.currentProfile = TAG_PROFILE;
+  state.importedData = { wearableConnections: {} };
   await manual.logManualBP(TAG_PROFILE, {
     date: '2026-04-24', systolic: 145, diastolic: 92,
     tags: ['post-workout', 'stress']
@@ -341,7 +341,7 @@ try {
   // Live behavior: write + read a manual metric with note, verify persistence.
   const probeProfile = 'test-note-' + Date.now();
   _idbProfiles.push(probeProfile);
-  window._labState.currentProfile = probeProfile;
+  state.currentProfile = probeProfile;
   await manual.logManualMetric(probeProfile, 'rhr', {
     date: '2099-05-12', value: 60, tags: ['resting'], note: 'morning, just woke'
   });
@@ -456,8 +456,8 @@ try {
     try { await store.deleteWearablesDB(pid); } catch {}
   }
   // Restore live profile
-  window._labState.currentProfile = origProfile;
-  window._labState.importedData = origImported;
+  state.currentProfile = origProfile;
+  state.importedData = origImported;
 }
 
 console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);

--- a/tests/test-wearables-sync-flow.js
+++ b/tests/test-wearables-sync-flow.js
@@ -41,7 +41,7 @@ function assert(name, condition, detail) {
 
 console.log('=== Wearables Sync-Flow Tests ===\n');
 
-await import('../js/state.js');
+const { state } = await import('../js/state.js');
 const connect = await import('../js/wearables-connect.js');
 const store = await import('../js/wearables-store.js');
 const summary = await import('../js/wearables-summary.js');
@@ -55,12 +55,12 @@ const TEST_PROFILE_ID = 'sync-flow-test-' + Date.now().toString(36);
 const origActiveProfile = localStorage.getItem('labcharts-active-profile');
 // CRITICAL: saveImportedData() keys off state.currentProfile, NOT the
 // localStorage active-profile entry. Snapshot AND restore both.
-const origCurrentProfile = window._labState.currentProfile;
+const origCurrentProfile = state.currentProfile;
 localStorage.setItem('labcharts-active-profile', TEST_PROFILE_ID);
-window._labState.currentProfile = TEST_PROFILE_ID;
+state.currentProfile = TEST_PROFILE_ID;
 
-const origState = window._labState.importedData;
-window._labState.importedData = {
+const origState = state.importedData;
+state.importedData = {
   entries: [],
   wearableConnections: {},
   wearableSummary: null,
@@ -92,7 +92,7 @@ function restore() { window.fetch = realFetch; }
 
 // Fake-connect Oura so wearables-connect.js sees an authenticated state.
 function fakeConnect(adapterId) {
-  window._labState.importedData.wearableConnections[adapterId] = {
+  state.importedData.wearableConnections[adapterId] = {
     accessToken: 'test-' + adapterId + '-token',
     refreshToken: 'test-' + adapterId + '-refresh',
     expiresAt: Date.now() + 24 * 60 * 60 * 1000, // 24h fresh
@@ -119,7 +119,7 @@ const oldManualRows = await store.getDailyRange(TEST_PROFILE_ID, 'manual', '2025
 assert('Older manual RHR row is persisted in L1',
   oldManualRows.some(r => r.date === oldManualDate && r.rhr === 57));
 const oldManualSync = await summary.syncWearableSummary(TEST_PROFILE_ID, connect.listConnectedSources());
-const oldManualSummary = window._labState.importedData?.wearableSummary;
+const oldManualSummary = state.importedData?.wearableSummary;
 assert('Older manual RHR writes an L2 summary metric outside the 90d vendor window',
   oldManualSync.wrote === true &&
   oldManualSummary?.metrics?.rhr?.latest === 57 &&
@@ -129,8 +129,8 @@ assert('Manual source coverage counts the old row',
   oldManualSummary?.sources?.manual?.coverageDays === 1,
   JSON.stringify(oldManualSummary?.sources?.manual));
 await store.clearSource(TEST_PROFILE_ID, 'manual');
-delete window._labState.importedData.wearableConnections.manual;
-window._labState.importedData.wearableSummary = null;
+delete state.importedData.wearableConnections.manual;
+state.importedData.wearableSummary = null;
 
 // ═══════════════════════════════════════
 // 1. backfillWearable — full pull populates IDB + meta
@@ -173,7 +173,7 @@ try {
   assert('last-sync meta carries rows count', typeof meta?.rows === 'number');
   assert('last-sync meta carries startDate + endDate', !!meta?.startDate && !!meta?.endDate);
 
-  const conn = window._labState.importedData.wearableConnections.oura;
+  const conn = state.importedData.wearableConnections.oura;
   assert('Connection.lastSyncAt updated post-backfill', conn?.lastSyncAt > 0);
 } finally { restore(); }
 
@@ -184,7 +184,7 @@ console.log('2. L2 Recompute');
 const sync2 = await summary.syncWearableSummary(TEST_PROFILE_ID, connect.listConnectedSources());
 assert('syncWearableSummary writes on first call (initial summary, no prior)',
   sync2.wrote === true && sync2.reason === 'initial');
-const sumState = window._labState.importedData?.wearableSummary;
+const sumState = state.importedData?.wearableSummary;
 assert('wearableSummary persisted into state.importedData', !!sumState);
 assert('wearableSummary.metrics carries hrv_rmssd entry from IDB rows',
   !!sumState?.metrics?.hrv_rmssd);
@@ -261,15 +261,15 @@ try {
     { matcher: /heartrate.*start_datetime/, body: { data: [], next_token: null }},
     { matcher: /usercollection\//, body: { data: [], next_token: null }},
   ]);
-  window._labState.importedData.wearableConnections.oura.lastSyncAt = Date.now() - (13 * 60 * 60 * 1000);
+  state.importedData.wearableConnections.oura.lastSyncAt = Date.now() - (13 * 60 * 60 * 1000);
   await connect.syncStaleWearablesNow();
-  const afterStaleAuto = window._labState.importedData.wearableConnections.oura.lastSyncAt || 0;
+  const afterStaleAuto = state.importedData.wearableConnections.oura.lastSyncAt || 0;
   assert('syncStaleWearablesNow auto-syncs stale connected sources',
     calls.length > 0 && Date.now() - afterStaleAuto < 60 * 1000,
     `calls=${calls.length}, lastSyncAt=${afterStaleAuto}`);
 
   calls = [];
-  window._labState.importedData.wearableConnections.oura.lastSyncAt = Date.now();
+  state.importedData.wearableConnections.oura.lastSyncAt = Date.now();
   await connect.syncStaleWearablesNow();
   assert('syncStaleWearablesNow skips fresh connected sources',
     calls.length === 0,
@@ -304,11 +304,11 @@ try {
 // 5. L2 gate — minimum-cadence force-write after 14d silence
 // ═══════════════════════════════════════
 console.log('5. Gate Min-Cadence');
-const old = window._labState.importedData.wearableSummary;
+const old = state.importedData.wearableSummary;
 if (old) {
   const fortnightAgo = new Date(Date.now() - 15 * 24 * 60 * 60 * 1000).toISOString();
   old.summaryUpdatedAt = fortnightAgo;
-  window._labState.importedData.wearableSummary = old;
+  state.importedData.wearableSummary = old;
   const result = await summary.syncWearableSummary(TEST_PROFILE_ID, connect.listConnectedSources());
   assert('Gate force-writes after 14d silence (min-cadence)',
     result.wrote === true && result.reason === 'min-cadence');
@@ -325,9 +325,9 @@ const remainingRows = await store.getDailyRange(TEST_PROFILE_ID, 'oura', '2026-0
 assert('disconnectWearable clears L1 rows for that source',
   remainingRows.length === 0);
 assert('disconnectWearable removes wearableConnections entry',
-  !window._labState.importedData?.wearableConnections?.oura);
+  !state.importedData?.wearableConnections?.oura);
 assert('disconnectWearable removes the source from wearableSummary.sources',
-  !window._labState.importedData?.wearableSummary?.sources?.oura);
+  !state.importedData?.wearableSummary?.sources?.oura);
 
 // ═══════════════════════════════════════
 // 7. Push-to-gateway — exposed function + toggle helpers
@@ -364,7 +364,7 @@ console.log('8. stripWearableCredentials');
 const TEST_PROFILE_2 = 'strip-creds-test-' + Date.now().toString(36);
 const sentinelToken = 'SENTINEL-TOKEN-' + Math.random().toString(36).slice(2);
 const sentinelRefresh = 'SENTINEL-REFRESH-' + Math.random().toString(36).slice(2);
-window._labState.importedData = {
+state.importedData = {
   entries: [],
   wearableConnections: {
     oura: {
@@ -419,8 +419,8 @@ await wipeWearableIDB();
 localStorage.removeItem(`labcharts-${TEST_PROFILE_ID}-imported`);
 if (origActiveProfile) localStorage.setItem('labcharts-active-profile', origActiveProfile);
 else localStorage.removeItem('labcharts-active-profile');
-window._labState.currentProfile = origCurrentProfile;
-window._labState.importedData = origState;
+state.currentProfile = origCurrentProfile;
+state.importedData = origState;
 try { const { deleteWearablesDB } = await import('../js/wearables-store.js'); await deleteWearablesDB(TEST_PROFILE_ID); } catch {}
 
 console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);

--- a/tests/test-wearables-ui-flows.js
+++ b/tests/test-wearables-ui-flows.js
@@ -14,6 +14,7 @@ return (async function() {
   console.log('%c Wearables UI-Flow Tests ', 'background:#6366f1;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
 
   const bust = '?bust=' + Date.now();
+  const { state } = await import('../js/state.js');
   const manual    = await import('../js/wearables-manual.js' + bust);
   const store     = await import('../js/wearables-store.js' + bust);
   const summary   = await import('../js/wearables-summary.js' + bust);
@@ -31,11 +32,11 @@ return (async function() {
   // CRITICAL: saveImportedData() keys off state.currentProfile, NOT the
   // localStorage active-profile entry. Swap both — otherwise any save
   // inside the test writes the fake state to the USER'S real profile.
-  const origCurrentProfile = window._labState.currentProfile;
+  const origCurrentProfile = state.currentProfile;
   localStorage.setItem('labcharts-active-profile', TEST_PROFILE_ID);
-  window._labState.currentProfile = TEST_PROFILE_ID;
-  const origState = window._labState.importedData;
-  window._labState.importedData = {
+  state.currentProfile = TEST_PROFILE_ID;
+  const origState = state.importedData;
+  state.importedData = {
     entries: [],
     wearableConnections: { manual: { source: 'manual', connectedAt: new Date().toISOString(), lastSyncAt: Date.now(), coverageDays: 0 }},
     wearableSummary: null,
@@ -129,7 +130,7 @@ return (async function() {
   console.log('%c 4. Old Manual Reading ', 'font-weight:bold;color:#f59e0b');
   const oldManualDate = '2025-05-01';
   await manual.logManualMetric(TEST_PROFILE_ID, 'rhr', { date: oldManualDate, value: 57, tags: ['resting'] });
-  window._labState.importedData.wearableConnections.oura = {
+  state.importedData.wearableConnections.oura = {
     source: 'oura', connectedAt: new Date().toISOString(),
     lastSyncAt: Date.now(), coverageDays: 1,
     accessToken: 'fake-oura', refreshToken: 'fake-rfr',
@@ -141,7 +142,7 @@ return (async function() {
     rhr: 61,
   });
   await manual.refreshManualSummary(TEST_PROFILE_ID);
-  const oldRhrSummary = window._labState.importedData?.wearableSummary?.metrics?.rhr;
+  const oldRhrSummary = state.importedData?.wearableSummary?.metrics?.rhr;
   assert('Newer Oura RHR can remain primary while old manual RHR is stored',
     oldRhrSummary?.primarySource === 'oura' && oldRhrSummary?.latest === 61,
     JSON.stringify(oldRhrSummary));
@@ -153,13 +154,13 @@ return (async function() {
   localStorage.setItem('wearable-detail-range', 'all');
   await wearables.openWearableDetail('rhr');
   await new Promise(r => setTimeout(r, 500));
-  const chartDatasets = window._labState.chartInstances?.modal?.data?.datasets || [];
+  const chartDatasets = state.chartInstances?.modal?.data?.datasets || [];
   const manualOverlay = chartDatasets.find(ds => ds.label === 'Manual');
   const ouraLine = chartDatasets.find(ds => ds.label === 'Oura');
   assert('All-range chart keeps the Oura line and overlays old manual RHR readings',
     !!ouraLine?.data?.some(p => p.x === '2026-05-20' && p.y === 61) &&
     !!manualOverlay?.data?.some(p => p.x === oldManualDate && p.y === 57),
-    JSON.stringify(window._labState.chartInstances?.modal?.data?.datasets?.map(ds => ({ label: ds.label, n: ds.data?.length }))));
+    JSON.stringify(state.chartInstances?.modal?.data?.datasets?.map(ds => ({ label: ds.label, n: ds.data?.length }))));
   views.closeModal();
   await new Promise(r => setTimeout(r, 200));
 
@@ -168,10 +169,10 @@ return (async function() {
   // ═══════════════════════════════════════
   console.log('%c 5. Source Picker ', 'font-weight:bold;color:#f59e0b');
   // Add a second source so the swap button renders (gated on ≥2 connected)
-  window._labState.importedData.wearableConnections.oura.lastSyncAt = Date.now();
+  state.importedData.wearableConnections.oura.lastSyncAt = Date.now();
   // Stub the summary with BOTH sources directly so this section only tests
   // the source-picker UI, not the summary auto-picker.
-  window._labState.importedData.wearableSummary = {
+  state.importedData.wearableSummary = {
     summaryUpdatedAt: new Date().toISOString(),
     sources: {
       manual: { connectedSince: new Date().toISOString(), lastSyncAt: Date.now(), coverageDays: 1 },
@@ -260,11 +261,11 @@ return (async function() {
   // ═══════════════════════════════════════
   console.log('%c 8. Picker + Stale Sync ', 'font-weight:bold;color:#f59e0b');
   localStorage.setItem(BIOMETRIC_SELECTION_KEY, JSON.stringify(['rhr']));
-  if (window._labState.importedData.wearableSummary?.sources?.oura) {
-    window._labState.importedData.wearableSummary.sources.oura.coverageDays = 1;
-    window._labState.importedData.wearableConnections.oura.lastSyncAt = Date.now();
+  if (state.importedData.wearableSummary?.sources?.oura) {
+    state.importedData.wearableSummary.sources.oura.coverageDays = 1;
+    state.importedData.wearableConnections.oura.lastSyncAt = Date.now();
   }
-  const sum = window._labState.importedData.wearableSummary;
+  const sum = state.importedData.wearableSummary;
   if (sum) {
     sum.metrics.cardio_age = { primarySource: 'oura', latest: 35, latestDate: '2026-04-22',
       baseline: 35, baselineP25: 35, baselineP75: 35,
@@ -306,7 +307,7 @@ return (async function() {
     const overviewWithCardio = document.querySelector('.dashboard-widget[data-widget-id="wearables"]');
     assert('Picker add places the chosen biometric inside Biometrics Overview',
       !!overviewWithCardio && /Cardio age/i.test(overviewWithCardio.textContent || ''));
-    window._labState.importedData.wearableConnections.oura.lastSyncAt = Date.now() - (13 * 60 * 60 * 1000);
+    state.importedData.wearableConnections.oura.lastSyncAt = Date.now() - (13 * 60 * 60 * 1000);
     views.navigate('dashboard');
     await new Promise(r => setTimeout(r, 300));
     assert('Stale connected data shows the dashboard sync button',
@@ -318,7 +319,7 @@ return (async function() {
   // ═══════════════════════════════════════
   console.log('%c 9. Manual BP Card Reset ', 'font-weight:bold;color:#f59e0b');
   localStorage.setItem(BIOMETRIC_SELECTION_KEY, JSON.stringify(['bp_systolic', 'rhr']));
-  const resetSummary = window._labState.importedData.wearableSummary;
+  const resetSummary = state.importedData.wearableSummary;
   if (resetSummary?.metrics) {
     delete resetSummary.metrics.bp_systolic;
     delete resetSummary.metrics.bp_diastolic;
@@ -367,8 +368,8 @@ return (async function() {
   else localStorage.removeItem('wearable-detail-range');
   if (origActive) localStorage.setItem('labcharts-active-profile', origActive);
   else localStorage.removeItem('labcharts-active-profile');
-  window._labState.currentProfile = origCurrentProfile;
-  window._labState.importedData = origState;
+  state.currentProfile = origCurrentProfile;
+  state.importedData = origState;
   try { const { deleteWearablesDB } = await import('/js/wearables-store.js'); await deleteWearablesDB(TEST_PROFILE_ID); } catch {}
   views.navigate('dashboard');
 

--- a/tests/test-wearables.js
+++ b/tests/test-wearables.js
@@ -45,6 +45,7 @@ function assert(name, condition, detail) {
 
 console.log('=== Wearables Tests ===\n');
 
+const { state } = await import('../js/state.js');
 const reg = await import('../js/wearable-adapters.js');
 const store = await import('../js/wearables-store.js');
 const summary = await import('../js/wearables-summary.js');
@@ -565,8 +566,8 @@ const zeroBaselineSummary = {
   },
 };
 // Stash summary so renderWearableStrip reads it
-window._labState.importedData = window._labState.importedData || {};
-window._labState.importedData.wearableSummary = zeroBaselineSummary;
+state.importedData = state.importedData || {};
+state.importedData.wearableSummary = zeroBaselineSummary;
 const html = wearablesModule.renderWearableStrip();
 assert('render never emits NaN% on zero baseline', !/NaN/.test(html));
 // v1.26.0: zero-baseline metrics suppress the delta entirely (was "→ —"),
@@ -575,7 +576,7 @@ assert('render never emits NaN% on zero baseline', !/NaN/.test(html));
 // zero-baseline activity_score card.
 assert('render suppresses delta for zero-baseline activity score',
   !/wearable-delta[^"]*"[^>]*>\s*[↑↓→]/.test(html));
-delete window._labState.importedData.wearableSummary;
+delete state.importedData.wearableSummary;
 
 // ── Zero-coverage source: header drops it, footer surfaces "waiting on first sync" ──
 const mixedCoverageSummary = {
@@ -587,13 +588,13 @@ const mixedCoverageSummary = {
     hrv_rmssd: { primarySource: 'oura', latest: 39, baseline: 32, baselineP25: 28, baselineP75: 36, rolling: { d7: 39, d30: 33, d90: 32 }, trend30d: 'rising', weekly: [30, 32, 34, 39] },
   },
 };
-window._labState.importedData.wearableSummary = mixedCoverageSummary;
+state.importedData.wearableSummary = mixedCoverageSummary;
 const mixedHtml = wearablesModule.renderWearableStrip();
 assert('header source label omits zero-coverage vendor', !/wearable-source-label[^>]*>[^<]*Polar/.test(mixedHtml));
 assert('header source label still shows the data-bearing vendor', /wearable-source-label[^>]*>[^<]*Oura/.test(mixedHtml));
 assert('coverage label reflects only data-bearing source', /·\s*15d/.test(mixedHtml));
 assert('footer surfaces waiting hint for zero-coverage vendor', /Polar connected — waiting on first device sync/.test(mixedHtml));
-delete window._labState.importedData.wearableSummary;
+delete state.importedData.wearableSummary;
 
 // ── Per-metric staleness: when one metric's latestDate lags the source's
 // freshest reading, the card surfaces an "as of {date}" hint. Mirrors the
@@ -607,7 +608,7 @@ const stalenessSummary = {
     sleep_score: { primarySource: 'oura', latest: 76, latestDate: '2026-04-24', baseline: 78, baselineP25: 73, baselineP75: 84, rolling: { d7: 76, d30: 78, d90: 78 }, trend30d: 'flat', weekly: [80, 79, 78, 77, 76, 76] },
   },
 };
-window._labState.importedData.wearableSummary = stalenessSummary;
+state.importedData.wearableSummary = stalenessSummary;
 const stripStaleHtml = wearablesModule.renderWearableStrip();
 assert('Stale metric (HRV) gets "as of {date}" hint when its latestDate < source max',
   /wearable-staleness[^>]*>\s*as of\s*[A-Z][a-z]+/.test(stripStaleHtml));
@@ -618,7 +619,7 @@ assert('Exactly one staleness hint rendered (HRV stale, sleep_score fresh)',
   stalenessHints === 1, `got ${stalenessHints}`);
 assert('Staleness hint carries an explanatory tooltip on hover',
   /wearable-staleness[^>]*title="[^"]+process/i.test(stripStaleHtml));
-delete window._labState.importedData.wearableSummary;
+delete state.importedData.wearableSummary;
 
 // Section 9b (Detail Modal — openWearableDetail + Chart.js + live modal
 // DOM) lives in tests/playwright/wearables-browser-flows.spec.js.
@@ -1182,13 +1183,13 @@ const strip2 = {
     spo2_avg: { primarySource: 'oura', latest: 97, latestDate: '2026-04-22', baseline: 96, baselineP25: 95, baselineP75: 98, rolling: { d7: 97, d30: 97, d90: 96 }, trend30d: 'flat', weekly: [96, 96, 97, 97, 97] },
   },
 };
-window._labState.importedData.wearableSummary = strip2;
+state.importedData.wearableSummary = strip2;
 const stripSpo2Html = wearablesModule.renderWearableStrip();
 // Strip renderer is a pure string-builder — assert it here in Node. The
 // matching *modal*-renderer parity check (openWearableDetail) lives in
 // test-wearables-dom.js. Neither should produce "97.0 %" — both "97 %".
 assert('Strip renders SpO2 97 as integer (no .0)', !/97\.0/.test(stripSpo2Html));
-delete window._labState.importedData.wearableSummary;
+delete state.importedData.wearableSummary;
 
 // ═══════════════════════════════════════
 // 13. OAUTH_DISPATCH registry-vs-dispatch drift
@@ -1339,9 +1340,9 @@ try {
   const storeB  = await import('../js/wearables-store.js');
   const TEST_PROFILE_E = '__test-encrypt-' + Date.now().toString(36);
   const origActive = localStorage.getItem('labcharts-active-profile');
-  const origCurrent = window._labState.currentProfile;
+  const origCurrent = state.currentProfile;
   localStorage.setItem('labcharts-active-profile', TEST_PROFILE_E);
-  window._labState.currentProfile = TEST_PROFILE_E;
+  state.currentProfile = TEST_PROFILE_E;
   try {
     // Plaintext path (encryption disabled).
     localStorage.removeItem('labcharts-encryption-enabled');
@@ -1391,7 +1392,7 @@ try {
     localStorage.removeItem(`labcharts-${TEST_PROFILE_E}-imported`);
     if (origActive) localStorage.setItem('labcharts-active-profile', origActive);
     else localStorage.removeItem('labcharts-active-profile');
-    window._labState.currentProfile = origCurrent;
+    state.currentProfile = origCurrent;
     delete window.__WEARABLES_TEST;
   }
 } catch (e) {
@@ -1441,9 +1442,9 @@ try {
   const labCtxMcp = await import('../js/lab-context.js');
   labCtxMcp.setAgentWearableSeriesDays(7);
   // Stub a minimal summary so the builder produces a non-empty section.
-  const origSummary = window._labState.importedData?.wearableSummary;
-  window._labState.importedData = window._labState.importedData || { entries: [] };
-  window._labState.importedData.wearableSummary = {
+  const origSummary = state.importedData?.wearableSummary;
+  state.importedData = state.importedData || { entries: [] };
+  state.importedData.wearableSummary = {
     summaryUpdatedAt: new Date().toISOString(),
     sources: { oura: { connectedSince: '2026-01-01', lastSyncAt: Date.now(), coverageDays: 5 }},
     metrics: { hrv_rmssd: { primarySource: 'oura', latest: 38, baseline: 36, baselineP25: 32, baselineP75: 40, rolling: { d7: 37, d30: 36, d90: 36 }, trend30d: 'flat', weekly: [36, 37, 38] }},
@@ -1451,9 +1452,9 @@ try {
   // Need an L1 row so the series builder has data to pivot.
   const TEST_PROFILE_S = '__test-series-' + Date.now().toString(36);
   const origActive = localStorage.getItem('labcharts-active-profile');
-  const origCurrent = window._labState.currentProfile;
+  const origCurrent = state.currentProfile;
   localStorage.setItem('labcharts-active-profile', TEST_PROFILE_S);
-  window._labState.currentProfile = TEST_PROFILE_S;
+  state.currentProfile = TEST_PROFILE_S;
   try {
     const storeM = await import('../js/wearables-store.js');
     // Date must fall inside buildWearableSeriesSection's 7-day window
@@ -1475,10 +1476,10 @@ try {
   } finally {
     try { const { deleteWearablesDB } = await import('../js/wearables-store.js'); await deleteWearablesDB(TEST_PROFILE_S); } catch {}
     labCtxMcp.setAgentWearableSeriesDays(0);
-    window._labState.importedData.wearableSummary = origSummary;
+    state.importedData.wearableSummary = origSummary;
     if (origActive) localStorage.setItem('labcharts-active-profile', origActive);
     else localStorage.removeItem('labcharts-active-profile');
-    window._labState.currentProfile = origCurrent;
+    state.currentProfile = origCurrent;
   }
 }
 
@@ -1575,16 +1576,16 @@ labCtxV29.setAgentWearableSeriesDays(45);
 assert('Invalid day value (45) is silently rejected',
   labCtxV29.getAgentWearableSeriesDays() === 90); // unchanged from previous valid
 // Legacy 'on' migrates to 30 only when no synced preference exists.
-delete window._labState.importedData.agentAccessWearableSeriesDays;
-if (window._labState.importedData.agentAccess) delete window._labState.importedData.agentAccess.wearableSeriesDays;
+delete state.importedData.agentAccessWearableSeriesDays;
+if (state.importedData.agentAccess) delete state.importedData.agentAccess.wearableSeriesDays;
 localStorage.setItem(`labcharts-${localStorage.getItem('labcharts-active-profile') || 'default'}-agent-wearable-series`, 'on');
 assert('Legacy "on" reads as 30 (default migration)',
   labCtxV29.getAgentWearableSeriesDays() === 30);
 // Synced preference wins over stale legacy 'on'.
-window._labState.importedData.agentAccessWearableSeriesDays = 7;
+state.importedData.agentAccessWearableSeriesDays = 7;
 assert('Synced series preference beats legacy "on"',
   labCtxV29.getAgentWearableSeriesDays() === 7);
-delete window._labState.importedData.agentAccessWearableSeriesDays;
+delete state.importedData.agentAccessWearableSeriesDays;
 labCtxV29.setAgentWearableSeriesDays(0); // reset legacy shim only; synced writes go through sync-messenger
 
 // Boolean back-compat shims still work.
@@ -1593,7 +1594,7 @@ assert('isAgentWearableSeriesEnabled / setAgentWearableSeriesEnabled back-compat
   typeof labCtxV29.setAgentWearableSeriesEnabled === 'function');
 
 // Section tag matches selected window.
-if (window._labState?.importedData?.wearableSummary) {
+if (state?.importedData?.wearableSummary) {
   labCtxV29.setAgentWearableSeriesDays(7);
   const block7 = await labCtxV29.buildWearableSeriesSection().catch(() => '');
   if (block7) {
@@ -1676,12 +1677,12 @@ console.log('17v. Test Isolation');
 const syncFlowSrc = await fetch('/tests/test-wearables-sync-flow.js').then(r => r.text());
 const uiFlowSrc = await fetch('/tests/test-wearables-ui-flows.js').then(r => r.text());
 for (const [name, src] of [['sync-flow', syncFlowSrc], ['ui-flows', uiFlowSrc]]) {
-  assert(`${name}: snapshots window._labState.currentProfile before swapping profile`,
-    /origCurrentProfile\s*=\s*window\._labState\.currentProfile/.test(src));
-  assert(`${name}: assigns TEST_PROFILE_ID to window._labState.currentProfile (not just localStorage)`,
-    /window\._labState\.currentProfile\s*=\s*TEST_PROFILE_ID/.test(src));
-  assert(`${name}: cleanup restores window._labState.currentProfile`,
-    /window\._labState\.currentProfile\s*=\s*origCurrentProfile/.test(src));
+  assert(`${name}: snapshots state.currentProfile before swapping profile`,
+    /origCurrentProfile\s*=\s*state\.currentProfile/.test(src));
+  assert(`${name}: assigns TEST_PROFILE_ID to state.currentProfile (not just localStorage)`,
+    /state\.currentProfile\s*=\s*TEST_PROFILE_ID/.test(src));
+  assert(`${name}: cleanup restores state.currentProfile`,
+    /state\.currentProfile\s*=\s*origCurrentProfile/.test(src));
   assert(`${name}: cleanup removes the test profile's localStorage imported key`,
     /localStorage\.removeItem\(`labcharts-\$\{TEST_PROFILE_ID\}-imported`\)/.test(src));
 }
@@ -1791,8 +1792,8 @@ console.log('17x. Behavioral Replacements');
 
 // Set up an isolated test summary with TWO connected sources so the
 // source-badge gate is exercised positively.
-const _origImported = window._labState.importedData;
-window._labState.importedData = {
+const _origImported = state.importedData;
+state.importedData = {
   entries: [],
   wearableConnections: {
     oura:   { source: 'oura',   connectedAt: new Date().toISOString(), lastSyncAt: Date.now() },
@@ -1845,15 +1846,15 @@ labCtx2.setAgentWearableSeriesEnabled(true);
 const { upsertDailyBatch } = await import('../js/wearables-store.js');
 const TEST_PROFILE_3 = '__test-replace-' + Date.now().toString(36);
 const origActive2 = localStorage.getItem('labcharts-active-profile');
-// buildWearableSeriesSection queries IDB keyed on window._labState.currentProfile
+// buildWearableSeriesSection queries IDB keyed on state.currentProfile
 // — NOT the localStorage 'labcharts-active-profile' key. Setting only the
 // latter (the original test's bug) meant the builder read the wrong store,
 // seriesBlock came back empty, and the ordering assertions below were
 // silently skipped by the `if (seriesBlock)` guard. Swap both, like
 // section 17r does.
-const origCurrent2 = window._labState.currentProfile;
+const origCurrent2 = state.currentProfile;
 localStorage.setItem('labcharts-active-profile', TEST_PROFILE_3);
-window._labState.currentProfile = TEST_PROFILE_3;
+state.currentProfile = TEST_PROFILE_3;
 try {
   await upsertDailyBatch(TEST_PROFILE_3, [
     { source: 'oura', date: '2026-04-22', hrv_rmssd: 36 },
@@ -1876,10 +1877,10 @@ try {
   labCtx2.setAgentWearableSeriesEnabled(false);
   if (origActive2) localStorage.setItem('labcharts-active-profile', origActive2);
   else localStorage.removeItem('labcharts-active-profile');
-  window._labState.currentProfile = origCurrent2;
+  state.currentProfile = origCurrent2;
   try { const { deleteWearablesDB } = await import('../js/wearables-store.js'); await deleteWearablesDB(TEST_PROFILE_3); } catch {}
 }
-window._labState.importedData = _origImported;
+state.importedData = _origImported;
 
 // ═══════════════════════════════════════
 // 17y. P1 audit fallout (v1.27.4)
@@ -2218,12 +2219,12 @@ assert('Series builder returns empty string when toggle is off',
 
 // Behaviour: returns '' when toggle is on but no wearable summary exists.
 labCtxAgent.setAgentWearableSeriesEnabled(true);
-const origImported = window._labState.importedData;
-window._labState.importedData = { wearableSummary: null };
+const origImported = state.importedData;
+state.importedData = { wearableSummary: null };
 const noSummaryResult = await labCtxAgent.buildWearableSeriesSection(30);
 assert('Series builder returns empty string when no wearableSummary',
   noSummaryResult === '');
-window._labState.importedData = origImported;
+state.importedData = origImported;
 labCtxAgent.setAgentWearableSeriesEnabled(false);  // restore default
 
 // Source-grep guards: pushContextToGateway must concat the series block.


### PR DESCRIPTION
## Summary

- migrate all five wearable legacy fixtures from `window._labState` to the explicit `state` module export
- update the wearable isolation guards to verify explicit state-module profile swaps and cleanup
- ratchet the guarded test-file ceiling from 33 to 28

This is test-only, so no app cache/version bump is required.

## Validation

- three targeted Node wearable fixtures — 728 assertions passed
- `npx playwright test tests/playwright/wearables-browser-flows.spec.js` — 2 passed
- `node tests/test-quality-guardrails.js` — 25 passed
- `npm run quality` — 11 passed; 1/1 app files and 28/28 test files within the `_labState` ceilings
- `./run-tests.sh` — 399 Vitest tests, 352 Playwright tests, and 472 responsive-theme assertions passed

## Overall progress

- Before this PR: 24/58 files complete (41.4%)
- This PR: 5 wearable test consumers migrated
- After this PR: 29/58 files complete (50.0%)
- Entire work remaining: 29/58 files (50.0%) — the final app export plus 28 test consumers
