### PR TITLE
Remove lab state browser global

### DIFF
--- a/js/state.js
+++ b/js/state.js
@@ -1,8 +1,6 @@
 // @ts-check
 // state.js — Centralized mutable application state
 
-import { registerUtilsRuntimeExports } from './utils-runtime.js';
-
 export const state = {
   chartInstances: {},
   markerRegistry: {},
@@ -26,5 +24,3 @@ export const state = {
   compareDate1: null,
   compareDate2: null,
 };
-
-registerUtilsRuntimeExports({ _labState: state });

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -5,7 +5,7 @@
   "legacyWindowGlobalAssignments": 0,
   "viewRuntimeBridgeConsumers": 0,
   "viewRuntimeBridgeLookups": 0,
-  "labStateAppFiles": 1,
+  "labStateAppFiles": 0,
   "labStateTestFiles": 0,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -60,7 +60,7 @@ assert('quality guardrail ratchets _labState retirement by file',
   guardrailSrc.includes('LAB_STATE_RE') &&
     guardrailSrc.includes('labStateAppFiles') &&
     guardrailSrc.includes('labStateTestFiles') &&
-    baseline.labStateAppFiles === 1 &&
+    baseline.labStateAppFiles === 0 &&
     baseline.labStateTestFiles === 0);
 const forbiddenAppEventWindowGlobals = [
   'closeModal',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.293';
+self.APP_VERSION = '1.10.294';


### PR DESCRIPTION
## Summary
- remove the final `window._labState` compatibility export from `js/state.js`
- remove the now-unused runtime-export import
- ratchet the app-side and test-side `_labState` quality baselines to 0
- bump the app cache version to `1.10.294`

## Whole-migration progress
- before this PR: **57/58 files complete (98.3%)**
- completed in this PR: **1/58 files (1.7%)**
- after this PR: **58/58 files complete (100%)**
- entire work remaining: **0/58 files (0%)**
- remaining scope: **none — the `_labState` retirement is complete**

## Testing
- `node tests/test-quality-guardrails.js` — 25 passed
- `npm run quality` — 11 passed; app and test `_labState` files both 0/0; 461 JS/MJS files parse
- `npm test` — 399 passed
- `PORT=8001 ./run-tests.sh` — 125 static verifications, 399 Vitest tests, 352 Playwright tests, and 472 responsive assertions passed

The isolated port ensures Playwright runs against this worktree while the separate `local-lmstudio` worktree continues using port 8000.