### PR TITLE
Add Free T3/Free T4 calculated ratio

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -593,6 +593,7 @@ export function getActiveData() {
     ratios.markers.plr.values = divide(getVals('hematology', 'platelets'), getVals('differential', 'lymphocytes'));
     ratios.markers.deRitisRatio.values = divide(getVals('biochemistry', 'ast'), getVals('biochemistry', 'alt'));
     ratios.markers.copperZincRatio.values = divide(getVals('electrolytes', 'copper'), getVals('electrolytes', 'zinc'));
+    ratios.markers.ft3ft4Ratio.values = divide(getVals('thyroid', 'ft3'), getVals('thyroid', 'ft4'));
 
     // BUN/Creatinine Ratio — computed in US units: (urea×2.801) / (creatinine×0.01131)
     const ureaVals = getVals('biochemistry', 'urea');

--- a/js/marker-detail-modal.js
+++ b/js/marker-detail-modal.js
@@ -575,6 +575,7 @@ export function showDetailModal(id, opts = {}) {
     'calculatedRatios_plr': [['hematology', 'platelets', 'Platelets'], ['differential', 'lymphocytes', 'Lymphocytes']],
     'calculatedRatios_deRitisRatio': [['biochemistry', 'ast', 'AST'], ['biochemistry', 'alt', 'ALT']],
     'calculatedRatios_copperZincRatio': [['electrolytes', 'copper', 'Copper'], ['electrolytes', 'zinc', 'Zinc']],
+    'calculatedRatios_ft3ft4Ratio': [['thyroid', 'ft3', 'Free T3'], ['thyroid', 'ft4', 'Free T4']],
     'calculatedRatios_apoBapoAIRatio': [['lipids', 'apoB', 'ApoB'], ['lipids', 'apoAI', 'ApoA-I']],
     'calculatedRatios_crpHdlRatio': [['proteins', 'hsCRP', 'hs-CRP'], ['lipids', 'hdl', 'HDL']],
   };

--- a/js/schema.js
+++ b/js/schema.js
@@ -240,6 +240,7 @@ export const MARKER_SCHEMA = {
       plr: { name: "Platelet-Lymphocyte Ratio (PLR)", unit: "", refMin: 50, refMax: 150, desc: "Reflects the balance between thrombotic and immune responses; elevated in inflammation, cardiovascular disease, and cancer." },
       deRitisRatio: { name: "De Ritis Ratio (AST/ALT)", unit: "", refMin: 0.8, refMax: 1.2, desc: "AST divided by ALT; helps distinguish liver damage types \u2014 values above 2 suggest alcoholic liver disease or cirrhosis." },
       copperZincRatio: { name: "Copper/Zinc Ratio", unit: "", refMin: 0.7, refMax: 1.0, desc: "Balance between copper and zinc; elevated ratios indicate oxidative stress, inflammation, or immune dysfunction." },
+      ft3ft4Ratio: { name: "Free T3/Free T4 Ratio", unit: "", refMin: 0.262, refMax: 0.346, desc: "Compares active Free T3 with its Free T4 precursor; helps show whether circulating thyroid hormone balance is relatively T3- or T4-dominant and should be read alongside TSH and the individual hormone values." },
       bunCreatRatio: { name: "BUN/Creatinine Ratio", unit: "", refMin: 10, refMax: 20, desc: "Blood urea nitrogen divided by creatinine; helps differentiate pre-renal, renal, and post-renal causes of kidney dysfunction." },
       freeWaterDeficit: { name: "Free Water Deficit", unit: "L", refMin: -1.5, refMax: 1.5, desc: "Estimated water surplus or deficit based on sodium level; positive values indicate dehydration, negative values overhydration." },
       crpHdlRatio: { name: "hs-CRP/HDL Ratio", unit: "", refMin: 0, refMax: 0.94, desc: "High-sensitivity CRP divided by HDL cholesterol; a composite inflammation-lipid marker that captures cardiovascular risk better than either marker alone. Requires hs-CRP specifically." },
@@ -329,6 +330,7 @@ export const UNIT_CONVERSIONS = {
   'thyroid.t3total': { factor: 0.6513, usUnit: 'ng/dl', type: 'multiply' },
   'diabetes.hba1c': { type: 'hba1c' },
   'calculatedRatios.tgHdlRatio': { factor: 2.29, usUnit: '', type: 'multiply' },
+  'calculatedRatios.ft3ft4Ratio': { factor: 8.3833, usUnit: '', type: 'multiply' },
   'bodyComposition.leanMass': { factor: 2.20462, usUnit: 'lbs', type: 'multiply' },
   'bodyComposition.fatMass': { factor: 2.20462, usUnit: 'lbs', type: 'multiply' },
   // ── Label-only US conventions (factor: 1) ─────────────────────────────────
@@ -707,4 +709,5 @@ export const OPTIMAL_RANGES = {
   'calculatedRatios.deRitisRatio': { optimalMin: 0.8, optimalMax: 1.1 },
   'calculatedRatios.bunCreatRatio': { optimalMin: 10, optimalMax: 16 },
   'calculatedRatios.crpHdlRatio': { optimalMin: 0, optimalMax: 0.24 },
+  'calculatedRatios.ft3ft4Ratio': { optimalMin: 0.286, optimalMax: 0.322 },
 };

--- a/tests/test-calculated-markers.js
+++ b/tests/test-calculated-markers.js
@@ -32,6 +32,7 @@ console.log('=== Calculated Markers Tests ===\n');
 // Bring in state.js and the module-only data API.
 const { state } = await import('../js/state.js');
 const dataModule = await import('../js/data.js');
+const { MARKER_SCHEMA, OPTIMAL_RANGES, UNIT_CONVERSIONS } = await import('../js/schema.js');
 
   // Save originals
   const origEntries = state.importedData.entries;
@@ -563,7 +564,9 @@ const dataModule = await import('../js/data.js');
       'biochemistry.ast': 0.4,
       'biochemistry.alt': 0.5,
       'electrolytes.copper': 15,
-      'electrolytes.zinc': 18
+      'electrolytes.zinc': 18,
+      'thyroid.ft3': 4.5,
+      'thyroid.ft4': 15
     }
   }];
 
