### PR TITLE
Improve Local AI imports and diagnostics

### DIFF
--- a/css/settings.css
+++ b/css/settings.css
@@ -105,6 +105,127 @@
   font-family: var(--font-mono);
   letter-spacing: 0.1em;
 }
+.import-benchmarks-entrypoint {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px solid var(--border);
+}
+.import-benchmarks-entrypoint > div {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  color: var(--text-primary);
+  font-size: 12px;
+}
+.import-benchmarks-entrypoint span {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+.import-benchmarks-modal {
+  width: min(94vw, 920px);
+  max-width: 920px;
+  max-height: 90vh;
+  padding: 0;
+  overflow: hidden;
+  background: var(--bg-secondary);
+}
+.import-benchmarks-body {
+  max-height: calc(90vh - 82px);
+  overflow-y: auto;
+  padding: 20px 26px 26px;
+}
+.import-benchmarks-note {
+  margin: 0 0 16px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.55;
+}
+.import-benchmarks-list {
+  display: grid;
+  gap: 12px;
+}
+.import-benchmark-card {
+  padding: 15px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+}
+.import-benchmark-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 13px;
+}
+.import-benchmark-file {
+  max-width: min(60vw, 620px);
+  overflow: hidden;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.import-benchmark-date {
+  margin-top: 3px;
+  color: var(--text-muted);
+  font-size: 10px;
+}
+.import-benchmark-status {
+  flex: 0 0 auto;
+  padding: 3px 7px;
+  border: 1px solid color-mix(in srgb, var(--green) 45%, var(--border));
+  border-radius: 999px;
+  color: var(--green);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  text-transform: uppercase;
+}
+.import-benchmark-status.retried {
+  border-color: color-mix(in srgb, var(--orange) 50%, var(--border));
+  color: var(--orange);
+}
+.import-benchmark-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px 16px;
+}
+.import-benchmark-grid > div {
+  min-width: 0;
+}
+.import-benchmark-grid span,
+.import-benchmark-grid strong {
+  display: block;
+}
+.import-benchmark-grid span {
+  margin-bottom: 3px;
+  color: var(--text-muted);
+  font-size: 9px;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+}
+.import-benchmark-grid strong {
+  overflow: hidden;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.import-benchmarks-empty {
+  padding: 28px 18px;
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.5;
+  text-align: center;
+}
 .settings-modal .ai-provider-btn,
 .settings-modal .imported-entry,
 .settings-modal .local-ai-settings,
@@ -786,6 +907,9 @@
     min-height: 42px;
     border-radius: var(--radius-sm);
   }
