### PR TITLE
Add Free T3/Free T4 calculated ratio

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -593,6 +593,7 @@ export function getActiveData() {
     ratios.markers.plr.values = divide(getVals('hematology', 'platelets'), getVals('differential', 'lymphocytes'));
     ratios.markers.deRitisRatio.values = divide(getVals('biochemistry', 'ast'), getVals('biochemistry', 'alt'));
     ratios.markers.copperZincRatio.values = divide(getVals('electrolytes', 'copper'), getVals('electrolytes', 'zinc'));
+    ratios.markers.ft3ft4Ratio.values = divide(getVals('thyroid', 'ft3'), getVals('thyroid', 'ft4'));
 
     // BUN/Creatinine Ratio — computed in US units: (urea×2.801) / (creatinine×0.01131)
     const ureaVals = getVals('biochemistry', 'urea');

--- a/js/marker-detail-modal.js
+++ b/js/marker-detail-modal.js
@@ -575,6 +575,7 @@ export function showDetailModal(id, opts = {}) {
     'calculatedRatios_plr': [['hematology', 'platelets', 'Platelets'], ['differential', 'lymphocytes', 'Lymphocytes']],
     'calculatedRatios_deRitisRatio': [['biochemistry', 'ast', 'AST'], ['biochemistry', 'alt', 'ALT']],
     'calculatedRatios_copperZincRatio': [['electrolytes', 'copper', 'Copper'], ['electrolytes', 'zinc', 'Zinc']],
+    'calculatedRatios_ft3ft4Ratio': [['thyroid', 'ft3', 'Free T3'], ['thyroid', 'ft4', 'Free T4']],
     'calculatedRatios_apoBapoAIRatio': [['lipids', 'apoB', 'ApoB'], ['lipids', 'apoAI', 'ApoA-I']],
     'calculatedRatios_crpHdlRatio': [['proteins', 'hsCRP', 'hs-CRP'], ['lipids', 'hdl', 'HDL']],
   };

--- a/js/schema.js
+++ b/js/schema.js
@@ -240,6 +240,7 @@ export const MARKER_SCHEMA = {
       plr: { name: "Platelet-Lymphocyte Ratio (PLR)", unit: "", refMin: 50, refMax: 150, desc: "Reflects the balance between thrombotic and immune responses; elevated in inflammation, cardiovascular disease, and cancer." },
       deRitisRatio: { name: "De Ritis Ratio (AST/ALT)", unit: "", refMin: 0.8, refMax: 1.2, desc: "AST divided by ALT; helps distinguish liver damage types \u2014 values above 2 suggest alcoholic liver disease or cirrhosis." },
       copperZincRatio: { name: "Copper/Zinc Ratio", unit: "", refMin: 0.7, refMax: 1.0, desc: "Balance between copper and zinc; elevated ratios indicate oxidative stress, inflammation, or immune dysfunction." },
+      ft3ft4Ratio: { name: "Free T3/Free T4 Ratio", unit: "", refMin: 0.262, refMax: 0.346, desc: "Free T3 divided by free T4; used to evaluate how efficiently the body converts thyroid hormones (T4\u2192T3) and to differentiate between specific thyroid disorders. A low ratio suggests impaired conversion or low-T3 syndrome; a high ratio may indicate hyperthyroidism or Graves' disease." },
       bunCreatRatio: { name: "BUN/Creatinine Ratio", unit: "", refMin: 10, refMax: 20, desc: "Blood urea nitrogen divided by creatinine; helps differentiate pre-renal, renal, and post-renal causes of kidney dysfunction." },
       freeWaterDeficit: { name: "Free Water Deficit", unit: "L", refMin: -1.5, refMax: 1.5, desc: "Estimated water surplus or deficit based on sodium level; positive values indicate dehydration, negative values overhydration." },
       crpHdlRatio: { name: "hs-CRP/HDL Ratio", unit: "", refMin: 0, refMax: 0.94, desc: "High-sensitivity CRP divided by HDL cholesterol; a composite inflammation-lipid marker that captures cardiovascular risk better than either marker alone. Requires hs-CRP specifically." },
@@ -329,6 +330,7 @@ export const UNIT_CONVERSIONS = {
   'thyroid.t3total': { factor: 0.6513, usUnit: 'ng/dl', type: 'multiply' },
   'diabetes.hba1c': { type: 'hba1c' },
   'calculatedRatios.tgHdlRatio': { factor: 2.29, usUnit: '', type: 'multiply' },
+  'calculatedRatios.ft3ft4Ratio': { factor: 8.3833, usUnit: '', type: 'multiply' },
   'bodyComposition.leanMass': { factor: 2.20462, usUnit: 'lbs', type: 'multiply' },
   'bodyComposition.fatMass': { factor: 2.20462, usUnit: 'lbs', type: 'multiply' },
   // ── Label-only US conventions (factor: 1) ─────────────────────────────────
@@ -707,4 +709,5 @@ export const OPTIMAL_RANGES = {
   'calculatedRatios.deRitisRatio': { optimalMin: 0.8, optimalMax: 1.1 },
   'calculatedRatios.bunCreatRatio': { optimalMin: 10, optimalMax: 16 },
   'calculatedRatios.crpHdlRatio': { optimalMin: 0, optimalMax: 0.24 },
+  'calculatedRatios.ft3ft4Ratio': { optimalMin: 0.286, optimalMax: 0.322 },
 };

--- a/tests/test-calculated-markers.js
+++ b/tests/test-calculated-markers.js
@@ -563,7 +563,9 @@ const dataModule = await import('../js/data.js');
       'biochemistry.ast': 0.4,
       'biochemistry.alt': 0.5,
       'electrolytes.copper': 15,
-      'electrolytes.zinc': 18
+      'electrolytes.zinc': 18,
+      'thyroid.ft3': 4.5,
+      'thyroid.ft4': 15
     }
   }];
 