@@ -600,6 +603,29 @@ const dataModule = await import('../js/data.js');
   // Cu/Zn = 15/18 = 0.833
   assert('Cu/Zn ratio is 0.833', cr?.copperZincRatio?.values?.[0] === 0.833,
     `expected 0.833, got ${cr?.copperZincRatio?.values?.[0]}`);
+
+  // Free T3/Free T4 = 4.5/15 = 0.3 (both stored in SI pmol/L)
+  assert('FT3/FT4 ratio is 0.3', cr?.ft3ft4Ratio?.values?.[0] === 0.3,
+    `expected 0.3, got ${cr?.ft3ft4Ratio?.values?.[0]}`);
+  assert('FT3/FT4 ratio has reference and optimal ranges',
+    MARKER_SCHEMA.calculatedRatios.markers.ft3ft4Ratio.refMin === 0.262
+      && MARKER_SCHEMA.calculatedRatios.markers.ft3ft4Ratio.refMax === 0.346
+      && OPTIMAL_RANGES['calculatedRatios.ft3ft4Ratio']?.optimalMin === 0.286
+      && OPTIMAL_RANGES['calculatedRatios.ft3ft4Ratio']?.optimalMax === 0.322);
+  assert('FT3/FT4 ratio converts to the conventional US ratio',
+    UNIT_CONVERSIONS['calculatedRatios.ft3ft4Ratio']?.factor === 8.3833);
+  state.unitSystem = 'US';
+  dataModule.invalidateActiveDataCache();
+  const usFt3Ft4 = dataModule.getActiveData().categories.calculatedRatios?.markers?.ft3ft4Ratio;
+  assert('FT3/FT4 US value and ranges are converted consistently',
+    usFt3Ft4?.values?.[0] === 2.515
+      && usFt3Ft4.refMin === 2.196
+      && usFt3Ft4.refMax === 2.901
+      && usFt3Ft4.optimalMin === 2.398
+      && usFt3Ft4.optimalMax === 2.699,
+    JSON.stringify(usFt3Ft4));
+  state.unitSystem = 'EU';
+  dataModule.invalidateActiveDataCache();
 
   // ── Division by zero → null ──
   state.importedData.entries = [{

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.294';
+self.APP_VERSION = '1.10.299';


### PR DESCRIPTION
## Summary

- Add a date-aligned Free T3/Free T4 marker to Calculated Ratios.
- Use reference range `0.262–0.346` and optimal range `0.286–0.322` in SI, converted consistently to approximately `2.20–2.90` and `2.40–2.70` in US units.
- Add neutral marker copy, missing-input diagnostics, and focused SI/US regression coverage.
- Bump the app cache version to `1.10.299`.

## Context

This PR salvages the useful core of https://github.com/elkimek/get-based/pull/1284 in a smaller implementation built fresh from `main`.

It keeps the calculated marker, established ranges, unit conversion, and input diagnostics, while avoiding disease-level claims in the static marker description and avoiding any special context-only UI/status behavior. The existing Thyroid Coherence Biology Score is intentionally unchanged and continues to calculate and score its own FT3/FT4 input independently.

## Validation

- `./run-tests.sh`
- Vitest: 399 passed
- Playwright: 352 passed
- Responsive/theme sweep: 472 passed
- Calculated marker tests: 65 passed
- TypeScript/check-JS and repository guardrails passed