### PR TITLE
Migrate Light browser tests off lab state global

### DIFF
--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -6,7 +6,7 @@
   "viewRuntimeBridgeConsumers": 0,
   "viewRuntimeBridgeLookups": 0,
   "labStateAppFiles": 1,
-  "labStateTestFiles": 18,
+  "labStateTestFiles": 14,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/playwright/light-ai-analysis-coverage-batch.spec.js
+++ b/tests/playwright/light-ai-analysis-coverage-batch.spec.js
@@ -8,13 +8,13 @@ test('sun and device session AI analysis covers contexts fingerprints and render
   await page.goto('/app', { waitUntil: 'load' });
 
   const results = await page.evaluate(async ({ sunUrl, deviceUrl, apiUrl }) => {
-    const [sun, device, api, aiVerdictRuntime] = await Promise.all([
+    const [{ state }, sun, device, api, aiVerdictRuntime] = await Promise.all([
+      import('/js/state.js'),
       import(sunUrl),
       import(deviceUrl),
       import(apiUrl),
       import('/js/ai-verdict-engine-runtime.js'),
     ]);
-    const state = window._labState;
     const outcomes = {};
     const saved = {
       importedData: JSON.parse(JSON.stringify(state.importedData || {})),
@@ -354,14 +354,14 @@ test('light environment AI analysis covers audit room screen and onboarding verd
   await page.goto('/app', { waitUntil: 'load' });
 
   const results = await page.evaluate(async ({ auditUrl, roomUrl, screenUrl, onboardingUrl }) => {
-    const [audit, roomAI, screenAI, onboarding, aiVerdictRuntime] = await Promise.all([
+    const [{ state }, audit, roomAI, screenAI, onboarding, aiVerdictRuntime] = await Promise.all([
+      import('/js/state.js'),
       import(auditUrl),
       import(roomUrl),
       import(screenUrl),
       import(onboardingUrl),
       import('/js/ai-verdict-engine-runtime.js'),
     ]);
-    const state = window._labState;
     const outcomes = {};
     const saved = {
       importedData: JSON.parse(JSON.stringify(state.importedData || {})),
@@ -633,13 +633,13 @@ test('light aggregate AI analysis covers channel burden and daily verdicts', asy
   await page.goto('/app', { waitUntil: 'load' });
 
   const results = await page.evaluate(async ({ channelUrl, burdenUrl, todayUrl }) => {
-    const [channelAI, burdenAI, todayAI, aiVerdictRuntime] = await Promise.all([
+    const [{ state }, channelAI, burdenAI, todayAI, aiVerdictRuntime] = await Promise.all([
+      import('/js/state.js'),
       import(channelUrl),
       import(burdenUrl),
       import(todayUrl),
       import('/js/ai-verdict-engine-runtime.js'),
     ]);
-    const state = window._labState;
     const outcomes = {};
     const saved = {
       importedData: JSON.parse(JSON.stringify(state.importedData || {})),

--- a/tests/playwright/light-coverage-batch-2.spec.js
+++ b/tests/playwright/light-coverage-batch-2.spec.js
@@ -8,8 +8,10 @@ test('light device setup covers preset pick custom form validation unit conversi
   await page.goto('/app', { waitUntil: 'load' });
 
   const results = await page.evaluate(async ({ setupUrl }) => {
-    const setup = await import(setupUrl);
-    const state = window._labState;
+    const [{ state }, setup] = await Promise.all([
+      import('/js/state.js'),
+      import(setupUrl),
+    ]);
     const outcomes = {};
     const calls = [];
     const saved = {
@@ -257,8 +259,10 @@ test('light channel view covers pills detail panels suggestions and light-page r
   await page.goto('/app', { waitUntil: 'load' });
 
   const results = await page.evaluate(async ({ channelUrl }) => {
-    const channel = await import(channelUrl);
-    const state = window._labState;
+    const [{ state }, channel] = await Promise.all([
+      import('/js/state.js'),
+      import(channelUrl),
+    ]);
     const outcomes = {};
     const calls = [];
     const host = document.createElement('section');
@@ -413,8 +417,10 @@ test('light tools AI analysis covers per-tool contexts fingerprints and inline s
   await page.goto('/app', { waitUntil: 'load' });
 
   const results = await page.evaluate(async ({ analysisUrl }) => {
-    const analysis = await import(analysisUrl);
-    const state = window._labState;
+    const [{ state }, analysis] = await Promise.all([
+      import('/js/state.js'),
+      import(analysisUrl),
+    ]);
     const outcomes = {};
     const saved = {
       importedData: JSON.parse(JSON.stringify(state.importedData || {})),

--- a/tests/playwright/light-env-browser-coverage.spec.js
+++ b/tests/playwright/light-env-browser-coverage.spec.js
@@ -13,9 +13,17 @@ function expectAll(outcomes) {
   expect(failed).toEqual([]);
 }
 
+async function waitForInitialView(page) {
+  await page.waitForFunction(async () => {
+    const { state } = await import('/js/state.js');
+    return typeof state.currentView === 'string' && state.currentView.length > 0;
+  });
+}
+
 test('light environment browser coverage handles summary modal prompt and source helpers', async ({ page }) => {
   await page.addInitScript(seedCompletedTour);
   await page.goto('/app', { waitUntil: 'load' });
+  await waitForInitialView(page);
 
   const outcomes = await page.evaluate(async () => {
     const [{ state }, data, lightEnv] = await Promise.all([
@@ -203,6 +211,7 @@ test('light environment browser coverage handles summary modal prompt and source
 test('light environment browser coverage handles screens tools and confirm deletes', async ({ page }) => {
   await page.addInitScript(seedCompletedTour);
   await page.goto('/app', { waitUntil: 'load' });
+  await waitForInitialView(page);
 
   const outcomes = await page.evaluate(async () => {
     const [{ state }, data, lightEnv] = await Promise.all([

--- a/tests/playwright/light-page-view.spec.js
+++ b/tests/playwright/light-page-view.spec.js
@@ -6,7 +6,10 @@ function moduleUrl(path) {
 
 test('Light page view delegates session, link, channel, and prompt actions', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() => !!window._labState);
+  await page.waitForFunction(async () => {
+    const { state } = await import('/js/state.js');
+    return !!state;
+  });
 
   const results = await page.evaluate(async () => {
     const { configureLightPageView, renderDashboardLightChannelPills, renderLightSessionLogActions } = await import('/js/light-page-view.js');

--- a/tests/playwright/light-sun-coverage-batch.spec.js
+++ b/tests/playwright/light-sun-coverage-batch.spec.js
@@ -8,8 +8,10 @@ test('sun session UI covers list detail edit delete and past-session save paths'
   await page.goto('/app', { waitUntil: 'load' });
 
   const results = await page.evaluate(async ({ sunSessionUiUrl }) => {
-    const sunUI = await import(sunSessionUiUrl);
-    const state = window._labState;
+    const [{ state }, sunUI] = await Promise.all([
+      import('/js/state.js'),
+      import(sunSessionUiUrl),
+    ]);
     const outcomes = {};
     const originalView = state.currentView;
     let sessions = [
@@ -252,9 +254,11 @@ test('sun active session covers start dialog stop summary and live dose helpers'
   await page.goto('/app', { waitUntil: 'load' });
 
   const results = await page.evaluate(async ({ activeUrl, sessionUiUrl }) => {
-    const active = await import(activeUrl);
-    const sunUI = await import(sessionUiUrl);
-    const state = window._labState;
+    const [{ state }, active, sunUI] = await Promise.all([
+      import('/js/state.js'),
+      import(activeUrl),
+      import(sessionUiUrl),
+    ]);
     const outcomes = {};
     const originalImported = JSON.parse(JSON.stringify(state.importedData || {}));
     let sessions = [{
@@ -789,12 +793,21 @@ test('light devices cover session detail edit log active card and rendered list 
   await page.goto('/app', { waitUntil: 'load' });
 
   const results = await page.evaluate(async ({ devicesUrl }) => {
-    const lightDevices = await import(devicesUrl);
-    const lightDevicesRuntime = await import('/js/light-devices-runtime.js');
-    const recommendationRuntime = await import('/js/recommendations-runtime.js');
-    const { profileStorageKey } = await import('/js/profile.js');
-    const blobStorage = await import('/js/blob-storage.js');
-    const state = window._labState;
+    const [
+      { state },
+      lightDevices,
+      lightDevicesRuntime,
+      recommendationRuntime,
+      { profileStorageKey },
+      blobStorage,
+    ] = await Promise.all([
+      import('/js/state.js'),
+      import(devicesUrl),
+      import('/js/light-devices-runtime.js'),
+      import('/js/recommendations-runtime.js'),
+      import('/js/profile.js'),
+      import('/js/blob-storage.js'),
+    ]);
     const outcomes = {};
     const originalImported = JSON.parse(JSON.stringify(state.importedData || {}));
     const importedStorageKey = profileStorageKey(state.currentProfile || 'default', 'imported');

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -61,7 +61,7 @@ assert('quality guardrail ratchets _labState retirement by file',
     guardrailSrc.includes('labStateAppFiles') &&
     guardrailSrc.includes('labStateTestFiles') &&
     baseline.labStateAppFiles === 1 &&
-    baseline.labStateTestFiles === 18);
+    baseline.labStateTestFiles === 14);
 const forbiddenAppEventWindowGlobals = [
   'closeModal',
   'toggleChatPanel',


### PR DESCRIPTION
## Summary
- migrate four remaining Light/Sun browser fixtures from `window._labState` to the explicit `state` module export
- load state alongside the feature modules in each browser context
- ratchet the quality ceiling from 18 to 14 test files
- make the Light environment fixture wait for the app's initial route before overriding state, removing a CI-only startup race

This is test-only, so no app cache version bump is required.

## Validation
- focused migration Playwright batch: 13 passed
- Light environment CI-race stress run: 20 passed across 10 repetitions
- `node tests/test-quality-guardrails.js`: 25 passed
- `npm run quality`: 11 checks passed; all 461 JavaScript modules parsed
- `./run-tests.sh` after the CI fix: 399 Vitest tests, 352 Playwright tests, and 472 responsive-theme assertions passed

## CI follow-up
The initial GitHub test run had 351/352 Playwright cases pass. The unrelated Light environment fixture raced asynchronous startup and missed two mocked navigation calls. Waiting for the initial app route removes that race; the affected spec and full suite are green locally, and required checks are rerunning on the new head.

## Overall progress
- before this PR: 39/58 files complete (67.2%)
- completed here: 4/58 files (6.9%)
- after this PR: 43/58 files complete (74.1%)
- entire work remaining: 15/58 files (25.9%) — the final app export plus 14 browser test files
