### PR TITLE
Migrate light and Sun fixtures off lab state global

### DIFF
--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -6,7 +6,7 @@
   "viewRuntimeBridgeConsumers": 0,
   "viewRuntimeBridgeLookups": 0,
   "labStateAppFiles": 1,
-  "labStateTestFiles": 28,
+  "labStateTestFiles": 23,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/test-light-devices.js
+++ b/tests/test-light-devices.js
@@ -34,7 +34,7 @@ function assert(name, condition, detail) {
 
 console.log('=== Light Devices Tests ===\n');
 
-await import('../js/state.js');
+const { state } = await import('../js/state.js');
 const dev = await import('../js/light-devices.js');
 const sessionEngine = await import('../js/light-device-session-engine.js');
 const { synthesizeDeviceSpectrum } = await import('../js/sun-spectrum.js');
@@ -52,9 +52,9 @@ const {
   resolveDeviceMode,
 } = sessionEngine;
 
-  const orig = window._labState.importedData;
+  const orig = state.importedData;
   function reset(seed = {}) {
-    window._labState.importedData = Object.assign({ entries: [] }, seed);
+    state.importedData = Object.assign({ entries: [] }, seed);
   }
 
   // ─── 1. Lazy init ────────────────────────────────────────────────────
@@ -196,7 +196,7 @@ const {
   // ─── 3. deleteDevice ─────────────────────────────────────────────────
   console.log('%c 3. deleteDevice ', 'font-weight:bold;color:#f59e0b');
 
-  window._labState.importedData = { entries: [], lightDevices: [dPulse, dCustom], deviceSessions: [] };
+  state.importedData = { entries: [], lightDevices: [dPulse, dCustom], deviceSessions: [] };
   const removed = await deleteDevice(dCustom.id);
   assert('deleteDevice → true on hit', removed === true);
   assert('Device removed from list', getDevices().length === 1);
@@ -284,9 +284,9 @@ const {
     endedAt: Date.now() - 30 * 86400 * 1000 + 60000,
     doses: { pbm_red: 9999 },
   };
-  if (!Array.isArray(window._labState.importedData.deviceSessions))
-    window._labState.importedData.deviceSessions = [];
-  window._labState.importedData.deviceSessions.push(inWindow1, inWindow2, outOfWindow);
+  if (!Array.isArray(state.importedData.deviceSessions))
+    state.importedData.deviceSessions = [];
+  state.importedData.deviceSessions.push(inWindow1, inWindow2, outOfWindow);
 
   const tot7 = rollingDeviceTotals(7);
   assert('rollingDeviceTotals(7) sums in-window pbm_red (1000+2000)',
@@ -301,7 +301,7 @@ const {
     tot30.pbm_red >= 12000);
 
   // Tolerates session with null doses
-  window._labState.importedData.deviceSessions.push({
+  state.importedData.deviceSessions.push({
     id: 'd4', deviceId: 'X',
     startedAt: Date.now() - 1 * 86400 * 1000,
     endedAt: Date.now() - 1 * 86400 * 1000 + 60000,
@@ -312,7 +312,7 @@ const {
     Number.isFinite(totSafe.pbm_red));
 
   // Restore
-  window._labState.importedData = orig;
+  state.importedData = orig;
 
   // ─── peakShares: explicit shares override the heuristic ──────────────
   // A device with `peakShares: [0.05, 0.95]` for [297nm UVB, 660nm red]
@@ -376,11 +376,11 @@ const {
       peakWavelengths: [660], mwPerCm2At15cm: 50,
       recommendedDistanceCm: 30, peakShares: [1.0],
     };
-    window._labState.importedData = { lightDevices: [distDevice], deviceSessions: [] };
+    state.importedData = { lightDevices: [distDevice], deviceSessions: [] };
     await logDeviceSession({ deviceId: 'D-dist', durationMin: 10, distanceCm: 30, bodyArea: 'torso', eyesProtected: true });
     await logDeviceSession({ deviceId: 'D-dist', durationMin: 10, distanceCm: 15, bodyArea: 'torso', eyesProtected: true });
     await logDeviceSession({ deviceId: 'D-dist', durationMin: 10, distanceCm: 5, bodyArea: 'torso', eyesProtected: true });
-    const sess = window._labState.importedData.deviceSessions;
+    const sess = state.importedData.deviceSessions;
     const at30 = sess[0]?.doses?.pbm_red || 0;
     const at15 = sess[1]?.doses?.pbm_red || 0;
     const at5  = sess[2]?.doses?.pbm_red || 0;
@@ -395,7 +395,7 @@ const {
       at30 > 0 && Math.abs(at5 / at30 - 3.0) < 0.2,
       `5cm ratio=${at30 > 0 ? (at5/at30).toFixed(2) : 'n/a'} (expected ≈3.0, same cap)`);
   }
-  window._labState.importedData = orig;
+  state.importedData = orig;
 
   // ─── deleteDevice + orphaned-session render ────────────────────────
   // Sessions logged on a device deleted later must remain renderable
@@ -408,23 +408,23 @@ const {
       peakWavelengths: [660], mwPerCm2At15cm: 50,
       recommendedDistanceCm: 15, peakShares: [1.0],
     };
-    window._labState.importedData = { lightDevices: [ephemeral], deviceSessions: [] };
+    state.importedData = { lightDevices: [ephemeral], deviceSessions: [] };
     await logDeviceSession({ deviceId: 'D-ephemeral', durationMin: 10, distanceCm: 15, bodyArea: 'torso', eyesProtected: true });
-    const sessId = window._labState.importedData.deviceSessions[0]?.id;
+    const sessId = state.importedData.deviceSessions[0]?.id;
     assert('logDeviceSession persists session with deviceId reference',
-      sessId && window._labState.importedData.deviceSessions[0].deviceId === 'D-ephemeral');
+      sessId && state.importedData.deviceSessions[0].deviceId === 'D-ephemeral');
     // Now delete the device.
     await deleteDevice('D-ephemeral');
-    const stillThere = window._labState.importedData.deviceSessions[0];
+    const stillThere = state.importedData.deviceSessions[0];
     assert('Sessions persist after parent device is deleted (no auto-purge)',
       stillThere && stillThere.id === sessId);
     assert('Session retains its dangling deviceId for historical reference',
       stillThere.deviceId === 'D-ephemeral');
     // Tombstone recorded so cross-device sync drops the device on peers.
-    const tombs = window._labState.importedData?._deleted?.lightDevices || [];
+    const tombs = state.importedData?._deleted?.lightDevices || [];
     assert('deleteDevice records tombstone for cross-device sync',
       tombs.includes('D-ephemeral'));
-    window._labState.importedData = orig;
+    state.importedData = orig;
   }
 
   // ─── Recompute on legacy + mode-aware sessions ─────────────────────
@@ -465,13 +465,13 @@ const {
       ],
       coupling: [{ if: 'uv-blue', requires: ['red-nir'] }],
     };
-    window._labState.importedData = { lightDevices: [maxiDevice], deviceSessions: [] };
+    state.importedData = { lightDevices: [maxiDevice], deviceSessions: [] };
 
     // 1. Log session without explicit mode → resolves to default 'all-on'
     await logDeviceSession({
       deviceId: 'D-maxi-test', durationMin: 6, distanceCm: 60, bodyArea: 'torso', eyesProtected: true,
     });
-    const sess0 = window._labState.importedData.deviceSessions[0];
+    const sess0 = state.importedData.deviceSessions[0];
     const baseVitD = sess0?.doses?.vitamin_d || 0;
     const basePbmRed = sess0?.doses?.pbm_red || 0;
     assert('Recompute prep: fresh session resolves mode to all-on default',
@@ -483,7 +483,7 @@ const {
     const legacyId = sess0.id;
     delete sess0.mode;
     await updateDeviceSession(legacyId, { durationMin: 12 });
-    const recomputed = window._labState.importedData.deviceSessions.find(s => s.id === legacyId);
+    const recomputed = state.importedData.deviceSessions.find(s => s.id === legacyId);
     assert('Legacy recompute: mode auto-fills to default after edit',
       recomputed?.mode === 'all-on', `mode=${recomputed?.mode}`);
     // Doses should ~2× the original (duration doubled, all-on identity).
@@ -499,7 +499,7 @@ const {
 
     // 3. Switch mode mid-edit → vitamin_d crashes, pbm_red preserved
     await updateDeviceSession(legacyId, { mode: 'red-nir-only' });
-    const switched = window._labState.importedData.deviceSessions.find(s => s.id === legacyId);
+    const switched = state.importedData.deviceSessions.find(s => s.id === legacyId);
     assert('Mode switch (all-on → red-nir-only): mode persists',
       switched?.mode === 'red-nir-only');
     assert('Mode switch: vitamin_d ≈ 0 after switching off UV group',
@@ -514,7 +514,7 @@ const {
 
     // 4. Coupling enforcement: invalid mode silently falls back to default
     await updateDeviceSession(legacyId, { mode: 'completely-fake-mode' });
-    const validated = window._labState.importedData.deviceSessions.find(s => s.id === legacyId);
+    const validated = state.importedData.deviceSessions.find(s => s.id === legacyId);
     assert('Mode validation: unknown mode-id falls back to default',
       validated?.mode === 'all-on');
 
@@ -524,23 +524,23 @@ const {
       peakWavelengths: [660, 850], mwPerCm2At15cm: 100,
       recommendedDistanceCm: 15, peakShares: [0.5, 0.5],
     };
-    window._labState.importedData = { lightDevices: [pbmDevice], deviceSessions: [] };
+    state.importedData = { lightDevices: [pbmDevice], deviceSessions: [] };
     await logDeviceSession({
       deviceId: 'D-pbm-test', durationMin: 5, distanceCm: 15, bodyArea: 'torso', eyesProtected: true,
     });
-    const pbmSess = window._labState.importedData.deviceSessions[0];
+    const pbmSess = state.importedData.deviceSessions[0];
     assert('Non-moded device: session.mode stays null',
       pbmSess?.mode === null, `mode=${pbmSess?.mode}`);
     const basePbmDose = pbmSess.doses.pbm_red;
     await updateDeviceSession(pbmSess.id, { durationMin: 10 });
-    const pbmRecomputed = window._labState.importedData.deviceSessions.find(s => s.id === pbmSess.id);
+    const pbmRecomputed = state.importedData.deviceSessions.find(s => s.id === pbmSess.id);
     assert('Non-moded device: recompute scales linearly (no mode drift)',
       Math.abs(pbmRecomputed.doses.pbm_red / basePbmDose - 2.0) < 0.05,
       `ratio=${(pbmRecomputed.doses.pbm_red / basePbmDose).toFixed(3)}`);
     assert('Non-moded device: mode stays null after recompute',
       pbmRecomputed?.mode === null);
 
-    window._labState.importedData = orig;
+    state.importedData = orig;
   }
 
   // ─── hydrateDevicesFromPresets — pre-Round-7 device backfill ──────
@@ -551,18 +551,18 @@ const {
   // no-op since fields are now present.
   console.log('%c hydrateDevicesFromPresets backfill ', 'font-weight:bold;color:#f59e0b');
   {
-    window._labState.importedData = { lightDevices: [], deviceSessions: [] };
+    state.importedData = { lightDevices: [], deviceSessions: [] };
     // Add a Maxi UVB then strip the Round-7 fields, simulating a device
     // record persisted to localStorage before the schema additions.
     await addDeviceFromPreset('mitochondriak-maxi-uvb');
-    const dev = window._labState.importedData.lightDevices[0];
+    const dev = state.importedData.lightDevices[0];
     delete dev.channelGroups;
     delete dev.modes;
     delete dev.coupling;
     assert('Pre-hydration: legacy device record has no `modes`',
       !Array.isArray(dev.modes));
     const dirty = await hydrateDevicesFromPresets();
-    const hydrated = window._labState.importedData.lightDevices[0];
+    const hydrated = state.importedData.lightDevices[0];
     assert('hydrateDevicesFromPresets reports dirty when fields were missing',
       dirty === true);
     assert('Hydration backfills `modes` from preset',
@@ -576,15 +576,15 @@ const {
     assert('hydrateDevicesFromPresets is idempotent (second run = no-op)',
       dirty2 === false);
     // Custom devices (no presetId) skip hydration even if they're missing fields.
-    window._labState.importedData.lightDevices.push({
+    state.importedData.lightDevices.push({
       id: 'D-custom-no-preset', brand: 'Custom', model: 'Test',
       peakWavelengths: [660], mwPerCm2At15cm: 50,
     });
     await hydrateDevicesFromPresets();
-    const customDev = window._labState.importedData.lightDevices.find(d => d.id === 'D-custom-no-preset');
+    const customDev = state.importedData.lightDevices.find(d => d.id === 'D-custom-no-preset');
     assert('Hydration skips custom (no-presetId) devices',
       !customDev.modes && !customDev.channelGroups);
-    window._labState.importedData = orig;
+    state.importedData = orig;
   }
 
   // ─── addDeviceFromPreset copies Round-7 schema through ─────────────
@@ -593,9 +593,9 @@ const {
   // the boot-time hydration migration to fire.
   console.log('%c addDeviceFromPreset copies Round-7 schema ', 'font-weight:bold;color:#f59e0b');
   {
-    window._labState.importedData = { lightDevices: [], deviceSessions: [] };
+    state.importedData = { lightDevices: [], deviceSessions: [] };
     await addDeviceFromPreset('mitochondriak-maxi-uvb');
-    const fresh = window._labState.importedData.lightDevices[0];
+    const fresh = state.importedData.lightDevices[0];
     assert('Fresh-add: device carries `modes` immediately',
       Array.isArray(fresh.modes) && fresh.modes.length >= 2);
     assert('Fresh-add: device carries `channelGroups` immediately',
@@ -604,10 +604,10 @@ const {
       Array.isArray(fresh.coupling));
     // Non-moded preset (Pulse) → fields stay null
     await addDeviceFromPreset('mitochondriak-pulse');
-    const pulse = window._labState.importedData.lightDevices.find(d => d.presetId === 'mitochondriak-pulse');
+    const pulse = state.importedData.lightDevices.find(d => d.presetId === 'mitochondriak-pulse');
     assert('Fresh-add: non-moded preset (Pulse) has null modes',
       pulse.modes === null);
-    window._labState.importedData = orig;
+    state.importedData = orig;
   }
 
   // ─── Runtime adapter ownership ─────────────────────────────────────

--- a/tests/test-light-env.js
+++ b/tests/test-light-env.js
@@ -15,7 +15,7 @@ function assert(name, condition, detail) {
 
 console.log('=== Light Environment Tests ===\n');
 
-await import('../js/state.js');
+const { state } = await import('../js/state.js');
 const { buildSunContext } = await import('../js/sun-context.js');
 const env = await import('../js/light-env.js');
 const model = await import('../js/light-env-model.js');
@@ -40,9 +40,9 @@ const {
   computeIndoorBurdenForEnvironment,
 } = model;
 
-  const orig = window._labState.importedData;
+  const orig = state.importedData;
   function reset(seed = {}) {
-    window._labState.importedData = Object.assign({ entries: [] }, seed);
+    state.importedData = Object.assign({ entries: [] }, seed);
   }
 
   // ─── 1. Constant shape ───────────────────────────────────────────────
@@ -80,7 +80,7 @@ const {
   assert('getEnvironment seeds rooms[] + screens[]',
     e && Array.isArray(e.rooms) && Array.isArray(e.screens));
 
-  window._labState.importedData = null;
+  state.importedData = null;
   assert('getEnvironment returns null when importedData missing',
     getEnvironment() === null);
 
@@ -324,7 +324,7 @@ const {
   assert('Empty env → tier 0 light load with mapping hint',
     burden.tier === 0 && burden.color === 'green' &&
     /add a room|add a screen/i.test(burden.interp));
-  window._labState.importedData.lightEnvironment.burdenAI = {
+  state.importedData.lightEnvironment.burdenAI = {
     status: 'ok',
     dot: 'yellow',
     tip: 'stale moderate verdict',
@@ -415,9 +415,9 @@ const {
   reset();
   await addRoom('Bedroom');
   // Drop a measurement so saveLightAudit has something to snapshot.
-  if (!Array.isArray(window._labState.importedData.lightMeasurements))
-    window._labState.importedData.lightMeasurements = [];
-  window._labState.importedData.lightMeasurements.push({
+  if (!Array.isArray(state.importedData.lightMeasurements))
+    state.importedData.lightMeasurements = [];
+  state.importedData.lightMeasurements.push({
     id: 'lm_x', tool: 'lux', value: 200, capturedAt: Date.now(),
     roomId: getEnvironment().rooms[0].id,
   }, {
@@ -512,7 +512,7 @@ const {
     window.deleteLightEnvScreenConfirm === undefined &&
     window.computeLightDeficitAxes === undefined);
 
-  const beforeModalSyncData = window._labState.importedData;
+  const beforeModalSyncData = state.importedData;
   const originalCreateElement = document.createElement;
   const originalGetElementById = document.getElementById;
   const originalBodyAppendChild = document.body.appendChild;
@@ -549,13 +549,13 @@ const {
     document.body.appendChild = el => { storedOverlay = el; return el; };
     document.getElementById = id => id === 'light-env-assessment-overlay' ? storedOverlay : originalGetElementById.call(document, id);
 
-    window._labState.importedData = {
+    state.importedData = {
       lightEnvironment: { rooms: [{ id: 'sync-room', name: 'Office', hoursOccupiedPerDay: 8 }], screens: [] },
       lightMeasurements: [],
     };
     openLightEnvironmentAssessment();
     const initialModalHtml = storedOverlay?.innerHTML || '';
-    window._labState.importedData.lightEnvironment.rooms[0].name = 'Bedroom';
+    state.importedData.lightEnvironment.rooms[0].name = 'Bedroom';
     window.dispatchEvent({ type: 'labcharts-sync-applied' });
     assert('Open Light Environment modal refreshes clean content on sync',
       initialModalHtml.includes('light-env-room-disclosure-name">Office') &&
@@ -564,7 +564,7 @@ const {
 
     dirtyModal = true;
     const cleanSyncedHtml = storedOverlay.innerHTML;
-    window._labState.importedData.lightEnvironment.rooms[0].name = 'Kitchen';
+    state.importedData.lightEnvironment.rooms[0].name = 'Kitchen';
     window.dispatchEvent({ type: 'labcharts-sync-applied' });
     assert('Open Light Environment modal skips sync refresh while form is dirty',
       storedOverlay?.innerHTML === cleanSyncedHtml &&
@@ -574,7 +574,7 @@ const {
     document.createElement = originalCreateElement;
     document.getElementById = originalGetElementById;
     document.body.appendChild = originalBodyAppendChild;
-    window._labState.importedData = beforeModalSyncData;
+    state.importedData = beforeModalSyncData;
   }
 
   const envSrc = await (await import('node:fs/promises')).readFile(new URL('../js/light-env.js', import.meta.url), 'utf8');
@@ -759,8 +759,8 @@ const {
   assert('Assessment modal owns vertical scrolling',
     /max-height:\s*calc\(100dvh - 48px\)/.test(modalCss) &&
     /overflow-y:\s*auto/.test(modalCss));
-  const beforeEmptyAssessment = window._labState.importedData;
-  window._labState.importedData = {
+  const beforeEmptyAssessment = state.importedData;
+  state.importedData = {
     lightEnvironment: { rooms: [], screens: [] },
     lightMeasurements: [{ id: 'orphan-reading', tool: 'lux', roomId: null, value: 50, takenAt: Date.now() }],
     lightAudits: [{ id: 'old-audit', date: '2026-05-01', label: 'Old room' }],
@@ -782,7 +782,7 @@ const {
     emptyAssessmentHtml.includes('📱 Phone') &&
     !emptyAssessmentHtml.includes('+ Bedroom') &&
     !emptyAssessmentHtml.includes('+ 📱 Phone'));
-  window._labState.importedData = {
+  state.importedData = {
     lightEnvironment: { rooms: [{ id: 'mapped-room', name: 'Bedroom' }], screens: [] },
     lightMeasurements: [
       { id: 'unmapped-reading', tool: 'lux', roomId: null, value: 50, takenAt: Date.now() },
@@ -797,14 +797,14 @@ const {
   assert('Assessment workspace hides unmapped portable readings',
     !unmappedAssessmentHtml.includes('Portable readings') &&
     !unmappedAssessmentHtml.includes('not matched to a room'));
-  window._labState.importedData = beforeEmptyAssessment;
+  state.importedData = beforeEmptyAssessment;
 
-  const beforeDisclosureState = window._labState.importedData;
-  const beforeDisclosureView = window._labState.currentView;
+  const beforeDisclosureState = state.importedData;
+  const beforeDisclosureView = state.currentView;
   let savedActiveRoom = null;
   try { savedActiveRoom = localStorage.getItem('labcharts-light-env-active-room'); localStorage.removeItem('labcharts-light-env-active-room'); } catch (_) {}
-  window._labState.currentView = 'dashboard';
-  window._labState.importedData = {
+  state.currentView = 'dashboard';
+  state.importedData = {
     lightEnvironment: { rooms: [{ id: 'room_single', name: 'Bedroom', hoursOccupiedPerDay: 8 }], screens: [] },
     lightMeasurements: [],
   };
@@ -822,23 +822,23 @@ const {
   assert('Single room expands again after explicit collapse',
     singleRoomExpandedAgain.includes('aria-expanded="true"') &&
     singleRoomExpandedAgain.includes('light-env-room-disclosure-body'));
-  window._labState.importedData = beforeDisclosureState;
-  window._labState.currentView = beforeDisclosureView;
+  state.importedData = beforeDisclosureState;
+  state.currentView = beforeDisclosureView;
   try {
     if (savedActiveRoom === null) localStorage.removeItem('labcharts-light-env-active-room');
     else localStorage.setItem('labcharts-light-env-active-room', savedActiveRoom);
   } catch (_) {}
 
-  const beforeScreenToggleState = window._labState.importedData;
-  const beforeScreenToggleView = window._labState.currentView;
+  const beforeScreenToggleState = state.importedData;
+  const beforeScreenToggleView = state.currentView;
   let screenNavCall = null;
   const beforeScreenNavigateDeps = configureLightEnv({
     navigate: (route, data) => { screenNavCall = { route, data }; },
   });
   let screenPrevented = false;
   let screenStopped = false;
-  window._labState.currentView = 'light';
-  window._labState.importedData = {
+  state.currentView = 'light';
+  state.importedData = {
     lightEnvironment: { rooms: [], screens: [{ id: 'screen_single', device: 'phone', roomId: null }] },
     lightMeasurements: [],
   };
@@ -853,15 +853,15 @@ const {
     screenNavCall?.data?.scrollAnchor === '.light-env-screen-card[data-id="screen_single"]',
     JSON.stringify(screenNavCall));
   configureLightEnv(beforeScreenNavigateDeps);
-  window._labState.currentView = beforeScreenToggleView;
-  window._labState.importedData = beforeScreenToggleState;
+  state.currentView = beforeScreenToggleView;
+  state.importedData = beforeScreenToggleState;
 
   // ─── deleteRoom orphan cleanup ─────────────────────────────────────
   // Earlier deleteRoom dropped the room but left measurements + screens
   // pointing at the dead id. Room-bound measurements are now deleted
   // with the room; screens are kept but become portable.
   console.log('%c deleteRoom orphan cleanup ', 'font-weight:bold;color:#f59e0b');
-  window._labState.importedData = {
+  state.importedData = {
     lightEnvironment: {
       rooms: [{ id: 'r-orphan', name: 'Bedroom' }],
       screens: [{ id: 's-orphan', device: 'phone', roomId: 'r-orphan' }],
@@ -872,25 +872,25 @@ const {
     ],
   };
   await deleteRoom('r-orphan');
-  const measurementsAfter = window._labState.importedData.lightMeasurements;
-  const screensAfter = window._labState.importedData.lightEnvironment.screens;
+  const measurementsAfter = state.importedData.lightMeasurements;
+  const screensAfter = state.importedData.lightEnvironment.screens;
   assert('deleteRoom removes linked measurements',
     !measurementsAfter.find(m => m.id === 'm-orphan-1'));
   assert('deleteRoom tombstones linked measurements for sync',
-    window._labState.importedData._deleted?.lightMeasurements?.includes('m-orphan-1'));
+    state.importedData._deleted?.lightMeasurements?.includes('m-orphan-1'));
   assert('deleteRoom leaves measurements pointing at OTHER rooms untouched',
     measurementsAfter.find(m => m.id === 'm-orphan-2').roomId === 'other-room');
   assert('deleteRoom nulls roomId on linked screens',
     screensAfter.find(s => s.id === 's-orphan').roomId === null);
 
   // Restore
-  window._labState.importedData = orig;
+  state.importedData = orig;
 
   // ─── lightEnvironmentBlock surfaces in AI context ──────────────────
   console.log('%c AI context — light environment block ', 'font-weight:bold;color:#f59e0b');
   {
-    const beforeCtx = window._labState.importedData;
-    window._labState.importedData = {
+    const beforeCtx = state.importedData;
+    state.importedData = {
       sunSessions: [],
       deviceSessions: [],
       lightEnvironment: {
@@ -918,7 +918,7 @@ const {
       /Screens tracked: 1/.test(ctx));
     assert('AI context surfaces no-blue-blocker after-sunset screens',
       /without blue-blocker/.test(ctx));
-    window._labState.importedData = beforeCtx;
+    state.importedData = beforeCtx;
   }
 
   // ─── addRoom returns the new room's id ──────────────────────────────
@@ -926,19 +926,19 @@ const {
   // a return value the binding silently fails and pause-detected lux
   // never reaches the room cards.
   console.log('%c addRoom return value ', 'font-weight:bold;color:#f59e0b');
-  window._labState.importedData = { lightEnvironment: { rooms: [], screens: [] } };
+  state.importedData = { lightEnvironment: { rooms: [], screens: [] } };
   const newId = await addRoom('Office');
   assert('addRoom returns the created room id (string starting with room_)',
     typeof newId === 'string' && newId.startsWith('room_'),
     `got ${typeof newId} ${newId}`);
   assert('addRoom-returned id matches the new room in env.rooms',
-    window._labState.importedData.lightEnvironment.rooms.find(r => r.id === newId)?.name === 'Office');
+    state.importedData.lightEnvironment.rooms.find(r => r.id === newId)?.name === 'Office');
 
   // ─── AI context surfaces tool-measurement warnings ─────────────────
   {
     console.log('%c AI context — tool warnings ', 'font-weight:bold;color:#f59e0b');
-    const beforeCtx = window._labState.importedData;
-    window._labState.importedData = {
+    const beforeCtx = state.importedData;
+    state.importedData = {
       sunSessions: [],
       deviceSessions: [],
       lightEnvironment: { rooms: [{ id: 'r1', name: 'Bedroom' }], screens: [] },
@@ -961,11 +961,11 @@ const {
       /after-sunset CCT 4500K/.test(ctx));
     assert('AI does NOT flag CCT readings taken before sunset',
       !/CCT 5500K/.test(ctx));
-    window._labState.importedData = beforeCtx;
+    state.importedData = beforeCtx;
   }
 
   // Restore
-  window._labState.importedData = orig;
+  state.importedData = orig;
 
 console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
 process.exit(fail > 0 ? 1 : 0);

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -61,7 +61,7 @@ assert('quality guardrail ratchets _labState retirement by file',
     guardrailSrc.includes('labStateAppFiles') &&
     guardrailSrc.includes('labStateTestFiles') &&
     baseline.labStateAppFiles === 1 &&
-    baseline.labStateTestFiles === 28);
+    baseline.labStateTestFiles === 23);
 const forbiddenAppEventWindowGlobals = [
   'closeModal',
   'toggleChatPanel',

--- a/tests/test-sun-correlations.js
+++ b/tests/test-sun-correlations.js
@@ -14,8 +14,7 @@ function assert(name, condition, detail) {
 
 console.log('=== Sun Correlations Tests ===\n');
 
-// state.js initializes window._labState; importing it loads the wiring.
-await import('../js/state.js');
+const { state } = await import('../js/state.js');
 const mod = await import('../js/sun-correlations.js');
 const { computeSunCorrelations, getSunCorrelations } = mod;
 assert('sun correlations exports stay module-scoped',
@@ -24,7 +23,7 @@ assert('sun correlations exports stay module-scoped',
 
   // Stash and restore importedData around the run so we don't pollute the
   // host page's profile state.
-  const orig = window._labState.importedData;
+  const orig = state.importedData;
 
   // Helper — build a session record at the given week-offset (0 = this week).
   // Sessions are bucketed by `endedAt` against now.
@@ -54,7 +53,7 @@ assert('sun correlations exports stay module-scoped',
   // ─── 1. Empty-state contract ──────────────────────────────────────────
   console.log('%c 1. Empty-state contract ', 'font-weight:bold;color:#f59e0b');
 
-  window._labState.importedData = { sunSessions: [], deviceSessions: [], entries: [] };
+  state.importedData = { sunSessions: [], deviceSessions: [], entries: [] };
   const empty = computeSunCorrelations({ weeks: 12 });
   assert('Empty session set → empty pairs', Array.isArray(empty.pairs) && empty.pairs.length === 0);
   assert('Empty result still carries computedAt', typeof empty.computedAt === 'number');
@@ -62,7 +61,7 @@ assert('sun correlations exports stay module-scoped',
   // ─── 2. Insufficient data → skip pairs ────────────────────────────────
   console.log('%c 2. n<4 weeks → skip ', 'font-weight:bold;color:#f59e0b');
 
-  window._labState.importedData = {
+  state.importedData = {
     sunSessions: [
       session(0, { vitamin_d: 5 }),
       session(1, { vitamin_d: 4 }),
@@ -80,7 +79,7 @@ assert('sun correlations exports stay module-scoped',
   console.log('%c 3. Strong positive correlation ', 'font-weight:bold;color:#f59e0b');
 
   // Vitamin-D dose ↑ alongside vitamin_d_25oh ↑ across 6 weeks
-  window._labState.importedData = {
+  state.importedData = {
     sunSessions: [
       session(0, { vitamin_d: 8 }),
       session(1, { vitamin_d: 7 }),
@@ -108,7 +107,7 @@ assert('sun correlations exports stay module-scoped',
   console.log('%c 4. Strong negative correlation ', 'font-weight:bold;color:#f59e0b');
 
   // Inverse: dose climbs while marker falls
-  window._labState.importedData = {
+  state.importedData = {
     sunSessions: [
       session(0, { vitamin_d: 1 }),
       session(1, { vitamin_d: 2 }),
@@ -128,7 +127,7 @@ assert('sun correlations exports stay module-scoped',
   // ─── 5. Constant series → no correlation (skip) ──────────────────────
   console.log('%c 5. Zero-variance skip ', 'font-weight:bold;color:#f59e0b');
 
-  window._labState.importedData = {
+  state.importedData = {
     sunSessions: [
       session(0, { vitamin_d: 5 }),
       session(1, { vitamin_d: 5 }),
@@ -146,7 +145,7 @@ assert('sun correlations exports stay module-scoped',
   // ─── 6. Device sessions accumulate alongside sun sessions ─────────────
   console.log('%c 6. Device + sun sessions accumulate ', 'font-weight:bold;color:#f59e0b');
 
-  window._labState.importedData = {
+  state.importedData = {
     sunSessions: [
       session(0, { vitamin_d: 3 }), session(1, { vitamin_d: 2 }),
       session(2, { vitamin_d: 1 }), session(3, { vitamin_d: 0 }),
@@ -165,7 +164,7 @@ assert('sun correlations exports stay module-scoped',
   // ─── 7. Cache invalidation via getSunCorrelations ─────────────────────
   console.log('%c 7. Cache key respects session/entry counts ', 'font-weight:bold;color:#f59e0b');
 
-  window._labState.importedData = {
+  state.importedData = {
     sunSessions: [
       session(0, { vitamin_d: 1 }), session(1, { vitamin_d: 2 }),
       session(2, { vitamin_d: 3 }), session(3, { vitamin_d: 4 }),
@@ -179,8 +178,8 @@ assert('sun correlations exports stay module-scoped',
   assert('Identical state → cached result returned (same reference)', first === second);
 
   // Mutating fixture (extra session) must invalidate cache
-  window._labState.importedData.sunSessions.push(session(4, { vitamin_d: 5 }));
-  window._labState.importedData.entries.push(entry(4, 80));
+  state.importedData.sunSessions.push(session(4, { vitamin_d: 5 }));
+  state.importedData.entries.push(entry(4, 80));
   const third = getSunCorrelations();
   assert('New session → cache invalidated (fresh result)', first !== third);
 
@@ -191,7 +190,7 @@ assert('sun correlations exports stay module-scoped',
   const allChannels = ['vitamin_d','pomc','no_cv','violet_eye','circadian','nir_solar'];
   const synthDose = {};
   allChannels.forEach((c, i) => { synthDose[c] = 1 + i; });
-  window._labState.importedData = {
+  state.importedData = {
     sunSessions: [0,1,2,3,4,5].map(w => session(w, Object.fromEntries(allChannels.map(c => [c, 1 + Math.random()])))),
     deviceSessions: [],
     entries: [entry(0,60),entry(1,55),entry(2,70),entry(3,50),entry(4,65),entry(5,58)],
@@ -217,7 +216,7 @@ assert('sun correlations exports stay module-scoped',
   }
 
   // Restore
-  window._labState.importedData = orig;
+  state.importedData = orig;
 
 console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
 process.exit(fail > 0 ? 1 : 0);

--- a/tests/test-sun-defaults.js
+++ b/tests/test-sun-defaults.js
@@ -58,7 +58,7 @@ function restoreDelegateDomGlobals() {
   }
 }
 
-await import('../js/state.js');
+const { state } = await import('../js/state.js');
 const mod = await import('../js/sun-defaults.js');
 const {
   FITZPATRICK_OPTIONS,
@@ -76,7 +76,7 @@ const {
 } = mod;
 
   // Stash importedData so we don't pollute the host page.
-  const orig = window._labState.importedData;
+  const orig = state.importedData;
 
   // ─── 0. Light setup delegated events ─────────────────────────────────
   console.log('%c 0. Light setup delegated events ', 'font-weight:bold;color:#f59e0b');
@@ -261,14 +261,14 @@ const {
 
   // Stub a clean importedData with a no-op saveImportedData so we don't
   // hit the real CRDT/IDB save path.
-  window._labState.importedData = { entries: [] };
+  state.importedData = { entries: [] };
   // saveImportedData is imported by sun-defaults from data.js; the real
   // implementation persists. We don't need to mock it — just keep the
   // test profile id constant so artifacts don't accumulate.
 
   const empty = getSunDefaults();
   assert('getSunDefaults seeds importedData.sunDefaults when missing',
-    empty && typeof empty === 'object' && window._labState.importedData.sunDefaults === empty);
+    empty && typeof empty === 'object' && state.importedData.sunDefaults === empty);
 
   await saveSunDefaults({ fitzpatrick: 'III', homeLight: 'led-warm' });
   const after1 = getSunDefaults();
@@ -313,22 +313,22 @@ const {
   assert('collectSunSetupValues blocks visual default skin type until confirmed',
     missingSkin.ok === false && missingSkin.reason === 'skin-type-required');
 
-  window._labState.importedData = { entries: [], sunDefaults: {}, lightCircadian: null };
+  state.importedData = { entries: [], sunDefaults: {}, lightCircadian: null };
   await persistSunSetupValues(collected.values, 1234567890);
   assert('persistSunSetupValues saves defaults and mirrors skin context in one path',
-    window._labState.importedData.sunDefaults.fitzpatrick === 'IV' &&
-    window._labState.importedData.sunDefaults.photosensitiveMeds === 'severe' &&
-    window._labState.importedData.sunDefaults.homeLight === 'led-warm' &&
-    window._labState.importedData.sunDefaults.eyewear === 'sunglasses' &&
-    window._labState.importedData.sunDefaults.ottScore === 2 &&
-    window._labState.importedData.sunDefaults.completedAt === 1234567890 &&
-    window._labState.importedData.lightCircadian?.skinType?.startsWith('IV'));
+    state.importedData.sunDefaults.fitzpatrick === 'IV' &&
+    state.importedData.sunDefaults.photosensitiveMeds === 'severe' &&
+    state.importedData.sunDefaults.homeLight === 'led-warm' &&
+    state.importedData.sunDefaults.eyewear === 'sunglasses' &&
+    state.importedData.sunDefaults.ottScore === 2 &&
+    state.importedData.sunDefaults.completedAt === 1234567890 &&
+    state.importedData.lightCircadian?.skinType?.startsWith('IV'));
 
   // ─── 6. isOnboardingComplete gate ─────────────────────────────────────
   console.log('%c 6. Onboarding-complete gate ', 'font-weight:bold;color:#f59e0b');
 
   // Just fitzpatrick set is not enough — needs completedAt
-  window._labState.importedData = { entries: [], sunDefaults: { fitzpatrick: 'III' } };
+  state.importedData = { entries: [], sunDefaults: { fitzpatrick: 'III' } };
   assert('isOnboardingComplete falsy without completedAt',
     !isOnboardingComplete());
 
@@ -342,19 +342,19 @@ const {
     !isOnboardingComplete());
 
   // Empty importedData → falsy
-  window._labState.importedData = null;
+  state.importedData = null;
   assert('isOnboardingComplete falsy when importedData missing',
     !isOnboardingComplete());
 
   // ─── 7. getSunDefaults handles missing importedData ──────────────────
   console.log('%c 7. Defensive guards ', 'font-weight:bold;color:#f59e0b');
 
-  window._labState.importedData = null;
+  state.importedData = null;
   assert('getSunDefaults() returns null when importedData missing',
     getSunDefaults() === null);
 
   // Restore
-  window._labState.importedData = orig;
+  state.importedData = orig;
 
   // ─── 8. getSunCoords country-band path — SKIPPED in Node ──────────────
   // The country-centroid resolution requires profile state (currentProfile +
@@ -372,8 +372,8 @@ const {
   // Stash original profile location
   const origLoc = getProfileLocation();
   // Ensure we're in country-band mode (no profile-precise coords)
-  const stashedSunDefaults = window._labState.importedData?.sunDefaults;
-  if (window._labState.importedData) window._labState.importedData.sunDefaults = null;
+  const stashedSunDefaults = state.importedData?.sunDefaults;
+  if (state.importedData) state.importedData.sunDefaults = null;
 
   setProfileLocation(null, 'czech republic', '');
   const cz = getSunCoords();
@@ -405,7 +405,7 @@ const {
 
   // Restore profile location
   setProfileLocation(null, origLoc.country || '', origLoc.zip || '');
-  if (window._labState.importedData) window._labState.importedData.sunDefaults = stashedSunDefaults;
+  if (state.importedData) state.importedData.sunDefaults = stashedSunDefaults;
   } // end if (!SKIP_SECTION_8)
 
 console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);

--- a/tests/test-v1-6-shipped.js
+++ b/tests/test-v1-6-shipped.js
@@ -30,14 +30,14 @@ console.log('=== v1.6.7–v1.6.16 Regression Tests ===\n');
 // Load modules whose window-exposed handlers are checked below:
 // sun.js → dailyVitaminDIUBreakdown, light-tools.js → saveMeasurement,
 // light-sessions-view.js → _openAllSessionsModal.
-await import('../js/state.js');
+const { state } = await import('../js/state.js');
 const { dailyVitaminDIUBreakdown, rollingVitaminDIU } = await import('../js/sun.js');
 const lightTools = await import('../js/light-tools.js');
 const viewsModule = await import('../js/views.js');
 
 // Snapshot mutable state we touch.
-const _origImported = window._labState ? JSON.parse(JSON.stringify(window._labState.importedData)) : null;
-const _origProfileSex = window._labState ? window._labState.profileSex : null;
+const _origImported = state ? JSON.parse(JSON.stringify(state.importedData)) : null;
+const _origProfileSex = state ? state.profileSex : null;
 
   // ─── 1. v1.6.7 CAMS source-flip guard (sun-active-session.js _snapshotActiveRate) ─
   console.log('%c 1. CAMS source-flip guard ', 'font-weight:bold;color:#0891b2');
@@ -90,7 +90,7 @@ const _origProfileSex = window._labState ? window._labState.profileSex : null;
   // ─── 4. v1.6.6 + v1.6.7 dailyVitaminDIUBreakdown matches rollingIU ──
   console.log('%c 4. dailyVitaminDIUBreakdown ↔ rollingVitaminDIU parity ', 'font-weight:bold;color:#0891b2');
   {
-    const S = window._labState;
+    const S = state;
     if (!S || typeof dailyVitaminDIUBreakdown !== 'function' || typeof rollingVitaminDIU !== 'function') {
       assert('dailyVitaminDIUBreakdown exported by sun.js', false);
     } else {
@@ -139,7 +139,7 @@ const _origProfileSex = window._labState ? window._labState.profileSex : null;
   // ─── 5. v1.6.7 Measurement retention model (latest per roomId+tool) ─
   console.log('%c 5. Latest-per-(roomId, tool) measurement model ', 'font-weight:bold;color:#0891b2');
   {
-    const S = window._labState;
+    const S = state;
     if (!S || typeof lightTools.saveMeasurement !== 'function' || typeof lightTools.getMeasurements !== 'function') {
       assert('saveMeasurement / getMeasurements exported', false);
     } else {
@@ -697,8 +697,8 @@ const _origProfileSex = window._labState ? window._labState.profileSex : null;
   }
 
   // ─── Restore state ──────────────────────────────────────────────────
-  if (window._labState && _origImported) window._labState.importedData = _origImported;
-  if (window._labState) window._labState.profileSex = _origProfileSex;
+  if (state && _origImported) state.importedData = _origImported;
+  if (state) state.profileSex = _origProfileSex;
 
 console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
 process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

- migrate the five remaining Node light/Sun regression fixtures from `window._labState` to the explicit `state` module export
- keep all existing state isolation, restoration, and module-boundary assertions intact
- ratchet the guarded test-file ceiling from 28 to 23

This is test-only, so no app cache/version bump is required.

## Validation

- five targeted light/Sun Node fixtures — 439 assertions passed
- `node tests/test-quality-guardrails.js` — 25 passed
- `npm run quality` — 11 passed; 1/1 app files and 23/23 test files within the `_labState` ceilings
- `./run-tests.sh` — 399 Vitest tests, 352 Playwright tests, and 472 responsive-theme assertions passed

## Overall progress

- Before this PR: 29/58 files complete (50.0%)
- This PR: 5 light/Sun test consumers migrated
- After this PR: 34/58 files complete (58.6%)
- Entire work remaining: 24/58 files (41.4%) — the final app export plus 23 browser test consumers