@@ -600,6 +602,10 @@ const dataModule = await import('../js/data.js');
   // Cu/Zn = 15/18 = 0.833
   assert('Cu/Zn ratio is 0.833', cr?.copperZincRatio?.values?.[0] === 0.833,
     `expected 0.833, got ${cr?.copperZincRatio?.values?.[0]}`);
+
+  // Free T3/Free T4 = 4.5/15 = 0.3 (both stored in SI pmol/L)
+  assert('FT3/FT4 ratio is 0.3', cr?.ft3ft4Ratio?.values?.[0] === 0.3,
+    `expected 0.3, got ${cr?.ft3ft4Ratio?.values?.[0]}`);
 
   // ── Division by zero → null ──
   state.importedData.entries = [{


### PR DESCRIPTION
## Summary

Adds a new **Free T3 / Free T4 ratio** to the **Calculated Ratios** category.

The FT3:FT4 ratio reflects how efficiently the body converts thyroid hormone (peripheral T4 -> T3 deiodination, mostly in liver/kidney) and helps differentiate thyroid disorders: a **low** ratio suggests impaired conversion / low-T3 syndrome / T4-only therapy; a **high** ratio can indicate hyperthyroidism or Graves' disease.

Computed per-date as `thyroid.ft3 / thyroid.ft4`, consistent with the existing calculated ratios.

## Reference ranges

Both `thyroid.ft3` and `thyroid.ft4` are stored internally in SI (pmol/L), so the raw ratio is the SI-unit ratio. Because FT3 and FT4 convert to US conventional units by **different** factors (FT3 -> pg/mL x0.6513; FT4 -> ng/dL x0.07769), the ratio changes by a fixed **x8.3833** between unit systems — exactly the TG/HDL precedent. So the range is defined once in SI and a `UNIT_CONVERSIONS` entry auto-derives the US display, keeping both views consistent.

| | SI (stored) | US display (auto) |
|---|---|---|
| Standard | 0.262 - 0.346 | **2.2 - 2.9** |
| Optimal | 0.286 - 0.322 | **2.4 - 2.7** |

Ranges per OptimalDX / ODX Research (FT3 in pg/mL, FT4 in ng/dL): standard 2.2-2.9, optimal 2.4-2.7.

## Changes

- **`js/schema.js`** — `calculatedRatios.ft3ft4Ratio` marker def (SI ref 0.262-0.346), `UNIT_CONVERSIONS` factor 8.3833 for correct US display, `OPTIMAL_RANGES` 0.286-0.322.
- **`js/data.js`** — per-date computation `divide(getVals('thyroid','ft3'), getVals('thyroid','ft4'))`.
- **`js/marker-detail-modal.js`** — missing-input diagnostic mapping (Free T3, Free T4).
- **`tests/test-calculated-markers.js`** — regression test (4.5/15 = 0.3).

## Testing

- `node tests/test-calculated-markers.js` — 62/62 (incl. new FT3/FT4 assertion)
- Full `npx vitest run` — **399/399** across 32 files
- `npx tsc -p tsconfig.checkjs.json` — clean
- `node scripts/quality-guardrails.mjs` — 11/11
