### PR TITLE
Migrate import and export tests off lab state global

### DIFF
--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -6,7 +6,7 @@
   "viewRuntimeBridgeConsumers": 0,
   "viewRuntimeBridgeLookups": 0,
   "labStateAppFiles": 1,
-  "labStateTestFiles": 14,
+  "labStateTestFiles": 9,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/playwright/cycle-import-browser-coverage.spec.js
+++ b/tests/playwright/cycle-import-browser-coverage.spec.js
@@ -181,10 +181,11 @@ test('Clue JSON import is classified as cycle data and reaches the preview', asy
 test('cycle import confirms before changing an explicitly male profile', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
   const profileId = await initializeCycleProfile(page, 'cycle_profile_sex_confirmation');
-  await page.evaluate(() => {
-    window._labState.profileSex = 'male';
-    window._labState.profiles[0].sex = 'male';
-    localStorage.setItem('labcharts-profiles', JSON.stringify(window._labState.profiles));
+  await page.evaluate(async () => {
+    const { state } = await import('/js/state.js');
+    state.profileSex = 'male';
+    state.profiles[0].sex = 'male';
+    localStorage.setItem('labcharts-profiles', JSON.stringify(state.profiles));
   });
   await page.locator('#pdf-input').setInputFiles({
     name: 'ClueBackup.json',
@@ -198,12 +199,12 @@ test('cycle import confirms before changing an explicitly male profile', async (
   await expect(page.locator('#confirm-dialog-overlay')).toContainText('Change the profile to Female');
   await page.locator('#confirm-cancel').click();
   await expect(preview).toHaveClass(/show/);
-  expect(await page.evaluate(() => window._labState.profileSex)).toBe('male');
+  expect(await page.evaluate(async () => (await import('/js/state.js')).state.profileSex)).toBe('male');
 
   await page.locator('[data-cycle-import-action="confirm"]').click();
   await page.locator('#confirm-ok').click();
   await expect(preview).not.toHaveClass(/show/);
-  expect(await page.evaluate(() => window._labState.profileSex)).toBe('female');
+  expect(await page.evaluate(async () => (await import('/js/state.js')).state.profileSex)).toBe('female');
   await page.evaluate(async id => (await import('/js/cycle-store.js')).deleteCycleDB(id), profileId);
 });
 
@@ -277,10 +278,14 @@ test('shared Apple Health ZIP import saves wearable metrics before cycle review'
 
   await page.locator('[data-cycle-import-action="confirm"]').click();
   await expect(preview).not.toHaveClass(/show/);
-  await expect.poll(() => page.evaluate(() => window._labState.importedData.menstrualCycle?.periods?.length || 0)).toBe(1);
+  await expect.poll(() => page.evaluate(async () => {
+    const { state } = await import('/js/state.js');
+    return state.importedData.menstrualCycle?.periods?.length || 0;
+  })).toBe(1);
 
-  const periods = await page.evaluate(id => {
-    const result = window._labState.importedData.menstrualCycle.periods.map(period => ({
+  const periods = await page.evaluate(async id => {
+    const { state } = await import('/js/state.js');
+    const result = state.importedData.menstrualCycle.periods.map(period => ({
       startDate: period.startDate,
       endDate: period.endDate,
       source: period.source,
@@ -399,19 +404,21 @@ test('cycle import only shows conflict controls and row warnings for real overla
   await page.goto('/app', { waitUntil: 'load' });
   const profileId = await initializeCycleProfile(page, 'cycle_import_conflicts');
 
-  await page.evaluate((csv) => {
-    import('/js/cycle-import.js').then(cycleImport => {
-      window._labState.importedData.menstrualCycle = {
-        periods: [{
-          startDate: '2026-04-01',
-          endDate: '2026-04-04',
-          flow: 'moderate',
-          source: 'manual',
-        }],
-      };
-      const parsed = cycleImport.parseDripCycleCsv(csv, 'drip-conflicts.csv');
-      void cycleImport.showCycleImportPreview(parsed);
-    });
+  await page.evaluate(async (csv) => {
+    const [{ state }, cycleImport] = await Promise.all([
+      import('/js/state.js'),
+      import('/js/cycle-import.js'),
+    ]);
+    state.importedData.menstrualCycle = {
+      periods: [{
+        startDate: '2026-04-01',
+        endDate: '2026-04-04',
+        flow: 'moderate',
+        source: 'manual',
+      }],
+    };
+    const parsed = cycleImport.parseDripCycleCsv(csv, 'drip-conflicts.csv');
+    void cycleImport.showCycleImportPreview(parsed);
   }, DRIP_CSV);
 
   const modal = page.locator('#import-modal');

--- a/tests/playwright/import-review-browser-coverage.spec.js
+++ b/tests/playwright/import-review-browser-coverage.spec.js
@@ -135,7 +135,7 @@ test('PDF import review modal covers filtering mapping exclusion and batch close
 
   const results = await page.evaluate(async ({ reviewUrl }) => {
     const review = await import(reviewUrl);
-    const state = window._labState;
+    const { state } = await import('/js/state.js');
     const outcomes = {};
     const originalProfile = state.currentProfile;
     const dropZone = document.getElementById('drop-zone');
@@ -529,7 +529,8 @@ test('PDF import review draft restores after refresh', async ({ page }) => {
     const dispatchChange = el => el?.dispatchEvent(new Event('change', { bubbles: true }));
     sessionStorage.removeItem('labcharts-import-review-draft-v1');
     localStorage.setItem('labcharts-active-profile', 'default');
-    window._labState.currentProfile = 'default';
+    const { state } = await import('/js/state.js');
+    state.currentProfile = 'default';
     review.showImportPreview({
       date: '2026-06-05',
       fileName: 'refresh-review.pdf',
@@ -668,7 +669,7 @@ test('PDF import persistence covers snapshots removal and date rename prompts', 
   const results = await page.evaluate(async ({ persistenceUrl }) => {
     const persistence = await import(persistenceUrl);
     const reviewRuntime = await import('/js/pdf-import-review-runtime.js');
-    const state = window._labState;
+    const { state } = await import('/js/state.js');
     const outcomes = {};
     const originals = {
       importedData: JSON.parse(JSON.stringify(state.importedData || {})),

--- a/tests/playwright/pdf-import-browser-coverage.spec.js
+++ b/tests/playwright/pdf-import-browser-coverage.spec.js
@@ -15,7 +15,7 @@ test('PDF import progress and AI-needed dialog cover browser UI states', async (
       import('/js/settings-runtime-bridge.js'),
       import('/js/pdf-import-review-runtime.js'),
     ]);
-    const state = window._labState;
+    const { state } = await import('/js/state.js');
     const outcomes = {};
     const saved = {
       profileSex: state.profileSex,
@@ -267,7 +267,7 @@ test('PDF import runtime handlers cover AI parse fallback text and image routes'
       import(pdfImportUrl),
       import(reviewUrl),
     ]);
-    const state = window._labState;
+    const { state } = await import('/js/state.js');
     const outcomes = {};
     const storageKeys = [
       'labcharts-ai-provider',
@@ -708,7 +708,7 @@ test('PDF import confirm flow covers preview persistence', async ({ page }) => {
       import(reviewUrl),
       import('/js/pdf-import-commit.js'),
     ]);
-    const state = window._labState;
+    const { state } = await import('/js/state.js');
     const outcomes = {};
     const storage = new Map(Array.from({ length: localStorage.length }, (_, i) => {
       const key = localStorage.key(i);
@@ -801,7 +801,7 @@ test('PDF import preflight covers model mismatch and unsupported lab dialogs', a
 
   const results = await page.evaluate(async ({ preflightUrl }) => {
     const preflight = await import(preflightUrl);
-    const state = window._labState;
+    const { state } = await import('/js/state.js');
     const outcomes = {};
     const originalEntries = Array.isArray(state.importedData?.entries)
       ? JSON.parse(JSON.stringify(state.importedData.entries))
@@ -922,7 +922,7 @@ test('PDF import preflight covers duplicate prompts, cancellation, and supported
       import(preflightUrl),
       import(utilsUrl),
     ]);
-    const state = window._labState;
+    const { state } = await import('/js/state.js');
     const outcomes = {};
     const originals = {
       importedData: JSON.parse(JSON.stringify(state.importedData || {})),

--- a/tests/playwright/report-export-browser-coverage.spec.js
+++ b/tests/playwright/report-export-browser-coverage.spec.js
@@ -12,7 +12,7 @@ test('report builder modal delegates presets categories AI state and preview exp
     const builder = await import(builderUrl);
     const dataModule = await import('/js/data.js');
     const profile = await import('/js/profile.js');
-    const state = window._labState;
+    const { state } = await import('/js/state.js');
     const outcomes = {};
     const originalProfiles = profile.getProfiles();
     if (!Array.isArray(originalProfiles)) {
@@ -253,7 +253,7 @@ test('report payload and HTML cover filtered context genetics and supplement bra
       import('/js/profile.js'),
       import('/js/data.js'),
     ]);
-    const state = window._labState;
+    const { state } = await import('/js/state.js');
     const outcomes = {};
     const originalProfiles = profile.getProfiles();
     const original = {
@@ -485,7 +485,7 @@ test('report HTML renderer covers sparse single-date trend and print branches', 
   const results = await page.evaluate(async ({ htmlUrl }) => {
     const html = await import(htmlUrl);
     const dataModule = await import('/js/data.js');
-    const state = window._labState;
+    const { state } = await import('/js/state.js');
     const outcomes = {};
     const original = {
       importedData: JSON.parse(JSON.stringify(state.importedData || {})),
@@ -748,7 +748,7 @@ test('report AI summary generation covers unavailable success and empty-response
     const report = await import(reportUrl);
     const dataModule = await import('/js/data.js');
     const profile = await import('/js/profile.js');
-    const state = window._labState;
+    const { state } = await import('/js/state.js');
     const outcomes = {};
     const originalProfiles = profile.getProfiles();
     const original = {
@@ -890,7 +890,7 @@ test('report export helpers cover option normalization AI markup and popup block
     const report = await import(reportUrl);
     const html = await import(htmlUrl);
     const dataModule = await import('/js/data.js');
-    const state = window._labState;
+    const { state } = await import('/js/state.js');
     const outcomes = {};
     const original = {
       importedData: JSON.parse(JSON.stringify(state.importedData || {})),
@@ -972,7 +972,7 @@ test('export facade covers JSON downloads imports chat bundle and clear cancel',
       import(cryptoUrl),
       import('/js/data.js'),
     ]);
-    const state = window._labState;
+    const { state } = await import('/js/state.js');
     const outcomes = {};
     const profileId = 'export-facade-coverage';
     const originalProfiles = profileStore.getProfiles();

--- a/tests/playwright/settings-browser-coverage.spec.js
+++ b/tests/playwright/settings-browser-coverage.spec.js
@@ -38,7 +38,7 @@ test('settings browser coverage exercises delegates for themes tweaks privacy us
       headers: { 'Content-Type': 'application/json' },
     });
 
-    const state = window._labState;
+    const { state } = await import('/js/state.js');
     const profileId = 'settings-browser-coverage-profile';
     const usageKey = `labcharts-${profileId}-usage`;
     const saved = {
@@ -232,7 +232,7 @@ test('settings browser coverage renames imported entry dates through the data se
       throw new Error(`Timed out waiting for ${label}`);
     };
 
-    const state = window._labState;
+    const { state } = await import('/js/state.js');
     const profileId = 'settings-rename-coverage-profile';
     const saved = {
       importedData: JSON.parse(JSON.stringify(state.importedData || {})),

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -61,7 +61,7 @@ assert('quality guardrail ratchets _labState retirement by file',
     guardrailSrc.includes('labStateAppFiles') &&
     guardrailSrc.includes('labStateTestFiles') &&
     baseline.labStateAppFiles === 1 &&
-    baseline.labStateTestFiles === 14);
+    baseline.labStateTestFiles === 9);
 const forbiddenAppEventWindowGlobals = [
   'closeModal',
   'toggleChatPanel',


### PR DESCRIPTION
## Summary
- migrate five cycle import, PDF import/review, report export, and settings browser fixtures from `window._labState` to the explicit `state` module export
- preserve the existing browser-context behavior while removing the hidden global dependency
- ratchet the quality ceiling from 14 to 9 test files

This is test-only, so no app cache version bump is required.

## Validation
- focused Playwright batch: 31 passed
- `node tests/test-quality-guardrails.js`: 25 passed
- `npm run quality`: 11 checks passed; all 461 JavaScript modules parsed
- `./run-tests.sh`: 399 Vitest tests, 352 Playwright tests, and 472 responsive-theme assertions passed

## Overall progress
- before this PR: 43/58 files complete (74.1%)
- completed here: 5/58 files (8.6%)
- after this PR: 48/58 files complete (82.8%)
- entire work remaining: 10/58 files (17.2%) — the final app export plus 9 browser test files
