### PR TITLE
Migrate DOM browser tests off lab state global

### DIFF
--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -6,7 +6,7 @@
   "viewRuntimeBridgeConsumers": 0,
   "viewRuntimeBridgeLookups": 0,
   "labStateAppFiles": 1,
-  "labStateTestFiles": 9,
+  "labStateTestFiles": 2,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/playwright/audit-dom.spec.js
+++ b/tests/playwright/audit-dom.spec.js
@@ -2,7 +2,10 @@ import { expect, test } from './coverage-fixture.js';
 
 test('audit runtime guards no-op on adversarial marker ids', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() => !!window._labState);
+  await page.waitForFunction(async () => {
+    const { state } = await import('/js/state.js');
+    return !!state;
+  });
 
   const results = await page.evaluate(async () => {
     const [{ state }, dataModule, viewsModule, navModule, categoryPageModule] = await Promise.all([

--- a/tests/playwright/browser-coverage-batch.spec.js
+++ b/tests/playwright/browser-coverage-batch.spec.js
@@ -83,7 +83,7 @@ test('notes editor browser contract adds edits and deletes notes', async ({ page
       import(notesUrl),
       import(notesRuntimeUrl),
     ]);
-    const state = window._labState;
+    const { state } = await import('/js/state.js');
     const outcomes = {};
     const originalNotes = Array.isArray(state.importedData?.notes)
       ? JSON.parse(JSON.stringify(state.importedData.notes))
@@ -295,7 +295,7 @@ test('discussion round and sync diagnose render helpers cover active and empty s
 
   const results = await page.evaluate(async ({ roundViewUrl, syncRenderUrl }) => {
     const roundView = await import(roundViewUrl);
-    const state = window._labState;
+    const { state } = await import('/js/state.js');
     const syncRender = await import(syncRenderUrl);
     const outcomes = {};
     const originalThreadId = state.currentThreadId;
@@ -454,7 +454,7 @@ test('import preflight and marker normalization cover browser decision paths', a
   const results = await page.evaluate(async ({ preflightUrl, normalizationUrl, utilsUrl }) => {
     const preflight = await import(preflightUrl);
     const normalization = await import(normalizationUrl);
-    const state = window._labState;
+    const { state } = await import('/js/state.js');
     const { hashString } = await import(utilsUrl);
     const outcomes = {};
     const originalEntries = Array.isArray(state.importedData?.entries)
@@ -534,7 +534,7 @@ test('sync diagnostics schema and snapshot helpers cover browser contracts', asy
     const diagnosticsText = await import(textUrl);
     const snapshot = await import(snapshotUrl);
     const diagnosticsContext = await import('/js/sync-diagnostics-context.js');
-    const state = window._labState;
+    const { state } = await import('/js/state.js');
     const outcomes = {};
     const originalProfile = state.currentProfile;
     const originalImported = JSON.parse(JSON.stringify(state.importedData || {}));
@@ -758,7 +758,7 @@ test('sync scalar merge storage cleanup and QR loader cover browser contracts', 
     const syncState = await import('/js/sync-state.js');
     const { profileStorageKey } = await import('/js/profile.js');
     const blobStorage = await import('/js/blob-storage.js');
-    const state = window._labState;
+    const { state } = await import('/js/state.js');
     const outcomes = {};
     const originalImported = JSON.parse(JSON.stringify(state.importedData || {}));
     const importedStorageKey = profileStorageKey(state.currentProfile || 'default', 'imported');
@@ -866,7 +866,7 @@ test('discussion round runner covers empty and missing container paths', async (
   const results = await page.evaluate(async ({ runnerUrl }) => {
     const runner = await import(runnerUrl);
     const callbacks = await import('/js/chat-discussion-callbacks.js');
-    const state = window._labState;
+    const { state } = await import('/js/state.js');
     const outcomes = {};
     const originalThreadId = state.currentThreadId;
     const originalHistory = Array.isArray(state.chatHistory)
@@ -936,7 +936,7 @@ test('sync diagnose action helpers cover guarded UI branches', async ({ page }) 
     const actionContext = await import('/js/sync-diagnose-actions-context.js');
     const confirmRuntime = await import('/js/sync-diagnose-runtime.js');
     const relayHealth = await import('/js/sync-relay-health.js');
-    const state = window._labState;
+    const { state } = await import('/js/state.js');
     const outcomes = {};
     let confirmAnswer = false;
     const originalConfirmDeps = confirmRuntime.configureSyncDiagnoseRuntimeDeps({

--- a/tests/playwright/chat-actions-dom.spec.js
+++ b/tests/playwright/chat-actions-dom.spec.js
@@ -2,13 +2,16 @@ import { expect, test } from './coverage-fixture.js';
 
 test('chat action bars, clipboard, and context toggles work in the live DOM', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() => !!window._labState);
+  await page.waitForFunction(async () => {
+    const { state } = await import('/js/state.js');
+    return !!state;
+  });
 
   const results = await page.evaluate(async () => {
     const api = await import('/js/api.js');
     const chatActions = await import('/js/chat-actions.js');
     const chatRender = await import('/js/chat-render.js');
-    const state = window._labState;
+    const { state } = await import('/js/state.js');
     const originalHistory = JSON.parse(JSON.stringify(state.chatHistory || []));
     const outcomes = {};
 
@@ -145,7 +148,10 @@ test('chat action bars, clipboard, and context toggles work in the live DOM', as
 
 test('chat action browser coverage handles copy and regenerate branches', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() => !!window._labState);
+  await page.waitForFunction(async () => {
+    const { state } = await import('/js/state.js');
+    return !!state;
+  });
 
   const results = await page.evaluate(async () => {
     const [chatActions, chatRuntime, chatThreads] = await Promise.all([
@@ -153,7 +159,7 @@ test('chat action browser coverage handles copy and regenerate branches', async 
       import('/js/chat-runtime.js'),
       import('/js/chat-threads.js'),
     ]);
-    const state = window._labState;
+    const { state } = await import('/js/state.js');
     const outcomes = {};
     const copied = [];
     const threadStorageKey = state.currentThreadId

--- a/tests/playwright/chat-threads-dom.spec.js
+++ b/tests/playwright/chat-threads-dom.spec.js
@@ -2,7 +2,10 @@ import { expect, test } from './coverage-fixture.js';
 
 test('chat thread rail and delegated thread actions work in the live DOM', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() => !!window._labState);
+  await page.waitForFunction(async () => {
+    const { state } = await import('/js/state.js');
+    return !!state;
+  });
 
   const results = await page.evaluate(async () => {
     const chatThreads = await import('/js/chat-threads.js');

--- a/tests/playwright/custom-personality-dom.spec.js
+++ b/tests/playwright/custom-personality-dom.spec.js
@@ -311,7 +311,10 @@ test('custom personality save path updates picker, header, and persisted state',
   ];
 
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() => !!window._labState);
+  await page.waitForFunction(async () => {
+    const { state } = await import('/js/state.js');
+    return !!state;
+  });
 
   const results = await page.evaluate(async () => {
     const [{ state }, chatPersonalities, chatRuntime] = await Promise.all([

--- a/tests/playwright/dashboard-widget-delegated-actions-dom.spec.js
+++ b/tests/playwright/dashboard-widget-delegated-actions-dom.spec.js
@@ -2,7 +2,10 @@ import { expect, test } from './coverage-fixture.js';
 
 test('dashboard widget delegated actions cover organize, picker, biometrics, and body actions', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() => !!window._labState);
+  await page.waitForFunction(async () => {
+    const { state } = await import('/js/state.js');
+    return !!state;
+  });
 
   const results = await page.evaluate(async () => {
     const [{ state }, dataModule, dashboardWidgetsModule, contextCardsRuntime, dashboardWidgetRuntime, wearablesRuntime, viewsModule, navModule] = await Promise.all([
@@ -246,7 +249,10 @@ test('dashboard widget delegated actions cover organize, picker, biometrics, and
 
 test('dashboard widget state transitions cover layout, recommendations, and picker branches', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() => !!window._labState);
+  await page.waitForFunction(async () => {
+    const { state } = await import('/js/state.js');
+    return !!state;
+  });
 
   const results = await page.evaluate(async () => {
     const { state } = await import('/js/state.js');

--- a/tests/playwright/lens-page-shell.spec.js
+++ b/tests/playwright/lens-page-shell.spec.js
@@ -11,7 +11,10 @@ async function prepareApp(page) {
     localStorage.setItem(`labcharts-${profileId}-tour`, 'completed');
   });
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() => !!window._labState);
+  await page.waitForFunction(async () => {
+    const { state } = await import('/js/state.js');
+    return !!state;
+  });
 }
 
 test('lens page shell default dashboard deps render fallback widgets', async ({ page }) => {

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -61,7 +61,7 @@ assert('quality guardrail ratchets _labState retirement by file',
     guardrailSrc.includes('labStateAppFiles') &&
     guardrailSrc.includes('labStateTestFiles') &&
     baseline.labStateAppFiles === 1 &&
-    baseline.labStateTestFiles === 9);
+    baseline.labStateTestFiles === 2);
 const forbiddenAppEventWindowGlobals = [
   'closeModal',
   'toggleChatPanel',


### PR DESCRIPTION
## Summary
- migrate seven audit, chat, dashboard, lens, and mixed browser fixtures from `window._labState` to the explicit `state` module export
- replace readiness probes with explicit state-module loading
- ratchet the quality ceiling from 9 to 2 test files

This is test-only, so no app cache version bump is required.

## Validation
- focused Playwright batch: 21 passed
- targeted load-stability reruns: 2 wearable OAuth cases passed; responsive-theme case passed all 472 assertions
- `node tests/test-quality-guardrails.js`: 25 passed
- `npm run quality`: 11 checks passed; all 461 JavaScript modules parsed
- fresh `./run-tests.sh`: 399 Vitest tests, 352 Playwright tests, and 472 responsive-theme assertions passed

## Overall progress
- before this PR: 48/58 files complete (82.8%)
- completed here: 7/58 files (12.1%)
- after this PR: 55/58 files complete (94.8%)
- entire work remaining: 3/58 files (5.2%) — the final app export plus 2 browser test files
