### PR TITLE
Migrate final browser tests off lab state global

### DIFF
--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -6,7 +6,7 @@
   "viewRuntimeBridgeConsumers": 0,
   "viewRuntimeBridgeLookups": 0,
   "labStateAppFiles": 1,
-  "labStateTestFiles": 2,
+  "labStateTestFiles": 0,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/playwright/sync-two-device-e2e.spec.js
+++ b/tests/playwright/sync-two-device-e2e.spec.js
@@ -114,9 +114,12 @@ async function makePage(browser, label, importedData, recordPageError, testInfo)
     });
     await page.goto(BASE_URL, { waitUntil: 'networkidle', timeout: 20000 });
     await page.waitForFunction(
-      async () => window._labState
-        && typeof (await import('/js/sun-session-ui.js')).openSunSessionDetail === 'function'
-        && typeof (await import('/js/light-devices.js')).openDeviceSessionDetail === 'function',
+      async () => {
+        const { state } = await import('/js/state.js');
+        return !!state
+          && typeof (await import('/js/sun-session-ui.js')).openSunSessionDetail === 'function'
+          && typeof (await import('/js/light-devices.js')).openDeviceSessionDetail === 'function';
+      },
       null,
       { timeout: 15000 }
     );
@@ -151,15 +154,18 @@ async function makePage(browser, label, importedData, recordPageError, testInfo)
       { timeout: 15000 }
     );
     await page.evaluate(async ({ profileId, imported }) => {
-      const { saveImportedData } = await import('/js/data.js');
+      const [{ state }, { saveImportedData }] = await Promise.all([
+        import('/js/state.js'),
+        import('/js/data.js'),
+      ]);
       localStorage.clear();
       sessionStorage.clear();
       localStorage.setItem('labcharts-active-profile', profileId);
-      window._labState.currentProfile = profileId;
-      window._labState.currentView = 'dashboard';
-      window._labState.importedData = JSON.parse(JSON.stringify(imported));
-      window._labState.markerRegistry = {};
-      window._labState._activeDetailMarkerId = null;
+      state.currentProfile = profileId;
+      state.currentView = 'dashboard';
+      state.importedData = JSON.parse(JSON.stringify(imported));
+      state.markerRegistry = {};
+      state._activeDetailMarkerId = null;
       document.querySelectorAll('.modal-overlay').forEach(el => {
         if (el.id) el.classList.remove('show');
         else el.remove();
@@ -176,11 +182,15 @@ async function makePage(browser, label, importedData, recordPageError, testInfo)
 }
 
 async function getImportedData(page) {
-  return page.evaluate(() => JSON.parse(JSON.stringify(window._labState.importedData)));
+  return page.evaluate(async () => {
+    const { state } = await import('/js/state.js');
+    return JSON.parse(JSON.stringify(state.importedData));
+  });
 }
 
 async function pullRemoteImportedData(page, remoteImportedData) {
   return page.evaluate(async ({ profileId, remote }) => {
+    const { state } = await import('/js/state.js');
     const result = await window.__syncE2EMergePulledImportedData(profileId, JSON.parse(JSON.stringify(remote)), {
       debug: () => {},
     });
@@ -197,13 +207,14 @@ async function pullRemoteImportedData(page, remoteImportedData) {
       needsRebroadcast: result.needsRebroadcast,
       remoteBroughtNewRows: result.remoteBroughtNewRows,
       localDataChanged: result.localDataChanged,
-      merged: JSON.parse(JSON.stringify(window._labState.importedData)),
+      merged: JSON.parse(JSON.stringify(state.importedData)),
     };
   }, { profileId: PROFILE_ID, remote: remoteImportedData });
 }
 
 async function applyMergedImportedData(page, mergedImportedData, remoteBroughtNewRows = true) {
   return page.evaluate(async ({ profileId, merged, remoteBroughtNewRows: broughtRows }) => {
+    const { state } = await import('/js/state.js');
     window.__syncE2ERefreshActiveProfileAfterPull({
       profileId,
       merged: JSON.parse(JSON.stringify(merged)),
@@ -211,7 +222,7 @@ async function applyMergedImportedData(page, mergedImportedData, remoteBroughtNe
       remoteBroughtNewRows: broughtRows,
       debug: () => {},
     });
-    return JSON.parse(JSON.stringify(window._labState.importedData));
+    return JSON.parse(JSON.stringify(state.importedData));
   }, { profileId: PROFILE_ID, merged: mergedImportedData, remoteBroughtNewRows });
 }
 
@@ -230,7 +241,10 @@ async function openMarkerModal(page) {
 
 async function editOpenMarkerValue(page, newValue) {
   await page.evaluate(async ({ markerId, date, markerKey, mirrorKey, next }) => {
-    const viewsModule = await import('/js/views.js');
+    const [{ state }, viewsModule] = await Promise.all([
+      import('/js/state.js'),
+      import('/js/views.js'),
+    ]);
     const waitFor = async (fn, timeoutMs = 2500) => {
       const start = Date.now();
       while (Date.now() - start < timeoutMs) {
@@ -249,7 +263,7 @@ async function editOpenMarkerValue(page, newValue) {
     input.value = String(next);
     input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }));
     await waitFor(() => {
-      const entry = window._labState.importedData.entries?.find(e => e.date === date);
+      const entry = state.importedData.entries?.find(e => e.date === date);
       return entry?.markers?.[markerKey] === next
         && entry?.markers?.[mirrorKey] === next
         && !document.querySelector('#detail-modal input.ref-edit-input');
@@ -265,6 +279,7 @@ async function editOpenMarkerValue(page, newValue) {
 
 async function clickManualRevertBadge(page) {
   await page.evaluate(async ({ date, markerKey, mirrorKey, originalValue }) => {
+    const { state } = await import('/js/state.js');
     const waitFor = async (fn, timeoutMs = 5000) => {
       const start = Date.now();
       while (Date.now() - start < timeoutMs) {
@@ -286,11 +301,11 @@ async function clickManualRevertBadge(page) {
     if (!badge) throw new Error('Manual revert badge not found');
     badge.click();
     await waitFor(() => {
-      const entry = window._labState.importedData.entries?.find(e => e.date === date);
+      const entry = state.importedData.entries?.find(e => e.date === date);
       return entry?.markers?.[markerKey] === originalValue
         && entry?.markers?.[mirrorKey] === originalValue
-        && window._labState.importedData.manualValues?.[`${markerKey}:${date}`] === null
-        && window._labState.importedData.manualValues?.[`${mirrorKey}:${date}`] === null
+        && state.importedData.manualValues?.[`${markerKey}:${date}`] === null
+        && state.importedData.manualValues?.[`${mirrorKey}:${date}`] === null
         && !manualRevertBadge()
         && modalShowsOriginalValue();
     });
@@ -303,9 +318,10 @@ async function clickManualRevertBadge(page) {
 }
 
 async function markerModalSnapshot(page) {
-  return page.evaluate(({ date, markerKey, mirrorKey }) => {
+  return page.evaluate(async ({ date, markerKey, mirrorKey }) => {
+    const { state } = await import('/js/state.js');
     const modal = document.getElementById('detail-modal');
-    const entry = window._labState.importedData.entries?.find(e => e.date === date);
+    const entry = state.importedData.entries?.find(e => e.date === date);
     return {
       open: !!document.getElementById('modal-overlay')?.classList?.contains('show'),
       modalClass: modal?.className || '',
@@ -313,8 +329,8 @@ async function markerModalSnapshot(page) {
       badges: Array.from(modal?.querySelectorAll('.ref-edited-badge') || []).map(el => el.textContent.trim()),
       marker: entry?.markers?.[markerKey],
       mirror: entry?.markers?.[mirrorKey],
-      manualValue: window._labState.importedData.manualValues?.[`${markerKey}:${date}`],
-      mirrorManualValue: window._labState.importedData.manualValues?.[`${mirrorKey}:${date}`],
+      manualValue: state.importedData.manualValues?.[`${markerKey}:${date}`],
+      mirrorManualValue: state.importedData.manualValues?.[`${mirrorKey}:${date}`],
     };
   }, {
     date: LAB_DATE,
@@ -325,7 +341,7 @@ async function markerModalSnapshot(page) {
 
 async function navigateLight(page) {
   await page.evaluate(async () => (await import('/js/views.js')).navigate('light'));
-  await page.waitForFunction(() => window._labState.currentView === 'light', null, { timeout: 5000 });
+  await page.waitForFunction(async () => (await import('/js/state.js')).state.currentView === 'light', null, { timeout: 5000 });
 }
 
 async function openSunSessionModal(page) {
@@ -369,11 +385,12 @@ async function updateDeviceDuration(page, durationMin) {
 }
 
 async function sessionModalSnapshot(page, kind) {
-  return page.evaluate(({ kind, sunSessionId, deviceSessionId }) => {
+  return page.evaluate(async ({ kind, sunSessionId, deviceSessionId }) => {
+    const { state } = await import('/js/state.js');
     const modal = document.querySelector(`.modal-overlay.show .sun-detail-modal[data-session-kind="${kind}"]`);
     const source = kind === 'sun'
-      ? window._labState.importedData.sunSessions?.find(s => s.id === sunSessionId)
-      : window._labState.importedData.deviceSessions?.find(s => s.id === deviceSessionId);
+      ? state.importedData.sunSessions?.find(s => s.id === sunSessionId)
+      : state.importedData.deviceSessions?.find(s => s.id === deviceSessionId);
     return {
       open: !!modal,
       text: modal?.textContent || '',
@@ -398,11 +415,14 @@ async function closeFloatingModals(page) {
 
 async function enableAgentAccessForSync(page) {
   return page.evaluate(async () => {
-    const { saveImportedData } = await import('/js/data.js');
+    const [{ state }, { saveImportedData }] = await Promise.all([
+      import('/js/state.js'),
+      import('/js/data.js'),
+    ]);
     const token = 'syncagent'.padEnd(64, 'a');
     const contextKey = `gbctx_v1_${'S'.repeat(43)}`;
     const now = Date.now();
-    window._labState.importedData.agentAccess = {
+    state.importedData.agentAccess = {
       version: 1,
       enabled: true,
       token,
@@ -411,24 +431,25 @@ async function enableAgentAccessForSync(page) {
       revokedAt: null,
       updatedAt: now,
     };
-    window._labState.importedData.agentAccessWearableSeriesDays = 30;
+    state.importedData.agentAccessWearableSeriesDays = 30;
     localStorage.removeItem('labcharts-messenger-token');
     localStorage.removeItem('labcharts-agent-context-key');
     await saveImportedData({ immediate: true });
-    return JSON.parse(JSON.stringify(window._labState.importedData));
+    return JSON.parse(JSON.stringify(state.importedData));
   });
 }
 
 async function agentAccessSnapshot(page) {
   return page.evaluate(async () => {
+    const { state } = await import('/js/state.js');
     const messenger = window.__syncE2EMessenger;
     if (!messenger) throw new Error('sync-messenger helper module not loaded');
     return {
       enabled: messenger.isMessengerEnabled(),
       token: messenger.getMessengerToken(),
       contextKey: messenger.getMessengerContextKey(),
-      state: JSON.parse(JSON.stringify(window._labState.importedData.agentAccess || null)),
-      seriesDays: window._labState.importedData.agentAccessWearableSeriesDays,
+      state: JSON.parse(JSON.stringify(state.importedData.agentAccess || null)),
+      seriesDays: state.importedData.agentAccessWearableSeriesDays,
       legacyToken: localStorage.getItem('labcharts-messenger-token'),
       legacyContextKey: localStorage.getItem('labcharts-agent-context-key'),
     };
@@ -437,14 +458,17 @@ async function agentAccessSnapshot(page) {
 
 async function disableAgentAccessForSync(page) {
   return page.evaluate(async () => {
-    const { saveImportedData } = await import('/js/data.js');
+    const [{ state }, { saveImportedData }] = await Promise.all([
+      import('/js/state.js'),
+      import('/js/data.js'),
+    ]);
     const messenger = window.__syncE2EMessenger;
     if (!messenger) throw new Error('sync-messenger helper module not loaded');
     const previousToken = messenger.disableMessengerTokenLocal();
     await saveImportedData({ immediate: true });
     return {
       previousToken,
-      imported: JSON.parse(JSON.stringify(window._labState.importedData)),
+      imported: JSON.parse(JSON.stringify(state.importedData)),
     };
   });
 }

--- a/tests/playwright/theme-responsive-e2e.spec.js
+++ b/tests/playwright/theme-responsive-e2e.spec.js
@@ -45,7 +45,7 @@ function delay(ms) {
 
 async function waitForApp(page) {
   await page.waitForFunction(
-    () => !!window._labState,
+    async () => !!(await import('/js/state.js')).state,
     null,
     { timeout: 15000 }
   );
@@ -53,10 +53,13 @@ async function waitForApp(page) {
 
 async function seedDemoData(page) {
   await page.evaluate(async () => {
-    const dataModule = await import('/js/data.js');
-    const profileModule = await import('/js/profile.js');
+    const [{ state }, dataModule, profileModule] = await Promise.all([
+      import('/js/state.js'),
+      import('/js/data.js'),
+      import('/js/profile.js'),
+    ]);
     const demo = await fetch('/data/demo-male.json', { cache: 'no-store' }).then(r => r.json());
-    const profileId = window._labState.currentProfile || 'default';
+    const profileId = state.currentProfile || 'default';
     const profiles = profileModule.getProfiles() || [];
     let profile = profiles.find(p => p.id === profileId);
     if (!profile) {
@@ -101,9 +104,9 @@ async function seedDemoData(page) {
     window.fetchAtmosphere = fetchAtmosphereStub;
     const conditionsNow = await import('/js/light-conditions-now.js');
     conditionsNow.configureLightConditionsNow?.({ fetchAtmosphere: fetchAtmosphereStub });
-    window._labState.importedData = demo;
-    window._labState.profileSex = 'male';
-    window._labState.profileDob = '1987-11-22';
+    state.importedData = demo;
+    state.profileSex = 'male';
+    state.profileDob = '1987-11-22';
     await dataModule.saveImportedData();
     (await import('/js/nav.js')).buildSidebar();
     (await import('/js/views.js')).navigate('dashboard');
@@ -115,13 +118,15 @@ async function seedDemoData(page) {
 
 async function seedMobileLightSessions(page) {
   await page.evaluate(async () => {
-    const S = window._labState;
-    const { logCompletedSession } = await import('/js/sun-sessions-store.js');
-    if (!S?.importedData || typeof logCompletedSession !== 'function') return;
+    const [{ state }, { logCompletedSession }] = await Promise.all([
+      import('/js/state.js'),
+      import('/js/sun-sessions-store.js'),
+    ]);
+    if (!state?.importedData || typeof logCompletedSession !== 'function') return;
     const now = Date.now();
-    S.importedData.sunSessions = [];
-    S.importedData.deviceSessions = [];
-    S.importedData.lightDevices = [{
+    state.importedData.sunSessions = [];
+    state.importedData.deviceSessions = [];
+    state.importedData.lightDevices = [{
       id: 'D-mobile-long',
       brand: 'Mitochondriak Performance Systems',
       model: 'Ultra Bright Red Near Infrared Panel Max 9000',
@@ -821,8 +826,10 @@ async function checkMobileInteractions(page, theme, viewportName, assert) {
   }
 
   await page.evaluate(async () => {
-    const supplements = await import('/js/supplements.js');
-    const state = window._labState;
+    const [{ state }, supplements] = await Promise.all([
+      import('/js/state.js'),
+      import('/js/supplements.js'),
+    ]);
     window.__suppModalSnapshot = JSON.stringify(state?.importedData?.supplements || []);
     if (state?.importedData) {
       state.importedData.supplements = [{
@@ -892,7 +899,7 @@ async function checkMobileInteractions(page, theme, viewportName, assert) {
     const horizontalOverflow = Math.max(document.body.scrollWidth, document.documentElement.scrollWidth) - document.documentElement.clientWidth;
     const open = overlay?.classList.contains('show');
     (await import('/js/views.js')).closeModal();
-    const state = window._labState;
+    const { state } = await import('/js/state.js');
     if (state?.importedData && window.__suppModalSnapshot) {
       state.importedData.supplements = JSON.parse(window.__suppModalSnapshot);
     }
@@ -925,7 +932,8 @@ async function checkMobileInteractions(page, theme, viewportName, assert) {
         { timeout: 2500 }
       ).catch(() => {});
     }
-    result = await page.evaluate(({ tab, theme }) => {
+    result = await page.evaluate(async ({ tab, theme }) => {
+      const { state } = await import('/js/state.js');
       const active = document.querySelector(`#mobile-bottom-tabs .m-tab[data-tab="${tab}"], .m-tabbar .m-tab[data-tab="${tab}"]`);
       const conditionsGrid = document.querySelector('.lens-page-widgets[data-lens-route="light"] .conditions-now-grid') || document.querySelector('.conditions-now-grid');
       const supportColumns = conditionsGrid
@@ -975,7 +983,7 @@ async function checkMobileInteractions(page, theme, viewportName, assert) {
       return {
         active: !!active?.classList.contains('active'),
         hasBottomTabs: !!document.querySelector('#mobile-bottom-tabs, .m-shell .m-tabbar'),
-        currentView: window._labState?.currentView,
+        currentView: state?.currentView,
         visibleMain: document.getElementById('main-content')?.textContent?.trim().length > 40,
         rootTabsActive: document.documentElement.classList.contains('mobile-tabs-active'),
         headerSticky:

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -61,7 +61,7 @@ assert('quality guardrail ratchets _labState retirement by file',
     guardrailSrc.includes('labStateAppFiles') &&
     guardrailSrc.includes('labStateTestFiles') &&
     baseline.labStateAppFiles === 1 &&
-    baseline.labStateTestFiles === 2);
+    baseline.labStateTestFiles === 0);
 const forbiddenAppEventWindowGlobals = [
   'closeModal',
   'toggleChatPanel',


### PR DESCRIPTION
## Summary
- migrate the final two browser fixtures from `window._labState` to the explicit `state` module export
- ratchet the test-side `_labState` quality baseline from 2 files to 0
- keep the sole remaining app-side compatibility export guarded at 1 file

## Whole-migration progress
- before this PR: **55/58 files complete (94.8%)**
- completed in this PR: **2/58 files (3.4%)**
- after this PR: **57/58 files complete (98.3%)**
- entire work remaining: **1/58 files (1.7%)**
- remaining scope: remove the final compatibility export from `js/state.js`

## Testing
- `node tests/test-quality-guardrails.js` — 25 passed
- `npm run quality` — 11 passed; test-side `_labState` files 0/0; 461 JS/MJS files parse
- focused Playwright — 2 passed: two-device sync 10/10 assertions; responsive matrix 472/472 assertions
- `./run-tests.sh` — type checks, 125 static verifications, 399 Vitest tests, and 350/352 Playwright tests passed; two unrelated wearable OAuth iframe loads timed out under concurrent load
- isolated wearable OAuth rerun — 2/2 passed

Test-only change; no `version.js` bump required.