+  .import-benchmarks-body { padding: 16px; }
+  .import-benchmark-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .import-benchmark-file { max-width: 65vw; }
 }
 
 @media (max-width: 600px) {

--- a/js/api-local.js
+++ b/js/api-local.js
@@ -1,9 +1,154 @@
 // @ts-check
 // api-local.js - Ollama/LM Studio/Jan provider adapters.
 
-import { readWithStallTimeout } from './api-transport.js';
+import { createInitialResponseTimeout, FETCH_REQUEST_TIMEOUT_MS, readWithStallTimeout } from './api-transport.js';
 import { getOllamaConfig, getOllamaMainModel } from './api-provider-storage.js';
 import { callOpenAICompatibleAPI } from './api-openai-compatible.js';
+import { discoverLocalAI, getCachedLocalAiModelDetail, markCachedLocalAiModelLoaded } from './local-ai-discovery.js';
+
+function contentTokenEstimate(content) {
+  if (typeof content === 'string') return content.length / 3.5;
+  if (!Array.isArray(content)) return 0;
+  return content.reduce((total, block) => {
+    if (typeof block?.text === 'string') return total + block.text.length / 3.5;
+    if (block?.type === 'image' || block?.type === 'image_url') return total + 1600;
+    return total;
+  }, 0);
+}
+
+export function estimateLocalAiPromptTokens({ system, messages }) {
+  const contentTokens = String(system || '').length / 3.5
+    + (Array.isArray(messages) ? messages.reduce((total, message) => total + contentTokenEstimate(message?.content), 0) : 0);
+  const messageOverhead = (Array.isArray(messages) ? messages.length : 0) * 6 + (system ? 6 : 0);
+  return Math.ceil(contentTokens) + messageOverhead;
+}
+
+export function planLocalAiRequest(opts, modelDetail) {
+  const requestedMaxTokens = Math.max(1, Number(opts.maxTokens) || 4096);
+  const estimatedPromptTokens = estimateLocalAiPromptTokens(opts);
+  const contextLength = Number(modelDetail?.contextLength) || 0;
+  let maxTokens = requestedMaxTokens;
+  let availableOutputTokens = null;
+  if (contextLength > 0) {
+    const safetyTokens = Math.max(256, Math.ceil(contextLength * 0.04));
+    availableOutputTokens = contextLength - estimatedPromptTokens - safetyTokens;
+    const minimumOutputTokens = Math.max(64, Math.min(requestedMaxTokens, Number(opts.minOutputTokens) || 256));
+    if (availableOutputTokens < minimumOutputTokens) {
+      const maxContext = Number(modelDetail?.maxContextLength) || 0;
+      const maxHint = maxContext > contextLength ? ` This model supports up to ${maxContext.toLocaleString()} tokens.` : '';
+      throw new Error(`Local AI context is too small for this request: about ${estimatedPromptTokens.toLocaleString()} prompt tokens plus output, but ${modelDetail?.name || 'the model'} is loaded with ${contextLength.toLocaleString()}.${maxHint} Reload it with a larger context or use a smaller/chunked input.`);
+    }
+    maxTokens = Math.min(requestedMaxTokens, availableOutputTokens);
+  }
+  return {
+    maxTokens,
+    diagnostics: {
+      estimatedPromptTokens,
+      requestedMaxTokens,
+      plannedMaxTokens: maxTokens,
+      contextLength,
+      maxContextLength: Number(modelDetail?.maxContextLength) || 0,
+      quantLevel: modelDetail?.quantLevel || '',
+      modelSize: Number(modelDetail?.size) || 0,
+      vramAllocated: Number(modelDetail?.vramAllocated) || 0,
+      executionLocation: modelDetail?.executionLocation || 'unknown',
+    },
+  };
+}
+
+function publishLoadedModel(config, model, runtimePatch = {}) {
+  const result = markCachedLocalAiModelLoaded(config.url, model, config.apiKey, runtimePatch);
+  if (result && typeof globalThis.dispatchEvent === 'function' && typeof CustomEvent !== 'undefined') {
+    globalThis.dispatchEvent(new CustomEvent('local-ai-discovery-updated', { detail: result }));
+  }
+}
+
+function roundContextLength(required, maximum) {
+  const steps = [4096, 8192, 16384, 32768, 65536, 131072, 262144];
+  const target = steps.find(step => step >= required) || required;
+  return maximum > 0 ? Math.min(target, maximum) : target;
+}
+
+function nativeLMStudioInput(messages) {
+  const input = [];
+  for (const message of Array.isArray(messages) ? messages : []) {
+    if (message?.role !== 'user') return null;
+    if (typeof message.content === 'string') {
+      input.push({ type: 'message', content: message.content });
+      continue;
+    }
+    if (!Array.isArray(message.content)) return null;
+    for (const block of message.content) {
+      if (block?.type === 'text') input.push({ type: 'message', content: block.text || '' });
+      else if (block?.type === 'image_url' && block.image_url?.url) input.push({ type: 'image', data_url: block.image_url.url });
+      else if (block?.type === 'image' && block.source?.data) {
+        input.push({ type: 'image', data_url: `data:${block.source.media_type || 'image/jpeg'};base64,${block.source.data}` });
+      }
+    }
+  }
+  return input;
+}
+
+async function callLMStudioNativeAPI(config, model, opts, plan, contextLength) {
+  const input = nativeLMStudioInput(opts.messages);
+  if (!input) throw new Error('LM Studio context override is unavailable for requests containing assistant history. Reload the model with a larger context in LM Studio.');
+  const requestInit = {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...(config.apiKey ? { Authorization: `Bearer ${config.apiKey}` } : {}) },
+    body: JSON.stringify({
+      model,
+      input: input.length === 1 && input[0].type === 'message' ? input[0].content : input,
+      system_prompt: opts.system || undefined,
+      temperature: opts.jsonMode || opts.temperature === 0 ? 0 : undefined,
+      max_output_tokens: plan.maxTokens,
+      reasoning: opts.jsonMode || opts.reasoningEffort === 'none' ? 'off' : undefined,
+      context_length: contextLength,
+      stream: false,
+      store: false,
+    }),
+    signal: opts.signal,
+  };
+  const timeoutState = createInitialResponseTimeout(requestInit, opts.requestTimeoutMs || FETCH_REQUEST_TIMEOUT_MS);
+  let response;
+  try {
+    response = await fetch(`${config.url.replace(/\/+$/, '')}/api/v1/chat`, timeoutState.fetchOptions);
+  } finally {
+    timeoutState.clearRequestTimeout();
+  }
+  if (!response.ok) {
+    const body = await response.json().catch(() => null);
+    throw new Error(`LM Studio native API error (${response.status}): ${body?.error?.message || body?.error || response.statusText}`);
+  }
+  const data = await response.json();
+  const text = (Array.isArray(data.output) ? data.output : [])
+    .filter(item => item?.type === 'message' && typeof item.content === 'string')
+    .map(item => item.content)
+    .join('\n')
+    .trim();
+  if (!text) throw new Error('LM Studio returned no final response content.');
+  if (opts.onStream) opts.onStream(text);
+  const stats = data.stats || {};
+  return {
+    text,
+    usage: {
+      inputTokens: Number(stats.input_tokens) || 0,
+      outputTokens: Number(stats.total_output_tokens) || 0,
+    },
+    finishReason: null,
+    truncated: false,
+    diagnostics: {
+      nativeContextOverride: true,
+      contextLength,
+      schemaUnavailableOnNativeEndpoint: !!opts.jsonMode,
+      performance: {
+        tokensPerSecond: Number(stats.tokens_per_second) || 0,
+        timeToFirstTokenMs: Number(stats.time_to_first_token_seconds) > 0 ? Math.round(Number(stats.time_to_first_token_seconds) * 1000) : 0,
+        modelLoadMs: Number(stats.model_load_time_seconds) > 0 ? Math.round(Number(stats.model_load_time_seconds) * 1000) : 0,
+        reasoningTokens: Number(stats.reasoning_output_tokens) || 0,
+      },
+    },
+  };
+}
 
 export async function callOllamaChat({ system, messages, maxTokens, onStream, signal }) {
   const config = getOllamaConfig();
@@ -15,7 +160,7 @@ export async function callOllamaChat({ system, messages, maxTokens, onStream, si
       let text = '';
       const images = [];
       for (const block of msg.content) {
-        if (block.type === 'text') text = block.text;
+        if (block.type === 'text') text += block.text;
         else if (block.type === 'image' && block.source?.data) images.push(block.source.data);
         else if (block.type === 'image_url' && block.image_url?.url) {
           const match = block.image_url.url.match(/^data:[^;]+;base64,(.+)$/);
@@ -37,16 +182,17 @@ export async function callOllamaChat({ system, messages, maxTokens, onStream, si
   try {
     res = await fetch(`${config.url}/api/chat`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...(config.apiKey ? { Authorization: `Bearer ${config.apiKey}` } : {}) },
       body: JSON.stringify(body),
       signal
     });
   } catch (e) {
     if (e instanceof TypeError || /Failed to fetch|Load failed|NetworkError/.test(e.message || '')) {
       const ua = navigator.userAgent || '';
-      const hint = /Mac/i.test(ua) ? 'Ollama: launchctl setenv OLLAMA_ORIGINS "*" and restart. LM Studio: Settings -> Enable CORS'
-        : /Win/i.test(ua) ? 'Ollama: set OLLAMA_ORIGINS=* as system env var and restart. LM Studio: Settings -> Enable CORS'
-        : 'Ollama: OLLAMA_ORIGINS=* ollama serve. LM Studio: Settings -> Enable CORS';
+      const origin = typeof location !== 'undefined' ? location.origin : 'the getbased origin';
+      const hint = /Mac/i.test(ua) ? `Ollama: set OLLAMA_ORIGINS to ${origin} and restart. LM Studio: enable CORS and API authentication`
+        : /Win/i.test(ua) ? `Ollama: set OLLAMA_ORIGINS=${origin} and restart. LM Studio: enable CORS and API authentication`
+        : `Ollama: OLLAMA_ORIGINS=${origin} ollama serve. LM Studio: enable CORS and API authentication`;
       throw new Error(`Cannot reach local server - CORS blocked. ${hint}`);
     }
     throw new Error(`Cannot reach local server. Check that it's running. (${e.message})`);
@@ -106,6 +252,49 @@ export async function callOpenAICompatibleLocalAPI(opts) {
   const config = getOllamaConfig();
   const model = getOllamaMainModel();
   const url = config.url.replace(/\/+$/, '');
-  const key = config.apiKey || 'not-needed';
-  return callOpenAICompatibleAPI(`${url}/v1/chat/completions`, key, model, 'Local AI', opts, {}, { useProxy: false });
+  let modelDetail = getCachedLocalAiModelDetail(url, model, config.apiKey);
+  // Routine chat should not pay for four capability probes before its first
+  // token. Imports opt in because they need exact LM Studio context metadata;
+  // Settings and the hardware advisor also refresh discovery explicitly.
+  if (!modelDetail && opts.preferNativeContext) {
+    const discovery = await discoverLocalAI(url, config.apiKey);
+    modelDetail = discovery.modelDetails?.find(detail => detail.name === model) || null;
+  }
+  const estimatedPromptTokens = estimateLocalAiPromptTokens(opts);
+  const currentContext = Number(modelDetail?.contextLength) || 0;
+  const maxContext = Number(modelDetail?.maxContextLength) || 0;
+  const requestedOutput = Math.max(1, Number(opts.maxTokens) || 4096);
+  const requiredContext = estimatedPromptTokens + requestedOutput + Math.max(512, Math.ceil((estimatedPromptTokens + requestedOutput) * 0.04));
+  const useNativeContextOverride = !!opts.preferNativeContext
+    && modelDetail?.source === 'lmstudio'
+    && currentContext > 0
+    && requiredContext > currentContext
+    && maxContext >= requiredContext;
+  const overrideContext = useNativeContextOverride ? roundContextLength(requiredContext, maxContext) : currentContext;
+  const plan = planLocalAiRequest(opts, useNativeContextOverride ? { ...modelDetail, contextLength: overrideContext } : modelDetail);
+  if (useNativeContextOverride) {
+    const nativeResult = await callLMStudioNativeAPI(config, model, opts, plan, overrideContext);
+    publishLoadedModel(config, model, { contextLength: overrideContext });
+    return {
+      ...nativeResult,
+      diagnostics: { ...nativeResult.diagnostics, localPlan: plan.diagnostics },
+    };
+  }
+  const extraBody = {};
+  if (opts.jsonMode || opts.reasoningEffort === 'none') extraBody.reasoning_effort = 'none';
+  if (opts.jsonMode || opts.temperature === 0) extraBody.temperature = 0;
+  const result = await callOpenAICompatibleAPI(
+    `${url}/v1/chat/completions`,
+    config.apiKey,
+    model,
+    'Local AI',
+    { ...opts, maxTokens: plan.maxTokens },
+    {},
+    { useProxy: false, extraBody },
+  );
+  publishLoadedModel(config, model);
+  return {
+    ...result,
+    diagnostics: { ...result?.diagnostics, localPlan: plan.diagnostics },
+  };
 }

--- a/js/api-models.js
+++ b/js/api-models.js
@@ -2,6 +2,7 @@
 // api-models.js - Provider model catalogs, pricing, and capability helpers.
 
 import { getModelPricing } from './schema.js';
+import { isCloudModel } from './local-ai-discovery.js';
 import {
   getAIProvider,
   getOllamaMainModel,
@@ -251,7 +252,12 @@ export async function validateOpenRouterKey(key) {
 }
 
 export function renderModelPricingHint(provider, modelId) {
-  if (provider === 'ollama') return '<span style="font-size:11px;color:var(--green)">Free (local)</span>';
+  if (provider === 'ollama') {
+    const selected = modelId || getOllamaMainModel();
+    return isCloudModel(selected)
+      ? '<span style="font-size:11px;color:var(--warning)">Cloud model · provider terms may apply</span>'
+      : '<span style="font-size:11px;color:var(--green)">No app fee · configured server</span>';
+  }
   if (provider === 'custom') return '';
   const p = getModelPricing(provider, modelId);
   if (p.input === 0 && p.output === 0) return '<span style="font-size:11px;color:var(--green)">Free</span>';

--- a/js/api-openai-compatible.js
+++ b/js/api-openai-compatible.js
@@ -81,22 +81,41 @@ async function fetchWithOptionalTimeout(fetchImpl, endpoint, requestInit, reques
   }
 }
 
-export async function callOpenAICompatibleAPI(endpoint, key, model, providerName, { system, messages, maxTokens, onStream, signal, requestTimeoutMs, jsonMode, forceNonStream }, extraHeaders = {}, { useProxy = true, extraBody = {}, fetchImpl = null } = {}) {
+function localAIJsonResponseFormat(schema) {
+  return {
+    type: 'json_schema',
+    json_schema: {
+      name: 'structured_response',
+      strict: true,
+      schema: schema || { type: 'object' },
+    },
+  };
+}
+
+function localAIStructuredOutputRejected(res, errorText) {
+  return (res.status === 400 || res.status === 422) && /response[_ ]format|json[_ ]schema|structured output/i.test(errorText);
+}
+
+function localAIReasoningControlRejected(res, errorText) {
+  return (res.status === 400 || res.status === 422) && /reasoning[_ .-]?(?:effort|control)|invalid.*reasoning/i.test(errorText);
+}
+
+export async function callOpenAICompatibleAPI(endpoint, key, model, providerName, { system, messages, maxTokens, onStream, signal, requestTimeoutMs, jsonMode, jsonSchema, forceNonStream }, extraHeaders = {}, { useProxy = true, extraBody = {}, fetchImpl = null } = {}) {
   const apiMessages = [];
   if (system) apiMessages.push({ role: 'system', content: system });
   for (const msg of messages) apiMessages.push({ role: msg.role, content: msg.content });
 
   // Thinking models burn reasoning tokens against max_tokens, so low caps need
   // extra room while still constraining total output.
-  const isThinkingModel = /deepseek-r1|kimi-k|qwq|glm-[45]|claude-.*sonnet|claude-.*opus|:cloud/.test(model);
-  const effectiveMaxTokens = isThinkingModel
+  const isThinkingModel = /deepseek-r1|kimi-k|qwq|qwen3(?:[.\-:]|$)|glm-[45]|claude-.*sonnet|claude-.*opus|(?:^|[/:_.-])cloud(?:$|[/:_.-])/i.test(model);
+  const effectiveMaxTokens = isThinkingModel && providerName !== 'Local AI'
     ? Math.max(maxTokens || 4096, 16384)
     : (maxTokens || 4096);
   const tokenLimitField = needsMaxCompletionTokens(model) ? 'max_completion_tokens' : 'max_tokens';
   /** @type {Record<string, any>} */
   const body = { model, messages: apiMessages, [tokenLimitField]: effectiveMaxTokens || 4096, ...extraBody };
   if (jsonMode && providerName === 'Local AI') {
-    body.response_format = { type: 'json_object' };
+    body.response_format = localAIJsonResponseFormat(jsonSchema);
   }
   const useStream = !!onStream && !forceNonStream;
   if (useStream) {
@@ -104,21 +123,43 @@ export async function callOpenAICompatibleAPI(endpoint, key, model, providerName
     body.stream_options = { include_usage: true };
   }
 
-  let res;
-  try {
+  const fetchRequest = async (requestBody) => {
     const requestInit = {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${key}`,
+        ...(key ? { 'Authorization': `Bearer ${key}` } : {}),
         ...extraHeaders
       },
-      body: JSON.stringify(body),
+      body: JSON.stringify(requestBody),
       signal
     };
-    res = fetchImpl
-      ? await fetchWithOptionalTimeout(fetchImpl, endpoint, requestInit, requestTimeoutMs)
-      : await fetchWithApiRetry(endpoint, requestInit, 2, useProxy, requestTimeoutMs);
+    return fetchImpl
+      ? fetchWithOptionalTimeout(fetchImpl, endpoint, requestInit, requestTimeoutMs)
+      : fetchWithApiRetry(endpoint, requestInit, providerName === 'Local AI' ? 0 : 2, useProxy, requestTimeoutMs);
+  };
+
+  let res;
+  let structuredOutputFallback = false;
+  let reasoningControlFallback = false;
+  try {
+    let requestBody = { ...body };
+    for (let attempt = 0; attempt < 3; attempt++) {
+      res = await fetchRequest(requestBody);
+      if (res.ok) break;
+      const errorText = await res.clone().text();
+      if (requestBody.reasoning_effort && localAIReasoningControlRejected(res, errorText)) {
+        delete requestBody.reasoning_effort;
+        reasoningControlFallback = true;
+        continue;
+      }
+      if (requestBody.response_format?.type === 'json_schema' && localAIStructuredOutputRejected(res, errorText)) {
+        delete requestBody.response_format;
+        structuredOutputFallback = true;
+        continue;
+      }
+      break;
+    }
   } catch (e) {
     throw new Error(`Cannot reach ${providerName} API: ${redactApiSecretText(e.message, [key])}`);
   }
@@ -161,6 +202,7 @@ export async function callOpenAICompatibleAPI(endpoint, key, model, providerName
     let finishReason = null;
     let inputTokens = 0;
     let outputTokens = 0;
+    let performance = null;
     const handleSSELine = (line, boundary) => {
       if (!line.startsWith('data: ')) return;
       const data = line.slice(6);
@@ -176,12 +218,20 @@ export async function callOpenAICompatibleAPI(endpoint, key, model, providerName
           if (!hasContent) hasContent = true;
           fullText += delta.content;
           onStream(fullText);
-        } else if (delta?.reasoning_content) {
-          if (!hasContent) reasoningBuf += delta.reasoning_content;
+        } else if (delta?.reasoning_content || delta?.reasoning) {
+          if (!hasContent) reasoningBuf += delta.reasoning_content || delta.reasoning;
         }
         if (event.usage) {
           inputTokens = event.usage.prompt_tokens || inputTokens;
           outputTokens = event.usage.completion_tokens || outputTokens;
+        }
+        if (event.stats) {
+          performance = {
+            tokensPerSecond: Number(event.stats.tokens_per_second) || 0,
+            timeToFirstTokenMs: Number(event.stats.time_to_first_token_seconds) > 0 ? Math.round(Number(event.stats.time_to_first_token_seconds) * 1000) : 0,
+            modelLoadMs: Number(event.stats.model_load_time_seconds) > 0 ? Math.round(Number(event.stats.model_load_time_seconds) * 1000) : 0,
+            reasoningTokens: Number(event.stats.reasoning_output_tokens) || 0,
+          };
         }
       } catch (parseErr) {
         if (boundary && parseErr instanceof SyntaxError) return;
@@ -203,13 +253,22 @@ export async function callOpenAICompatibleAPI(endpoint, key, model, providerName
     }
     if (buffer.startsWith('data: ')) handleSSELine(buffer, false);
     if (!fullText && reasoningBuf) {
+      if (providerName === 'Local AI') {
+        throw new Error('Local AI returned reasoning but no final answer. Reasoning used the output budget; disable thinking for this task or increase the model context/output limit.');
+      }
       fullText = reasoningBuf;
       onStream(fullText);
     }
     if (!fullText.trim()) {
       throw new Error(`${providerName} stream ended without response content. No usage was reported by the app; check the provider account before retrying.`);
     }
-    return { text: fullText, usage: { inputTokens, outputTokens }, finishReason, truncated: isTokenLimitFinish(finishReason) };
+    return {
+      text: fullText,
+      usage: { inputTokens, outputTokens },
+      finishReason,
+      truncated: isTokenLimitFinish(finishReason),
+      ...((structuredOutputFallback || reasoningControlFallback || performance) ? { diagnostics: { structuredOutputFallback, reasoningControlFallback, ...(performance ? { performance } : {}) } } : {}),
+    };
   }
 
   const data = await res.json();
@@ -217,15 +276,29 @@ export async function callOpenAICompatibleAPI(endpoint, key, model, providerName
   const choice = data.choices?.[0];
   const msg = choice?.message;
   let text = msg?.content || '';
-  if (!text && msg?.reasoning_content) text = msg.reasoning_content.replace(/<think>[\s\S]*?<\/think>/g, '').trim();
+  const reasoningText = msg?.reasoning_content || msg?.reasoning || '';
+  if (!text && reasoningText) {
+    if (providerName === 'Local AI') {
+      throw new Error('Local AI returned reasoning but no final answer. Reasoning used the output budget; disable thinking for this task or increase the model context/output limit.');
+    }
+    text = reasoningText.replace(/<think>[\s\S]*?<\/think>/g, '').trim();
+  }
   if (!String(text).trim()) {
     throw new Error(`${providerName} returned no response content. No usage was reported by the app; check the provider account before retrying.`);
   }
   const finishReason = choice?.finish_reason || choice?.native_finish_reason || null;
+  const stats = data.stats || {};
+  const performance = Object.keys(stats).length ? {
+    tokensPerSecond: Number(stats.tokens_per_second) || 0,
+    timeToFirstTokenMs: Number(stats.time_to_first_token_seconds) > 0 ? Math.round(Number(stats.time_to_first_token_seconds) * 1000) : 0,
+    modelLoadMs: Number(stats.model_load_time_seconds) > 0 ? Math.round(Number(stats.model_load_time_seconds) * 1000) : 0,
+    reasoningTokens: Number(stats.reasoning_output_tokens || usage.completion_tokens_details?.reasoning_tokens) || 0,
+  } : null;
   return {
     text,
     usage: { inputTokens: usage.prompt_tokens || 0, outputTokens: usage.completion_tokens || 0 },
     finishReason,
-    truncated: isTokenLimitFinish(finishReason)
+    truncated: isTokenLimitFinish(finishReason),
+    ...((structuredOutputFallback || reasoningControlFallback || performance) ? { diagnostics: { structuredOutputFallback, reasoningControlFallback, ...(performance ? { performance } : {}) } } : {}),
   };
 }

--- a/js/api-provider-storage.js
+++ b/js/api-provider-storage.js
@@ -41,13 +41,31 @@ export function hasAIProvider() {
   return true; // Ollama — optimistic, errors caught at call time
 }
 
+function cleanLocalAiServerUrl(value) {
+  const raw = String(value || '').trim();
+  if (!raw) return raw;
+  try {
+    const parsed = new URL(raw);
+    parsed.hash = '';
+    parsed.search = '';
+    parsed.pathname = parsed.pathname.replace(/\/(?:v1(?:\/(?:models|chat\/completions))?|api\/v1\/models)\/?$/i, '') || '/';
+    return parsed.href.replace(/\/+$/, '');
+  } catch {
+    return raw.replace(/\/+$/, '');
+  }
+}
+
 export function getOllamaConfig() {
   const defaults = { url: 'http://localhost:11434', model: 'llama3.2', mode: 'ollama', apiKey: '' };
-  try { return { ...defaults, ...JSON.parse(getCachedKey('labcharts-ollama')) }; }
+  try {
+    const config = { ...defaults, ...JSON.parse(getCachedKey('labcharts-ollama')) };
+    config.url = cleanLocalAiServerUrl(config.url) || defaults.url;
+    return config;
+  }
   catch { return defaults; }
 }
 export async function saveOllamaConfig(config) {
-  const json = JSON.stringify(config);
+  const json = JSON.stringify({ ...config, url: cleanLocalAiServerUrl(config.url) });
   await encryptedSetItem('labcharts-ollama', json);
   updateKeyCache('labcharts-ollama', json);
   markAISettingsLocal();
@@ -59,9 +77,24 @@ export function setOllamaMainModel(model) {
   markAISettingsLocal();
   notifyAISelectionChanged();
 }
-export function getOllamaPIIUrl() { return localStorage.getItem('labcharts-ollama-pii-url') || getOllamaConfig().url; }
+export function getOllamaPIIUrl() { return cleanLocalAiServerUrl(localStorage.getItem('labcharts-ollama-pii-url') || getOllamaConfig().url); }
 export function setOllamaPIIUrl(url) {
-  localStorage.setItem('labcharts-ollama-pii-url', url);
+  localStorage.setItem('labcharts-ollama-pii-url', cleanLocalAiServerUrl(url));
+  markAISettingsLocal();
+}
+export function getOllamaPIIApiKey() {
+  const stored = getCachedKey('labcharts-ollama-pii-key');
+  if (stored) return stored;
+  try {
+    const main = getOllamaConfig();
+    return new URL(getOllamaPIIUrl()).origin === new URL(main.url).origin ? main.apiKey : '';
+  } catch {
+    return '';
+  }
+}
+export async function saveOllamaPIIApiKey(key) {
+  await encryptedSetItem('labcharts-ollama-pii-key', key);
+  updateKeyCache('labcharts-ollama-pii-key', key);
   markAISettingsLocal();
 }
 export function getOllamaPIIModel() { return localStorage.getItem('labcharts-ollama-pii-model') || getOllamaMainModel(); }

--- a/js/api.js
+++ b/js/api.js
@@ -43,6 +43,8 @@ export {
   setOllamaMainModel,
   getOllamaPIIUrl,
   setOllamaPIIUrl,
+  getOllamaPIIApiKey,
+  saveOllamaPIIApiKey,
   getOllamaPIIModel,
   setOllamaPIIModel,
   getVeniceKey,

--- a/js/backup.js
+++ b/js/backup.js
@@ -112,7 +112,7 @@ const GLOBAL_SETTINGS_KEYS = [
   'labcharts-ppq-credit-id',
   'labcharts-venice-model', 'labcharts-openrouter-model', 'labcharts-routstr-model', 'labcharts-ppq-model',
   'labcharts-ollama', 'labcharts-ollama-model',
-  'labcharts-ollama-pii-url', 'labcharts-ollama-pii-model',
+  'labcharts-ollama-pii-url', 'labcharts-ollama-pii-key', 'labcharts-ollama-pii-model',
   'labcharts-routstr-node',
   'labcharts-time-format', 'labcharts-theme', 'labcharts-sunset-mode', 'labcharts-crt-effects', 'labcharts-debug',
   'labcharts-pii-review', 'labcharts-ollama-pii-enabled', 'labcharts-chat-sources',

--- a/js/chat-discussion-round-state.js
+++ b/js/chat-discussion-round-state.js
@@ -6,7 +6,7 @@ import {
   getChatThreadKey, invalidateThreadContentCache, renderThreadList,
   saveChatThreadIndex,
 } from './chat-threads.js';
-import { encryptedSetItem, getEncryptionEnabled } from './crypto.js';
+import { encryptedSetItem } from './crypto.js';
 import { saveChatHistory } from './chat-history.js';
 
 export function isRoundThreadActive(threadId) {
@@ -43,11 +43,7 @@ export async function saveRoundChatHistory(threadId, messages) {
   invalidateThreadContentCache();
   const value = JSON.stringify(messages);
   const key = getChatThreadKey(threadId);
-  if (getEncryptionEnabled()) {
-    await encryptedSetItem(key, value);
-  } else {
-    localStorage.setItem(key, value);
-  }
+  await encryptedSetItem(key, value);
 
   const thread = getThreadById(threadId);
   if (thread) {

--- a/js/chat-history.js
+++ b/js/chat-history.js
@@ -2,7 +2,7 @@
 // chat-history.js - thread-aware chat history persistence and clearing
 
 import { state } from './state.js';
-import { encryptedSetItem, encryptedGetItem, getEncryptionEnabled } from './crypto.js';
+import { encryptedSetItem, encryptedGetItem } from './crypto.js';
 import { saveImportedData } from './data.js';
 import { deleteImportedArrayItems } from './data-merge.js';
 import { showConfirmDialog, showNotification } from './utils.js';
@@ -37,11 +37,7 @@ export async function saveChatHistory() {
   invalidateThreadContentCache();
   const key = getChatThreadKey(state.currentThreadId);
   const value = JSON.stringify(state.chatHistory);
-  if (getEncryptionEnabled()) {
-    await encryptedSetItem(key, value);
-  } else {
-    localStorage.setItem(key, value);
-  }
+  await encryptedSetItem(key, value);
   const thread = state.chatThreads.find(t => t.id === state.currentThreadId);
   if (thread) {
     if (thread.messageCount !== state.chatHistory.length) thread.updatedAt = new Date().toISOString();

--- a/js/crypto.js
+++ b/js/crypto.js
@@ -149,6 +149,7 @@ const SENSITIVE_PATTERNS = [
   /^labcharts-custom-key$/,
   /^labcharts-lens-key$/,
   /^labcharts-ollama$/,
+  /^labcharts-ollama-pii-key$/,
   /^labcharts-cashu-wallet-mnemonic$/,
   /^labcharts-meteo-config$/,
 ];
@@ -165,7 +166,7 @@ let _sessionKey = null;
 // ═══════════════════════════════════════════════
 // API KEY CACHE — sync access to decrypted API keys
 // ═══════════════════════════════════════════════
-const API_KEY_LS_KEYS = ['labcharts-api-key', 'labcharts-venice-key', 'labcharts-openrouter-key', 'labcharts-routstr-key', 'labcharts-ppq-key', 'labcharts-lens-key', 'labcharts-custom-key', 'labcharts-ollama', 'labcharts-cashu-wallet-mnemonic'];
+const API_KEY_LS_KEYS = ['labcharts-api-key', 'labcharts-venice-key', 'labcharts-openrouter-key', 'labcharts-routstr-key', 'labcharts-ppq-key', 'labcharts-lens-key', 'labcharts-custom-key', 'labcharts-ollama', 'labcharts-ollama-pii-key', 'labcharts-cashu-wallet-mnemonic'];
 const _keyCache = new Map();
 
 export async function decryptKeyCache() {

--- a/js/hardware.js
+++ b/js/hardware.js
@@ -144,10 +144,17 @@ export async function detectHardware() {
 
 export function assessModel(modelObj, hardware) {
   // Cloud models run on Ollama's servers — no local VRAM needed
-  if (modelObj.name && modelObj.name.includes(':cloud')) {
+  if (modelObj.executionLocation === 'cloud' || /(?:^|[/:_.-])cloud(?:$|[/:_.-])/i.test(modelObj.name || '')) {
     return { tier: 'cloud', badge: '\u2601', vramNeeded: 0, label: 'Cloud' };
   }
-  const vramNeeded = (modelObj.size / 1e9) * 1.15; // file size + 15% runtime overhead
+  // Prefer observed runtime allocation. Otherwise include model weights plus a
+  // conservative context/KV-cache allowance; disk size alone understates fit.
+  const observedVram = Number(modelObj.vramAllocated) / 1e9;
+  const contextTokens = Number(modelObj.contextLength) || 0;
+  const contextOverhead = contextTokens > 0 ? Math.min(8, (contextTokens / 8192) * 0.5) : 0.75;
+  const vramNeeded = observedVram > 0
+    ? observedVram
+    : (Number(modelObj.size) / 1e9) * 1.1 + contextOverhead;
   const available = hardware.gpu.vram;
   if (!available || !modelObj.size) {
     return { tier: 'unknown', badge: '?', vramNeeded, label: 'Unknown' };
@@ -186,6 +193,8 @@ const MODEL_FITNESS = [
   { match: 'qwen2.5:3b',      tier: 'underpowered', note: 'Frequent JSON errors on multi-page reports' },
   { match: 'qwen2.5:1.5b',    tier: 'inadequate',  note: 'Cannot reliably parse lab reports' },
   { match: 'qwen2.5:0.5b',    tier: 'inadequate',  note: 'Cannot parse lab reports' },
+  // Qwen 3.6
+  { match: 'qwen3.6:27b',     tier: 'recommended', note: 'Latest dense Qwen — strong structured extraction and vision' },
   // Qwen 3.5
   { match: 'qwen3.5:72b',     tier: 'recommended', note: 'Cloud-grade, latest generation' },
   { match: 'qwen3.5:32b',     tier: 'recommended', note: 'Excellent for all lab report types' },
@@ -244,6 +253,7 @@ const MODEL_FITNESS = [
   { match: 'gemini-3-flash-preview:cloud', tier: 'capable', note: 'Cloud — fast, may truncate on complex reports' },
   { match: 'qwen3-coder-next:cloud', tier: 'capable', note: 'Cloud — code-focused, decent at structured extraction' },
   { match: ':cloud',           tier: 'capable',     note: 'Cloud model — runs on Ollama servers, no GPU required' },
+  { match: '-cloud',           tier: 'capable',     note: 'Cloud model — runs on Ollama servers, no GPU required' },
   // Others
   { match: 'solar:',          tier: 'underpowered', note: 'Inconsistent JSON output' },
   { match: 'yi:',             tier: 'underpowered', note: 'Weak at strict structured output' },
@@ -310,7 +320,9 @@ export function getBestModel(modelDetails, hardware) {
 // ── UPDATE when new model generations launch (same cadence as OPENROUTER_RECOMMENDED in api.js)
 //    Also update MODEL_FITNESS above.
 const MODEL_CATALOG = [
-  // Qwen 3.5 — latest gen, best structured extraction
+  // Qwen 3.6 — newest dense generation
+  { model: 'qwen3.6:27b',  sizeGb: 17,  tier: 'recommended', quality: 105 },
+  // Qwen 3.5
   { model: 'qwen3.5:72b',  sizeGb: 43,  tier: 'recommended', quality: 100 },
   { model: 'qwen3.5:32b',  sizeGb: 20,  tier: 'recommended', quality: 95 },
   { model: 'qwen3.5:14b',  sizeGb: 9,   tier: 'recommended', quality: 90 },

--- a/js/import-benchmarks.js
+++ b/js/import-benchmarks.js
@@ -1,0 +1,139 @@
+// @ts-check
+// import-benchmarks.js - Durable, privacy-conscious diagnostics for AI import attempts.
+
+import { getAIProvider, getActiveModelId, getOllamaConfig } from './api.js';
+import { saveImportedData } from './data.js';
+import { getCachedLocalAiModelDetail } from './local-ai-discovery.js';
+import { state } from './state.js';
+
+const MAX_BENCHMARKS = 50;
+
+function ensureBenchmarks() {
+  const importedData = /** @type {any} */ (state.importedData);
+  if (!Array.isArray(importedData.importBenchmarks)) importedData.importBenchmarks = [];
+  return importedData.importBenchmarks;
+}
+
+function scrubError(value) {
+  return String(value || '')
+    .replace(/\bBearer\s+\S+/gi, 'Bearer [redacted]')
+    .replace(/\bsk-[A-Za-z0-9._~+/=-]+/g, '[redacted]')
+    .slice(0, 500);
+}
+
+function runtimeSnapshot(provider, modelId) {
+  if (provider !== 'ollama') return null;
+  const config = getOllamaConfig();
+  const detail = getCachedLocalAiModelDetail(config.url, modelId, config.apiKey);
+  if (!detail) return null;
+  return {
+    provider: detail.source || 'local-ai',
+    executionLocation: detail.executionLocation || 'unknown',
+    quantLevel: detail.quantLevel || '',
+    parameterSize: detail.paramSize || '',
+    modelSize: Number(detail.size) || 0,
+    contextLength: Number(detail.contextLength) || 0,
+    maxContextLength: Number(detail.maxContextLength) || 0,
+    vramAllocated: Number(detail.vramAllocated) || 0,
+    loadedAtStart: detail.loaded,
+  };
+}
+
+export function startImportBenchmark(meta = {}) {
+  const provider = getAIProvider();
+  const modelId = getActiveModelId();
+  const now = Date.now();
+  const record = {
+    id: `bench_${now}_${Math.random().toString(36).slice(2, 7)}`,
+    benchmarkAt: now,
+    updatedAt: now,
+    status: 'started',
+    stage: 'start',
+    fileName: String(meta.fileName || ''),
+    fileSize: Math.max(0, Number(meta.fileSize) || 0),
+    importMode: meta.importMode || 'text',
+    inputChars: Math.max(0, Number(meta.inputChars) || 0),
+    pageCount: Math.max(0, Number(meta.pageCount) || 0),
+    provider,
+    modelId,
+    runtime: runtimeSnapshot(provider, modelId),
+    timings: {},
+    usage: {},
+    diagnostics: {},
+  };
+  const benchmarks = ensureBenchmarks();
+  benchmarks.push(record);
+  if (benchmarks.length > MAX_BENCHMARKS) benchmarks.splice(0, benchmarks.length - MAX_BENCHMARKS);
+  return record.id;
+}
+
+/** @param {string} id @param {any} patch @param {{persist?: boolean}} options */
+export function updateImportBenchmark(id, patch = {}, options = {}) {
+  const record = ensureBenchmarks().find(item => item.id === id);
+  if (!record) return null;
+  const next = { ...patch };
+  if (next.error) next.error = scrubError(next.error);
+  if (next.timings) next.timings = { ...record.timings, ...next.timings };
+  if (next.usage) next.usage = { ...record.usage, ...next.usage };
+  if (next.diagnostics) next.diagnostics = { ...record.diagnostics, ...next.diagnostics };
+  Object.assign(record, next, { updatedAt: Date.now() });
+  if (options.persist !== false) saveImportedData({ immediate: true }).catch(() => {});
+  return record;
+}
+
+export function finishImportBenchmark(id, status, patch = {}) {
+  return updateImportBenchmark(id, { ...patch, status, finishedAt: Date.now() });
+}
+
+export function benchmarkResultPatch(result, totalMs) {
+  const performance = result?.diagnostics?.performance || {};
+  const localPlan = result?.diagnostics?.localPlan || {};
+  const provider = result?.costInfo?.provider || result?.provider || getAIProvider();
+  const modelId = result?.costInfo?.modelId || getActiveModelId(provider);
+  return {
+    markerCount: Array.isArray(result?.markers) ? result.markers.length : 0,
+    testType: result?.testType || null,
+    privacyMethod: result?.privacyMethod || null,
+    totalMs: Math.max(0, Math.round(Number(totalMs) || 0)),
+    timings: {
+      piiMs: Math.max(0, Number(result?.timings?.piiMs) || 0),
+      analysisMs: Math.max(0, Number(result?.timings?.analysisMs) || 0),
+      modelLoadMs: Math.max(0, Number(performance.modelLoadMs) || 0),
+      timeToFirstTokenMs: Math.max(0, Number(performance.timeToFirstTokenMs) || 0),
+    },
+    usage: {
+      inputTokens: Math.max(0, Number(result?.costInfo?.inputTokens || result?.usage?.inputTokens) || 0),
+      outputTokens: Math.max(0, Number(result?.costInfo?.outputTokens || result?.usage?.outputTokens) || 0),
+      reasoningTokens: Math.max(0, Number(performance.reasoningTokens) || 0),
+    },
+    generationTokensPerSecond: Math.max(0, Number(performance.tokensPerSecond) || 0),
+    diagnostics: {
+      streamFallback: !!result?.diagnostics?.streamFallback,
+      structuredOutputFallback: !!result?.diagnostics?.structuredOutputFallback,
+      reasoningControlFallback: !!result?.diagnostics?.reasoningControlFallback,
+      nativeContextOverride: !!result?.diagnostics?.nativeContextOverride,
+      estimatedPromptTokens: Math.max(0, Number(localPlan.estimatedPromptTokens) || 0),
+      plannedMaxTokens: Math.max(0, Number(localPlan.plannedMaxTokens) || 0),
+      contextLength: Math.max(0, Number(localPlan.contextLength) || 0),
+    },
+    runtime: runtimeSnapshot(provider, modelId),
+  };
+}
+
+export function markImportBenchmarkConfirmed(id, result, excludedIndices) {
+  const initial = Array.isArray(result?._benchmarkInitialMappings) ? result._benchmarkInitialMappings : [];
+  const markers = Array.isArray(result?.markers) ? result.markers : [];
+  const correctedMappings = markers.reduce((count, marker, index) => {
+    const current = marker?.mappedKey || marker?.suggestedKey || null;
+    return count + (initial[index] !== undefined && initial[index] !== current ? 1 : 0);
+  }, 0);
+  finishImportBenchmark(id, 'confirmed', {
+    importedMarkerCount: markers.filter((marker, index) => !excludedIndices.has(index) && (marker?.mappedKey || marker?.suggestedKey)).length,
+    excludedMarkerCount: excludedIndices.size,
+    correctedMappingCount: correctedMappings,
+  });
+}
+
+export function getImportBenchmarks() {
+  return ensureBenchmarks().slice().sort((a, b) => (b.benchmarkAt || 0) - (a.benchmarkAt || 0));
+}

--- a/js/import-drop-zone.js
+++ b/js/import-drop-zone.js
@@ -42,7 +42,8 @@ export function setupDropZone() {
     try {
       importMod = await loadPdfImport();
     } catch (err) {
-      showDropZoneImportNotification('Could not load import module - check your connection and try again.', 'error');
+      console.error('[import-drop-zone] Could not load PDF import module:', err);
+      showDropZoneImportNotification('Could not load import module. Reload the app to finish updating, then try again.', 'error');
       return;
     }
     const { jsonFiles, pdfFiles, imageFiles, dnaFiles, textFiles, cycleFiles = [], unsupportedCount } = await importMod.classifyImportFiles(files);

--- a/js/import-file-input.js
+++ b/js/import-file-input.js
@@ -26,7 +26,8 @@ export async function handleImportInputChange(e) {
   try {
     importMod = await loadPdfImport();
   } catch (err) {
-    showImportNotificationRuntime('Could not load import module - check your connection and try again.', 'error');
+    console.error('[import-file-input] Could not load PDF import module:', err);
+    showImportNotificationRuntime('Could not load import module. Reload the app to finish updating, then try again.', 'error');
     e.target.value = '';
     return;
   }

--- a/js/local-ai-discovery.js
+++ b/js/local-ai-discovery.js
@@ -1,0 +1,399 @@
+// @ts-check
+// local-ai-discovery.js - Provider-aware Local AI model, capability, and runtime discovery.
+
+import { getOllamaConfig } from './api-provider-storage.js';
+
+const DISCOVERY_TIMEOUT_MS = 3000;
+const DISCOVERY_CACHE_MS = 30000;
+const FAILED_DISCOVERY_CACHE_MS = 3000;
+const discoveryCache = new Map();
+const latestDiscoveryKey = new Map();
+
+const QUANT_BPW = {
+  q2: 0.3,
+  q3: 0.4,
+  q4: 0.55,
+  q5: 0.65,
+  q6: 0.8,
+  q8: 1.0,
+  fp16: 2.0,
+  fp32: 4.0,
+  int4: 0.55,
+  int8: 1.0,
+};
+
+function normalizeBaseUrl(url) {
+  return String(url || getOllamaConfig().url || '').replace(/\/+$/, '');
+}
+
+function createHeaders(apiKey) {
+  /** @type {Record<string, string>} */
+  const headers = {};
+  if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+  return headers;
+}
+
+function discoveryError(kind, detail = {}) {
+  return { kind, ...detail };
+}
+
+function fetchFailure(error) {
+  const name = String(error?.name || '');
+  const message = String(error?.message || 'Request failed');
+  return discoveryError(name === 'TimeoutError' || name === 'AbortError' ? 'timeout' : 'network', { message });
+}
+
+function unavailableResult(provider = 'unknown', error = null) {
+  return {
+    available: false,
+    provider,
+    models: [],
+    modelDetails: [],
+    vramAllocated: 0,
+    runningStatusKnown: false,
+    error,
+  };
+}
+
+export function isCloudModel(modelName) {
+  return /(?:^|[/:_.-])cloud(?:$|[/:_.-])/i.test(String(modelName || ''));
+}
+
+export function isLikelyEmbeddingModel(modelName) {
+  return /(?:^|[/:_.-])(?:embed(?:ding)?|nomic-embed|mxbai-embed|all-minilm|bge(?:-m3)?|e5)(?:$|[/:_.-])/i.test(String(modelName || ''));
+}
+
+function isPrivateIPv4(host) {
+  const parts = host.split('.').map(Number);
+  if (parts.length !== 4 || parts.some(part => !Number.isInteger(part) || part < 0 || part > 255)) return false;
+  return parts[0] === 10
+    || parts[0] === 127
+    || (parts[0] === 169 && parts[1] === 254)
+    || (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31)
+    || (parts[0] === 192 && parts[1] === 168);
+}
+
+export function getLocalAiExecutionLocation(url, modelName = '') {
+  if (isCloudModel(modelName)) return 'cloud';
+  try {
+    const host = new URL(url).hostname.toLowerCase();
+    if (host === 'localhost' || host === '127.0.0.1' || host === '::1') return 'local';
+    if (host.endsWith('.local') || isPrivateIPv4(host) || /^(?:fc|fd|fe8|fe9|fea|feb)/i.test(host.replace(/:/g, ''))) return 'lan';
+    return 'remote';
+  } catch {
+    return 'unknown';
+  }
+}
+
+export function isPIIEligibleModel(modelName) {
+  return !!modelName && !isCloudModel(modelName) && !isLikelyEmbeddingModel(modelName);
+}
+
+export function filterPIIEligibleModels(models) {
+  return (Array.isArray(models) ? models : []).filter(isPIIEligibleModel);
+}
+
+function parseNameMetadata(id) {
+  const paramMatch = id.match(/[\-:](\d+\.?\d*)[bB]/);
+  const quantMatch = id.match(/(Q\d+_K(?:_[A-Z]+)?|Q\d+|fp16|fp32|int[48])/i);
+  const params = paramMatch ? parseFloat(paramMatch[1]) : 0;
+  const quantKey = quantMatch ? quantMatch[1].toLowerCase().replace(/_.*/, '') : '';
+  const bpw = QUANT_BPW[quantKey] || 0.55;
+  return {
+    params,
+    quantLevel: quantMatch ? quantMatch[1] : '',
+    estimatedSize: params > 0 ? Math.round(params * bpw * 1e9) : 0,
+  };
+}
+
+function parseOpenAIModel(model, baseUrl) {
+  const id = typeof model?.id === 'string' ? model.id : '';
+  const parsed = parseNameMetadata(id);
+  const reportedSize = Number(model?.size || model?.vram_required) || 0;
+  return {
+    name: id,
+    type: model?.type || 'llm',
+    size: reportedSize || parsed.estimatedSize,
+    sizeSource: reportedSize ? 'reported' : parsed.estimatedSize ? 'estimated' : 'unknown',
+    paramSize: model?.parameter_size || (parsed.params > 0 ? `${parsed.params}B` : ''),
+    quantLevel: model?.quantization || parsed.quantLevel,
+    family: model?.owned_by || '',
+    format: model?.format || '',
+    loaded: null,
+    runningStatusKnown: false,
+    contextLength: Number(model?.context_length) || 0,
+    maxContextLength: Number(model?.max_context_length || model?.context_length) || 0,
+    vramAllocated: Number(model?.size_vram) || 0,
+    vision: null,
+    reasoning: null,
+    executionLocation: getLocalAiExecutionLocation(baseUrl, id),
+    source: 'openai-compatible',
+  };
+}
+
+function indexLMStudioModels(rawModels) {
+  const index = new Map();
+  for (const model of rawModels) {
+    if (!model || !model.key) continue;
+    index.set(model.key, model);
+    if (model.selected_variant) index.set(model.selected_variant, model);
+    for (const instance of Array.isArray(model.loaded_instances) ? model.loaded_instances : []) {
+      if (instance?.id) index.set(instance.id, model);
+    }
+  }
+  return index;
+}
+
+function enrichWithLMStudioModel(detail, model, baseUrl) {
+  if (!model) return detail;
+  const loadedInstances = Array.isArray(model.loaded_instances) ? model.loaded_instances : [];
+  const loadedInstance = loadedInstances.find(instance => instance?.id === detail.name) || loadedInstances[0];
+  const exactSize = Number(model.size_bytes) || 0;
+  const reasoning = model.capabilities?.reasoning;
+  return {
+    ...detail,
+    type: model.type || detail.type,
+    size: exactSize || detail.size,
+    sizeSource: exactSize ? 'lmstudio' : detail.sizeSource,
+    paramSize: model.params_string || detail.paramSize,
+    quantLevel: model.quantization?.name || detail.quantLevel,
+    family: model.architecture || model.publisher || detail.family,
+    format: model.format || detail.format,
+    loaded: loadedInstances.length > 0,
+    runningStatusKnown: true,
+    contextLength: Number(loadedInstance?.config?.context_length) || 0,
+    maxContextLength: Number(model.max_context_length) || detail.maxContextLength,
+    vision: typeof model.capabilities?.vision === 'boolean' ? model.capabilities.vision : null,
+    reasoning: reasoning ? {
+      allowedOptions: Array.isArray(reasoning.allowed_options) ? reasoning.allowed_options.slice() : [],
+      default: reasoning.default || null,
+    } : null,
+    nativeModelKey: model.key || '',
+    loadedInstanceId: loadedInstance?.id || '',
+    executionLocation: getLocalAiExecutionLocation(baseUrl, detail.name),
+    source: 'lmstudio',
+  };
+}
+
+function dedupeLMStudioAliases(modelDetails) {
+  const output = [];
+  const indexByKey = new Map();
+  for (const detail of modelDetails) {
+    const key = detail.nativeModelKey || detail.name;
+    const existingIndex = indexByKey.get(key);
+    if (existingIndex === undefined) {
+      indexByKey.set(key, output.length);
+      output.push(detail);
+      continue;
+    }
+    const existing = output[existingIndex];
+    const existingIsLoadedId = existing.name === existing.loadedInstanceId;
+    const candidateIsLoadedId = detail.name === detail.loadedInstanceId;
+    if (candidateIsLoadedId && !existingIsLoadedId) output[existingIndex] = detail;
+  }
+  return output;
+}
+
+async function fetchLMStudioModels(baseUrl, headers) {
+  try {
+    const response = await fetch(`${baseUrl}/api/v1/models`, {
+      headers,
+      signal: AbortSignal.timeout(DISCOVERY_TIMEOUT_MS),
+    });
+    if (!response.ok) return { models: [], available: false };
+    const data = await response.json();
+    return { models: Array.isArray(data.models) ? data.models : [], available: true };
+  } catch {
+    return { models: [], available: false };
+  }
+}
+
+/**
+ * Probe an OpenAI-compatible model endpoint and enrich LM Studio responses with
+ * exact native model metadata when its v1 REST API is available.
+ */
+export async function checkOpenAICompatible(url, apiKey) {
+  const baseUrl = normalizeBaseUrl(url);
+  const headers = createHeaders(apiKey);
+  const lmStudioModelsPromise = fetchLMStudioModels(baseUrl, headers);
+  try {
+    const response = await fetch(`${baseUrl}/v1/models`, {
+      headers,
+      signal: AbortSignal.timeout(DISCOVERY_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      return unavailableResult('openai-compatible', discoveryError('http', { status: response.status, message: response.statusText }));
+    }
+    const data = await response.json();
+    const raw = Array.isArray(data.data) ? data.data : [];
+    const lmStudioResult = await lmStudioModelsPromise;
+    const lmStudioIndex = indexLMStudioModels(lmStudioResult.models);
+    const modelDetails = dedupeLMStudioAliases(raw
+      .map(model => parseOpenAIModel(model, baseUrl))
+      .filter(model => model.name && model.type !== 'embedding' && lmStudioIndex.get(model.name)?.type !== 'embedding' && !isLikelyEmbeddingModel(model.name))
+      .map(model => enrichWithLMStudioModel(model, lmStudioIndex.get(model.name), baseUrl)));
+    return {
+      available: true,
+      provider: lmStudioResult.available ? 'lmstudio' : 'openai-compatible',
+      models: modelDetails.map(model => model.name),
+      modelDetails,
+      vramAllocated: modelDetails.reduce((total, model) => total + (Number(model.vramAllocated) || 0), 0),
+      runningStatusKnown: lmStudioResult.available,
+      error: null,
+    };
+  } catch (error) {
+    return unavailableResult('openai-compatible', fetchFailure(error));
+  }
+}
+
+function indexRunningOllamaModels(rawModels) {
+  const index = new Map();
+  for (const model of rawModels) {
+    const name = model?.name || model?.model;
+    if (name) index.set(name, model);
+  }
+  return index;
+}
+
+/**
+ * Probe Ollama's installed and running model endpoints. `size_vram` is current
+ * allocation, not server capacity, and is kept separate for advisor labelling.
+ */
+export async function checkOllama(url, apiKey) {
+  const baseUrl = normalizeBaseUrl(url);
+  const headers = createHeaders(apiKey);
+  const request = path => fetch(`${baseUrl}${path}`, {
+    headers,
+    signal: AbortSignal.timeout(DISCOVERY_TIMEOUT_MS),
+  });
+  const [tagsResult, runningResult] = await Promise.allSettled([
+    request('/api/tags'),
+    request('/api/ps'),
+  ]);
+  if (tagsResult.status !== 'fulfilled') return unavailableResult('ollama', fetchFailure(tagsResult.reason));
+  if (!tagsResult.value.ok) {
+    return unavailableResult('ollama', discoveryError('http', { status: tagsResult.value.status, message: tagsResult.value.statusText }));
+  }
+  try {
+    const tagsData = await tagsResult.value.json();
+    const raw = Array.isArray(tagsData.models) ? tagsData.models : [];
+    let runningRaw = [];
+    const runningStatusKnown = runningResult.status === 'fulfilled' && runningResult.value.ok;
+    if (runningStatusKnown) {
+      const runningData = await runningResult.value.json();
+      runningRaw = Array.isArray(runningData.models) ? runningData.models : [];
+    }
+    const runningIndex = indexRunningOllamaModels(runningRaw);
+    const modelDetails = raw.map(model => {
+      const name = model?.name || model?.model;
+      const running = runningIndex.get(name);
+      return {
+        name,
+        type: isLikelyEmbeddingModel(name) ? 'embedding' : 'llm',
+        size: Number(model?.size) || 0,
+        sizeSource: Number(model?.size) > 0 ? 'ollama' : 'unknown',
+        paramSize: model?.details?.parameter_size || '',
+        quantLevel: model?.details?.quantization_level || '',
+        family: model?.details?.family || '',
+        format: model?.details?.format || '',
+        loaded: runningStatusKnown ? !!running : null,
+        runningStatusKnown,
+        contextLength: Number(running?.context_length) || 0,
+        maxContextLength: 0,
+        vramAllocated: Number(running?.size_vram) || 0,
+        vision: null,
+        reasoning: null,
+        executionLocation: getLocalAiExecutionLocation(baseUrl, name),
+        source: 'ollama',
+      };
+    }).filter(model => model.name && model.type !== 'embedding');
+    const vramAllocated = runningRaw.reduce((total, model) => total + (Number(model?.size_vram) || 0), 0);
+    return {
+      available: true,
+      provider: 'ollama',
+      models: modelDetails.map(model => model.name),
+      modelDetails,
+      vramAllocated,
+      runningStatusKnown,
+      error: null,
+    };
+  } catch (error) {
+    return unavailableResult('ollama', discoveryError('parse', { message: String(error?.message || error) }));
+  }
+}
+
+export async function discoverLocalAI(url, apiKey, options = {}) {
+  const baseUrl = normalizeBaseUrl(url);
+  const cacheKey = `${baseUrl}\n${String(apiKey || '')}`;
+  const cached = discoveryCache.get(cacheKey);
+  const maxAge = cached?.result?.available ? DISCOVERY_CACHE_MS : FAILED_DISCOVERY_CACHE_MS;
+  if (!options.force && cached && Date.now() - cached.at < maxAge) return cached.result;
+  const openai = await checkOpenAICompatible(baseUrl, apiKey);
+  // LM Studio exposes authoritative native metadata at /api/v1/models. Once
+  // that endpoint identifies the server, do not send it Ollama-only probes
+  // such as /api/tags or /api/ps (LM Studio logs those as unexpected routes).
+  const ollama = openai.provider === 'lmstudio'
+    ? unavailableResult('ollama', discoveryError('not-probed', { message: 'LM Studio identified by native API' }))
+    : await checkOllama(baseUrl, apiKey);
+  const primary = ollama.available && ollama.models.length > 0
+    ? ollama
+    : openai.available ? openai : ollama.available ? ollama : openai;
+  const result = {
+    ...primary,
+    baseUrl,
+    discoveredAt: Date.now(),
+    executionLocation: getLocalAiExecutionLocation(baseUrl),
+    openai,
+    ollama,
+  };
+  discoveryCache.set(cacheKey, { at: Date.now(), result });
+  latestDiscoveryKey.set(baseUrl, cacheKey);
+  return result;
+}
+
+export function getCachedLocalAiDiscovery(url, apiKey) {
+  const baseUrl = normalizeBaseUrl(url);
+  const key = apiKey === undefined
+    ? latestDiscoveryKey.get(baseUrl)
+    : `${baseUrl}\n${String(apiKey || '')}`;
+  return key ? discoveryCache.get(key)?.result || null : null;
+}
+
+export function getCachedLocalAiModelDetail(url, modelName, apiKey) {
+  const result = getCachedLocalAiDiscovery(url, apiKey);
+  return result?.modelDetails?.find(model => model.name === modelName) || null;
+}
+
+export function markCachedLocalAiModelLoaded(url, modelName, apiKey, runtimePatch = {}) {
+  const result = getCachedLocalAiDiscovery(url, apiKey);
+  const detail = result?.modelDetails?.find(model => model.name === modelName);
+  if (!result || !detail) return result || null;
+  Object.assign(detail, runtimePatch, { loaded: true, runningStatusKnown: true });
+  result.runningStatusKnown = true;
+  if (result.openai?.modelDetails) {
+    const openaiDetail = result.openai.modelDetails.find(model => model.name === modelName);
+    if (openaiDetail) {
+      Object.assign(openaiDetail, runtimePatch, { loaded: true, runningStatusKnown: true });
+    }
+  }
+  if (result.ollama?.modelDetails) {
+    const ollamaDetail = result.ollama.modelDetails.find(model => model.name === modelName);
+    if (ollamaDetail) {
+      Object.assign(ollamaDetail, runtimePatch, { loaded: true, runningStatusKnown: true });
+    }
+  }
+  return result;
+}
+
+export function clearLocalAiDiscovery(url) {
+  if (url) {
+    const baseUrl = normalizeBaseUrl(url);
+    for (const key of discoveryCache.keys()) {
+      if (key.startsWith(`${baseUrl}\n`)) discoveryCache.delete(key);
+    }
+    latestDiscoveryKey.delete(baseUrl);
+  } else {
+    discoveryCache.clear();
+    latestDiscoveryKey.clear();
+  }
+}

--- a/js/pdf-import-ai-utils.js
+++ b/js/pdf-import-ai-utils.js
@@ -4,6 +4,54 @@
 import { callClaudeAPI, AI_IMPORT_REQUEST_TIMEOUT_MS } from './api.js';
 import { isDebugMode } from './utils.js';
 
+export const IMPORT_JSON_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    testType: { type: ['string', 'null'] },
+    date: { type: ['string', 'null'] },
+    markers: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          rawName: { type: 'string' },
+          value: { type: ['number', 'string'] },
+          mappedKey: { type: ['string', 'null'] },
+          suggestedKey: { type: ['string', 'null'] },
+          suggestedName: { type: ['string', 'null'] },
+          suggestedCategoryLabel: { type: ['string', 'null'] },
+          suggestedGroup: { type: ['string', 'null'] },
+          unit: { type: ['string', 'null'] },
+          refMin: { type: ['number', 'null'] },
+          refMax: { type: ['number', 'null'] },
+        },
+        required: ['rawName', 'value', 'mappedKey', 'unit', 'refMin', 'refMax'],
+      },
+    },
+  },
+  required: ['testType', 'date', 'markers'],
+};
+
+export const IMPORT_CLASSIFICATION_JSON_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    testType: { type: 'string' },
+    labName: { type: ['string', 'null'] },
+  },
+  required: ['testType'],
+};
+
+export function compactMarkerReference(markerRef) {
+  return Object.entries(markerRef || {}).map(([key, def]) => {
+    const name = String(def?.name || '').replace(/[|\n\r]/g, ' ');
+    const unit = String(def?.unit || '').replace(/[|\n\r]/g, ' ');
+    return `${key}|${name}|${unit}`;
+  }).join('\n');
+}
+
 /**
  * @typedef {{
  *   inputTokens?: number,
@@ -27,7 +75,11 @@ export async function callImportAIWithStreamFallback(request, label) {
     if (!request.onStream || request.signal?.aborted || !isAIStreamAbortError(err)) throw err;
     if (isDebugMode()) console.warn(`[Import] ${label} stream aborted; retrying without streaming`, err);
     try {
-      return await callClaudeAPI({ ...request, onStream: undefined, forceNonStream: true, requestTimeoutMs: AI_IMPORT_REQUEST_TIMEOUT_MS });
+      const result = await callClaudeAPI({ ...request, onStream: undefined, forceNonStream: true, requestTimeoutMs: AI_IMPORT_REQUEST_TIMEOUT_MS });
+      return {
+        ...result,
+        diagnostics: { ...result?.diagnostics, streamFallback: true },
+      };
     } catch (retryErr) {
       if (isAIStreamAbortError(retryErr)) {
         throw new Error('AI analysis request was aborted after retrying without streaming. The PDF text extracted correctly; try another model/provider if this persists.');

--- a/js/pdf-import-commit.js
+++ b/js/pdf-import-commit.js
@@ -25,6 +25,7 @@ import {
   resolveImportPreviewBatch,
   showImportPreview,
 } from './pdf-import-review.js';
+import { markImportBenchmarkConfirmed } from './import-benchmarks.js';
 
 const pdfImportCommitDeps = { maybeShowEncryptionNudge };
 
@@ -210,6 +211,29 @@ export async function confirmImport() {
     suggestedGroup: m.suggestedGroup || null,
     matched: !!m.matched,
   });
+  const snapshotCostInfo = result.costInfo ? {
+    provider: result.costInfo.provider || null,
+    modelId: result.costInfo.modelId || null,
+    inputTokens: Number(result.costInfo.inputTokens) || 0,
+    outputTokens: Number(result.costInfo.outputTokens) || 0,
+    cost: Number(result.costInfo.cost) || 0,
+  } : null;
+  const snapshotTimings = result.timings ? {
+    pii: Number(result.timings.pii) || 0,
+    analysis: Number(result.timings.analysis) || 0,
+    piiMs: Number.isFinite(Number(result.timings.piiMs))
+      ? Math.max(0, Math.round(Number(result.timings.piiMs)))
+      : Math.max(0, Math.round((Number(result.timings.pii) || 0) * 1000)),
+    analysisMs: Number.isFinite(Number(result.timings.analysisMs))
+      ? Math.max(0, Math.round(Number(result.timings.analysisMs)))
+      : Math.max(0, Math.round((Number(result.timings.analysis) || 0) * 1000)),
+  } : null;
+  const snapshotDiagnostics = result.diagnostics?.streamFallback || result.diagnostics?.structuredOutputFallback
+    ? {
+      streamFallback: !!result.diagnostics.streamFallback,
+      structuredOutputFallback: !!result.diagnostics.structuredOutputFallback,
+    }
+    : null;
   const snapBase = {
     fileName: result.fileName || '',
     date: result.date || '',
@@ -217,7 +241,11 @@ export async function confirmImport() {
     type: deriveImportType(result.fileName),
     markerCount: importCount,
     excludedIndices: Array.from(excludedIdxs),
-    costInfo: result.costInfo ? { provider: result.costInfo.provider, modelId: result.costInfo.modelId } : null,
+    costInfo: snapshotCostInfo,
+    timings: snapshotTimings,
+    importMode: result.imageMode ? 'image' : 'text',
+    diagnostics: snapshotDiagnostics,
+    benchmarkId: result.benchmarkId || null,
   };
   if (isReReview) {
     if (!state.importedData.importSnapshots) state.importedData.importSnapshots = [];
@@ -228,6 +256,7 @@ export async function confirmImport() {
         ...state.importedData.importSnapshots[snapIdx],
         ...snapBase,
         markers: result.markers.map(m => snapshotPayload(m)),
+        benchmarkAt: importTs,
         importedAt: importTs,
       };
     } else {
@@ -235,6 +264,7 @@ export async function confirmImport() {
         id: snapshotId,
         ...snapBase,
         markers: result.markers.map(m => snapshotPayload(m)),
+        benchmarkAt: importTs,
         importedAt: importTs,
       });
     }
@@ -244,6 +274,7 @@ export async function confirmImport() {
       id: snapshotId,
       ...snapBase,
       markers: result.markers.map(m => snapshotPayload(m)),
+      benchmarkAt: importTs,
       importedAt: importTs,
     });
   }
@@ -253,6 +284,10 @@ export async function confirmImport() {
     restoreImportedDataSnapshot(rollback);
     if (confirmBtn) confirmBtn.disabled = false;
     return;
+  }
+  if (result.benchmarkId) {
+    markImportBenchmarkConfirmed(result.benchmarkId, result, excludedIdxs);
+    result.benchmarkId = null;
   }
   // Resolve batch promise before closeImportModal (which would resolve with 'skip').
   if (!resolveImportPreviewBatch('import')) closeImportModal();
@@ -357,6 +392,9 @@ export function openImportReviewFromSnapshot(snapId) {
     testType: snapshot.testType,
     markers: snapshot.markers.map(m => ({ ...m })),
     costInfo: snapshot.costInfo,
+    timings: snapshot.timings,
+    imageMode: snapshot.importMode === 'image',
+    diagnostics: snapshot.diagnostics,
     importHash: snapshot.importHash,
     _reReviewSnapshotId: snapshot.id,
     _excludedImportIndices: snapshot.excludedIndices || [],

--- a/js/pdf-import-preflight.js
+++ b/js/pdf-import-preflight.js
@@ -6,6 +6,7 @@ import { callClaudeAPI, getActiveModelId, getAIProvider, hasAIProvider, setAIPro
 import { detectProduct, getAdapterByTestType } from './adapters.js';
 import { escapeHTML, hashString, isDebugMode } from './utils.js';
 import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
+import { IMPORT_CLASSIFICATION_JSON_SCHEMA } from './pdf-import-ai-utils.js';
 
 function ensurePreflightOverlay() {
   let overlay = document.getElementById('confirm-dialog-overlay');
@@ -162,7 +163,12 @@ Always include "labName" if you can identify the lab or product name from the te
 
 First ~2000 characters of the PDF:
 ${snippet}` }],
-      maxTokens: 80
+      maxTokens: 80,
+      minOutputTokens: 64,
+      jsonMode: true,
+      jsonSchema: IMPORT_CLASSIFICATION_JSON_SCHEMA,
+      reasoningEffort: 'none',
+      temperature: 0,
     });
     const text = (response || '').trim();
     const json = text.match(/\{[^}]*\}/);

--- a/js/pdf-import-review.js
+++ b/js/pdf-import-review.js
@@ -43,6 +43,7 @@ import {
   startBatchImport,
   takeBatchImportResolve,
 } from './pdf-import-review-runtime.js';
+import { finishImportBenchmark } from './import-benchmarks.js';
 
 function clearPendingImport() {
   clearPendingImportRuntime();
@@ -770,6 +771,8 @@ export function getExcludedImportIndices() {
 }
 
 export function closeImportModal() {
+  const pending = getPendingImport();
+  if (pending?.benchmarkId) finishImportBenchmark(pending.benchmarkId, 'cancelled', { stage: 'review' });
   if (resolveImportPreviewBatch('skip')) return;
   hideImportOverlay();
   clearPendingImport();

--- a/js/pdf-import.js
+++ b/js/pdf-import.js
@@ -12,8 +12,10 @@ import { importDataJSON, loadDemoData } from './export.js';
 import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 import {
   callImportAIWithStreamFallback,
+  compactMarkerReference,
   formatImportError,
   getUsageTokens,
+  IMPORT_JSON_SCHEMA,
   tryParseJSON,
 } from './pdf-import-ai-utils.js';
 import { extractXLSXText, isCsvTextFile, isTextImportFile, isXlsxFile } from './pdf-import-spreadsheet.js';
@@ -64,6 +66,12 @@ import {
 } from './pdf-import-commit.js';
 import { getDnaModuleFunction } from './dna-runtime-bridge.js';
 import { getSettingsModuleFunction } from './settings-runtime-bridge.js';
+import {
+  benchmarkResultPatch,
+  finishImportBenchmark,
+  startImportBenchmark,
+  updateImportBenchmark,
+} from './import-benchmarks.js';
 
 const pdfImportDeps = {
   importDataJSON,
@@ -195,8 +203,8 @@ export async function parseLabPDFWithAI(pdfText, fileName, onProgress) {
     : `   IMPORTANT — for ambiguous numeric dates like "12/7/2025", look for context (other dates, a printed format like "DD/MM/YYYY" in the report header, or month names elsewhere) before deciding. Do not assume MM/DD by default — most of the world uses DD/MM/YYYY.`;
   const system = `You are a lab report data extraction assistant. You extract biomarker results from lab report text and map them to a known set of marker keys.
 
-Here is the complete list of known markers with their keys, expected units, and reference ranges:
-${JSON.stringify(markerRef)}
+Known markers are listed as key|English name|expected unit. Reference ranges must come from the report, never this list:
+${compactMarkerReference(markerRef)}
 
 IMPORTANT — The lab report may contain test names in Bulgarian, Czech, German, Russian, Ukrainian, or other languages. Before matching, translate every non-English test name into its English medical equivalent. For example: "Креатинин" → "Creatinine", "Урея" → "Urea", "Мочевая кислота" → "Uric Acid", "АСТ" → "AST", "Glukóza" → "Glucose". Use the English name when searching the known markers list.
 IMPORTANT — Use English unit abbreviations only. Do not use Cyrillic or localized unit names, replace them with English instead.
@@ -270,7 +278,7 @@ Return ONLY valid JSON in this exact format, no other text:
 }`;
 
   const provider = getAIProvider();
-  const maxTokens = 32768;
+  const maxTokens = 16384;
   // Stream AI response to report real-time progress during analysis (15% → 90%)
   let onStream;
   if (onProgress) {
@@ -286,13 +294,18 @@ Return ONLY valid JSON in this exact format, no other text:
     ? `\n\nIMPORTANT — These marker keys were used in previous imports for this profile. Reuse them for the same biomarkers to ensure consistency:\n${[...existingKeys].join(', ')}`
     : '';
 
-  const { text: response, usage } = await callImportAIWithStreamFallback({
+  const { text: response, usage, diagnostics } = await callImportAIWithStreamFallback({
     system: system + existingKeysNote,
     messages: [{ role: 'user', content: `Extract all biomarker results from this lab report${fileName ? ' (file: ' + fileName + ')' : ''}:\n\n${pdfText}` }],
     maxTokens,
     onStream,
     requestTimeoutMs: AI_IMPORT_REQUEST_TIMEOUT_MS,
-    jsonMode: true
+    jsonMode: true,
+    jsonSchema: IMPORT_JSON_SCHEMA,
+    reasoningEffort: 'none',
+    temperature: 0,
+    minOutputTokens: 2048,
+    preferNativeContext: true,
   }, 'PDF text analysis');
 
   // Parse JSON from response (handle markdown code blocks, thinking tags, truncated output)
@@ -320,7 +333,9 @@ Return ONLY valid JSON in this exact format, no other text:
     markers,
     fileName,
     usage,
-    provider
+    provider,
+    diagnostics,
+    imageMode: false,
   };
 }
 
@@ -398,8 +413,8 @@ export async function parseLabPDFWithAIImages(images, fileName, onProgress) {
   // Same system prompt as text-based parsing
   const system = `You are a lab report data extraction assistant. You extract biomarker results from lab report images and map them to a known set of marker keys.
 
-Here is the complete list of known markers with their keys, expected units, and reference ranges:
-${JSON.stringify(markerRef)}
+Known markers are listed as key|English name|expected unit. Reference ranges must come from the report, never this list:
+${compactMarkerReference(markerRef)}
 
 IMPORTANT — The lab report may contain test names in Bulgarian, Czech, German, Russian, Ukrainian, or other languages. Before matching, translate every non-English test name into its English medical equivalent. For example: "Креатинин" → "Creatinine", "Урея" → "Urea", "Мочевая кислота" → "Uric Acid", "АСТ" → "AST", "Glukóza" → "Glucose". Use the English name when searching the known markers list.
 IMPORTANT — Use English unit abbreviations only. Do not use Cyrillic or localized unit names, replace them with English instead.
@@ -439,7 +454,7 @@ Return ONLY valid JSON in this exact format:
 }`;
 
   const provider = getAIProvider();
-  const maxTokens = 32768;
+  const maxTokens = 16384;
   let onStream;
   if (onProgress) {
     let lastPct = -1;
@@ -459,13 +474,18 @@ Return ONLY valid JSON in this exact format:
     { type: 'text', text: `Extract all biomarker results from this lab report${fileName ? ' (file: ' + fileName + ')' : ''}. Read every page carefully.` }
   ];
 
-  const { text: response, usage } = await callImportAIWithStreamFallback({
+  const { text: response, usage, diagnostics } = await callImportAIWithStreamFallback({
     system,
     messages: [{ role: 'user', content }],
     maxTokens,
     onStream,
     requestTimeoutMs: AI_IMPORT_REQUEST_TIMEOUT_MS,
-    jsonMode: true
+    jsonMode: true,
+    jsonSchema: IMPORT_JSON_SCHEMA,
+    reasoningEffort: 'none',
+    temperature: 0,
+    minOutputTokens: 2048,
+    preferNativeContext: true,
   }, 'PDF image analysis');
 
   let jsonStr = (response || '').trim();
@@ -489,6 +509,7 @@ Return ONLY valid JSON in this exact format:
     fileName,
     usage: usage || {},
     provider,
+    diagnostics,
     imageMode: true,
   };
 }
@@ -533,6 +554,19 @@ async function _showImageModeDialog() {
 
 export async function handlePDFFile(file, forceImageMode = false, preExtractedText = null) {
   const _startProfileId = state.currentProfile;
+  const benchmarkStarted = performance.now();
+  const benchmarkId = startImportBenchmark({ fileName: file.name, fileSize: file.size, importMode: forceImageMode ? 'image' : 'text' });
+  let benchmarkFinished = false;
+  let benchmarkStage = 'extract';
+  const setBenchmarkStage = (stage, patch = {}) => {
+    benchmarkStage = stage;
+    updateImportBenchmark(benchmarkId, { stage, ...patch }, { persist: false });
+  };
+  const finishBenchmark = (status, patch = {}) => {
+    if (benchmarkFinished) return;
+    benchmarkFinished = true;
+    finishImportBenchmark(benchmarkId, status, { stage: benchmarkStage, ...patch });
+  };
   const hasPreExtractedText = preExtractedText !== null;
   const isCsvImport = isCsvTextFile(file);
   const isXlsxImport = isXlsxFile(file);
@@ -543,6 +577,11 @@ export async function handlePDFFile(file, forceImageMode = false, preExtractedTe
     await showImportProgress(0, file.name);
     const pdfText = hasPreExtractedText ? preExtractedText : await extractPDFText(file);
     const textQuality = hasPreExtractedText ? 'good' : assessTextQuality(pdfText);
+    setBenchmarkStage('mode-selection', {
+      inputChars: pdfText.length,
+      pageCount: (pdfText.match(/^=== Page \d+ ===$/gm) || []).length,
+      textQuality,
+    });
 
     // Determine import mode — ask user for scanned/empty PDFs
     let useImageMode = forceImageMode;
@@ -550,6 +589,7 @@ export async function handlePDFFile(file, forceImageMode = false, preExtractedTe
       const choice = await _showImageModeDialog();
       if (choice === 'cancel') { hideImportProgress(); return; }
       useImageMode = choice === 'image';
+      updateImportBenchmark(benchmarkId, { importMode: useImageMode ? 'image' : 'text' }, { persist: false });
       if (isDebugMode()) console.log(`[Import] User chose ${choice} for ${textQuality} text quality`);
     }
 
@@ -565,11 +605,13 @@ export async function handlePDFFile(file, forceImageMode = false, preExtractedTe
       if (images.length === 0) { hideImportProgress('error'); showNotification("Could not render PDF pages", "error"); return; }
       await showImportProgress(3, file.name);
       const analysisStart = performance.now();
+      setBenchmarkStage('analysis', { importMode: 'image', pageCount: images.length });
       const result = await parseLabPDFWithAIImages(images, file.name, updateImportProgressPct);
-      const analysisTime = Math.round((performance.now() - analysisStart) / 1000);
+      const analysisMs = Math.round(performance.now() - analysisStart);
+      const analysisTime = Math.round(analysisMs / 1000);
       if (isDebugMode()) console.log(`[Analysis] Image mode parsed in ${analysisTime}s`);
       result.privacyMethod = 'none (image mode)';
-      result.timings = { pii: 0, analysis: analysisTime };
+      result.timings = { pii: 0, analysis: analysisTime, piiMs: 0, analysisMs };
       const prov = result.provider || getAIProvider();
       const mid = getActiveModelId();
       const tokens = getUsageTokens(result.usage);
@@ -581,9 +623,12 @@ export async function handlePDFFile(file, forceImageMode = false, preExtractedTe
       };
       trackUsage(prov, mid, tokens.inputTokens, tokens.outputTokens);
       result.importHash = hashString(file.name + file.size);
+      result.benchmarkId = benchmarkId;
+      result._benchmarkInitialMappings = result.markers.map(marker => marker.mappedKey || marker.suggestedKey || null);
       result._importProfileId = _startProfileId;
       if (!result.date) showNotification("Could not find collection date in PDF", "error");
-      if (result.markers.length === 0) { hideImportProgress('error'); showNotification("No biomarkers found in PDF images", "error"); return; }
+      if (result.markers.length === 0) { finishBenchmark('no-markers', benchmarkResultPatch(result, performance.now() - benchmarkStarted)); hideImportProgress('error'); showNotification("No biomarkers found in PDF images", "error"); return; }
+      finishBenchmark('preview', benchmarkResultPatch(result, performance.now() - benchmarkStarted));
       await showImportProgress(4, file.name);
       showImportPreview(result);
       hideImportProgress();
@@ -601,16 +646,19 @@ export async function handlePDFFile(file, forceImageMode = false, preExtractedTe
 
     // Pre-flight checks — before spending tokens
     await showImportProgress(1, file.name);
+    setBenchmarkStage('preflight');
     const preflight = await runPreflightChecks(pdfText, file.name);
     if (!preflight) { hideImportProgress('cancel'); return; }
 
     // PII obfuscation step
     await showImportProgress(2, file.name);
+    setBenchmarkStage('privacy');
     let textForAI = pdfText;
     let privacyMethod = null;
     let privacyReplacements = 0;
     let privacyOriginal = null;
     let piiTime = 0;
+    let piiMs = 0;
     const ollama = await checkOllamaPII();
 
     if (ollama.available && isPIIReviewEnabled()) {
@@ -619,7 +667,8 @@ export async function handlePDFFile(file, forceImageMode = false, preExtractedTe
       const reviewResult = await reviewPIIBeforeSend(pdfText, {
         streamFn: (onChunk, signal, onThinking) => sanitizeWithOllamaStreaming(pdfText, onChunk, signal, onThinking)
       });
-      piiTime = Math.round((performance.now() - piiStart) / 1000);
+      piiMs = Math.round(performance.now() - piiStart);
+      piiTime = Math.round(piiMs / 1000);
       if (reviewResult === 'cancel') { hideImportProgress('cancel'); showNotification('Import cancelled.', 'info'); return; }
       textForAI = reviewResult;
       privacyMethod = 'ollama+review';
@@ -629,7 +678,8 @@ export async function handlePDFFile(file, forceImageMode = false, preExtractedTe
       try {
         const piiStart = performance.now();
         textForAI = await sanitizeWithOllama(pdfText);
-        piiTime = Math.round((performance.now() - piiStart) / 1000);
+        piiMs = Math.round(performance.now() - piiStart);
+        piiTime = Math.round(piiMs / 1000);
         privacyMethod = 'ollama';
         privacyOriginal = pdfText;
         if (isDebugMode()) console.log(`[PII] Obfuscated via Local AI (${piiTime}s)`);
@@ -669,13 +719,15 @@ export async function handlePDFFile(file, forceImageMode = false, preExtractedTe
     if (isDebugMode()) { console.log('[PII] Original:', pdfText); console.log('[PII] Obfuscated:', textForAI); }
 
     await showImportProgress(3, file.name);
+    setBenchmarkStage('analysis');
     const analysisStart = performance.now();
     const result = await parseLabPDFWithAI(textForAI, file.name, updateImportProgressPct);
-    const analysisTime = Math.round((performance.now() - analysisStart) / 1000);
+    const analysisMs = Math.round(performance.now() - analysisStart);
+    const analysisTime = Math.round(analysisMs / 1000);
     if (isDebugMode()) console.log(`[Analysis] Parsed in ${analysisTime}s`);
     result.privacyMethod = privacyMethod;
     result.privacyReplacements = privacyReplacements;
-    result.timings = { pii: piiTime, analysis: analysisTime };
+    result.timings = { pii: piiTime, analysis: analysisTime, piiMs, analysisMs };
     const prov = result.provider || getAIProvider();
     const mid = getActiveModelId();
     const tokens = getUsageTokens(result.usage);
@@ -687,17 +739,23 @@ export async function handlePDFFile(file, forceImageMode = false, preExtractedTe
     };
     trackUsage(prov, mid, tokens.inputTokens, tokens.outputTokens);
     result.importHash = hashString(pdfText);
+    result.benchmarkId = benchmarkId;
+    result._benchmarkInitialMappings = result.markers.map(marker => marker.mappedKey || marker.suggestedKey || null);
     result._importProfileId = _startProfileId;
     if (isDebugMode()) { result.privacyOriginal = privacyOriginal; result.privacyObfuscated = textForAI; }
     if (!result.date) { showNotification(`Could not find collection date in ${textImportKind}`, "error"); }
-    if (result.markers.length === 0) { hideImportProgress('error'); showNotification(`No biomarkers found in ${textImportKind}`, "error"); return; }
+    if (result.markers.length === 0) { finishBenchmark('no-markers', benchmarkResultPatch(result, performance.now() - benchmarkStarted)); hideImportProgress('error'); showNotification(`No biomarkers found in ${textImportKind}`, "error"); return; }
+    finishBenchmark('preview', benchmarkResultPatch(result, performance.now() - benchmarkStarted));
     await showImportProgress(4, file.name);
     showImportPreview(result);
     hideImportProgress();
   } catch (err) {
+    finishBenchmark('failed', { error: formatImportError(err), totalMs: Math.round(performance.now() - benchmarkStarted) });
     hideImportProgress('error');
     if (isDebugMode()) console.error("PDF parse error:", err);
     showNotification("Error parsing PDF: " + formatImportError(err), "error", 10000);
+  } finally {
+    if (!benchmarkFinished) finishBenchmark('stopped', { reason: benchmarkStage, totalMs: Math.round(performance.now() - benchmarkStarted) });
   }
 }
 
@@ -705,14 +763,23 @@ export async function handlePDFFile(file, forceImageMode = false, preExtractedTe
 // BATCH PDF IMPORT
 // ═══════════════════════════════════════════════
 async function _processBatchFile(file, ollama, fileNum, totalFiles) {
+  const benchmarkStarted = performance.now();
+  const benchmarkId = startImportBenchmark({ fileName: file.name, fileSize: file.size, importMode: 'text' });
+  const finishBatchBenchmark = (status, patch = {}) => finishImportBenchmark(benchmarkId, status, { totalMs: Math.round(performance.now() - benchmarkStarted), ...patch });
+  try {
   await showBatchImportProgress(0, file.name, fileNum, totalFiles);
   const pdfText = await extractPDFText(file);
-  if (!pdfText.trim()) { showNotification(`${file.name}: PDF appears empty`, 'error'); return 'empty'; }
+  updateImportBenchmark(benchmarkId, {
+    stage: 'preflight',
+    inputChars: pdfText.length,
+    pageCount: (pdfText.match(/^=== Page \d+ ===$/gm) || []).length,
+  }, { persist: false });
+  if (!pdfText.trim()) { finishBatchBenchmark('empty'); showNotification(`${file.name}: PDF appears empty`, 'error'); return 'empty'; }
 
   // Pre-flight checks — before spending tokens
   await showBatchImportProgress(1, file.name, fileNum, totalFiles);
   const preflight = await runPreflightChecks(pdfText, file.name);
-  if (!preflight) return 'skipped';
+  if (!preflight) { finishBatchBenchmark('cancelled', { stage: 'preflight' }); return 'skipped'; }
 
   // PII obfuscation
   await showBatchImportProgress(2, file.name, fileNum, totalFiles);
@@ -721,6 +788,7 @@ async function _processBatchFile(file, ollama, fileNum, totalFiles) {
   let privacyReplacements = 0;
   let privacyOriginal = null;
   let piiTime = 0;
+  let piiMs = 0;
 
   if (ollama.available && isPIIReviewEnabled()) {
     // Streaming mode — modal opens immediately, AI streams into it
@@ -728,8 +796,9 @@ async function _processBatchFile(file, ollama, fileNum, totalFiles) {
     const reviewResult = await reviewPIIBeforeSend(pdfText, {
       streamFn: (onChunk, signal, onThinking) => sanitizeWithOllamaStreaming(pdfText, onChunk, signal, onThinking)
     });
-    piiTime = Math.round((performance.now() - piiStart) / 1000);
-    if (reviewResult === 'cancel') { return 'skipped'; }
+    piiMs = Math.round(performance.now() - piiStart);
+    piiTime = Math.round(piiMs / 1000);
+    if (reviewResult === 'cancel') { finishBatchBenchmark('cancelled', { stage: 'privacy' }); return 'skipped'; }
     textForAI = reviewResult;
     privacyMethod = 'ollama+review';
     privacyOriginal = pdfText;
@@ -737,7 +806,8 @@ async function _processBatchFile(file, ollama, fileNum, totalFiles) {
     try {
       const piiStart = performance.now();
       textForAI = await sanitizeWithOllama(pdfText);
-      piiTime = Math.round((performance.now() - piiStart) / 1000);
+      piiMs = Math.round(performance.now() - piiStart);
+      piiTime = Math.round(piiMs / 1000);
       privacyMethod = 'ollama';
       privacyOriginal = pdfText;
     } catch (e) {
@@ -748,7 +818,7 @@ async function _processBatchFile(file, ollama, fileNum, totalFiles) {
         privacyMethod = 'regex';
       } catch (e2) {
         showNotification(`${file.name}: Privacy protection failed \u2014 skipped`, 'error');
-        return 'pii-fail';
+        finishBatchBenchmark('failed', { stage: 'privacy', error: e2.message }); return 'pii-fail';
       }
     }
   } else {
@@ -758,11 +828,11 @@ async function _processBatchFile(file, ollama, fileNum, totalFiles) {
       privacyMethod = 'regex';
     } catch (e) {
       showNotification(`${file.name}: Privacy protection failed \u2014 skipped`, 'error');
-      return 'pii-fail';
+      finishBatchBenchmark('failed', { stage: 'privacy', error: e.message }); return 'pii-fail';
     }
     if (isPIIReviewEnabled()) {
       const reviewResult = await reviewPIIBeforeSend(pdfText, { obfuscatedText: textForAI });
-      if (reviewResult === 'cancel') { return 'skipped'; }
+      if (reviewResult === 'cancel') { finishBatchBenchmark('cancelled', { stage: 'privacy' }); return 'skipped'; }
       textForAI = reviewResult;
     }
   }
@@ -771,11 +841,12 @@ async function _processBatchFile(file, ollama, fileNum, totalFiles) {
   await showBatchImportProgress(3, file.name, fileNum, totalFiles);
   const analysisStart = performance.now();
   const result = await parseLabPDFWithAI(textForAI, file.name, updateImportProgressPct);
-  const analysisTime = Math.round((performance.now() - analysisStart) / 1000);
+  const analysisMs = Math.round(performance.now() - analysisStart);
+  const analysisTime = Math.round(analysisMs / 1000);
   if (isDebugMode()) console.log(`[Analysis] ${file.name} parsed in ${analysisTime}s`);
   result.privacyMethod = privacyMethod;
   result.privacyReplacements = privacyReplacements;
-  result.timings = { pii: piiTime, analysis: analysisTime };
+  result.timings = { pii: piiTime, analysis: analysisTime, piiMs, analysisMs };
   const prov = result.provider || getAIProvider();
   const mid = getActiveModelId();
   const tokens = getUsageTokens(result.usage);
@@ -787,11 +858,18 @@ async function _processBatchFile(file, ollama, fileNum, totalFiles) {
   };
   trackUsage(prov, mid, tokens.inputTokens, tokens.outputTokens);
   result.importHash = hashString(pdfText);
+  result.benchmarkId = benchmarkId;
+  result._benchmarkInitialMappings = result.markers.map(marker => marker.mappedKey || marker.suggestedKey || null);
   if (isDebugMode()) { result.privacyOriginal = privacyOriginal; result.privacyObfuscated = textForAI; }
-  if (result.markers.length === 0) { showNotification(`${file.name}: No markers found`, 'error'); return 'no-markers'; }
+  if (result.markers.length === 0) { finishBatchBenchmark('no-markers', benchmarkResultPatch(result, performance.now() - benchmarkStarted)); showNotification(`${file.name}: No markers found`, 'error'); return 'no-markers'; }
+  finishBatchBenchmark('preview', benchmarkResultPatch(result, performance.now() - benchmarkStarted));
   await showBatchImportProgress(4, file.name, fileNum, totalFiles);
   const action = await showImportPreviewAsync(result, fileNum, totalFiles);
   return action === 'skip' ? 'skipped' : 'imported';
+  } catch (error) {
+    finishBatchBenchmark('failed', { stage: 'analysis', error: error.message });
+    throw error;
+  }
 }
 
 export async function handleBatchPDFs(pdfFiles) {
@@ -858,13 +936,12 @@ export async function handleImageFile(file) {
     return;
   }
   // PII warning — images cannot be scrubbed
-  const provider = getAIProvider();
-  if (provider !== 'ollama') {
-    if (!await showConfirmDialog(
-      'This image will be sent directly to the AI provider. Personal details visible in the image cannot be scrubbed before upload. Continue?'
-    )) return;
-  }
+  if (!await showConfirmDialog(
+    'This image will be sent directly to the configured AI server or provider. Personal details visible in the image cannot be scrubbed before upload. Continue?'
+  )) return;
   const _startProfileId = state.currentProfile;
+  const benchmarkStarted = performance.now();
+  const benchmarkId = startImportBenchmark({ fileName: file.name, fileSize: file.size, importMode: 'image', pageCount: 1 });
   try {
     await showImportProgress(3, file.name);
     const base64 = await new Promise((resolve, reject) => {
@@ -876,11 +953,13 @@ export async function handleImageFile(file) {
     const mediaType = file.type || (file.name.match(/\.png$/i) ? 'image/png' : file.name.match(/\.webp$/i) ? 'image/webp' : 'image/jpeg');
     const images = [{ base64, mediaType, page: 1 }];
     const analysisStart = performance.now();
+    updateImportBenchmark(benchmarkId, { stage: 'analysis', pageCount: 1 }, { persist: false });
     const result = await parseLabPDFWithAIImages(images, file.name, updateImportProgressPct);
-    const analysisTime = Math.round((performance.now() - analysisStart) / 1000);
+    const analysisMs = Math.round(performance.now() - analysisStart);
+    const analysisTime = Math.round(analysisMs / 1000);
     if (isDebugMode()) console.log(`[Analysis] Image file parsed in ${analysisTime}s`);
     result.privacyMethod = 'none (image mode)';
-    result.timings = { pii: 0, analysis: analysisTime };
+    result.timings = { pii: 0, analysis: analysisTime, piiMs: 0, analysisMs };
     const prov = result.provider || getAIProvider();
     const mid = getActiveModelId();
     const tokens = getUsageTokens(result.usage);
@@ -892,16 +971,29 @@ export async function handleImageFile(file) {
     };
     trackUsage(prov, mid, tokens.inputTokens, tokens.outputTokens);
     result.importHash = hashString(file.name + file.size);
+    result.benchmarkId = benchmarkId;
+    result._benchmarkInitialMappings = result.markers.map(marker => marker.mappedKey || marker.suggestedKey || null);
     result._importProfileId = _startProfileId;
     if (!result.date) showNotification("Could not find collection date in image", "error");
-    if (result.markers.length === 0) { hideImportProgress('error'); showNotification("No biomarkers found in image", "error"); return; }
+    if (result.markers.length === 0) {
+      finishImportBenchmark(benchmarkId, 'no-markers', benchmarkResultPatch(result, performance.now() - benchmarkStarted));
+      hideImportProgress('error');
+      showNotification("No biomarkers found in image", "error");
+      return;
+    }
+    finishImportBenchmark(benchmarkId, 'preview', benchmarkResultPatch(result, performance.now() - benchmarkStarted));
     await showImportProgress(4, file.name);
     showImportPreview(result);
     hideImportProgress();
   } catch (err) {
+    finishImportBenchmark(benchmarkId, 'failed', {
+      stage: 'analysis',
+      error: formatImportError(err),
+      totalMs: Math.round(performance.now() - benchmarkStarted),
+    });
     if (isDebugMode()) console.error('Image import error:', err);
     hideImportProgress('error');
-    showNotification(`Import failed: ${err.message}`, 'error');
+    showNotification(`Import failed: ${formatImportError(err)}`, 'error');
   }
 }
 

--- a/js/pii.js
+++ b/js/pii.js
@@ -2,9 +2,21 @@
 // pii.js — PII obfuscation (Ollama + regex), diff viewer
 
 import { showNotification, escapeHTML } from './utils.js';
-import { getOllamaConfig, getOllamaPIIModel, getOllamaPIIUrl } from './api.js';
+import { getOllamaPIIApiKey, getOllamaPIIModel, getOllamaPIIUrl } from './api.js';
+import {
+  checkOllama,
+  checkOpenAICompatible,
+  discoverLocalAI,
+  filterPIIEligibleModels,
+  getCachedLocalAiDiscovery,
+  isCloudModel,
+  isPIIEligibleModel,
+} from './local-ai-discovery.js';
+import { createInitialResponseTimeout } from './api-transport.js';
 import { openModalOverlay, removeModalOverlay, trapModalFocus } from './modal-lifecycle.js';
 import { state } from './state.js';
+
+export { checkOllama, checkOpenAICompatible };
 
 // ═══════════════════════════════════════════════
 // PII OBFUSCATION — Fake data generators & sanitization
@@ -48,64 +60,6 @@ export function fakeDate() {
 }
 export function fakePatientId() { return randomDigits(10); }
 
-export async function checkOllama(url) {
-  const baseUrl = url || getOllamaConfig().url;
-  try {
-    const resp = await fetch(`${baseUrl}/api/tags`, { signal: AbortSignal.timeout(3000) });
-    if (!resp.ok) return { available: false, models: [] };
-    const data = await resp.json();
-    const raw = data.models || [];
-    const models = raw.map(m => m.name || m.model).filter(Boolean);
-    const modelDetails = raw.map(m => ({
-      name: m.name || m.model,
-      size: m.size || 0,
-      paramSize: m.details?.parameter_size || '',
-      quantLevel: m.details?.quantization_level || '',
-      family: m.details?.family || '',
-    })).filter(m => m.name);
-    return { available: true, models, modelDetails };
-  } catch {
-    return { available: false, models: [] };
-  }
-}
-
-export async function checkOpenAICompatible(url, apiKey) {
-  const baseUrl = (url || getOllamaConfig().url).replace(/\/+$/, '');
-  try {
-    /** @type {Record<string, string>} */
-    const headers = {};
-    if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`;
-    const resp = await fetch(`${baseUrl}/v1/models`, { headers, signal: AbortSignal.timeout(3000) });
-    if (!resp.ok) return { available: false, models: [] };
-    const data = await resp.json();
-    const raw = data.data || [];
-    const models = raw.map(m => m.id).filter(Boolean);
-    // Extract model details when available (LM Studio, Ollama /v1/models, Jan)
-    // Parse param size and quant from model name when API doesn't provide them
-    // Estimate file size from params + quant when not reported by API
-    const QUANT_BPW = { q2: 0.3, q3: 0.4, q4: 0.55, q5: 0.65, q6: 0.8, q8: 1.0, fp16: 2.0, fp32: 4.0, int4: 0.55, int8: 1.0 };
-    const modelDetails = raw.map(m => {
-      const id = m.id || '';
-      const paramMatch = id.match(/[\-:](\d+\.?\d*)[bB]/);
-      const quantMatch = id.match(/(Q\d+_K(?:_[A-Z]+)?|Q\d+|fp16|fp32|int[48])/i);
-      const params = paramMatch ? parseFloat(paramMatch[1]) : 0;
-      const quantKey = quantMatch ? quantMatch[1].toLowerCase().replace(/_.*/, '') : '';
-      const bpw = QUANT_BPW[quantKey] || 0.55; // default to Q4 estimate
-      const estimatedSize = params > 0 ? Math.round(params * bpw * 1e9) : 0;
-      return {
-        name: id,
-        size: m.size || m.vram_required || estimatedSize,
-        paramSize: m.parameter_size || (params > 0 ? params + 'B' : ''),
-        quantLevel: m.quantization || (quantMatch ? quantMatch[1] : ''),
-        family: m.owned_by || '',
-      };
-    }).filter(m => m.name);
-    return { available: true, models, modelDetails };
-  } catch {
-    return { available: false, models: [] };
-  }
-}
-
 export function isOllamaPIIEnabled() {
   return localStorage.getItem('labcharts-ollama-pii-enabled') === 'true';
 }
@@ -116,18 +70,31 @@ export function setOllamaPIIEnabled(enabled) {
 
 export async function checkOllamaPII() {
   if (!isOllamaPIIEnabled()) return { available: false, models: [] };
-  const config = getOllamaConfig();
-  return checkOpenAICompatible(getOllamaPIIUrl(), config.apiKey);
+  const url = getOllamaPIIUrl();
+  const result = await discoverLocalAI(url, getOllamaPIIApiKey());
+  const models = filterPIIEligibleModels(result.models);
+  return {
+    ...result,
+    available: result.available && models.length > 0,
+    models,
+    modelDetails: (result.modelDetails || []).filter(model => models.includes(model.name)),
+    blockedCloudModels: (result.models || []).filter(isCloudModel),
+  };
 }
 
 export function unloadOllamaPIIModel() {
-  // Ollama-specific: send keep_alive:0 to free VRAM. Only fires for Ollama servers (port 11434).
   const piiUrl = getOllamaPIIUrl();
-  try { if (new URL(piiUrl).port !== '11434') return; } catch { return; }
+  const discovery = getCachedLocalAiDiscovery(piiUrl, getOllamaPIIApiKey());
+  let isOllamaServer = discovery?.provider === 'ollama';
+  if (!discovery) {
+    try { isOllamaServer = new URL(piiUrl).port === '11434'; } catch { return; }
+  }
+  if (!isOllamaServer) return;
   const piiModel = getOllamaPIIModel();
+  const apiKey = getOllamaPIIApiKey();
   fetch(`${piiUrl}/api/generate`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}) },
     body: JSON.stringify({ model: piiModel, prompt: '', stream: false, keep_alive: 0 }),
     signal: AbortSignal.timeout(5000)
   }).catch(() => {});
@@ -137,6 +104,7 @@ const PII_PROMPT_PREFIX = `TASK: Replace ONLY personal identifiers in this lab r
 
 REPLACE these with fake data:
 - Patient names → fictional names
+- Dates of birth → fictional dates in the same format
 - Birth numbers (e.g. 850115/1234) → random numbers in same format
 - Addresses → fictional addresses
 - Phone numbers → random phone numbers
@@ -145,7 +113,7 @@ REPLACE these with fake data:
 - Patient IDs → random numbers
 
 DO NOT CHANGE (copy exactly as-is):
-- ALL dates (collection dates, sample dates, report dates) — these are critical
+- Collection dates, sample dates, and report dates — these are critical. Only dates of birth should change
 - ALL "=== Page N ===" headers
 - ALL lab test names, numeric values, units, reference ranges
 - ALL line structure and formatting
@@ -155,23 +123,134 @@ Output ONLY the modified text. No explanations, no markdown, no commentary.
 TEXT TO PROCESS:
 `;
 
-function validatePIIResult(result, pdfText) {
+const SENSITIVE_LABEL_RE = /\b(?:jm[eé]no|name|pacient|patient|p[rř][ií]jmen[ií]|surname|adresa|address|bydli[sš]t[eě]|residence|datum\s*narozen|date\s*of\s*birth|DOB|rodn[eé]\s*[cč][ií]slo|birth\s*number|patient\s*id|member\s*id|medical\s*record|MRN|email|phone|telephone|tel\.?|doctor|physician|ordering|provider|referring)\b/i;
+const LAB_UNIT_RE = /\b(?:mmol|[uµμ]mol|[uµμ]kat|g\/l|mg\/(?:l|dl)|ng\/(?:l|dl|ml)|pg|pmol|nmol|mU\/l|U\/l|IU\/l|mEq\/l|fL|cells\/uL|thou\/uL|mill\/uL)\b|%/i;
+
+function normalizePIIComparison(text) {
+  return String(text || '').replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+function extractSensitiveValues(text) {
+  const values = [];
+  for (const line of String(text || '').split(/\r?\n/)) {
+    if (!SENSITIVE_LABEL_RE.test(line)) continue;
+    const value = line.split(/[:=]/).slice(1).join(':').trim();
+    if (value.length >= 3) values.push(value);
+  }
+  const patterns = [
+    /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi,
+    /\b\d{3}-\d{2}-\d{4}\b/g,
+    /\b\d{2}(?:0[1-9]|1[0-2]|5[1-9]|6[0-2])(?:0[1-9]|[12]\d|3[01])\/\d{3,4}\b/g,
+  ];
+  for (const pattern of patterns) values.push(...(String(text || '').match(pattern) || []));
+  return [...new Set(values.map(value => normalizePIIComparison(value)).filter(value => value.length >= 3))];
+}
+
+function labNumberPreservationRatio(input, output) {
+  const numbers = text => String(text || '').split(/\r?\n/)
+    .filter(line => LAB_UNIT_RE.test(line) && !SENSITIVE_LABEL_RE.test(line))
+    .flatMap(line => line.match(/[-+]?\d+(?:[.,]\d+)?/g) || [])
+    .map(value => value.replace(',', '.'));
+  const original = numbers(input);
+  if (original.length === 0) return 1;
+  const remaining = new Map();
+  for (const value of numbers(output)) remaining.set(value, (remaining.get(value) || 0) + 1);
+  let kept = 0;
+  for (const value of original) {
+    const count = remaining.get(value) || 0;
+    if (count > 0) { kept++; remaining.set(value, count - 1); }
+  }
+  return kept / original.length;
+}
+
+function extractProtectedReportDates(text) {
+  const dates = [];
+  const datePattern = /\b\d{4}[-/.]\d{2}[-/.]\d{2}\b|\b\d{1,2}[./]\d{1,2}[./]\d{4}\b/g;
+  const reportDateLabel = /\b(?:collection|collected|sample|specimen|report(?:ed)?|result(?:ed)?|drawn|odb[eě]r|datum\s*odb[eě]ru|vzork|nasb[ií]r)\b/i;
+  for (const line of String(text || '').split(/\r?\n/)) {
+    if (!reportDateLabel.test(line) || /\b(?:date\s*of\s*birth|datum\s*narozen|DOB)\b/i.test(line)) continue;
+    dates.push(...(line.match(datePattern) || []));
+  }
+  return [...new Set(dates)];
+}
+
+export function validatePIIResult(result, pdfText) {
   if (!result) return 'Local AI returned empty response';
   if (result.length < pdfText.length * 0.25) return `Local AI output too short (${result.length} vs ${pdfText.length} chars)`;
+  if (normalizePIIComparison(result) === normalizePIIComparison(pdfText)) return 'Local AI returned the original text without removing personal information';
   const inputDates = pdfText.match(/\b\d{4}[-/.]\d{2}[-/.]\d{2}\b|\b\d{1,2}[./]\d{1,2}[./]\d{4}\b/g) || [];
   const outputDates = result.match(/\b\d{4}[-/.]\d{2}[-/.]\d{2}\b|\b\d{1,2}[./]\d{1,2}[./]\d{4}\b/g) || [];
   if (inputDates.length > 0 && outputDates.length === 0) return 'Local AI lost all dates from the text';
+  const missingReportDates = extractProtectedReportDates(pdfText).filter(date => !result.includes(date));
+  if (missingReportDates.length > 0) return 'Local AI changed or removed a collection/report date';
+  if (labNumberPreservationRatio(pdfText, result) < 0.85) return 'Local AI changed or removed too many lab values';
   return null;
+}
+
+export function finalizePIIResult(result, pdfText) {
+  const validationError = validatePIIResult(result, pdfText);
+  if (validationError) throw new Error(validationError);
+  const deterministic = obfuscatePDFText(result).obfuscated;
+  const normalizedFinal = normalizePIIComparison(deterministic);
+  const retained = extractSensitiveValues(pdfText).filter(value => normalizedFinal.includes(value));
+  if (retained.length > 0) throw new Error(`Privacy check found ${retained.length} original identifier${retained.length === 1 ? '' : 's'} still present`);
+  const finalValidationError = validatePIIResult(deterministic, pdfText);
+  if (finalValidationError) throw new Error(finalValidationError);
+  return deterministic;
+}
+
+function ensurePIIModelEligible(model) {
+  if (!isPIIEligibleModel(model)) {
+    throw new Error(`Privacy model "${model}" is not a self-hosted text model. Cloud-tagged and embedding models cannot be used for PII protection.`);
+  }
+}
+
+function createThinkingContentFilter(onText, onThinking) {
+  let buffer = '';
+  let inThinking = false;
+  const openTag = '<think>';
+  const closeTag = '</think>';
+  const emitThinking = text => { if (text && onThinking) onThinking(text); };
+  const emitText = text => { if (text) onText(text); };
+  const drain = final => {
+    while (buffer) {
+      const tag = inThinking ? closeTag : openTag;
+      const index = buffer.toLowerCase().indexOf(tag);
+      if (index >= 0) {
+        const before = buffer.slice(0, index);
+        if (inThinking) emitThinking(before); else emitText(before);
+        buffer = buffer.slice(index + tag.length);
+        inThinking = !inThinking;
+        continue;
+      }
+      if (final) {
+        if (inThinking) emitThinking(buffer); else emitText(buffer);
+        buffer = '';
+        return;
+      }
+      const keep = tag.length - 1;
+      if (buffer.length <= keep) return;
+      const safe = buffer.slice(0, buffer.length - keep);
+      if (inThinking) emitThinking(safe); else emitText(safe);
+      buffer = buffer.slice(-keep);
+      return;
+    }
+  };
+  return {
+    push(content) { buffer += content; drain(false); },
+    flush() { drain(true); },
+  };
 }
 
 export async function sanitizeWithOllamaStreaming(pdfText, onChunk, signal, onThinking) {
   const piiUrl = getOllamaPIIUrl();
   const piiModel = getOllamaPIIModel();
-  const config = getOllamaConfig();
+  ensurePIIModelEligible(piiModel);
+  const apiKey = getOllamaPIIApiKey();
   const promptText = PII_PROMPT_PREFIX + pdfText;
   const baseUrl = piiUrl.replace(/\/+$/, '');
   const headers = { 'Content-Type': 'application/json' };
-  if (config.apiKey) headers['Authorization'] = `Bearer ${config.apiKey}`;
+  if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`;
 
   // Quick reachability probe with a 5s timeout BEFORE issuing the
   // streaming request. If Ollama is unreachable (server stopped,
@@ -202,24 +281,42 @@ export async function sanitizeWithOllamaStreaming(pdfText, onChunk, signal, onTh
     } else {
       probeSignal = timeoutSig;
     }
-    await fetch(`${baseUrl}/api/version`, { signal: probeSignal });
+    const probe = await fetch(`${baseUrl}/v1/models`, { headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : {}, signal: probeSignal });
+    if (!probe.ok) throw new Error(`HTTP ${probe.status}`);
   } catch (e) {
     throw new Error(`Local PII server unreachable at ${baseUrl} — falling back to regex obfuscation. (${e.message})`);
   }
 
-  const resp = await fetch(`${baseUrl}/v1/chat/completions`, {
+  const requestState = createInitialResponseTimeout({
     method: 'POST',
     headers,
-    body: JSON.stringify({ model: piiModel, messages: [{ role: 'user', content: promptText }], stream: true }),
+    body: JSON.stringify({
+      model: piiModel,
+      messages: [{ role: 'user', content: promptText }],
+      stream: true,
+      temperature: 0,
+      reasoning_effort: 'none',
+    }),
     signal
-  });
+  }, 30000);
+  let resp;
+  try {
+    resp = await fetch(`${baseUrl}/v1/chat/completions`, requestState.fetchOptions);
+  } finally {
+    requestState.clearRequestTimeout();
+  }
   if (!resp.ok) throw new Error(`Local server error: ${resp.status}`);
+  if (!resp.body) throw new Error('Local server returned no response stream');
 
   const reader = resp.body.getReader();
   const decoder = new TextDecoder();
   let accumulated = '';
   let buffer = '';
-  let inThinkTag = false; // track <think>...</think> blocks in content
+  const contentFilter = createThinkingContentFilter(content => {
+    accumulated += content;
+    onChunk(content);
+  }, onThinking);
+  let streamDone = false;
   // Per-chunk stall timeout — local Ollama can hang mid-stream if the
   // model crashes / OOMs / loses GPU access; fail loud after 45s so
   // the user can fall back to regex instead of waiting forever.
@@ -235,99 +332,76 @@ export async function sanitizeWithOllamaStreaming(pdfText, onChunk, signal, onTh
     );
   });
 
+  const processLine = line => {
+    const trimmed = line.trim();
+    if (!trimmed || !trimmed.startsWith('data:')) return false;
+    const payload = trimmed.slice(5).trimStart();
+    if (payload === '[DONE]') return true;
+    const json = JSON.parse(payload);
+    if (json.error) throw new Error(json.error.message || String(json.error));
+    const delta = json.choices?.[0]?.delta;
+    if (!delta) return false;
+    const reasoning = delta.reasoning_content || delta.reasoning;
+    if (reasoning && onThinking) onThinking(reasoning);
+    if (delta.content) contentFilter.push(delta.content);
+    return false;
+  };
+
   try {
-    while (true) {
+    while (!streamDone) {
       const { done, value } = await readWithStall();
       if (done) break;
       buffer += decoder.decode(value, { stream: true });
       const lines = buffer.split('\n');
       buffer = lines.pop(); // keep incomplete line
       for (const line of lines) {
-        const trimmed = line.trim();
-        if (!trimmed || !trimmed.startsWith('data: ')) continue;
-        const payload = trimmed.slice(6);
-        if (payload === '[DONE]') break;
-        try {
-          const json = JSON.parse(payload);
-          const delta = json.choices?.[0]?.delta;
-          if (!delta) continue;
-
-          // Handle reasoning_content field (OpenAI-style thinking)
-          if (delta.reasoning_content && onThinking) {
-            onThinking(delta.reasoning_content);
-            continue;
-          }
-
-          const content = delta.content;
-          if (!content) continue;
-
-          // Handle <think>...</think> tags inline in content (Qwen/DeepSeek style)
-          if (onThinking) {
-            let remaining = content;
-            while (remaining) {
-              if (inThinkTag) {
-                const closeIdx = remaining.indexOf('</think>');
-                if (closeIdx === -1) { onThinking(remaining); remaining = ''; }
-                else { onThinking(remaining.slice(0, closeIdx)); inThinkTag = false; remaining = remaining.slice(closeIdx + 8); }
-              } else {
-                const openIdx = remaining.indexOf('<think>');
-                if (openIdx === -1) { accumulated += remaining; onChunk(remaining); remaining = ''; }
-                else {
-                  if (openIdx > 0) { accumulated += remaining.slice(0, openIdx); onChunk(remaining.slice(0, openIdx)); }
-                  inThinkTag = true;
-                  remaining = remaining.slice(openIdx + 7);
-                }
-              }
-            }
-          } else {
-            accumulated += content;
-            onChunk(content);
-          }
-        } catch { /* skip malformed chunks */ }
+        if (processLine(line)) { streamDone = true; break; }
       }
     }
+    buffer += decoder.decode();
+    if (!streamDone && buffer.trim()) processLine(buffer);
+    contentFilter.flush();
   } finally {
     reader.releaseLock();
+    unloadOllamaPIIModel();
   }
 
-  const result = accumulated.trim();
-  const validationError = validatePIIResult(result, pdfText);
-  if (validationError) throw new Error(validationError);
-
-  unloadOllamaPIIModel();
-  return result;
+  return finalizePIIResult(accumulated.trim(), pdfText);
 }
 
 export async function sanitizeWithOllama(pdfText) {
   const piiUrl = getOllamaPIIUrl();
   const piiModel = getOllamaPIIModel();
-  const config = getOllamaConfig();
+  ensurePIIModelEligible(piiModel);
+  const apiKey = getOllamaPIIApiKey();
   const promptText = PII_PROMPT_PREFIX + pdfText;
   try {
     const baseUrl = piiUrl.replace(/\/+$/, '');
     const headers = { 'Content-Type': 'application/json' };
-    if (config.apiKey) headers['Authorization'] = `Bearer ${config.apiKey}`;
+    if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`;
     const resp = await fetch(`${baseUrl}/v1/chat/completions`, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ model: piiModel, messages: [{ role: 'user', content: promptText }], stream: false }),
+      body: JSON.stringify({
+        model: piiModel,
+        messages: [{ role: 'user', content: promptText }],
+        stream: false,
+        temperature: 0,
+        reasoning_effort: 'none',
+      }),
       signal: AbortSignal.timeout(90000)
     });
     if (!resp.ok) throw new Error(`Local server error: ${resp.status}`);
     const data = await resp.json();
     const result = (data.choices?.[0]?.message?.content || '').trim();
-
-    const validationError = validatePIIResult(result, pdfText);
-    if (validationError) throw new Error(validationError);
-
-    unloadOllamaPIIModel();
-    return result;
+    return finalizePIIResult(result, pdfText);
   } catch (e) {
-    unloadOllamaPIIModel();
     if (e.name === 'TimeoutError' || e.message.includes('timed out')) {
       showNotification(`PII model "${piiModel}" timed out. Falling back to regex. Try a smaller model in Settings → Privacy.`, 'info', 6000);
     }
     throw e;
+  } finally {
+    unloadOllamaPIIModel();
   }
 }
 
@@ -572,19 +646,19 @@ export function reviewPIIBeforeSend(originalText, { obfuscatedText = '', streamF
             <div class="gb-modal-title">Review &amp; Edit</div>
           </div>
         </div>
-        <p class="pii-review-intro">Personal information has been replaced with fake data before AI sees the report. Review the text that will be sent and edit anything that still looks identifying.</p>
+        <p class="pii-review-intro">Personal information has been replaced with fake data before the analysis model sees the report. Review the text that will be sent and edit anything that still looks identifying.</p>
         <div class="pii-search-bar">
           <input type="text" class="pii-search-input" id="pii-search-input" placeholder="Search for your name, address, phone\u2026" autocomplete="off">
           <span class="pii-search-count" id="pii-search-count"></span>
         </div>
         <details class="pii-mobile-original">
-          <summary>Original text (stays local)</summary>
+          <summary>Original report (comparison only)</summary>
           <div class="pii-mobile-original-body">${leftHtml}</div>
         </details>
         <div class="pii-diff-viewer pii-review-viewer">
-          <div class="pii-diff-left"><div class="pii-diff-header">Original (stays local)</div>${leftHtml}</div>
+          <div class="pii-diff-left"><div class="pii-diff-header">Original report (comparison only)</div>${leftHtml}</div>
           <div class="pii-diff-right">
-            <div class="pii-diff-header">Sent to AI <button class="pii-edit-btn" id="pii-edit-btn" type="button">&#9998; Edit</button></div>
+            <div class="pii-diff-header">Sent to analysis AI <button class="pii-edit-btn" id="pii-edit-btn" type="button">&#9998; Edit</button></div>
             ${isStreaming ? '<details class="pii-thinking-section" id="pii-thinking-section" hidden><summary>Thinking\u2026</summary><pre class="pii-thinking-content" id="pii-thinking-content"></pre></details>' : ''}
             <textarea class="pii-edit-textarea" id="pii-edit-textarea" spellcheck="false"${isStreaming ? ' readonly' : ''}>${initialText}</textarea>
             ${isStreaming ? '<div class="pii-stream-status pii-stream-waiting" id="pii-stream-status">Waiting for model response\u2026</div>' : ''}
@@ -678,7 +752,7 @@ export function reviewPIIBeforeSend(originalText, { obfuscatedText = '', streamF
     // Show highlighted diff preview, hiding the textarea
     function showDiffPreview(obfuscatedText) {
       const { leftHtml, rightHtml } = buildPIIDiffHTML(originalText, obfuscatedText);
-      if (leftPanel) leftPanel.innerHTML = `<div class="pii-diff-header">Original (stays local)</div>${leftHtml}`;
+      if (leftPanel) leftPanel.innerHTML = `<div class="pii-diff-header">Original report (comparison only)</div>${leftHtml}`;
       if (mobileOriginal) mobileOriginal.innerHTML = leftHtml;
       textarea.style.display = 'none';
       let diffView = /** @type {HTMLElement | null} */ (overlay.querySelector('.pii-diff-preview'));
@@ -809,8 +883,8 @@ export function reviewPIIBeforeSend(originalText, { obfuscatedText = '', streamF
           flushToTextarea();
           if (err.name === 'AbortError') return; // stop button already handled
           textarea.readOnly = false;
-          sendBtn.disabled = false;
-          if (statusEl) statusEl.textContent = `Error: ${err.message}`;
+          sendBtn.disabled = true;
+          if (statusEl) statusEl.textContent = `Error: ${err.message} Use Regex fallback or retry before sending.`;
           stopBtn.hidden = true;
           retryBtn.hidden = false;
         });
@@ -821,8 +895,8 @@ export function reviewPIIBeforeSend(originalText, { obfuscatedText = '', streamF
         abortController.abort();
         abortController = null;
         textarea.readOnly = false;
-        sendBtn.disabled = false;
-        statusEl.textContent = 'Stopped \u2014 review partial result and edit below';
+        sendBtn.disabled = true;
+        statusEl.textContent = 'Stopped \u2014 partial output cannot be sent. Use Regex fallback or retry.';
         stopBtn.hidden = true;
         retryBtn.hidden = false;
         unloadOllamaPIIModel();

--- a/js/provider-local-ai-controls.js
+++ b/js/provider-local-ai-controls.js
@@ -6,16 +6,24 @@ import {
   getOllamaConfig,
   getOllamaMainModel,
   getOllamaPIIModel,
+  getOllamaPIIApiKey,
   getOllamaPIIUrl,
   saveOllamaConfig,
+  saveOllamaPIIApiKey,
   setOllamaMainModel,
   setOllamaPIIModel,
   setOllamaPIIUrl,
 } from './api.js';
-import { checkOllama, checkOpenAICompatible, setOllamaPIIEnabled } from './pii.js';
+import {
+  discoverLocalAI,
+  filterPIIEligibleModels,
+  getLocalAiExecutionLocation,
+  isCloudModel,
+} from './local-ai-discovery.js';
 import { detectHardware, assessModel, assessFitness, getBestModel, getUpgradeSuggestion, saveHardwareOverride, getHardwareOverride } from './hardware.js';
 import {
   cacheLocalAiModelDetails,
+  clearCachedLocalAiModelDetails,
   getCachedLocalAiModelDetails,
   updatePrivacyStatusCardFromRuntime,
 } from './provider-local-ai-runtime.js';
@@ -25,6 +33,9 @@ const LOCAL_AI_NOT_CONNECTED_TEXT = 'Not connected \u2014 check URL and ensure y
 const LOCAL_AI_ACTION_ATTR = 'data-local-ai-action';
 const LOCAL_AI_COMMAND_ATTR = 'data-local-ai-command';
 const localAiControlDelegateRoots = new WeakSet();
+let mainDiscoveryGeneration = 0;
+let piiDiscoveryGeneration = 0;
+let discoveryEventInstalled = false;
 
 export function configureLocalAiControls(options = {}) {
   if (typeof options.returnToChatIfOnboarding === 'function') {
@@ -32,60 +43,81 @@ export function configureLocalAiControls(options = {}) {
   }
 }
 
-export function initSettingsOllamaCheck() {
-  const config = getOllamaConfig();
-  const mainUrl = config.url;
-  const piiUrl = getOllamaPIIUrl();
-  const sameUrl = mainUrl === piiUrl;
+function clearMainDiscoveryUI() {
+  const modelSection = document.getElementById('local-ai-model-section');
+  const advisor = document.getElementById('local-ai-advisor');
+  if (modelSection) modelSection.style.display = 'none';
+  if (advisor) advisor.innerHTML = '';
+  clearCachedLocalAiModelDetails();
+}
 
-  if (document.getElementById('local-ai-dot')) {
-    Promise.allSettled([
-      checkOpenAICompatible(mainUrl, config.apiKey),
-      checkOllama(mainUrl),
-    ]).then(([openaiResult, ollamaResult]) => {
-      const result = openaiResult.status === 'fulfilled' ? openaiResult.value : { available: false, models: [] };
-      const ollama = ollamaResult.status === 'fulfilled' ? ollamaResult.value : { available: false, models: [], modelDetails: [] };
-      const dot = document.getElementById('local-ai-dot');
-      const text = document.getElementById('local-ai-status-text');
-      const modelSection = document.getElementById('local-ai-model-section');
-      const modelSelect = /** @type {HTMLSelectElement | null} */ (document.getElementById('local-ai-model-select'));
-      if (!dot || !text) return;
-      if (result.available && result.models.length > 0) {
-        dot.classList.add('connected');
-        let currentModel = getOllamaMainModel();
-        if (!result.models.includes(currentModel)) {
-          currentModel = result.models[0];
-          setOllamaMainModel(currentModel);
-        }
-        text.textContent = `Connected (${currentModel})`;
-        if (modelSection && modelSelect) {
-          modelSection.style.display = 'block';
-          modelSelect.innerHTML = result.models.map(m => `<option value="${escapeHTML(m)}" ${m === currentModel ? 'selected' : ''}>${escapeHTML(m)}</option>`).join('');
-        }
-        const isOllamaServer = ollama.available && ollama.modelDetails?.length > 0;
-        const modelDetails = isOllamaServer
-          ? ollama.modelDetails
-          : (result.modelDetails || []);
-        if (modelDetails.length > 0) {
-          cacheLocalAiModelDetails(modelDetails, isOllamaServer);
-          renderModelAdvisor(modelDetails, modelSelect, isOllamaServer);
-        }
-      } else if (result.available) {
-        dot.classList.add('disconnected');
-        text.textContent = 'Connected but no models found. Load a model in your server.';
-      } else {
-        dot.classList.add('disconnected');
-        text.textContent = 'Not connected \u2014 start your local server to use';
-      }
-      if (sameUrl) {
-        updatePrivacyStatusCardFromRuntime(result.available && result.models.length > 0);
-      } else {
-        updatePrivacyStatusCardFromRuntime();
-      }
-    });
-  } else {
-    updatePrivacyStatusCardFromRuntime();
+function discoveryErrorText(result) {
+  const error = result?.error || result?.openai?.error;
+  if (error?.kind === 'http' && error.status === 401) return 'Authentication failed \u2014 check the API key';
+  if (error?.kind === 'http' && error.status) return `Server returned HTTP ${error.status}`;
+  if (error?.kind === 'timeout') return 'Connection timed out \u2014 check the address and firewall';
+  return LOCAL_AI_NOT_CONNECTED_TEXT;
+}
+
+function applyMainDiscoveryResult(result, { reconcileModel = true } = {}) {
+  const dot = document.getElementById('local-ai-dot');
+  const text = document.getElementById('local-ai-status-text');
+  const modelSection = document.getElementById('local-ai-model-section');
+  const modelSelect = /** @type {HTMLSelectElement | null} */ (document.getElementById('local-ai-model-select'));
+  if (!dot || !text) return;
+  dot.className = 'local-ai-status-dot';
+  if (!result.available || result.models.length === 0) {
+    dot.classList.add('disconnected');
+    text.textContent = result.available ? 'Connected but no text-generation models were found.' : discoveryErrorText(result);
+    clearMainDiscoveryUI();
+    return;
   }
+  dot.classList.add('connected');
+  let currentModel = getOllamaMainModel();
+  if (!result.models.includes(currentModel) && reconcileModel) {
+    currentModel = result.models[0];
+    setOllamaMainModel(currentModel);
+  }
+  const location = getLocalAiExecutionLocation(result.baseUrl, currentModel);
+  const locationLabel = location === 'cloud' ? 'cloud' : location === 'local' ? 'this device' : location === 'lan' ? 'LAN server' : 'remote server';
+  text.textContent = `Connected (${currentModel} \u00b7 ${locationLabel})`;
+  if (modelSection && modelSelect) {
+    modelSection.style.display = 'block';
+    modelSelect.innerHTML = result.models.map(model => `<option value="${escapeHTML(model)}" ${model === currentModel ? 'selected' : ''}>${escapeHTML(model)}</option>`).join('');
+  }
+  const isOllamaServer = result.provider === 'ollama';
+  cacheLocalAiModelDetails(result.modelDetails || [], isOllamaServer);
+  renderModelAdvisor(result.modelDetails || [], modelSelect, isOllamaServer);
+}
+
+function installDiscoveryRefreshEvent() {
+  if (discoveryEventInstalled || typeof globalThis.addEventListener !== 'function') return;
+  discoveryEventInstalled = true;
+  globalThis.addEventListener('local-ai-discovery-updated', event => {
+    const result = /** @type {CustomEvent} */ (event).detail;
+    if (!result || result.baseUrl !== getOllamaConfig().url.replace(/\/+$/, '')) return;
+    if (document.getElementById('local-ai-dot')) applyMainDiscoveryResult(result);
+  });
+}
+
+export function initSettingsOllamaCheck() {
+  installDiscoveryRefreshEvent();
+  const config = getOllamaConfig();
+  const generation = ++mainDiscoveryGeneration;
+  const dot = document.getElementById('local-ai-dot');
+  const text = document.getElementById('local-ai-status-text');
+  if (!dot || !text) { updatePrivacyStatusCardFromRuntime(); return; }
+  dot.className = 'local-ai-status-dot';
+  text.textContent = 'Checking connection...';
+  discoverLocalAI(config.url, config.apiKey, { force: true }).then(result => {
+    if (generation !== mainDiscoveryGeneration) return;
+    applyMainDiscoveryResult(result);
+    if (config.url === getOllamaPIIUrl()) updatePrivacyStatusCardFromRuntime(result.available && filterPIIEligibleModels(result.models).length > 0);
+    else updatePrivacyStatusCardFromRuntime();
+  }).catch(() => {
+    if (generation !== mainDiscoveryGeneration) return;
+    applyMainDiscoveryResult({ available: false, models: [], error: { kind: 'network' } });
+  });
 }
 
 function isLocalUrl(url) {
@@ -180,7 +212,7 @@ export async function renderModelAdvisor(modelDetails, modelSelect, isOllama = f
     for (const opt of opts) {
       const detail = modelDetails.find(d => d.name === opt.value);
       if (!detail) continue;
-      const sizeGb = detail.size ? (detail.size / 1e9).toFixed(1) + ' GB' : '';
+      const sizeGb = detail.size ? `${detail.sizeSource === 'estimated' ? '~' : ''}${(detail.size / 1e9).toFixed(1)} GB` : '';
       const quant = detail.quantLevel || '';
       const assess = hw.gpu.vram ? assessModel(detail, hw) : null;
       const dot = assess ? assess.badge + ' ' : '';
@@ -202,21 +234,36 @@ export async function renderModelAdvisor(modelDetails, modelSelect, isOllama = f
           : 'GPU not detected';
   const ramLabel = hw.ram.gb ? `${hw.ram.gb} GB` : 'Unknown';
   const cpuLabel = hw.cpuThreads ? `${hw.cpuThreads} threads` : '';
+  const allocatedVram = modelDetails.reduce((total, model) => total + (Number(model.vramAllocated) || 0), 0);
+  const providerName = isOllama
+    ? 'Ollama'
+    : modelDetails.some(model => model.source === 'lmstudio') ? 'LM Studio' : 'Local AI';
 
   const fitnessLabel = { recommended: '\u2605 Recommended', capable: 'Capable', underpowered: 'Underpowered', inadequate: 'Inadequate' };
   const fitnessCss = { recommended: 'fitness-great', capable: 'fitness-good', underpowered: 'fitness-fair', inadequate: 'fitness-poor' };
   const rows = modelDetails.map(m => {
     const hasSize = m.size > 0;
-    const assess = !hasSize ? { tier: 'unknown', badge: '?', label: 'Size unknown' }
-      : hw.gpu.vram ? assessModel(m, hw) : { tier: 'unknown', badge: '?', vramNeeded: (m.size / 1e9) * 1.15, label: !isLocal ? 'Enter VRAM' : 'Set VRAM to check' };
+    const assess = (m.executionLocation === 'cloud' || isCloudModel(m.name))
+      ? assessModel(m, hw)
+      : !hasSize ? { tier: 'unknown', badge: '?', label: 'Size unknown' }
+        : hw.gpu.vram ? assessModel(m, hw) : { ...assessModel(m, { gpu: { vram: null, unified: false } }), label: !isLocal ? 'Enter VRAM' : 'Set VRAM to check' };
     const fitness = assessFitness(m.name);
-    const sizeLabel = hasSize ? `${(m.size / 1e9).toFixed(1)} GB` : '';
+    const sizeLabel = hasSize ? `${m.sizeSource === 'estimated' ? '~' : ''}${(m.size / 1e9).toFixed(1)} GB` : '';
+    const runtimeDetails = [
+      m.format,
+      m.loaded === true ? 'loaded now' : '',
+      m.loaded === false ? 'available \u2014 loads on first request' : '',
+      m.loaded === null ? 'runtime load state unavailable' : '',
+      m.contextLength > 0 ? `${Number(m.contextLength).toLocaleString()} token context loaded` : '',
+      m.maxContextLength > m.contextLength ? `${Number(m.maxContextLength).toLocaleString()} max context` : '',
+      m.vramAllocated > 0 ? `${(m.vramAllocated / 1e9).toFixed(1)} GB VRAM allocated` : '',
+    ].filter(Boolean);
     const isActive = m.name === currentModel;
     const isBest = best && m.name === best.name;
     return `<div class="model-advisor-row${isActive ? ' active' : ''}">
       <span class="model-advisor-badge model-advisor-verdict ${assess.tier}">${assess.badge}</span>
       <span class="model-advisor-name">${escapeHTML(m.name)}${isActive ? ' <span style="font-size:10px;opacity:0.6">\u2190 active</span>' : ''}${isBest && !isActive ? ' <span style="font-size:10px;opacity:0.6">\u2190 best pick</span>' : ''}</span>
-      <span class="model-advisor-size">${sizeLabel}${m.quantLevel ? ' \u00B7 ' + escapeHTML(m.quantLevel) : ''}${m.paramSize ? ' \u00B7 ' + escapeHTML(m.paramSize) : ''}</span>
+      <span class="model-advisor-size">${sizeLabel}${m.quantLevel ? ' \u00B7 ' + escapeHTML(m.quantLevel) : ''}${m.paramSize ? ' \u00B7 ' + escapeHTML(m.paramSize) : ''}${runtimeDetails.length ? ' \u00B7 ' + runtimeDetails.map(detail => escapeHTML(detail)).join(' \u00B7 ') : ''}</span>
       ${fitness ? `<span class="model-advisor-fitness ${fitnessCss[fitness.tier]}" title="${escapeAttr(fitness.note)}">${fitnessLabel[fitness.tier]}</span>` : '<span class="model-advisor-fitness" style="opacity:0.4">Unknown</span>'}
       <span class="model-advisor-verdict ${assess.tier}">${escapeHTML(assess.label)}</span>
     </div>`;
@@ -225,14 +272,14 @@ export async function renderModelAdvisor(modelDetails, modelSelect, isOllama = f
   const upgrade = getUpgradeSuggestion(modelDetails, hw.gpu.vram ? hw : null);
   const suggestHtml = upgrade ? `
     <div class="model-advisor-suggest">
-      <div class="model-advisor-suggest-title">Upgrade recommendation</div>
+      <div class="model-advisor-suggest-title">Heuristic model suggestion</div>
       ${isOllama ? `<div class="model-advisor-pull-row">
         <code class="model-advisor-pull-cmd">ollama pull ${escapeHTML(upgrade.model)}</code>
         <button type="button" class="import-btn import-btn-secondary" style="font-size:11px;padding:3px 8px" ${LOCAL_AI_ACTION_ATTR}="copy-pull" ${LOCAL_AI_COMMAND_ATTR}="${escapeAttr(`ollama pull ${upgrade.model}`)}">Copy</button>
       </div>` : `<div class="model-advisor-pull-row">
         <code class="model-advisor-pull-cmd">${escapeHTML(upgrade.model)}</code>
       </div>`}
-      <div class="model-advisor-pull-why">${escapeHTML(upgrade.note)}</div>
+      <div class="model-advisor-pull-why">${escapeHTML(upgrade.note)} Validate quality with Import Benchmarks on your own reports; this suggestion is not benchmark-derived.</div>
     </div>` : '';
 
   const overrideVal = getHardwareOverride();
@@ -255,6 +302,7 @@ export async function renderModelAdvisor(modelDetails, modelSelect, isOllama = f
     <div class="model-advisor">
       <div class="model-advisor-hw">
         <span class="model-advisor-hw-chip">${isLocal ? '\uD83C\uDFAE' : '\uD83C\uDF10'} ${gpuLabel}</span>
+        ${allocatedVram > 0 ? `<span class="model-advisor-hw-chip">\uD83D\uDCCA ${providerName} currently allocated \u2014 ${(allocatedVram / 1e9).toFixed(1)} GB VRAM</span>` : ''}
         ${isLocal && hw.ram.gb ? `<span class="model-advisor-hw-chip">\uD83D\uDDA5\uFE0F ${ramLabel} RAM</span>` : ''}
         ${isLocal && cpuLabel ? `<span class="model-advisor-hw-chip">\u2699\uFE0F ${cpuLabel}</span>` : ''}
       </div>
@@ -267,8 +315,10 @@ export async function renderModelAdvisor(modelDetails, modelSelect, isOllama = f
 function isHttpsToNonLocalhost(url) {
   if (location.protocol !== 'https:') return false;
   try {
-    const host = new URL(url).hostname;
-    return host !== 'localhost' && host !== '127.0.0.1' && host !== '::1';
+    const parsed = new URL(url);
+    const host = parsed.hostname;
+    const local = host === 'localhost' || host === '127.0.0.1' || host === '::1';
+    return parsed.protocol === 'http:' && !local;
   } catch { return false; }
 }
 
@@ -286,6 +336,9 @@ function normalizeLocalAiBaseUrl(rawUrl) {
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
     return { error: 'Local AI URL must start with http:// or https://' };
   }
+  parsed.hash = '';
+  parsed.search = '';
+  parsed.pathname = parsed.pathname.replace(/\/(?:v1(?:\/(?:models|chat\/completions))?|api\/v1\/models)\/?$/i, '') || '/';
   return { url: parsed.href.replace(/\/+$/, '') };
 }
 
@@ -321,17 +374,17 @@ function getCORSHelpText() {
   const ua = navigator.userAgent || '';
   const isMac = /Mac/i.test(ua);
   const isWin = /Win/i.test(ua);
-  if (isMac) return 'Blocked by CORS \u2014 Ollama: run launchctl setenv OLLAMA_ORIGINS "*" and restart. LM Studio: Settings \u2192 Enable CORS';
-  if (isWin) return 'Blocked by CORS \u2014 Ollama: set OLLAMA_ORIGINS=* as system env var and restart. LM Studio: Settings \u2192 Enable CORS';
-  return 'Blocked by CORS \u2014 Ollama: OLLAMA_ORIGINS=* ollama serve. LM Studio: Settings \u2192 Enable CORS';
+  const origin = location.origin;
+  if (isMac) return `Blocked by CORS \u2014 allow only ${origin}: launchctl setenv OLLAMA_ORIGINS "${origin}" and restart Ollama. LM Studio: enable CORS and API authentication.`;
+  if (isWin) return `Blocked by CORS \u2014 set OLLAMA_ORIGINS=${origin} as a system environment variable and restart Ollama. LM Studio: enable CORS and API authentication.`;
+  return `Blocked by CORS \u2014 start Ollama with OLLAMA_ORIGINS=${origin}. LM Studio: enable CORS and API authentication.`;
 }
 
 export async function testOllamaConnection() {
+  const generation = ++mainDiscoveryGeneration;
   const urlInput = /** @type {HTMLInputElement | null} */ (document.getElementById('local-ai-url-input'));
   const dot = document.getElementById('local-ai-dot');
   const text = document.getElementById('local-ai-status-text');
-  const modelSection = document.getElementById('local-ai-model-section');
-  const modelSelect = /** @type {HTMLSelectElement | null} */ (document.getElementById('local-ai-model-select'));
   if (!urlInput || !text) return;
   const urlCheck = normalizeLocalAiBaseUrl(urlInput.value);
   const config = getOllamaConfig();
@@ -347,49 +400,43 @@ export async function testOllamaConnection() {
   const url = urlCheck.url;
   if (isHttpsToNonLocalhost(url)) {
     dot.classList.add('disconnected');
-    text.textContent = 'Cannot reach LAN servers from HTTPS \u2014 Local AI must run on this machine (localhost)';
+    text.textContent = 'Browser mixed-content rules block an HTTP LAN server from an HTTPS page. Use HTTPS for the server, localhost, or an encrypted local tunnel.';
     return;
   }
   try {
     try { await fetch(`${url}/v1/models`, { method: 'HEAD', signal: AbortSignal.timeout(3000), ...(apiKey ? { headers: { Authorization: `Bearer ${apiKey}` } } : {}) }); }
     catch (preErr) { if (await handleLocalAiPreflightError(preErr, url, dot, text)) return; }
-    const [result, ollamaResult] = await Promise.all([
-      checkOpenAICompatible(url, apiKey),
-      checkOllama(url).catch(() => ({ available: false, models: [], modelDetails: [] })),
-    ]);
-    if (!result.available) throw new Error('Not reachable');
+    const result = await discoverLocalAI(url, apiKey, { force: true });
+    if (generation !== mainDiscoveryGeneration) return;
+    if (!result.available) {
+      applyMainDiscoveryResult(result);
+      return;
+    }
     const models = result.models;
     if (models.length === 0) {
-      dot.classList.add('disconnected');
-      text.textContent = 'Connected but no models found. Load a model in your server.';
+      applyMainDiscoveryResult(result);
     } else {
       dot.classList.add('connected');
-      await saveOllamaConfig({ ...config, url, model: models[0], apiKey });
-      if (!localStorage.getItem('labcharts-ollama-model')) setOllamaMainModel(models[0]);
-      text.textContent = `Connected (${getOllamaMainModel()})`;
-      if (modelSection && modelSelect) {
-        const currentModel = getOllamaMainModel();
-        modelSection.style.display = 'block';
-        modelSelect.innerHTML = models.map(m => `<option value="${escapeHTML(m)}" ${m === currentModel ? 'selected' : ''}>${escapeHTML(m)}</option>`).join('');
+      let currentModel = getOllamaMainModel();
+      if (!models.includes(currentModel)) {
+        currentModel = models[0];
+        setOllamaMainModel(currentModel);
       }
-      const isOllamaServer = ollamaResult.available && ollamaResult.modelDetails?.length > 0;
-      const modelDetails = isOllamaServer
-        ? ollamaResult.modelDetails
-        : (result.modelDetails || []);
-      if (modelDetails.length > 0 && modelSection && modelSelect) {
-        cacheLocalAiModelDetails(modelDetails, isOllamaServer);
-        renderModelAdvisor(modelDetails, modelSelect, isOllamaServer);
-      }
+      await saveOllamaConfig({ ...config, url, model: currentModel, apiKey });
+      applyMainDiscoveryResult(result);
     }
     updatePrivacyStatusCardFromRuntime();
     returnToChatIfOnboarding();
   } catch (e) {
+    if (generation !== mainDiscoveryGeneration) return;
     dot.classList.add('disconnected');
     text.textContent = LOCAL_AI_NOT_CONNECTED_TEXT;
+    clearMainDiscoveryUI();
   }
 }
 
 export async function testPIIOllamaConnection() {
+  const generation = ++piiDiscoveryGeneration;
   const urlInput = /** @type {HTMLInputElement | null} */ (document.getElementById('pii-local-url-input'));
   const dot = document.getElementById('pii-local-dot');
   const text = document.getElementById('pii-local-status-text');
@@ -397,7 +444,8 @@ export async function testPIIOllamaConnection() {
   const piiSelect = /** @type {HTMLSelectElement | null} */ (document.getElementById('pii-model-select'));
   if (!urlInput || !text) return;
   const urlCheck = normalizeLocalAiBaseUrl(urlInput.value);
-  const config = getOllamaConfig();
+  const apiKeyInput = /** @type {HTMLInputElement | null} */ (document.getElementById('pii-local-apikey-input'));
+  const apiKey = apiKeyInput ? apiKeyInput.value.trim() : getOllamaPIIApiKey();
   text.textContent = 'Testing...';
   dot.className = 'local-ai-status-dot';
   if (urlCheck.error) {
@@ -408,27 +456,29 @@ export async function testPIIOllamaConnection() {
   const url = urlCheck.url;
   if (isHttpsToNonLocalhost(url)) {
     dot.classList.add('disconnected');
-    text.textContent = 'Cannot reach LAN servers from HTTPS \u2014 Local AI must run on this machine (localhost)';
+    text.textContent = 'Browser mixed-content rules block this HTTP LAN server. Use HTTPS, localhost, or an encrypted local tunnel.';
     return;
   }
   try {
-    try { await fetch(`${url}/v1/models`, { method: 'HEAD', signal: AbortSignal.timeout(3000), ...(config.apiKey ? { headers: { Authorization: `Bearer ${config.apiKey}` } } : {}) }); }
+    try { await fetch(`${url}/v1/models`, { method: 'HEAD', signal: AbortSignal.timeout(3000), ...(apiKey ? { headers: { Authorization: `Bearer ${apiKey}` } } : {}) }); }
     catch (preErr) { if (await handleLocalAiPreflightError(preErr, url, dot, text)) return; }
-    const result = await checkOpenAICompatible(url, config.apiKey);
-    if (!result.available) throw new Error('Not reachable');
-    const models = result.models;
+    const result = await discoverLocalAI(url, apiKey, { force: true });
+    if (generation !== piiDiscoveryGeneration) return;
+    if (!result.available) throw new Error(discoveryErrorText(result));
+    const models = filterPIIEligibleModels(result.models);
     if (models.length === 0) {
       dot.classList.add('disconnected');
-      text.textContent = 'Connected but no models found';
+      text.textContent = (result.models || []).some(isCloudModel)
+        ? 'Connected, but only cloud/embedding models were found. Privacy protection requires an on-device text model.'
+        : 'Connected but no eligible text-generation models were found.';
+      if (piiDropdown) piiDropdown.style.display = 'none';
     } else {
       dot.classList.add('connected');
       setOllamaPIIUrl(url);
-      setOllamaPIIEnabled(true);
-      const toggle = /** @type {HTMLInputElement | null} */ (document.getElementById('pii-local-toggle'));
-      if (toggle) toggle.checked = true;
+      await saveOllamaPIIApiKey(apiKey);
       let currentPII = getOllamaPIIModel();
       if (!models.includes(currentPII)) { currentPII = models[0]; setOllamaPIIModel(currentPII); }
-      text.textContent = `Connected \u2014 using ${currentPII}`;
+      text.textContent = `Connection verified \u2014 ${currentPII}. Turn on the privacy toggle to use it.`;
       if (piiDropdown && piiSelect) {
         piiDropdown.style.display = 'block';
         piiSelect.innerHTML = models.map(m => `<option value="${escapeHTML(m)}" ${m === currentPII ? 'selected' : ''}>${escapeHTML(m)}</option>`).join('');
@@ -436,16 +486,19 @@ export async function testPIIOllamaConnection() {
     }
     updatePrivacyStatusCardFromRuntime();
   } catch (e) {
+    if (generation !== piiDiscoveryGeneration) return;
     dot.classList.add('disconnected');
-    text.textContent = LOCAL_AI_NOT_CONNECTED_TEXT;
+    text.textContent = e.message || LOCAL_AI_NOT_CONNECTED_TEXT;
     updatePrivacyStatusCardFromRuntime();
   }
 }
 
-export function refreshModelAdvisor() {
-  const { modelDetails: details, isOllamaServer } = getCachedLocalAiModelDetails();
-  const modelSelect = /** @type {HTMLSelectElement | null} */ (document.getElementById('local-ai-model-select'));
-  if (details.length) renderModelAdvisor(details, modelSelect, isOllamaServer);
+export async function refreshModelAdvisor() {
+  const config = getOllamaConfig();
+  const generation = ++mainDiscoveryGeneration;
+  const result = await discoverLocalAI(config.url, config.apiKey, { force: true });
+  if (generation !== mainDiscoveryGeneration) return;
+  applyMainDiscoveryResult(result);
 }
 
 export function copyOllamaPullCmd(cmd) {

--- a/js/provider-local-ai-runtime.js
+++ b/js/provider-local-ai-runtime.js
@@ -47,3 +47,10 @@ export function getCachedLocalAiModelDetails() {
     isOllamaServer: !!runtime?._lastIsOllamaServer,
   };
 }
+
+export function clearCachedLocalAiModelDetails() {
+  const runtime = getRuntimeWindow();
+  if (!runtime) return;
+  runtime._lastOllamaModelDetails = [];
+  runtime._lastIsOllamaServer = false;
+}

--- a/js/provider-panel-renderers.js
+++ b/js/provider-panel-renderers.js
@@ -13,8 +13,9 @@ import {
   getVeniceModelDisplay, getOpenRouterModelDisplay,
   getRoutstrModelDisplay, getPpqModelDisplay,
   renderModelPricingHint, isRecommendedModel,
-  getOllamaConfig
+  getOllamaConfig, getOllamaMainModel
 } from './api.js';
+import { getLocalAiExecutionLocation } from './local-ai-discovery.js';
 import { buildRoutstrNodeActions, routstrWalletActionButtons } from './provider-wallet-panels.js';
 import {
   discoverRoutstrNodesFromRuntime,
@@ -370,8 +371,18 @@ function renderCustomProviderPanel() {
 // Local AI panel — works with any OpenAI-compatible server (Ollama, LM Studio, Jan, etc.)
 function renderLocalAIProviderPanel() {
   const config = getOllamaConfig();
+  const executionLocation = getLocalAiExecutionLocation(config.url, getOllamaMainModel());
+  const locationCopy = executionLocation === 'cloud'
+    ? 'The selected model is cloud-hosted and sends requests off-device.'
+    : executionLocation === 'local'
+      ? 'The configured server is on this device.'
+      : executionLocation === 'lan'
+        ? 'The configured server is on your local network; requests leave this browser device.'
+        : 'The configured endpoint is remote; its operator and transport determine privacy.';
+  const insecureRemote = executionLocation !== 'local' && executionLocation !== 'cloud' && /^http:\/\//i.test(config.url);
   return `<div class="ai-provider-panel">
-    <div class="ai-provider-desc">Runs AI on your computer. Free, private, no data leaves your machine. Works with <a href="https://ollama.com" target="_blank" rel="noopener" style="color:var(--accent)">Ollama</a>, <a href="https://lmstudio.ai" target="_blank" rel="noopener" style="color:var(--accent)">LM Studio</a>, <a href="https://jan.ai" target="_blank" rel="noopener" style="color:var(--accent)">Jan</a>, llama.cpp, LocalAI, and others.</div>
+    <div class="ai-provider-desc">Connects directly to an OpenAI-compatible server. ${escapeHTML(locationCopy)} Cloud-tagged models are not considered private/local. Works with <a href="https://ollama.com" target="_blank" rel="noopener" style="color:var(--accent)">Ollama</a>, <a href="https://lmstudio.ai" target="_blank" rel="noopener" style="color:var(--accent)">LM Studio</a>, <a href="https://jan.ai" target="_blank" rel="noopener" style="color:var(--accent)">Jan</a>, llama.cpp, LocalAI, and others.</div>
+    ${insecureRemote ? '<div class="api-key-notice" style="color:var(--warning);margin-bottom:10px">This remote connection uses plain HTTP. Health data and API credentials are not protected by HTTPS unless your underlying VPN/tunnel encrypts the connection.</div>' : ''}
     <div class="local-ai-status" id="local-ai-status">
       <span class="local-ai-status-dot" id="local-ai-dot"></span>
       <span id="local-ai-status-text">Checking connection...</span>

--- a/js/settings-data.js
+++ b/js/settings-data.js
@@ -6,6 +6,8 @@ import { escapeHTML, escapeAttr, showNotification, showConfirmDialog, isDebugMod
 import { formatCost, getProfileUsage, getGlobalUsage, resetProfileUsage } from './schema.js';
 import { loadPdfImport } from './import-loader.js';
 import { isSnapshotDerivedHOMAIR } from './lab-entry.js';
+import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
+import { getImportBenchmarks } from './import-benchmarks.js';
 
 export function renderDataEntriesSection() {
   const snapshots = state.importedData?.importSnapshots || [];
@@ -141,6 +143,132 @@ function formatTokens(n) {
   return String(n);
 }
 
+function getImportBenchmarkSnapshots() {
+  const attempts = getImportBenchmarks();
+  const snapshots = state.importedData?.importSnapshots || [];
+  const legacy = snapshots.filter(snap => snap?.timings && snap?.costInfo?.modelId && !attempts.some(item => item.id === snap.benchmarkId));
+  return [...attempts, ...legacy].sort((a, b) => (b.benchmarkAt || b.importedAt || 0) - (a.benchmarkAt || a.importedAt || 0));
+}
+
+function formatBenchmarkDuration(ms) {
+  const value = Math.max(0, Number(ms) || 0);
+  if (value < 1000) return `${Math.round(value)} ms`;
+  if (value < 60_000) return `${(value / 1000).toFixed(value < 10_000 ? 1 : 0)} s`;
+  const minutes = Math.floor(value / 60_000);
+  const seconds = Math.round((value % 60_000) / 1000);
+  return `${minutes}m ${seconds}s`;
+}
+
+function formatOptionalBenchmarkDuration(ms) {
+  return Number(ms) > 0 ? formatBenchmarkDuration(ms) : '\u2014';
+}
+
+function benchmarkFallbackLabel(diagnostics) {
+  const fallbacks = [];
+  if (diagnostics?.structuredOutputFallback) fallbacks.push('schema retry');
+  if (diagnostics?.streamFallback) fallbacks.push('stream retry');
+  if (diagnostics?.reasoningControlFallback) fallbacks.push('reasoning retry');
+  if (diagnostics?.nativeContextOverride) fallbacks.push('context override');
+  return fallbacks.length ? fallbacks.join(' + ') : 'direct';
+}
+
+function renderImportBenchmarkCards(snapshots) {
+  if (snapshots.length === 0) {
+    return `<div class="import-benchmarks-empty">
+      No benchmark runs yet. Confirm a new AI import to record its model, timing, token, and result metrics here.
+    </div>`;
+  }
+
+  return snapshots.map(snap => {
+    const analysisMs = Number.isFinite(Number(snap.timings?.analysisMs))
+      ? Number(snap.timings.analysisMs)
+      : (Number(snap.timings?.analysis) || 0) * 1000;
+    const piiMs = Number.isFinite(Number(snap.timings?.piiMs))
+      ? Number(snap.timings.piiMs)
+      : (Number(snap.timings?.pii) || 0) * 1000;
+    const inputTokens = Number(snap.usage?.inputTokens ?? snap.costInfo?.inputTokens) || 0;
+    const outputTokens = Number(snap.usage?.outputTokens ?? snap.costInfo?.outputTokens) || 0;
+    const reasoningTokens = Number(snap.usage?.reasoningTokens) || 0;
+    const measuredThroughput = Number(snap.generationTokensPerSecond) || 0;
+    const endToEndRate = analysisMs > 0 && outputTokens > 0 ? outputTokens / (analysisMs / 1000) : 0;
+    const throughput = measuredThroughput > 0 ? `${measuredThroughput.toFixed(1)} tok/s` : endToEndRate > 0 ? `${endToEndRate.toFixed(1)} tok/s e2e` : '\u2014';
+    const recordedAt = Number(snap.benchmarkAt || snap.importedAt);
+    const recordedLabel = Number.isFinite(recordedAt)
+      ? new Date(recordedAt).toLocaleString()
+      : 'Unknown time';
+    const mode = snap.importMode === 'image' ? 'image' : 'text';
+    const fallbackLabel = benchmarkFallbackLabel(snap.diagnostics);
+    const modelId = snap.modelId || snap.costInfo?.modelId || 'unknown';
+    const provider = snap.provider || snap.costInfo?.provider || 'unknown';
+    const status = snap.status || 'confirmed';
+    const statusLabel = fallbackLabel === 'direct' ? status : `${status} \u00b7 ${fallbackLabel}`;
+    const contextLength = Number(snap.runtime?.contextLength || snap.diagnostics?.contextLength) || 0;
+    const quant = snap.runtime?.quantLevel || '';
+    const executionLocation = snap.runtime?.executionLocation || '';
+    const totalMs = Number(snap.totalMs) || analysisMs + piiMs;
+    const resultQuality = snap.correctedMappingCount != null
+      ? `${Number(snap.correctedMappingCount)} corrected \u00b7 ${Number(snap.excludedMarkerCount) || 0} excluded`
+      : '\u2014';
+    return `<article class="import-benchmark-card">
+      <div class="import-benchmark-head">
+        <div>
+          <div class="import-benchmark-file" title="${escapeAttr(snap.fileName || 'Unknown file')}">${escapeHTML(snap.fileName || 'Unknown file')}</div>
+          <div class="import-benchmark-date">${escapeHTML(recordedLabel)}</div>
+        </div>
+        <span class="import-benchmark-status${status !== 'confirmed' || fallbackLabel !== 'direct' ? ' retried' : ''}">${escapeHTML(statusLabel)}</span>
+      </div>
+      <div class="import-benchmark-grid">
+        <div><span>Model</span><strong title="${escapeAttr(modelId)}">${escapeHTML(modelId)}</strong></div>
+        <div><span>Provider / mode</span><strong>${escapeHTML(provider)} \u00b7 ${mode}</strong></div>
+        <div><span>Total attempt</span><strong>${formatBenchmarkDuration(totalMs)}</strong></div>
+        <div><span>AI analysis</span><strong>${formatBenchmarkDuration(analysisMs)}</strong></div>
+        <div><span>PII preparation</span><strong>${formatBenchmarkDuration(piiMs)}</strong></div>
+        <div><span>Tokens</span><strong>${formatTokens(inputTokens)} in \u00b7 ${formatTokens(outputTokens)} out${reasoningTokens ? ` \u00b7 ${formatTokens(reasoningTokens)} reasoning` : ''}</strong></div>
+        <div><span>${measuredThroughput > 0 ? 'Generation speed' : 'Output rate'}</span><strong>${throughput}</strong></div>
+        <div><span>${status === 'confirmed' ? 'Imported markers' : 'Detected markers'}</span><strong>${Number(snap.importedMarkerCount ?? snap.markerCount) || 0}</strong></div>
+        <div><span>Input</span><strong>${Number(snap.inputChars) ? `${formatTokens(Number(snap.inputChars))} chars` : '\u2014'}${Number(snap.pageCount) ? ` \u00b7 ${Number(snap.pageCount)} pages` : ''}</strong></div>
+        <div><span>Runtime</span><strong>${contextLength ? `${formatTokens(contextLength)} ctx` : 'ctx unknown'}${quant ? ` \u00b7 ${escapeHTML(quant)}` : ''}${executionLocation ? ` \u00b7 ${escapeHTML(executionLocation)}` : ''}</strong></div>
+        <div><span>Review changes</span><strong>${resultQuality}</strong></div>
+        <div><span>Load / TTFT</span><strong>${formatOptionalBenchmarkDuration(snap.timings?.modelLoadMs)} / ${formatOptionalBenchmarkDuration(snap.timings?.timeToFirstTokenMs)}</strong></div>
+        ${snap.error ? `<div style="grid-column:1/-1"><span>Error</span><strong>${escapeHTML(snap.error)}</strong></div>` : ''}
+      </div>
+    </article>`;
+  }).join('');
+}
+
+export function closeImportBenchmarksModal() {
+  const overlay = document.getElementById('import-benchmarks-overlay');
+  if (overlay) removeModalOverlay(overlay);
+}
+
+export function openImportBenchmarksModal() {
+  if (!isDebugMode()) return false;
+  closeImportBenchmarksModal();
+  const snapshots = getImportBenchmarkSnapshots();
+  const overlay = document.createElement('div');
+  overlay.id = 'import-benchmarks-overlay';
+  overlay.className = 'modal-overlay';
+  overlay.innerHTML = `<div class="modal import-benchmarks-modal" role="dialog" aria-modal="true" aria-labelledby="import-benchmarks-title">
+    <div class="gb-modal-head">
+      <div>
+        <div class="gb-modal-kicker">Local diagnostics</div>
+        <div class="gb-modal-title" id="import-benchmarks-title">Import Benchmarks</div>
+      </div>
+      <button type="button" class="modal-close" data-import-benchmarks-action="close" aria-label="Close import benchmarks">&times;</button>
+    </div>
+    <div class="import-benchmarks-body">
+      <p class="import-benchmarks-note">Recent attempts include failures and cancellations so model comparisons are not biased toward successes. AI analysis excludes file extraction and review time; PII preparation is measured separately. Diagnostics stay in this profile's local storage and are not sent to analytics.</p>
+      <div class="import-benchmarks-list">${renderImportBenchmarkCards(snapshots)}</div>
+    </div>
+  </div>`;
+  overlay.addEventListener('click', event => {
+    const target = event.target instanceof Element ? event.target : null;
+    if (target?.closest('[data-import-benchmarks-action="close"]')) closeImportBenchmarksModal();
+  });
+  openAppendedModalOverlay(overlay, closeImportBenchmarksModal, { initialFocus: '.modal-close', focusDelay: 30 });
+  return true;
+}
+
 export function renderAIUsageSection() {
   const pu = getProfileUsage(state.currentProfile);
   const gu = getGlobalUsage();
@@ -152,6 +280,13 @@ export function renderAIUsageSection() {
   html += '</div>';
   if (pu.requestCount > 0) {
     html += `<button class="import-btn import-btn-secondary" style="margin-top:8px;font-size:11px" data-settings-action="reset-profile-usage">Reset profile usage</button>`;
+  }
+  if (isDebugMode()) {
+    const benchmarkCount = getImportBenchmarkSnapshots().length;
+    html += `<div class="import-benchmarks-entrypoint">
+      <div><strong>Import diagnostics</strong><span>${benchmarkCount} recorded run${benchmarkCount === 1 ? '' : 's'}</span></div>
+      <button type="button" class="import-btn import-btn-secondary" data-settings-action="open-import-benchmarks">View benchmarks</button>
+    </div>`;
   }
   return html;
 }

--- a/js/settings-privacy.js
+++ b/js/settings-privacy.js
@@ -1,8 +1,8 @@
 // @ts-check
 // settings-privacy.js - Settings privacy and Sun data-source controls.
 
-import { getOllamaConfig, getOllamaPIIUrl, getOllamaPIIModel } from './api.js';
-import { isOllamaPIIEnabled, setOllamaPIIEnabled, checkOpenAICompatible } from './pii.js';
+import { getOllamaPIIApiKey, getOllamaPIIUrl, getOllamaPIIModel } from './api.js';
+import { isOllamaPIIEnabled, setOllamaPIIEnabled, checkOllamaPII } from './pii.js';
 import { escapeAttr, isPIIReviewEnabled, isAnalyticsEnabled, showNotification } from './utils.js';
 import {
   getSettingsMeteoConfig,
@@ -11,12 +11,13 @@ import {
 
 export function renderPrivacySection() {
   const piiUrl = getOllamaPIIUrl();
+  const piiApiKey = getOllamaPIIApiKey();
   const piiEnabled = isOllamaPIIEnabled();
   return `<div class="settings-action-row privacy-overview-row">
       <div class="privacy-overview-icon" aria-hidden="true">&#128274;</div>
       <div class="settings-copy">
-        <div class="settings-copy-title">Personal details are scrubbed before AI analysis</div>
-        <div class="settings-copy-desc">Names, dates of birth, ID numbers, and addresses are replaced before lab PDFs, EMF assessments, image imports, or chat context leave this device. Lab values and interpretation context are preserved.</div>
+        <div class="settings-copy-title">Privacy protection runs before text-based AI analysis</div>
+        <div class="settings-copy-desc">Text imports use deterministic patterns and, optionally, a trusted self-hosted model (this device, LAN, or your remote server) to replace likely identifiers. Review remains recommended because automated detection can miss unusual layouts. Image imports cannot be scrubbed and always require a separate warning.</div>
       </div>
     </div>
     <div class="privacy-status-card" id="privacy-status-card">
@@ -37,9 +38,13 @@ export function renderPrivacySection() {
           <span id="pii-local-status-text">Click Test to check</span>
         </div>
         <div style="margin-top:8px">
+          <label style="font-size:12px;color:var(--text-muted)">Privacy server API key <span style="font-size:11px">(optional, stored separately)</span></label>
+          <input type="password" class="api-key-input" id="pii-local-apikey-input" value="${escapeAttr(piiApiKey)}" placeholder="Leave empty if not required" style="margin-top:4px">
+        </div>
+        <div style="margin-top:8px">
           <label style="font-size:12px;color:var(--text-muted)">Server address</label>
           <div style="display:flex;gap:8px;align-items:center;margin-top:4px">
-            <input type="text" class="api-key-input" id="pii-local-url-input" value="${piiUrl}" placeholder="http://localhost:11434" style="flex:1">
+            <input type="text" class="api-key-input" id="pii-local-url-input" value="${escapeAttr(piiUrl)}" placeholder="http://localhost:11434" style="flex:1">
             <button class="import-btn import-btn-secondary" data-settings-action="test-pii-ollama" style="white-space:nowrap">Test</button>
           </div>
         </div>
@@ -51,8 +56,8 @@ export function renderPrivacySection() {
     </div>
     <div class="settings-action-row privacy-setting-row">
       <div class="settings-copy">
-        <div class="settings-copy-title">Use local AI for privacy protection</div>
-        <div class="settings-copy-desc">Requires a local AI server. When disabled, regex pattern matching is used instead.</div>
+        <div class="settings-copy-title">Use self-hosted AI for privacy protection</div>
+        <div class="settings-copy-desc">Requires a server you trust; the original report is sent to that endpoint for scrubbing. Cloud-tagged models are blocked. When disabled, deterministic pattern matching is used instead.</div>
       </div>
       <label class="toggle-switch">
         <input type="checkbox" id="pii-local-toggle" ${piiEnabled ? 'checked' : ''} data-settings-action="toggle-pii-local">
@@ -225,9 +230,7 @@ export async function updatePrivacyStatusCard(enhanced) {
   // If not passed explicitly, check PII Ollama.
   else if (enhanced === undefined) {
     try {
-      const piiUrl = getOllamaPIIUrl();
-      const config = getOllamaConfig();
-      const result = await checkOpenAICompatible(piiUrl, config.apiKey);
+      const result = await checkOllamaPII();
       enhanced = result.available && result.models.length > 0;
     } catch { enhanced = false; }
   }
@@ -236,11 +239,11 @@ export async function updatePrivacyStatusCard(enhanced) {
     card.className = 'privacy-status-card privacy-status-enhanced';
     if (icon) icon.innerHTML = '&#128274;';
     title.textContent = 'Enhanced protection';
-    detail.textContent = `Local AI (${model}) understands context and language, so it reliably finds and replaces all personal info — including uncommon formats and non-English text.`;
+    detail.textContent = `Trusted Local AI (${model}) adds contextual detection, followed by deterministic checks. Review the result before sending because no automated detector can guarantee every identifier is removed.`;
   } else {
     card.className = 'privacy-status-card privacy-status-basic';
     if (icon) icon.innerHTML = '&#128274;';
     title.textContent = 'Basic protection';
-    detail.innerHTML = 'Regex pattern matching catches common formats (names on labeled lines, IDs, emails, phone numbers). May miss unusual layouts or non-English personal data.<br><span style="margin-top:4px;display:inline-block">Set up Local AI for enhanced protection — a local server that reliably catches all personal info.</span>';
+    detail.innerHTML = 'Deterministic pattern matching catches common labeled names, IDs, emails, phone numbers, and addresses. It may miss unusual layouts or non-English personal data.<br><span style="margin-top:4px;display:inline-block">A trusted Local AI model can add contextual detection, but review is still recommended.</span>';
   }
 }

--- a/js/settings.js
+++ b/js/settings.js
@@ -44,8 +44,10 @@ import { startGuidedTour } from './tour.js';
 import { getActiveProfileId } from './profile.js';
 import { openChangelog } from './changelog.js';
 import { updateChatNudgeRuntime } from './chat-runtime.js';
+import { isPIIEligibleModel } from './local-ai-discovery.js';
 import {
   confirmDisablePIIReview,
+  openImportBenchmarksModal,
   refreshDataEntriesSection,
   removeImportedEntryFromSettings,
   renameImportedEntryDateFromSettings,
@@ -317,6 +319,8 @@ function applySettingsToggle(actionEl) {
   }
   if (action === 'set-debug-mode') {
     setDebugMode(checked);
+    const usageSection = document.getElementById('ai-usage-section');
+    if (usageSection) usageSection.innerHTML = renderAIUsageSection();
     return true;
   }
   if (action === 'toggle-ai-pause') {
@@ -479,6 +483,9 @@ async function handleSettingsClick(event) {
   } else if (action === 'reset-profile-usage') {
     event.preventDefault();
     resetCurrentProfileUsage();
+  } else if (action === 'open-import-benchmarks') {
+    event.preventDefault();
+    openImportBenchmarksModal();
   }
 }
 
@@ -495,7 +502,12 @@ function handleSettingsChange(event) {
 
   const action = actionEl.dataset.settingsAction;
   if (action === 'set-pii-model') {
-    setOllamaPIIModel(actionEl instanceof HTMLSelectElement ? actionEl.value : '');
+    const model = actionEl instanceof HTMLSelectElement ? actionEl.value : '';
+    if (!isPIIEligibleModel(model)) {
+      showNotification('Cloud and embedding models cannot be used for privacy protection.', 'error');
+      return;
+    }
+    setOllamaPIIModel(model);
     updatePrivacyStatusCard();
   }
 }
@@ -835,8 +847,8 @@ export function openSettingsModal(tab) {
         <div class="settings-section">
           <div class="settings-action-row">
             <div class="settings-copy">
-              <label class="settings-label">Verbose console logging</label>
-              <div class="settings-copy-desc">Adds detailed log output and reveals diagnostic UI in the sync popover. No data leaves your device.</div>
+              <label class="settings-label">Debug Mode</label>
+              <div class="settings-copy-desc">Adds detailed log output and reveals diagnostic UI such as sync details and import benchmarks. No data leaves your device.</div>
             </div>
             <label class="toggle-switch">
               <input type="checkbox" id="debug-mode-toggle" ${isDebugMode() ? 'checked' : ''} data-settings-action="set-debug-mode">

--- a/js/sync-apply.js
+++ b/js/sync-apply.js
@@ -42,7 +42,7 @@ function shouldKeepLocalAISetting(key, preferRemote = false) {
     || (AI_SETTINGS_KEYS.includes(key) && hasLocalAISettingsLock());
 }
 
-const ENCRYPTED_AI_KEYS = ['labcharts-openrouter-key', 'labcharts-venice-key', 'labcharts-routstr-key', 'labcharts-ppq-key', 'labcharts-ollama', 'labcharts-lens-key', 'labcharts-custom-key'];
+const ENCRYPTED_AI_KEYS = ['labcharts-openrouter-key', 'labcharts-venice-key', 'labcharts-routstr-key', 'labcharts-ppq-key', 'labcharts-ollama', 'labcharts-ollama-pii-key', 'labcharts-lens-key', 'labcharts-custom-key'];
 
 /** @param {Record<string, any> | null | undefined} settings
  * @param {{ preferRemote?: boolean }} [options]

--- a/js/sync-payload-collectors.js
+++ b/js/sync-payload-collectors.js
@@ -23,6 +23,7 @@ export const AI_SETTINGS_KEYS = [
   'labcharts-venice-e2ee',
   'labcharts-ollama-model',
   'labcharts-ollama-pii-url',
+  'labcharts-ollama-pii-key',       // Separate privacy-server API key (encrypted)
   'labcharts-ollama-pii-model',
   'labcharts-routstr-node',           // Selected Routstr node
   'labcharts-routstr-session-updated-at', // LWW clock for shared node session/balance refresh

--- a/service-worker.js
+++ b/service-worker.js
@@ -125,6 +125,8 @@ const APP_SHELL = [
   '/js/data.js',
   '/js/marker-analysis.js',
   '/js/blob-storage.js',
+  '/js/local-ai-discovery.js',
+  '/js/import-benchmarks.js',
   '/js/data-merge.js',
   '/js/pii.js',
   '/js/charts-runtime.js',

--- a/tests/api-provider-contracts.test.js
+++ b/tests/api-provider-contracts.test.js
@@ -24,6 +24,8 @@ vi.mock('../vendor/venice-e2ee.js', () => ({
 }));
 
 import { updateKeyCache } from '../js/crypto.js';
+import { checkOpenAICompatible, clearLocalAiDiscovery, discoverLocalAI } from '../js/local-ai-discovery.js';
+import { estimateLocalAiPromptTokens } from '../js/api-local.js';
 import {
   callClaudeAPI,
   fetchRoutstrModels,
@@ -130,6 +132,7 @@ beforeEach(() => {
   localStorage.clear();
   sessionStorage.clear();
   clearProviderKeyCaches();
+  clearLocalAiDiscovery();
   globalThis.fetch = vi.fn(async () => chatCompletionResponse());
   Object.defineProperty(globalThis, 'location', {
     configurable: true,
@@ -155,6 +158,7 @@ afterEach(() => {
   if (realLocationDescriptor) Object.defineProperty(globalThis, 'location', realLocationDescriptor);
   else delete globalThis.location;
   clearProviderKeyCaches();
+  clearLocalAiDiscovery();
   vi.restoreAllMocks();
 });
 
@@ -295,7 +299,13 @@ const providerContracts = [
       expect(request.body).toMatchObject({
         model: 'llama3.2',
         max_tokens: 32,
-        response_format: { type: 'json_object' },
+        response_format: {
+          type: 'json_schema',
+          json_schema: {
+            name: 'structured_response',
+            schema: { type: 'object' },
+          },
+        },
       });
     },
   },
@@ -305,17 +315,213 @@ describe('AI provider request contracts', () => {
   it.each(providerContracts)('routes $name through its expected chat-completion contract', async (contract) => {
     contract.setup();
 
-    await expect(callClaudeAPI(baseChatOptions(contract.options))).resolves.toEqual({
+    const result = await callClaudeAPI(baseChatOptions(contract.options));
+    expect(result).toMatchObject({
       text: 'contract ok',
       usage: { inputTokens: 11, outputTokens: 13 },
       finishReason: 'stop',
       truncated: false,
     });
 
-    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    const postCalls = globalThis.fetch.mock.calls.filter(([, init]) => init?.method === 'POST');
+    expect(postCalls).toHaveLength(1);
     const request = providerRequestFromFetchCall();
     contract.assertRequest(request);
     expect(JSON.stringify(request.body)).not.toContain(contract.key);
+  });
+
+  it('retries Local AI JSON requests without structured output when the server rejects it', async () => {
+    setAIProvider('ollama');
+    setOllamaMainModel('llama3.2');
+    let postCount = 0;
+    globalThis.fetch = vi.fn(async (url, init = {}) => {
+      if (init.method !== 'POST') {
+        if (String(url).endsWith('/v1/models')) return jsonResponse({ data: [{ id: 'llama3.2' }] });
+        return jsonResponse({}, { status: 404 });
+      }
+      postCount++;
+      if (postCount === 1) {
+        return jsonResponse({ error: { message: 'structured output is not supported by this model' } }, { status: 400 });
+      }
+      return chatCompletionResponse('{"ok":true}');
+    });
+
+    await expect(callClaudeAPI(baseChatOptions({ jsonMode: true }))).resolves.toMatchObject({
+      text: '{"ok":true}',
+      diagnostics: { structuredOutputFallback: true },
+    });
+
+    const postCalls = globalThis.fetch.mock.calls.filter(([, init]) => init?.method === 'POST');
+    expect(postCalls).toHaveLength(2);
+    const firstBody = JSON.parse(postCalls[0][1].body);
+    const fallbackBody = JSON.parse(postCalls[1][1].body);
+    expect(firstBody.response_format.type).toBe('json_schema');
+    expect(fallbackBody).not.toHaveProperty('response_format');
+  });
+
+  it('keeps the context-planned output cap for Local AI thinking models', async () => {
+    setAIProvider('ollama');
+    setOllamaMainModel('thinkingcap-qwen3.6-27b');
+    globalThis.fetch = vi.fn(async (url, init = {}) => {
+      if (init.method !== 'POST') {
+        if (String(url).endsWith('/v1/models')) return jsonResponse({ data: [{ id: 'thinkingcap-qwen3.6-27b' }] });
+        return jsonResponse({}, { status: 404 });
+      }
+      return chatCompletionResponse('short answer');
+    });
+
+    await callClaudeAPI(baseChatOptions({ maxTokens: 512, reasoningEffort: 'none' }));
+
+    const postCall = globalThis.fetch.mock.calls.find(([, init]) => init?.method === 'POST');
+    const body = JSON.parse(postCall[1].body);
+    expect(body.max_tokens).toBe(512);
+    expect(body.reasoning_effort).toBe('none');
+  });
+
+  it('can remove both unsupported schema and reasoning controls in validation-only retries', async () => {
+    setAIProvider('ollama');
+    setOllamaMainModel('llama3.2');
+    let postCount = 0;
+    globalThis.fetch = vi.fn(async (url, init = {}) => {
+      if (init.method !== 'POST') {
+        if (String(url).endsWith('/v1/models')) return jsonResponse({ data: [{ id: 'llama3.2' }] });
+        return jsonResponse({}, { status: 404 });
+      }
+      postCount++;
+      if (postCount === 1) return jsonResponse({ error: { message: 'response_format json_schema unsupported' } }, { status: 400 });
+      if (postCount === 2) return jsonResponse({ error: { message: 'reasoning_effort is invalid' } }, { status: 422 });
+      return chatCompletionResponse('{"ok":true}');
+    });
+
+    await expect(callClaudeAPI(baseChatOptions({ jsonMode: true, reasoningEffort: 'none' }))).resolves.toMatchObject({
+      diagnostics: { structuredOutputFallback: true, reasoningControlFallback: true },
+    });
+
+    const bodies = globalThis.fetch.mock.calls
+      .filter(([, init]) => init?.method === 'POST')
+      .map(([, init]) => JSON.parse(init.body));
+    expect(bodies).toHaveLength(3);
+    expect(bodies[0]).toHaveProperty('response_format');
+    expect(bodies[1]).not.toHaveProperty('response_format');
+    expect(bodies[1]).toHaveProperty('reasoning_effort');
+    expect(bodies[2]).not.toHaveProperty('reasoning_effort');
+  });
+
+  it('budgets vision inputs and deduplicates LM Studio loaded-instance aliases', async () => {
+    const imageEstimate = estimateLocalAiPromptTokens({
+      system: 'extract',
+      messages: [{ role: 'user', content: [{ type: 'image_url', image_url: { url: 'data:image/png;base64,AAAA' } }] }],
+    });
+    expect(imageEstimate).toBeGreaterThan(1600);
+
+    globalThis.fetch = vi.fn(async url => {
+      if (String(url).endsWith('/api/v1/models')) {
+        return jsonResponse({ models: [
+          {
+            type: 'llm',
+            key: 'thinkingcap-qwen3.6-27b@q4_k_m',
+            size_bytes: 17_741_858_944,
+            quantization: { name: 'Q4_K_M' },
+            loaded_instances: [{ id: 'thinkingcap-qwen3.6-27b', config: { context_length: 8192 } }],
+            max_context_length: 262144,
+          },
+        ] });
+      }
+      return jsonResponse({ data: [
+        { id: 'thinkingcap-qwen3.6-27b' },
+        { id: 'thinkingcap-qwen3.6-27b@q4_k_m' },
+      ] });
+    });
+    const discovery = await checkOpenAICompatible('http://lmstudio.test', '');
+    expect(discovery.models).toEqual(['thinkingcap-qwen3.6-27b']);
+    expect(discovery.modelDetails[0]).toMatchObject({ loaded: true, contextLength: 8192, maxContextLength: 262144 });
+  });
+
+  it('does not send Ollama-only discovery probes to an identified LM Studio server', async () => {
+    const requestedUrls = [];
+    globalThis.fetch = vi.fn(async url => {
+      requestedUrls.push(String(url));
+      if (String(url).endsWith('/api/v1/models')) {
+        return jsonResponse({ models: [{
+          type: 'llm',
+          key: 'thinkingcap-qwen3.6-27b',
+          loaded_instances: [{ id: 'thinkingcap-qwen3.6-27b', config: { context_length: 8192 } }],
+        }] });
+      }
+      if (String(url).endsWith('/v1/models')) {
+        return jsonResponse({ data: [{ id: 'thinkingcap-qwen3.6-27b' }] });
+      }
+      throw new Error(`Unexpected discovery URL: ${url}`);
+    });
+
+    const discovery = await discoverLocalAI('http://lmstudio.test', '', { force: true });
+
+    expect(discovery.provider).toBe('lmstudio');
+    expect(requestedUrls).toEqual([
+      'http://lmstudio.test/api/v1/models',
+      'http://lmstudio.test/v1/models',
+    ]);
+    expect(requestedUrls.some(url => url.endsWith('/api/tags') || url.endsWith('/api/ps'))).toBe(false);
+  });
+
+  it('uses LM Studio native chat to expand context for a large import request', async () => {
+    setAIProvider('ollama');
+    setOllamaMainModel('thinkingcap-qwen3.6-27b');
+    globalThis.fetch = vi.fn(async (url, init = {}) => {
+      if (init.method === 'POST') {
+        expect(String(url)).toBe('http://localhost:11434/api/v1/chat');
+        return jsonResponse({
+          output: [{ type: 'message', content: '{"markers":[]}' }],
+          stats: {
+            input_tokens: 7200,
+            total_output_tokens: 24,
+            tokens_per_second: 31.5,
+            reasoning_output_tokens: 0,
+          },
+        });
+      }
+      if (String(url).endsWith('/api/v1/models')) {
+        return jsonResponse({ models: [{
+          type: 'llm',
+          key: 'thinkingcap-qwen3.6-27b@q4_k_m',
+          loaded_instances: [{ id: 'thinkingcap-qwen3.6-27b', config: { context_length: 8192 } }],
+          max_context_length: 262144,
+        }] });
+      }
+      if (String(url).endsWith('/v1/models')) {
+        return jsonResponse({ data: [{ id: 'thinkingcap-qwen3.6-27b' }] });
+      }
+      return jsonResponse({}, { status: 404 });
+    });
+
+    const result = await callClaudeAPI(baseChatOptions({
+      system: 'Extract the report as JSON.',
+      messages: [{ role: 'user', content: 'x'.repeat(25_000) }],
+      maxTokens: 4096,
+      jsonMode: true,
+      reasoningEffort: 'none',
+      preferNativeContext: true,
+    }));
+
+    const postCall = globalThis.fetch.mock.calls.find(([, init]) => init?.method === 'POST');
+    const body = JSON.parse(postCall[1].body);
+    expect(body).toMatchObject({
+      model: 'thinkingcap-qwen3.6-27b',
+      context_length: 16384,
+      max_output_tokens: 4096,
+      reasoning: 'off',
+      stream: false,
+      store: false,
+    });
+    expect(result).toMatchObject({
+      text: '{"markers":[]}',
+      diagnostics: {
+        nativeContextOverride: true,
+        contextLength: 16384,
+        performance: { tokensPerSecond: 31.5 },
+        localPlan: { contextLength: 16384 },
+      },
+    });
   });
 
   it('parses OpenAI-compatible SSE streams without changing provider headers', async () => {

--- a/tests/chat-runtime.test.js
+++ b/tests/chat-runtime.test.js
@@ -179,7 +179,7 @@ describe('chat discussion callback bridge runtime behavior', () => {
   });
 });
 
-function installRoundStateMocks({ encryptionEnabled = false } = {}) {
+function installRoundStateMocks() {
   const deps = {
     state: {
       currentThreadId: 'active-thread',
@@ -199,7 +199,6 @@ function installRoundStateMocks({ encryptionEnabled = false } = {}) {
     renderThreadList: vi.fn(),
     saveChatThreadIndex: vi.fn(),
     encryptedSetItem: vi.fn(async () => {}),
-    getEncryptionEnabled: vi.fn(() => encryptionEnabled),
     saveChatHistory: vi.fn(async () => {}),
   };
 
@@ -212,7 +211,6 @@ function installRoundStateMocks({ encryptionEnabled = false } = {}) {
   }));
   vi.doMock('../js/crypto.js', () => ({
     encryptedSetItem: deps.encryptedSetItem,
-    getEncryptionEnabled: deps.getEncryptionEnabled,
   }));
   vi.doMock('../js/chat-history.js', () => ({
     saveChatHistory: deps.saveChatHistory,
@@ -248,7 +246,7 @@ describe('chat discussion round state runtime behavior', () => {
     expect(renderMessages).toHaveBeenCalled();
   });
 
-  it('saves active thread history through chat-history and inactive history through storage', async () => {
+  it('saves active thread history through chat-history and inactive history through the storage wrapper', async () => {
     const deps = installRoundStateMocks();
     const mod = await import('../js/chat-discussion-round-state.js');
     const activeMessages = [{ role: 'user', content: 'active' }];
@@ -264,18 +262,18 @@ describe('chat discussion round state runtime behavior', () => {
 
     await mod.saveRoundChatHistory('background-thread', backgroundMessages);
     expect(deps.invalidateThreadContentCache).toHaveBeenCalled();
-    expect(localStorage.getItem('chat-thread:background-thread')).toBe(JSON.stringify(backgroundMessages));
-    expect(deps.encryptedSetItem).not.toHaveBeenCalled();
+    expect(deps.encryptedSetItem).toHaveBeenCalledWith('chat-thread:background-thread', JSON.stringify(backgroundMessages));
+    expect(localStorage.getItem('chat-thread:background-thread')).toBeNull();
     expect(deps.state.chatThreads[1].messageCount).toBe(2);
     expect(deps.state.chatThreads[1].updatedAt).not.toBe('2026-01-01T00:00:00.000Z');
     expect(deps.saveChatThreadIndex).toHaveBeenCalledTimes(1);
     expect(deps.renderThreadList).toHaveBeenCalled();
   });
 
-  it('uses encrypted storage for inactive thread history when chat encryption is enabled', async () => {
-    const deps = installRoundStateMocks({ encryptionEnabled: true });
+  it('does not bypass the storage wrapper for credential-shaped chat content', async () => {
+    const deps = installRoundStateMocks();
     const mod = await import('../js/chat-discussion-round-state.js');
-    const messages = [{ role: 'assistant', content: 'encrypted' }];
+    const messages = [{ role: 'user', content: { api_key: 'sensitive-value' } }];
 
     await mod.saveRoundChatHistory('background-thread', messages);
 

--- a/tests/import-file-input-runtime.test.js
+++ b/tests/import-file-input-runtime.test.js
@@ -86,14 +86,20 @@ describe('import file input runtime routing', () => {
   });
 
   it('notifies and clears selection when the lazy import module fails', async () => {
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => {});
     mocks.loadPdfImport.mockRejectedValue(new Error('load failed'));
     const target = await runInput([makeFile('report.pdf')]);
 
     expect(target.value).toBe('');
+    expect(errorLog).toHaveBeenCalledWith(
+      '[import-file-input] Could not load PDF import module:',
+      expect.any(Error),
+    );
     expect(mocks.showDropZoneImportNotification).toHaveBeenCalledWith(
-      'Could not load import module - check your connection and try again.',
+      'Could not load import module. Reload the app to finish updating, then try again.',
       'error',
     );
+    errorLog.mockRestore();
   });
 
   it('routes JSON files through the runtime JSON importer', async () => {

--- a/tests/playwright/lens-hardware-browser-coverage.spec.js
+++ b/tests/playwright/lens-hardware-browser-coverage.spec.js
@@ -117,10 +117,13 @@ test('hardware browser contract detects GPUs and ranks model options', async ({ 
         { name: 'llama3.3:70b', size: 43e9 },
       ], desktop);
       const suggestion16 = hardware.getUpgradeSuggestion([], desktop);
+      const suggestion32 = hardware.getUpgradeSuggestion([], { gpu: { vram: 32, unified: false } });
       const suggestion8 = hardware.getUpgradeSuggestion([], { gpu: { vram: 8, unified: false } });
       outcomes.bestAndUpgradeSuggestionsPreferFittingQuality =
         best?.name === 'qwen3.5:14b'
         && suggestion16?.model === 'qwen3.5:14b'
+        && suggestion32?.model === 'qwen3.6:27b'
+        && suggestion32?.note.includes('~20 GB')
         && suggestion8?.model === 'qwen3.5:9b'
         && hardware.getModelSuggestions({ gpu: { vram: 8, unified: false } })[0]?.model === 'qwen3.5:9b'
         && hardware.getUpgradeSuggestion([{ name: 'qwen3.5:14b', size: 9e9 }], desktop) === null;
@@ -185,6 +188,11 @@ test('external lens browser contract covers validation fetch cache save and remo
       await lens.saveLensKey('secret-token');
 
       window.fetch = async (url, opts) => {
+        const href = String(url);
+        if (!opts?.body) {
+          if (href.endsWith('/v1/models')) return makeJsonResponse({ data: [{ id: 'lens-rewrite-test-model' }] });
+          return makeJsonResponse({ error: 'unsupported' }, 404);
+        }
         const body = JSON.parse(String(opts?.body || '{}'));
         if (Array.isArray(body.messages)) {
           calls.push({ kind: 'rewrite', url: String(url), body });

--- a/tests/playwright/pdf-import-browser-coverage.spec.js
+++ b/tests/playwright/pdf-import-browser-coverage.spec.js
@@ -514,7 +514,10 @@ test('PDF import runtime handlers cover AI parse fallback text and image routes'
         && xlsxFilePending.privacyMethod === 'regex';
       review.closeImportModal();
 
-      await pdfImport.handleImageFile(new File(['image bytes'], 'scan.png', { type: 'image/png' }));
+      const imageHandlePromise = pdfImport.handleImageFile(new File(['image bytes'], 'scan.png', { type: 'image/png' }));
+      for (let i = 0; i < 80 && !document.getElementById('confirm-ok'); i += 1) await new Promise(resolve => setTimeout(resolve, 25));
+      document.getElementById('confirm-ok')?.click();
+      await imageHandlePromise;
       const imagePending = review.getPendingImport();
       outcomes.imageFileHandlerOpensPreview = imagePending?.fileName === 'scan.png'
         && imagePending.markers.length === 2;
@@ -749,6 +752,9 @@ test('PDF import confirm flow covers preview persistence', async ({ page }) => {
           outputTokens: 5,
           cost: 0,
         },
+        timings: { pii: 1, analysis: 2, piiMs: 1250, analysisMs: 2400 },
+        imageMode: false,
+        diagnostics: { structuredOutputFallback: true, streamFallback: true },
         markers: [{
           rawName: 'Glucose',
           value: 5.4,
@@ -761,6 +767,7 @@ test('PDF import confirm flow covers preview persistence', async ({ page }) => {
       });
       await pdfImport.confirmImport();
       const imported = state.importedData.entries.find(entry => entry.date === '2026-06-07');
+      const snapshot = state.importedData.importSnapshots?.find(snap => snap.fileName === 'confirm-import.pdf');
       outcomes.confirmImportPersistsMatchedPreview =
         imported?.markers?.['biochemistry.glucose'] === 5.4
         && imported.importedWith?.provider === 'ollama'
@@ -768,6 +775,15 @@ test('PDF import confirm flow covers preview persistence', async ({ page }) => {
         && imported.importHash === 'confirm-import-hash'
         && imported.sourceFiles?.includes('confirm-import.pdf') === true
         && review.getPendingImport() === null;
+      outcomes.confirmImportPersistsBenchmarkMetrics = snapshot?.costInfo?.inputTokens === 10
+        && snapshot.costInfo.outputTokens === 5
+        && snapshot.costInfo.cost === 0
+        && snapshot.timings?.piiMs === 1250
+        && snapshot.timings.analysisMs === 2400
+        && snapshot.importMode === 'text'
+        && snapshot.diagnostics?.structuredOutputFallback === true
+        && snapshot.diagnostics?.streamFallback === true
+        && Number.isFinite(snapshot.benchmarkAt);
     } finally {
       state.importedData = original.importedData;
       state.currentProfile = original.currentProfile;
@@ -852,7 +868,12 @@ test('PDF import preflight covers model mismatch and unsupported lab dialogs', a
       state.importedData.entries = [];
       localStorage.setItem('labcharts-ollama-model', 'llama-current');
       let fetchCalls = 0;
-      window.fetch = async () => {
+      window.fetch = async (url, options = {}) => {
+        const href = typeof url === 'string' ? url : url?.url || '';
+        if (options.method !== 'POST') {
+          if (href.endsWith('/v1/models')) return new Response(JSON.stringify({ data: [{ id: 'llama-current' }] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+          return new Response(JSON.stringify({ error: 'unsupported' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+        }
         fetchCalls += 1;
         return new Response(JSON.stringify({
           choices: [{
@@ -1016,7 +1037,12 @@ test('PDF import preflight covers duplicate prompts, cancellation, and supported
         'not JSON',
       ];
       let fetchCalls = 0;
-      window.fetch = async () => {
+      window.fetch = async (url, options = {}) => {
+        const href = typeof url === 'string' ? url : url?.url || '';
+        if (options.method !== 'POST') {
+          if (href.endsWith('/v1/models')) return new Response(JSON.stringify({ data: [{ id: 'llama-current' }] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+          return new Response(JSON.stringify({ error: 'unsupported' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+        }
         fetchCalls += 1;
         const content = classificationResponses.shift();
         return new Response(JSON.stringify({

--- a/tests/playwright/pii-browser-coverage.spec.js
+++ b/tests/playwright/pii-browser-coverage.spec.js
@@ -40,6 +40,7 @@ test('PII browser coverage exercises config probes regex obfuscation and diff he
       'labcharts-ollama-model',
       'labcharts-ollama-pii-url',
       'labcharts-ollama-pii-model',
+      'labcharts-ollama-pii-key',
       'labcharts-ollama-pii-enabled',
     ];
     const savedStorage = Object.fromEntries(storageKeys.map(key => [key, localStorage.getItem(key)]));
@@ -57,6 +58,7 @@ test('PII browser coverage exercises config probes regex obfuscation and diff he
     try {
       for (const key of storageKeys) localStorage.removeItem(key);
       cryptoStore.updateKeyCache('labcharts-ollama', null);
+      cryptoStore.updateKeyCache('labcharts-ollama-pii-key', null);
       providerStorage.setOllamaPIIUrl('http://localhost:11434');
       providerStorage.setOllamaPIIModel('privacy-qwen:7b');
 
@@ -89,13 +91,61 @@ test('PII browser coverage exercises config probes regex obfuscation and diff he
             ],
           });
         }
+        if (href.endsWith('/api/ps')) {
+          if (mode === 'ps-non-ok') return jsonResponse({ error: 'nope' }, 503);
+          return jsonResponse({
+            models: [{
+              name: 'llama3.2:latest',
+              size: 3200000000,
+              size_vram: 2800000000,
+              context_length: 8192,
+              details: { parameter_size: '3B', quantization_level: 'Q4_K_M', family: 'llama', format: 'gguf' },
+            }],
+          });
+        }
+        if (href.endsWith('/api/v1/models')) {
+          // The localhost:11434 fixture represents Ollama; only compat.local
+          // exposes LM Studio's native model endpoint.
+          if (new URL(href).hostname === 'localhost') return jsonResponse({ error: 'unsupported' }, 404);
+          if (mode === 'lm-native-non-ok') return jsonResponse({ error: 'unsupported' }, 404);
+          return jsonResponse({
+            models: [
+              {
+                type: 'llm',
+                key: 'qwen2.5:7b-instruct-q4_k_m',
+                publisher: 'qwen',
+                architecture: 'qwen2',
+                quantization: { name: 'Q5_K_M', bits_per_weight: 5 },
+                size_bytes: 5100000000,
+                params_string: '7B',
+                loaded_instances: [{ id: 'qwen2.5:7b-instruct-q4_k_m', config: { context_length: 16384 } }],
+                max_context_length: 32768,
+                format: 'gguf',
+              },
+              {
+                type: 'embedding',
+                key: 'embed-small',
+                size_bytes: 200000000,
+                loaded_instances: [],
+                max_context_length: 2048,
+                format: 'gguf',
+              },
+            ],
+          });
+        }
         if (href.endsWith('/v1/models')) {
+          if (mode === 'probe-abort') {
+            return new Promise((resolve, reject) => {
+              options.signal?.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')), { once: true });
+            });
+          }
           if (mode === 'models-non-ok') return jsonResponse({ error: 'locked' }, 401);
           if (mode === 'models-throws') throw new Error('models offline');
           return jsonResponse({
             data: [
               { id: 'qwen2.5:7b-instruct-q4_k_m', owned_by: 'local', size: 4700000000 },
               { id: 'llama-3.2-3b-fp16' },
+              { id: 'embed-small' },
             ],
           });
         }
@@ -111,11 +161,13 @@ test('PII browser coverage exercises config probes regex obfuscation and diff he
           if (mode === 'streaming') {
             return streamResponse([
               'data: {"choices":[{"delta":{"reasoning_content":"checking identifiers"}}]}\n\n',
-              'data: {"not-json"\n\n',
               'data: {"choices":[{"delta":{"content":"Patient: "}}]}\n\n',
               'data: {"choices":[{"delta":{"content":"<think>hidden chain</think>Jana Novak\\nDate: 2026-01-02\\nPhone: +420 711 222 333"}}]}\n\n',
               'data: [DONE]\n\n',
             ]);
+          }
+          if (mode === 'streaming-malformed') {
+            return streamResponse(['data: {"not-json"\n\n']);
           }
           return jsonResponse({
             choices: [{
@@ -163,8 +215,19 @@ test('PII browser coverage exercises config probes regex obfuscation and diff he
         ollamaOk.available === true &&
         ollamaOk.models.includes('llama3.2:latest') &&
         ollamaOk.modelDetails[0].paramSize === '3B' &&
+        ollamaOk.modelDetails[0].loaded === true &&
+        ollamaOk.modelDetails[0].vramAllocated === 2800000000 &&
+        ollamaOk.modelDetails[0].contextLength === 8192 &&
+        ollamaOk.vramAllocated === 2800000000 &&
         ollamaNonOk.available === false &&
         ollamaThrows.available === false);
+
+      mode = 'ps-non-ok';
+      const ollamaWithoutRuntimeInfo = await pii.checkOllama('http://localhost:11434');
+      check('Ollama tags remain available when runtime allocation cannot be read',
+        ollamaWithoutRuntimeInfo.available === true &&
+        ollamaWithoutRuntimeInfo.modelDetails[0].loaded === null &&
+        ollamaWithoutRuntimeInfo.vramAllocated === 0);
 
       mode = 'ok';
       const compatibleOk = await pii.checkOpenAICompatible('http://compat.local/', 'compat-key');
@@ -174,11 +237,27 @@ test('PII browser coverage exercises config probes regex obfuscation and diff he
       const compatibleThrows = await pii.checkOpenAICompatible('http://compat.local/', '');
       check('OpenAI-compatible probe covers model parsing and auth header',
         compatibleOk.available === true &&
+        compatibleOk.provider === 'lmstudio' &&
         compatibleOk.models.includes('qwen2.5:7b-instruct-q4_k_m') &&
-        compatibleOk.modelDetails.some(model => model.paramSize === '7B' && /Q4/i.test(model.quantLevel)) &&
+        !compatibleOk.models.includes('embed-small') &&
+        compatibleOk.modelDetails.some(model =>
+          model.paramSize === '7B' &&
+          model.quantLevel === 'Q5_K_M' &&
+          model.size === 5100000000 &&
+          model.sizeSource === 'lmstudio' &&
+          model.loaded === true &&
+          model.contextLength === 16384) &&
         fetchCalls.some(call => call.href === 'http://compat.local/v1/models' && call.auth === 'Bearer compat-key') &&
+        fetchCalls.some(call => call.href === 'http://compat.local/api/v1/models' && call.auth === 'Bearer compat-key') &&
         compatibleNonOk.available === false &&
         compatibleThrows.available === false);
+
+      mode = 'lm-native-non-ok';
+      const compatibleFallback = await pii.checkOpenAICompatible('http://compat.local/', 'compat-key');
+      check('OpenAI-compatible metadata remains available without LM Studio native API',
+        compatibleFallback.available === true &&
+        compatibleFallback.provider === 'openai-compatible' &&
+        compatibleFallback.modelDetails.some(model => model.sizeSource === 'reported'));
 
       pii.setOllamaPIIEnabled(false);
       const disabledPII = await pii.checkOllamaPII();
@@ -218,6 +297,13 @@ test('PII browser coverage exercises config probes regex obfuscation and diff he
         !obfuscated.obfuscated.includes('alice@example.com') &&
         obfuscated.obfuscated.includes('Glucose 5.4 mmol/L') &&
         obfuscated.obfuscated.includes('Collection date: 2026-01-02'));
+      check('PII validation rejects an unchanged model response',
+        /original text/i.test(pii.validatePIIResult(reportText, reportText) || ''));
+      const changedCollectionDate = reportText
+        .replace('Alice Smith', 'Jana Novak')
+        .replace('Collection date: 2026-01-02', 'Collection date: 2026-02-03');
+      check('PII validation rejects changed collection dates',
+        /collection\/report date/i.test(pii.validatePIIResult(changedCollectionDate, reportText) || ''));
 
       const diff = pii.buildPIIDiffHTML('\nName: Alice\nSame\n', '\nName: Jana\nSame\n');
       check('PII diff HTML highlights changed words and trims outer blank lines',
@@ -241,6 +327,18 @@ test('PII browser coverage exercises config probes regex obfuscation and diff he
       check('showPIIDiffViewer close button removes overlay', !document.querySelector('.pii-warning-overlay'));
 
       mode = 'ok';
+      await providerStorage.saveOllamaPIIApiKey('pii-only-key');
+      providerStorage.setOllamaPIIModel('kimi-k2.5:cloud');
+      const beforeCloudAttempt = fetchCalls.length;
+      let cloudModelError = '';
+      try {
+        await pii.sanitizeWithOllama('Patient: Alice\nDate: 2026-01-02');
+      } catch (error) {
+        cloudModelError = error.message;
+      }
+      check('PII sanitizer blocks cloud models before any request',
+        /not a self-hosted text model/i.test(cloudModelError) && fetchCalls.length === beforeCloudAttempt);
+      providerStorage.setOllamaPIIModel('privacy-qwen:7b');
       const sanitized = await pii.sanitizeWithOllama('Patient: Alice\nDate: 2026-01-02\nPhone: +420 777 888 999');
       mode = 'sanitize-short';
       let shortError = '';
@@ -257,7 +355,9 @@ test('PII browser coverage exercises config probes regex obfuscation and diff he
         timeoutError = error.message;
       }
       check('sanitizeWithOllama covers success validation and timeout notification',
-        sanitized.includes('Jana Novak') &&
+        !sanitized.includes('Alice') &&
+        sanitized.includes('2026-01-02') &&
+        fetchCalls.some(call => call.href.endsWith('/v1/chat/completions') && call.auth === 'Bearer pii-only-key') &&
         /too short/i.test(shortError) &&
         /timed out/i.test(timeoutError) &&
         document.getElementById('notification-container')?.textContent.includes('timed out'));
@@ -271,6 +371,16 @@ test('PII browser coverage exercises config probes regex obfuscation and diff he
         undefined,
         chunk => thinkingChunks.push(chunk)
       );
+      mode = 'streaming-malformed';
+      let malformedError = '';
+      try {
+        await pii.sanitizeWithOllamaStreaming(
+          'Patient: Alice\nDate: 2026-01-02\nPhone: +420 777 888 999',
+          () => {},
+        );
+      } catch (error) {
+        malformedError = error.message;
+      }
       mode = 'probe-abort';
       let probeError = '';
       try {
@@ -286,11 +396,13 @@ test('PII browser coverage exercises config probes regex obfuscation and diff he
       } catch (error) {
         probeError = error.message;
       }
-      check('sanitizeWithOllamaStreaming handles stream chunks malformed JSON and thinking',
-        streamed.includes('Jana Novak') &&
+      check('sanitizeWithOllamaStreaming filters thinking and rejects malformed complete events',
+        !streamed.includes('Alice') &&
+        streamed.includes('2026-01-02') &&
         streamChunks.join('').includes('Patient: Jana') &&
         thinkingChunks.join('').includes('checking identifiers') &&
-        thinkingChunks.join('').includes('hidden chain'));
+        thinkingChunks.join('').includes('hidden chain') &&
+        malformedError.length > 0);
       check('sanitizeWithOllamaStreaming abort probe fallback reports unreachable server',
         /unreachable/i.test(probeError),
         probeError);
@@ -308,6 +420,7 @@ test('PII browser coverage exercises config probes regex obfuscation and diff he
         else localStorage.setItem(key, value);
       }
       cryptoStore.updateKeyCache('labcharts-ollama', savedStorage['labcharts-ollama']);
+      cryptoStore.updateKeyCache('labcharts-ollama-pii-key', savedStorage['labcharts-ollama-pii-key']);
     }
 
     return { failures };
@@ -427,7 +540,7 @@ test('PII browser coverage exercises review modal search edit streaming stop ret
       await waitFor(() => overlay.querySelector('#pii-stream-status')?.textContent.includes('Stopped'), 'stream stop status');
       const stopState = overlay.querySelector('#pii-stream-retry')?.hidden === false
         && overlay.querySelector('#pii-stream-stop')?.hidden === true
-        && overlay.querySelector('#pii-review-send')?.disabled === false;
+        && overlay.querySelector('#pii-review-send')?.disabled === true;
       overlay.querySelector('#pii-stream-retry').click();
       await waitFor(() => overlay.querySelector('#pii-stream-status')?.textContent.includes('Complete'), 'stream retry completion');
       const retryState = overlay.querySelector('#pii-thinking-section')?.hidden === false

--- a/tests/playwright/provider-coverage-batch.spec.js
+++ b/tests/playwright/provider-coverage-batch.spec.js
@@ -66,7 +66,7 @@ test('provider panel renderers cover Venice and Local AI markup branches', async
       crypto.updateKeyCache('labcharts-ollama', ollamaConfig);
       // Local AI has no named provider case, so it is rendered through the default fallback.
       fixture.innerHTML = renderers.renderAIProviderPanel('unknown-provider');
-      const localAIRenders = fixture.querySelector('#local-ai-url-input')?.value === 'https://local.example/v1'
+      const localAIRenders = fixture.querySelector('#local-ai-url-input')?.value === 'https://local.example'
         && fixture.querySelector('#local-ai-apikey-input')?.value === 'local-secret'
         && fixture.querySelector('#local-ai-status-text')?.textContent === 'Checking connection...'
         && fixture.querySelector('[data-provider-panel-action="test-ollama-connection"]')?.textContent === 'Test'

--- a/tests/playwright/settings-browser-coverage.spec.js
+++ b/tests/playwright/settings-browser-coverage.spec.js
@@ -23,6 +23,7 @@ test('settings browser coverage exercises delegates for themes tweaks privacy us
 
   const results = await page.evaluate(async () => {
     const settingsModule = await import('/js/settings.js');
+    const settingsData = await import('/js/settings-data.js');
     const settingsRuntime = await import('/js/settings-runtime.js');
     const themeModule = await import('/js/theme.js');
     const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
@@ -44,6 +45,7 @@ test('settings browser coverage exercises delegates for themes tweaks privacy us
     const saved = {
       currentProfile: state.currentProfile,
       profiles: state.profiles,
+      importedData: JSON.parse(JSON.stringify(state.importedData || {})),
       fetch: window.fetch,
       theme: localStorage.getItem('labcharts-theme'),
       accent: localStorage.getItem('labcharts-accent'),
@@ -55,6 +57,7 @@ test('settings browser coverage exercises delegates for themes tweaks privacy us
       piiAck: localStorage.getItem('labcharts-pii-review-disable-ack'),
       usage: localStorage.getItem(usageKey),
       globalUsage: localStorage.getItem('labcharts-global-usage'),
+      debug: localStorage.getItem('labcharts-debug'),
     };
     const results = {};
     let meteoConfig = {
@@ -133,6 +136,26 @@ test('settings browser coverage exercises delegates for themes tweaks privacy us
 
       state.currentProfile = profileId;
       state.profiles = [{ id: profileId, name: 'Coverage profile' }];
+      state.importedData = {
+        ...state.importedData,
+        importSnapshots: [{
+          id: 'benchmark-coverage',
+          fileName: 'benchmark-coverage.pdf',
+          markerCount: 24,
+          benchmarkAt: Date.UTC(2026, 6, 18, 10, 30),
+          importedAt: Date.UTC(2026, 6, 18, 10, 30),
+          importMode: 'text',
+          costInfo: {
+            provider: 'ollama',
+            modelId: 'benchmark-model',
+            inputTokens: 1500,
+            outputTokens: 600,
+            cost: 0,
+          },
+          timings: { pii: 1, analysis: 2, piiMs: 1200, analysisMs: 2400 },
+          diagnostics: { structuredOutputFallback: true, streamFallback: true },
+        }],
+      };
       localStorage.setItem(usageKey, JSON.stringify({
         totalCost: 0.012,
         totalInputTokens: 1500,
@@ -145,7 +168,28 @@ test('settings browser coverage exercises delegates for themes tweaks privacy us
         totalOutputTokens: 1200,
         requestCount: 4,
       }));
+      localStorage.setItem('labcharts-debug', 'false');
       settingsModule.openSettingsModal('ai');
+      results.importBenchmarksHiddenOutsideDebugMode = document.querySelector('[data-settings-action="open-import-benchmarks"]') === null;
+      settingsModule.openSettingsModal('display');
+      const debugToggle = document.getElementById('debug-mode-toggle');
+      debugToggle.checked = true;
+      debugToggle.dispatchEvent(new Event('change', { bubbles: true }));
+      settingsModule.openSettingsModal('ai');
+      const benchmarkButton = document.querySelector('[data-settings-action="open-import-benchmarks"]');
+      benchmarkButton.click();
+      const benchmarkOverlay = document.getElementById('import-benchmarks-overlay');
+      const benchmarkText = benchmarkOverlay?.textContent || '';
+      results.importBenchmarksModalShowsLocalMetrics = benchmarkOverlay?.classList.contains('show') === true
+        && benchmarkText.includes('benchmark-coverage.pdf')
+        && benchmarkText.includes('benchmark-model')
+        && benchmarkText.includes('2.4 s')
+        && benchmarkText.includes('1.5k in')
+        && benchmarkText.includes('250.0 tok/s')
+        && benchmarkText.includes('24')
+        && benchmarkText.includes('schema retry + stream retry');
+      benchmarkOverlay.querySelector('[data-import-benchmarks-action="close"]').click();
+      results.importBenchmarksModalCloses = document.getElementById('import-benchmarks-overlay') === null;
       document.querySelector('#ai-usage-section [data-settings-action="reset-profile-usage"]').click();
       await wait(0);
       results.resetCurrentProfileUsage = localStorage.getItem(usageKey) === null
@@ -187,6 +231,7 @@ test('settings browser coverage exercises delegates for themes tweaks privacy us
       }
       state.currentProfile = saved.currentProfile;
       state.profiles = saved.profiles;
+      state.importedData = saved.importedData;
       const restoreStorage = (key, value) => {
         if (value == null) localStorage.removeItem(key);
         else localStorage.setItem(key, value);
@@ -201,6 +246,8 @@ test('settings browser coverage exercises delegates for themes tweaks privacy us
       restoreStorage('labcharts-pii-review-disable-ack', saved.piiAck);
       restoreStorage(usageKey, saved.usage);
       restoreStorage('labcharts-global-usage', saved.globalUsage);
+      restoreStorage('labcharts-debug', saved.debug);
+      settingsData.closeImportBenchmarksModal();
       settingsModule.closeTweaksPanel();
       document.getElementById('sun-source-fixture')?.remove();
       document.getElementById('confirm-dialog-overlay')?.remove();

--- a/tests/playwright/settings-provider-browser-coverage.spec.js
+++ b/tests/playwright/settings-provider-browser-coverage.spec.js
@@ -23,6 +23,7 @@ test('local AI settings controls cover connection, advisor, privacy, and hardwar
       'labcharts-ollama-model',
       'labcharts-ollama-pii-url',
       'labcharts-ollama-pii-model',
+      'labcharts-ollama-pii-key',
       'labcharts-ollama-pii-enabled',
       'labcharts-hw-vram-override',
     ];
@@ -62,6 +63,7 @@ test('local AI settings controls cover connection, advisor, privacy, and hardwar
           </div>
           <div id="local-ai-advisor"></div>
           <input id="pii-local-url-input">
+          <input id="pii-local-apikey-input" value="sk-pii-local">
           <span id="pii-local-dot" class="local-ai-status-dot"></span>
           <span id="pii-local-status-text"></span>
           <input id="pii-local-toggle" type="checkbox">
@@ -85,10 +87,16 @@ test('local AI settings controls cover connection, advisor, privacy, and hardwar
             data: [{ id: 'llama3.2', name: 'Llama 3.2', size: 3200000000 }],
           });
         }
+        if (href === 'http://localhost:11434/api/v1/models') {
+          return jsonResponse({ error: 'unsupported' }, 404);
+        }
         if (href === 'http://localhost:11434/api/tags') {
           return jsonResponse({
             models: [{ name: 'llama3.2', size: 3200000000, details: { parameter_size: '3B', quantization_level: 'Q4_K_M', family: 'llama' } }],
           });
+        }
+        if (href === 'http://localhost:11434/api/ps') {
+          return jsonResponse({ models: [{ name: 'llama3.2', size_vram: 2800000000, context_length: 8192 }] });
         }
         return oldGlobals.fetch.call(window, url, opts);
       };
@@ -139,6 +147,9 @@ test('local AI settings controls cover connection, advisor, privacy, and hardwar
             ],
           });
         }
+        if (href === 'http://localhost:11434/api/v1/models') {
+          return jsonResponse({ error: 'unsupported' }, 404);
+        }
         if (href === 'http://localhost:11434/api/tags') {
           return jsonResponse({
             models: [
@@ -147,9 +158,15 @@ test('local AI settings controls cover connection, advisor, privacy, and hardwar
             ],
           });
         }
+        if (href === 'http://localhost:11434/api/ps') {
+          return jsonResponse({
+            models: [{ name: 'qwen2.5:14b', size_vram: 8700000000, context_length: 16384 }],
+          });
+        }
         return oldGlobals.fetch.call(window, url, opts);
       };
       urlInput.value = ' http://localhost:11434/ ';
+      providerStorage.setOllamaMainModel('kimi-k2.5:cloud');
       await controls.testOllamaConnection();
       await wait(0);
       const localConnectSuccess = statusText.textContent.includes('Connected')
@@ -160,6 +177,14 @@ test('local AI settings controls cover connection, advisor, privacy, and hardwar
         && localFetchCount >= 1
         && privacyUpdates >= 1
         && chatReturns === 1;
+      const staleLocalModelReconciled = providerStorage.getOllamaMainModel() === 'llama3.2'
+        && statusText.textContent.includes('llama3.2')
+        && !statusText.textContent.includes('kimi-k2.5:cloud');
+      const ollamaAllocationDisplayed = document.getElementById('local-ai-advisor')?.textContent.includes('currently allocated')
+        && document.getElementById('local-ai-advisor')?.textContent.includes('8.7 GB VRAM')
+        && document.getElementById('local-ai-advisor')?.textContent.includes('loaded now')
+        && document.getElementById('local-ai-advisor')?.textContent.includes('available \u2014 loads on first request')
+        && !document.getElementById('local-ai-advisor')?.textContent.includes('not loaded');
 
       document.getElementById('local-ai-advisor').innerHTML = '';
       controls.refreshModelAdvisor();
@@ -196,12 +221,13 @@ test('local AI settings controls cover connection, advisor, privacy, and hardwar
 
       document.getElementById('pii-local-url-input').value = 'http://localhost:11434';
       await controls.testPIIOllamaConnection();
-      const piiConnectSuccess = document.getElementById('pii-local-status-text')?.textContent.includes('Connected')
+      const piiConnectSuccess = document.getElementById('pii-local-status-text')?.textContent.includes('Connection verified')
         && document.getElementById('pii-local-dot')?.classList.contains('connected')
-        && document.getElementById('pii-local-toggle')?.checked === true
+        && document.getElementById('pii-local-toggle')?.checked === false
         && document.getElementById('pii-model-dropdown')?.style.display === 'block'
         && document.getElementById('pii-model-select')?.options.length === 2
-        && localStorage.getItem('labcharts-ollama-pii-enabled') === 'true';
+        && localStorage.getItem('labcharts-ollama-pii-enabled') !== 'true'
+        && providerStorage.getOllamaPIIApiKey() === 'sk-pii-local';
 
       await providerStorage.saveOllamaConfig({ url: 'https://remote.example/v1', model: 'remote-model', mode: 'openai-compatible', apiKey: '' });
       document.getElementById('local-ai-model-select').innerHTML = '<option value="remote-small">remote-small</option><option value="remote-huge">remote-huge</option>';
@@ -217,6 +243,8 @@ test('local AI settings controls cover connection, advisor, privacy, and hardwar
         invalidUrlBranch,
         corsHelp,
         localConnectSuccess,
+        staleLocalModelReconciled,
+        ollamaAllocationDisplayed,
         refreshModelAdvisorRerendersCachedDetails,
         copyPullCommand,
         hardwareOverrideKeyboardToggle,

--- a/tests/playwright/settings-toggles.spec.js
+++ b/tests/playwright/settings-toggles.spec.js
@@ -41,6 +41,7 @@ test('Settings display toggles persist through delegated slider actions', async 
 
   await expect(page.locator('#settings-modal-overlay')).toHaveClass(SHOW_CLASS_TOKEN);
   await expect(page.locator('#settings-modal')).toHaveAttribute('data-delegated-actions', '1');
+  await expect(page.locator('label[for="debug-mode-toggle"], label.settings-label').filter({ hasText: 'Debug Mode' })).toHaveCount(1);
 
   await page.locator('#settings-product-recs + .toggle-slider').click();
   await page.locator('#debug-mode-toggle + .toggle-slider').click();

--- a/tests/test-correctness-phase2.js
+++ b/tests/test-correctness-phase2.js
@@ -252,10 +252,10 @@ assert('file input shares import browser-runtime adapter with drop zone',
   importDropZoneRuntimeSrc.includes('export function isDropZoneImportRunning'),
   'file-picker import path should not keep a parallel set of window global lookups');
 assert('PDF lazy import failure notifies from file input and clears selection',
-  /try\s*{\s*importMod\s*=\s*await loadPdfImport\(\);[\s\S]{0,220}catch\s*\(err\)\s*{[\s\S]{0,220}Could not load import module - check your connection and try again\.[\s\S]{0,120}e\.target\.value\s*=\s*''/.test(importFileInputSrc),
+  /try\s*{\s*importMod\s*=\s*await loadPdfImport\(\);[\s\S]{0,320}catch\s*\(err\)\s*{[\s\S]{0,320}Could not load import module\. Reload the app to finish updating, then try again\.[\s\S]{0,120}e\.target\.value\s*=\s*''/.test(importFileInputSrc),
   'file-picker import path should fail loudly and clear stale selection');
 assert('PDF lazy import failure notifies from drop zone',
-  /try\s*{\s*importMod\s*=\s*await loadPdfImport\(\);[\s\S]{0,220}catch\s*\(err\)\s*{[\s\S]{0,220}Could not load import module - check your connection and try again\./.test(importDropZoneSrc),
+  /try\s*{\s*importMod\s*=\s*await loadPdfImport\(\);[\s\S]{0,320}catch\s*\(err\)\s*{[\s\S]{0,320}Could not load import module\. Reload the app to finish updating, then try again\./.test(importDropZoneSrc),
   'drop-zone import path should fail loudly');
 assert('analytics consent remains deferred after first paint and behind legal gate',
   /const showAnalyticsConsent = \(\) => \{\s*startupUIDeps\.maybeShowAnalyticsConsent\?\.\(\);\s*\};/.test(startupUiSrc)

--- a/tests/test-hardware.js
+++ b/tests/test-hardware.js
@@ -41,6 +41,7 @@ console.log('=== Hardware & Model Advisor Tests ===\n');
   const medModel = { name: 'qwen2.5:14b', size: 9_000_000_000 }; // 9 GB file → ~10.35 GB VRAM
 
   const gpu16 = { gpu: { name: 'RTX 4080', vram: 16, unified: false }, ram: { gb: 32 }, cpuThreads: 16 };
+  const gpu32 = { gpu: { name: 'RTX 5090', vram: 32, unified: false }, ram: { gb: 64 }, cpuThreads: 24 };
   const gpu8 = { gpu: { name: 'RTX 3060', vram: 8, unified: false }, ram: { gb: 16 }, cpuThreads: 8 };
   const appleM3 = { gpu: { name: 'Apple M3 Pro', vram: 18, unified: true }, ram: { gb: 18 }, cpuThreads: 12 };
 
@@ -139,6 +140,9 @@ console.log('=== Hardware & Model Advisor Tests ===\n');
   const f6 = hw.assessFitness('totally-unknown-model:latest');
   assert('Unknown model = null', f6 === null);
 
+  const f7 = hw.assessFitness('qwen3.6:27b');
+  assert('qwen3.6:27b = recommended', f7 && f7.tier === 'recommended', f7?.note);
+
   // getBestModel picks highest-fitness model that fits
   const testModels = [
     { name: 'phi3:3.5b', size: 2_000_000_000 },
@@ -156,20 +160,27 @@ console.log('=== Hardware & Model Advisor Tests ===\n');
   const upg1 = hw.getUpgradeSuggestion(weakModels, gpu16);
   assert('Suggests upgrade when only capable model', upg1 && upg1.model, upg1?.model);
 
+  const upg32 = hw.getUpgradeSuggestion([], gpu32);
+  assert('32GB GPU recommends qwen3.6:27b', upg32?.model === 'qwen3.6:27b', upg32?.model);
+  assert('qwen3.6:27b recommendation uses current Q4 estimate', upg32?.note.includes('~20 GB'), upg32?.note);
+
   const strongModels = [{ name: 'qwen2.5:14b', size: 9_000_000_000 }];
   const upg2 = hw.getUpgradeSuggestion(strongModels, gpu16);
   assert('No upgrade when recommended model present', upg2 === null);
 
   // ═══════════════════════════════════════
-  // 8. checkOllama modelDetails field
+  // 8. Local AI discovery metadata
   // ═══════════════════════════════════════
-  console.log('%c 7. checkOllama Return Shape ', 'font-weight:bold;color:#f59e0b');
+  console.log('%c 7. Local AI Discovery Return Shape ', 'font-weight:bold;color:#f59e0b');
 
-  const piiSrc = read('js/pii.js');
-  assert('checkOllama returns modelDetails', piiSrc.includes('modelDetails'));
-  assert('modelDetails includes size', piiSrc.includes('size: m.size'));
-  assert('modelDetails includes quantLevel', piiSrc.includes('quantization_level'));
-  assert('modelDetails includes paramSize', piiSrc.includes('parameter_size'));
+  const discoverySrc = read('js/local-ai-discovery.js');
+  assert('checkOllama returns modelDetails', discoverySrc.includes('modelDetails'));
+  assert('Ollama discovery probes running models', discoverySrc.includes("request('/api/ps')"));
+  assert('Ollama model details include allocated VRAM', discoverySrc.includes('vramAllocated'));
+  assert('LM Studio discovery probes native model metadata', discoverySrc.includes('/api/v1/models'));
+  assert('LM Studio model details include exact size', discoverySrc.includes('size_bytes'));
+  assert('modelDetails includes quantLevel', discoverySrc.includes('quantization_level'));
+  assert('modelDetails includes paramSize', discoverySrc.includes('parameter_size'));
 
   // ═══════════════════════════════════════
   // 8. Settings integration

--- a/tests/test-openrouter.js
+++ b/tests/test-openrouter.js
@@ -282,7 +282,8 @@ assert('unknown model pricing is approximate', unknownPricing.includes('~'));
 if (savedPr) localStorage.setItem('labcharts-openrouter-pricing', savedPr);
 else localStorage.removeItem('labcharts-openrouter-pricing');
 const ollamaPricing = api.renderModelPricingHint('ollama', '');
-assert('ollama pricing still says Free', ollamaPricing.includes('Free'));
+assert('Local AI pricing avoids claiming remote or cloud servers are free',
+  ollamaPricing.includes('configured server') && !ollamaPricing.includes('Free'));
 
 // ─── 12. Key removal clears pricing cache ───
 console.log('\n12. Key removal clears pricing cache');

--- a/tests/test-pii.js
+++ b/tests/test-pii.js
@@ -178,7 +178,7 @@ const piiSrc = read('js/pii.js');
   assert('Handles reasoning_content field',
     piiSrc.includes('delta.reasoning_content'));
   assert('Handles <think> tags',
-    piiSrc.includes("indexOf('<think>')") || piiSrc.includes("indexOf('<think>"));
+    piiSrc.includes("const openTag = '<think>'") && piiSrc.includes('createThinkingContentFilter'));
   assert('Thinking not added to accumulated output',
     piiSrc.includes('onThinking(') && !piiSrc.includes('accumulated += delta.reasoning_content'));
   assert('Thinking section in review modal HTML',
@@ -196,8 +196,9 @@ const piiSrc = read('js/pii.js');
   // ═══════════════════════════════════════
   console.log('%c 8. Ollama Unload Guard ', 'font-weight:bold;color:#f59e0b');
 
-  assert('unloadOllamaPIIModel checks port 11434',
-    piiSrc.includes("port !== '11434'"), 'should only fire for Ollama default port');
+  assert('unloadOllamaPIIModel checks discovered provider before Ollama unload',
+    piiSrc.includes("discovery?.provider === 'ollama'") && piiSrc.includes("port === '11434'"),
+    'should use provider discovery with a default-port compatibility fallback');
 
   // ═══════════════════════════════════════
 console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);

--- a/tests/test-settings-delegated-actions.js
+++ b/tests/test-settings-delegated-actions.js
@@ -147,7 +147,7 @@ assert('Settings version label uses the shared runtime adapter',
 assert('Delegated settings handler switches AI providers',
   /action === 'switch-ai-provider'[\s\S]*switchAIProviderBridge\(actionEl\.dataset\.provider/.test(src));
 assert('Delegated settings handler updates PII model selection',
-  /action === 'set-pii-model'[\s\S]*setOllamaPIIModel\(actionEl instanceof HTMLSelectElement \? actionEl\.value : ''\)/.test(src));
+  /action === 'set-pii-model'[\s\S]*isPIIEligibleModel\(model\)[\s\S]*setOllamaPIIModel\(model\)/.test(src));
 assert('Sun data-source delegate is installed on document change',
   /document\.addEventListener\('change', handleSunDataSourceChange\)/.test(privacySrc));
 assert('Sun data-source delegate is scoped to its section',

--- a/tests/test-v1-6-shipped.js
+++ b/tests/test-v1-6-shipped.js
@@ -347,8 +347,8 @@ const _origProfileSex = state ? state.profileSex : null;
   console.log('%c 10. PII Ollama reachability + stall protection ', 'font-weight:bold;color:#0891b2');
   {
     const piiSrc = await fetchSrc('js/pii.js');
-    assert('pii.js: probes /api/version before streaming',
-      /\/api\/version/.test(piiSrc) && /AbortSignal\.timeout\(5000\)/.test(piiSrc));
+    assert('pii.js: probes authenticated model endpoint before streaming',
+      /\/v1\/models/.test(piiSrc) && /AbortSignal\.timeout\(5000\)/.test(piiSrc));
     // v1.6.18 follow-up: probe signal composes the caller's signal
     // with the 5s deadline so user-initiated aborts (closing the
     // import dialog) take effect immediately instead of waiting up

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -419,6 +419,8 @@
     "js/lab-entry.js",
     "js/legal-consent.js",
     "js/lighting-hardware-caveats.js",
+    "js/local-ai-discovery.js",
+    "js/import-benchmarks.js",
     "js/marker-analysis.js",
     "js/marker-detail-actions.js",
     "js/marker-detail-editing.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.295';
+self.APP_VERSION = '1.10.296';

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.294';
+self.APP_VERSION = '1.10.295';


### PR DESCRIPTION
## What changed

- Fix Local AI structured-output requests to use the OpenAI-compatible `json_schema` contract, with validation-only fallbacks for servers that reject schema or reasoning controls.
- Add provider-aware Ollama and LM Studio discovery, including loaded instances, current/max context, quantization, model size, capabilities, execution location, and alias reconciliation.
- Use LM Studio native chat for import-only context expansion when a loaded context is too small, while keeping ordinary chat free of discovery latency.
- Stop sending Ollama-only `/api/tags` and `/api/ps` probes after LM Studio identifies itself.
- Correct stale Local AI model labels in chat and Settings, normalize endpoint URLs, and improve CORS, transport, and remote-server guidance.
- Harden the optional PII scrubber with separate credentials, cloud/embedding model blocking, output-integrity validation, safer streaming, deterministic final scrubbing, and accurate privacy copy.
- Add Debug Mode import benchmarks covering successes, failures, cancellations, previews, and confirmations without storing report contents.
- Improve the hardware advisor, loaded-state wording, context/VRAM diagnostics, and the 32 GB recommendation to Qwen3.6 27B.
- Give lazy import-module failures an actionable reload message and console diagnostic.
- Bump the app version to 1.10.295.

## Why

The original Local AI implementation treated different OpenAI-compatible servers too uniformly. This caused invalid structured-output payloads for LM Studio, inaccurate loaded-model status, unnecessary Ollama probes, stale model names, weak context planning, and privacy/diagnostic gaps during imports.

## User impact

Remote LM Studio imports now use valid JSON schema requests, recognize the actual loaded model, can expand context per request when supported, and expose useful local benchmark data behind Debug Mode. Normal chat remains direct and avoids capability-probe latency.

## Validation

- Rebased onto current `origin/main` at `4e7ed721`.
- Check-JS type checking passed.
- 31/31 targeted Local AI and import unit tests passed.
- 19/19 targeted Local AI, PDF import, PII, settings, provider, and hardware Chromium tests passed using the isolated Playwright server.
- Earlier full verification passed type checks, vendor integrity, 125 verification checks, 404 Vitest tests, and all 472 responsive-theme checks.
- Live LM Studio verification confirmed only `/api/v1/models` and `/v1/models` are probed, with the loaded Q4 model detected.