### PR TITLE
Migrate dashboard browser tests off lab state global

### DIFF
--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -6,7 +6,7 @@
   "viewRuntimeBridgeConsumers": 0,
   "viewRuntimeBridgeLookups": 0,
   "labStateAppFiles": 1,
-  "labStateTestFiles": 23,
+  "labStateTestFiles": 18,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/playwright/all-sessions-modal.spec.js
+++ b/tests/playwright/all-sessions-modal.spec.js
@@ -8,9 +8,11 @@ test('all sessions modal renders scrollable session list', async ({ page }) => {
   const before = await page.locator('.modal-overlay').count();
 
   await page.evaluate(async (sessionCount) => {
-    const viewsModule = await import('/js/views.js');
-    const state = window._labState;
-    if (!state?.importedData) throw new Error('window._labState.importedData unavailable');
+    const [{ state }, viewsModule] = await Promise.all([
+      import('/js/state.js'),
+      import('/js/views.js'),
+    ]);
+    if (!state?.importedData) throw new Error('state.importedData unavailable');
     if (typeof viewsModule._openAllSessionsModal !== 'function') {
       throw new Error('views._openAllSessionsModal unavailable');
     }

--- a/tests/playwright/biology-scores-dashboard-lens.spec.js
+++ b/tests/playwright/biology-scores-dashboard-lens.spec.js
@@ -2,7 +2,10 @@ import { expect, test } from './coverage-fixture.js';
 
 async function prepareDemoProfile(page) {
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() => !!window._labState);
+  await page.waitForFunction(async () => {
+    const { state } = await import('/js/state.js');
+    return !!state;
+  });
 
   await page.evaluate(async () => {
     const [{ getActiveProfileId }, dataModule, navModule] = await Promise.all([

--- a/tests/playwright/charts-browser-coverage.spec.js
+++ b/tests/playwright/charts-browser-coverage.spec.js
@@ -14,7 +14,10 @@ test('charts browser coverage exercises annotation supplement and theme callback
   await openBlankPage(page);
 
   const results = await page.evaluate(async ({ chartsUrl }) => {
-    const charts = await import(chartsUrl);
+    const [{ state }, charts] = await Promise.all([
+      import('/js/state.js'),
+      import(chartsUrl),
+    ]);
     const outcomes = {};
 
     const rootStyle = document.documentElement.style;
@@ -205,7 +208,7 @@ test('charts browser coverage exercises annotation supplement and theme callback
       return { canvas: canvasArg, options: config.options, data: config.data, update: () => {} };
     };
     try {
-      window._labState.rangeMode = 'optimal';
+      state.rangeMode = 'optimal';
       charts.createLineChart('coverage-marker', {
         name: 'Coverage Marker',
         unit: 'mg/L',
@@ -255,7 +258,7 @@ test('charts browser coverage exercises annotation supplement and theme callback
       updateMode: null,
       update(mode) { this.updateMode = mode; },
     };
-    window._labState.chartInstances = { themedChart };
+    state.chartInstances = { themedChart };
     charts.refreshChartThemeColors();
     outcomes.refreshChartThemeColorsAppliesLegendTooltipScalesAndDatasetColors = themedChart.updateMode === 'none'
       && themedChart.options.plugins.legend.labels.color === '#cbd5e1'

--- a/tests/playwright/data-browser-coverage.spec.js
+++ b/tests/playwright/data-browser-coverage.spec.js
@@ -21,8 +21,10 @@ test('data browser coverage exercises display toggles range refresh and helpers'
   await openBlankPage(page);
 
   const results = await page.evaluate(async () => {
-    const dataMod = await import('/js/data.js');
-    const state = window._labState;
+    const [{ state }, dataMod] = await Promise.all([
+      import('/js/state.js'),
+      import('/js/data.js'),
+    ]);
     const calls = [];
     const outcomes = {};
     const formerGlobalNames = [

--- a/tests/playwright/mobile-dashboard-browser-coverage.spec.js
+++ b/tests/playwright/mobile-dashboard-browser-coverage.spec.js
@@ -35,8 +35,10 @@ test('mobile dashboard browser coverage exercises defaults breakpoint search and
     });
     window.scrollTo = (...args) => calls.push(['scrollTo', ...args]);
 
-    const mobileDashboard = await import(mobileDashboardUrl);
-    const state = window._labState;
+    const [{ state }, mobileDashboard] = await Promise.all([
+      import('/js/state.js'),
+      import(mobileDashboardUrl),
+    ]);
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
     const originalState = {
       importedData: clone(state.importedData),

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -61,7 +61,7 @@ assert('quality guardrail ratchets _labState retirement by file',
     guardrailSrc.includes('labStateAppFiles') &&
     guardrailSrc.includes('labStateTestFiles') &&
     baseline.labStateAppFiles === 1 &&
-    baseline.labStateTestFiles === 23);
+    baseline.labStateTestFiles === 18);
 const forbiddenAppEventWindowGlobals = [
   'closeModal',
   'toggleChatPanel',


### PR DESCRIPTION
## Summary
- migrate five dashboard and visualization browser fixtures from `window._labState` to the explicit `state` module export
- load state alongside the feature module in each browser context
- ratchet the quality ceiling from 23 to 18 test files

This is test-only, so no app cache version bump is required.

## Validation
- focused Playwright batch: 9 passed
- `node tests/test-quality-guardrails.js`: 25 passed
- `npm run quality`: 11 checks passed; all 461 JavaScript modules parsed
- `./run-tests.sh`: 399 Vitest tests, 352 Playwright tests, and 472 responsive-theme assertions passed

## Overall progress
- before this PR: 34/58 files complete (58.6%)
- completed here: 5/58 files (8.6%)
- after this PR: 39/58 files complete (67.2%)
- entire work remaining: 19/58 files (32.8%) — the final app export plus 18 browser test files
