### PR TITLE
Isolate Playwright test server

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -2,6 +2,7 @@ import { defineConfig, devices } from '@playwright/test';
 
 const PORT = process.env.PORT || '8000';
 const chromiumExecutable = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE;
+const reuseExistingServer = process.env.PLAYWRIGHT_REUSE_SERVER === '1';
 
 export default defineConfig({
   testDir: './tests/playwright',
@@ -25,7 +26,9 @@ export default defineConfig({
   webServer: {
     command: `node dev-server.js ${PORT}`,
     url: `http://127.0.0.1:${PORT}/`,
-    reuseExistingServer: true,
+    // Direct Playwright runs must not silently use app files from another
+    // checkout. run-tests.sh opts in after starting a server it owns.
+    reuseExistingServer,
     timeout: 10_000,
   },
   projects: [

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -6,6 +6,7 @@ set -e
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
 PORT=${PORT:-8000}
+REUSE_TEST_SERVER=${REUSE_TEST_SERVER:-0}
 COVERAGE_ENABLED=0
 if [ "$COVERAGE" = "1" ] || [ "$COVERAGE" = "true" ]; then
   COVERAGE_ENABLED=1
@@ -18,11 +19,35 @@ fi
 npm run vendor:check || exit 1
 node "$DIR/tests/verify-modules.js" || exit 1
 
-# Start server if not already running. nohup + disown fully detaches it
-# from the shell — signals sent to the shell's process group won't
-# propagate. Log to /tmp so we can inspect if it ever dies unexpectedly.
+# Reusing an arbitrary process on the requested port can mix the current tests
+# with app files from another checkout. Only reuse when explicitly requested;
+# otherwise move to the next available HTTP port and start a server we own.
+server_reachable() {
+  curl -s -o /dev/null -m 1 "http://localhost:$1/" 2>/dev/null
+}
+
+if server_reachable "$PORT" && [ "$REUSE_TEST_SERVER" != "1" ] && [ "$REUSE_TEST_SERVER" != "true" ]; then
+  REQUESTED_PORT=$PORT
+  PORT_FOUND=0
+  for candidate in $(seq $((PORT + 1)) $((PORT + 50))); do
+    if ! server_reachable "$candidate"; then
+      PORT=$candidate
+      PORT_FOUND=1
+      break
+    fi
+  done
+  if [ "$PORT_FOUND" != "1" ]; then
+    echo "No available test port found after :$REQUESTED_PORT — aborting"
+    exit 2
+  fi
+  echo "Port :$REQUESTED_PORT is already serving; using isolated test port :$PORT"
+fi
+
+# Start a server unless reuse was explicitly requested. nohup + disown fully
+# detaches it from the shell, so signals sent to the shell's process group
+# won't propagate. Log to /tmp so we can inspect if it dies unexpectedly.
 SERVER_PID=""
-if ! curl -s -o /dev/null "http://localhost:$PORT/" 2>/dev/null; then
+if ! server_reachable "$PORT"; then
   nohup node "$DIR/dev-server.js" "$PORT" > /tmp/dev-server.log 2>&1 < /dev/null &
   SERVER_PID=$!
   disown "$SERVER_PID" 2>/dev/null || true
@@ -68,9 +93,9 @@ ensure_server
 # HTTP-reliant test before the browser suite (needs the dev server up).
 PORT=$PORT node "$DIR/tests/test-dev-server-origin.js" || exit 1
 if [ "$COVERAGE_ENABLED" = "1" ]; then
-  PLAYWRIGHT_SUITE_COVERAGE=1 PLAYWRIGHT_COVERAGE_DIR="$DIR/tests/.playwright-coverage" PORT=$PORT npm run test:playwright || exit 1
+  PLAYWRIGHT_REUSE_SERVER=1 PLAYWRIGHT_SUITE_COVERAGE=1 PLAYWRIGHT_COVERAGE_DIR="$DIR/tests/.playwright-coverage" PORT=$PORT npm run test:playwright || exit 1
 else
-  PORT=$PORT npm run test:playwright || exit 1
+  PLAYWRIGHT_REUSE_SERVER=1 PORT=$PORT npm run test:playwright || exit 1
 fi
 if [ "$COVERAGE_ENABLED" = "1" ]; then
   : "${COVERAGE_MIN:=0}"

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -27,6 +27,7 @@ const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'))
 const guardrailSrc = fs.readFileSync(path.join(ROOT, 'scripts', 'quality-guardrails.mjs'), 'utf8');
 const baseline = JSON.parse(fs.readFileSync(path.join(ROOT, 'scripts', 'quality-baseline.json'), 'utf8'));
 const runTestsSrc = fs.readFileSync(path.join(ROOT, 'run-tests.sh'), 'utf8');
+const playwrightConfigSrc = fs.readFileSync(path.join(ROOT, 'playwright.config.js'), 'utf8');
 const testWorkflowSrc = fs.readFileSync(path.join(ROOT, '.github/workflows/test.yml'), 'utf8');
 const checkJsConfig = JSON.parse(fs.readFileSync(path.join(ROOT, 'tsconfig.checkjs.json'), 'utf8'));
 const appEventListenersSrc = fs.readFileSync(path.join(ROOT, 'js', 'app-event-listeners.js'), 'utf8');
@@ -91,6 +92,13 @@ assert('full local test suite runs typecheck',
     runTestsSrc.includes('SKIP_TYPECHECK'));
 assert('full local test suite runs static module verification',
   runTestsSrc.includes('node "$DIR/tests/verify-modules.js" || exit 1'));
+assert('full local test suite isolates itself from an occupied default port',
+  runTestsSrc.includes('REUSE_TEST_SERVER=${REUSE_TEST_SERVER:-0}') &&
+    runTestsSrc.includes('Port :$REQUESTED_PORT is already serving; using isolated test port :$PORT') &&
+    runTestsSrc.includes('PLAYWRIGHT_REUSE_SERVER=1'));
+assert('direct Playwright runs do not silently reuse an unrelated server',
+  playwrightConfigSrc.includes("process.env.PLAYWRIGHT_REUSE_SERVER === '1'") &&
+    playwrightConfigSrc.includes('reuseExistingServer,'));
 assert('CI keeps a dedicated typecheck step and skips duplicate script typecheck',
   testWorkflowSrc.includes('name: Run typecheck') &&
     testWorkflowSrc.includes('run: npm run typecheck') &&


### PR DESCRIPTION
## Summary

- prevent the full test runner from reusing an unrelated server already listening on the requested port
- choose the next available local port unless server reuse is explicitly enabled
- require `PLAYWRIGHT_REUSE_SERVER=1` before Playwright reuses an existing server
- add quality guardrails for both behaviors

## Root cause

The test harness treated any HTTP server on the configured port as the app under test. Playwright could therefore run against a stale server from another checkout, producing false failures unrelated to the current code.

## Impact

Playwright runs are isolated and deterministic by default. Explicit reuse remains available for intentional workflows. No production app files or API behavior changed, so no version bump is needed.

## Verification

- `npm run quality` — 11/11 passed
- type checks and vendored dependency checks passed
- module verification — 125/125 passed
- Vitest — 399/399 passed
- origin guard tests — 18/18 passed
- Playwright regression suite — 352/352 passed
- responsive theme checks — 472/472 passed
