### PR TITLE
Restore snapshot-backed fatty acid imports

### DIFF
--- a/js/pdf-import-commit.js
+++ b/js/pdf-import-commit.js
@@ -128,24 +128,34 @@ export async function confirmImport() {
   const importGroup = (result.testType && result.testType !== 'blood')
     ? (result.testType === 'fattyAcids' ? 'Fatty Acids' : result.testType)
     : null;
-  // Auto-create custom markers for matched specialty keys (uses PDF's reference ranges)
+  // Auto-create custom markers for matched specialty and product-specific keys.
+  // Snapshot re-review can contain an already-matched custom key (for example
+  // spadiaFA.*) whose definition was lost, so matched does not imply schema-backed.
   if (!state.importedData.customMarkers) state.importedData.customMarkers = {};
   for (const m of matched) {
-    if (SPECIALTY_MARKER_DEFS[m.mappedKey]) {
-      const def = SPECIALTY_MARKER_DEFS[m.mappedKey];
-      const existing = state.importedData.customMarkers[m.mappedKey];
-      const cmDef = existing || {};
-      cmDef.name = cmDef.name || def.name;
-      cmDef.unit = m.unit || cmDef.unit || def.unit;
-      cmDef.refMin = m.refMin != null ? m.refMin : (cmDef.refMin != null ? cmDef.refMin : def.refMin);
-      cmDef.refMax = m.refMax != null ? m.refMax : (cmDef.refMax != null ? cmDef.refMax : def.refMax);
-      cmDef.icon = cmDef.icon || def.icon;
-      if (def.singlePoint) cmDef.singlePoint = true;
-      // Always update organizational fields from latest import
-      cmDef.categoryLabel = def.categoryLabel;
-      cmDef.group = importGroup || def.group || null;
-      state.importedData.customMarkers[m.mappedKey] = cmDef;
-    }
+    const [catKey, markerKey] = m.mappedKey.split('.');
+    const schemaMarker = MARKER_SCHEMA[catKey]?.markers?.[markerKey];
+    const exactSpecialtyDef = SPECIALTY_MARKER_DEFS[m.mappedKey];
+    const productBaseDef = catKey === 'spadiaFA'
+      ? SPECIALTY_MARKER_DEFS[`fattyAcids.${markerKey}`]
+      : null;
+    const def = exactSpecialtyDef || productBaseDef || {};
+    if (schemaMarker && !exactSpecialtyDef) continue;
+    const existing = state.importedData.customMarkers[m.mappedKey];
+    const cmDef = existing || {};
+    cmDef.name = cmDef.name || m.suggestedName || def.name || _cleanImportedMarkerDisplayName(m.rawName) || markerKey;
+    cmDef.unit = m.unit || cmDef.unit || def.unit || '';
+    cmDef.refMin = m.refMin != null ? m.refMin : (cmDef.refMin != null ? cmDef.refMin : def.refMin);
+    cmDef.refMax = m.refMax != null ? m.refMax : (cmDef.refMax != null ? cmDef.refMax : def.refMax);
+    cmDef.icon = cmDef.icon || def.icon;
+    if (def.singlePoint) cmDef.singlePoint = true;
+    // Always update organizational fields from latest import.
+    cmDef.categoryLabel = exactSpecialtyDef?.categoryLabel
+      || m.suggestedCategoryLabel
+      || cmDef.categoryLabel
+      || (catKey === 'spadiaFA' ? 'Spadia' : catKey.charAt(0).toUpperCase() + catKey.slice(1));
+    cmDef.group = m.suggestedGroup || importGroup || def.group || cmDef.group || null;
+    state.importedData.customMarkers[m.mappedKey] = cmDef;
   }
   // Save new (custom) marker values and definitions
   for (const m of newMarkers) {

--- a/js/profile-fatty-acid-migrations.js
+++ b/js/profile-fatty-acid-migrations.js
@@ -1,0 +1,106 @@
+// @ts-check
+// profile-fatty-acid-migrations.js - Snapshot-backed product fatty-acid metadata repairs.
+
+import { SPECIALTY_MARKER_DEFS } from './schema.js';
+
+/**
+ * @typedef {Record<string, any>} ProfileData
+ */
+
+/**
+ * @param {string | null | undefined} key
+ * @returns {{ categoryKey: string, markerPart: string } | null}
+ */
+function productFattyAcidKeyParts(key) {
+  if (!key || typeof key !== 'string') return null;
+  const parts = key.split('.');
+  if (parts.length !== 2 || !parts[0] || !parts[1]) return null;
+  const [categoryKey, markerPart] = parts;
+  if (!(categoryKey.endsWith('FA') || categoryKey === 'fattyAcidsTest')) return null;
+  return { categoryKey, markerPart };
+}
+
+/**
+ * @param {string} categoryKey
+ * @returns {string}
+ */
+function productFattyAcidCategoryLabel(categoryKey) {
+  const knownLabels = {
+    spadiaFA: 'Spadia',
+    zinzinoFA: 'ZinZino',
+    omegaquantFA: 'OmegaQuant',
+    metabolomixFA: 'Metabolomix+: Fatty Acids',
+    fattyAcidsTest: 'Fatty Acids Test',
+  };
+  if (knownLabels[categoryKey]) return knownLabels[categoryKey];
+  const raw = categoryKey.endsWith('FA') ? categoryKey.slice(0, -2) : categoryKey;
+  const spaced = raw.replace(/([a-z0-9])([A-Z])/g, '$1 $2').trim();
+  return spaced ? spaced.charAt(0).toUpperCase() + spaced.slice(1) : 'Fatty Acids';
+}
+
+/**
+ * @param {ProfileData} data
+ * @param {string} sourceKey
+ * @param {string} nextKey
+ * @param {any} [marker]
+ * @returns {void}
+ */
+export function ensureProductFattyAcidCustomMarker(data, sourceKey, nextKey, marker = null) {
+  const parts = productFattyAcidKeyParts(nextKey);
+  if (!parts) return;
+  if (!data.customMarkers) data.customMarkers = {};
+  const { categoryKey, markerPart } = parts;
+  const genericKey = `fattyAcids.${markerPart}`;
+  const exactDef = SPECIALTY_MARKER_DEFS[nextKey] || null;
+  const sourceDef = data.customMarkers[sourceKey]
+    || data.customMarkers[genericKey]
+    || SPECIALTY_MARKER_DEFS[sourceKey]
+    || exactDef
+    || SPECIALTY_MARKER_DEFS[genericKey]
+    || {};
+  const targetDef = data.customMarkers[nextKey] || {};
+  const cmDef = { ...sourceDef, ...targetDef };
+  cmDef.name = targetDef.name || marker?.suggestedName || sourceDef.name || marker?.rawName || markerPart;
+  cmDef.unit = targetDef.unit || marker?.unit || sourceDef.unit || '%';
+  cmDef.refMin = targetDef.refMin != null ? targetDef.refMin
+    : (marker?.refMin != null ? marker.refMin : (sourceDef.refMin != null ? sourceDef.refMin : null));
+  cmDef.refMax = targetDef.refMax != null ? targetDef.refMax
+    : (marker?.refMax != null ? marker.refMax : (sourceDef.refMax != null ? sourceDef.refMax : null));
+  cmDef.icon = targetDef.icon || exactDef?.icon || sourceDef.icon || '🐟';
+  cmDef.categoryLabel = exactDef?.categoryLabel
+    || marker?.suggestedCategoryLabel
+    || productFattyAcidCategoryLabel(categoryKey)
+    || targetDef.categoryLabel
+    || sourceDef.categoryLabel;
+  cmDef.group = exactDef?.group || marker?.suggestedGroup || targetDef.group || sourceDef.group || 'Fatty Acids';
+  data.customMarkers[nextKey] = cmDef;
+}
+
+/**
+ * Rebuild missing definitions only when both a saved import snapshot and a
+ * stored entry contain the same product-specific fatty-acid key. Snapshot
+ * evidence keeps the legacy corrupted-blood cleanup effective for unproven keys.
+ * @param {ProfileData} data
+ * @returns {void}
+ */
+export function repairSnapshotBackedProductFattyAcidMetadata(data) {
+  const storedKeys = new Set();
+  for (const entry of data.entries || []) {
+    for (const key of Object.keys(entry.markers || {})) {
+      if (productFattyAcidKeyParts(key)) storedKeys.add(key);
+    }
+  }
+  if (storedKeys.size === 0) return;
+  for (const snap of data.importSnapshots || []) {
+    if (!Array.isArray(snap?.markers)) continue;
+    const excluded = new Set(Array.isArray(snap.excludedIndices) ? snap.excludedIndices : []);
+    for (let i = 0; i < snap.markers.length; i++) {
+      if (excluded.has(i)) continue;
+      const marker = snap.markers[i];
+      const key = marker?.mappedKey || marker?.suggestedKey || null;
+      const parts = productFattyAcidKeyParts(key);
+      if (!parts || !storedKeys.has(key) || data.customMarkers?.[key]) continue;
+      ensureProductFattyAcidCustomMarker(data, `fattyAcids.${parts.markerPart}`, key, marker);
+    }
+  }
+}

--- a/js/profile-marker-migrations.js
+++ b/js/profile-marker-migrations.js
@@ -4,6 +4,10 @@
 import { MARKER_SCHEMA, SPECIALTY_MARKER_DEFS } from './schema.js';
 import { renameLabEntryMarker } from './lab-entry.js';
 import { normalizeToSI } from './pdf-import-marker-mapping.js';
+import {
+  ensureProductFattyAcidCustomMarker,
+  repairSnapshotBackedProductFattyAcidMetadata,
+} from './profile-fatty-acid-migrations.js';
 
 /**
  * @typedef {Record<string, any>} ProfileData
@@ -649,29 +653,6 @@ function _entryMatchesSpadiaSnapshotMarker(entry, snap, oldKey, marker) {
 
 /**
  * @param {ProfileData} data
- * @param {string} oldKey
- * @param {string} nextKey
- * @returns {void}
- */
-function _ensureSpadiaFattyAcidCustomMarker(data, oldKey, nextKey) {
-  if (!data.customMarkers) data.customMarkers = {};
-  const sourceDef = data.customMarkers[oldKey] || SPECIALTY_MARKER_DEFS[oldKey] || {};
-  const cmDef = {
-    ...sourceDef,
-    ...(data.customMarkers[nextKey] || {}),
-  };
-  cmDef.name = cmDef.name || sourceDef.name || nextKey.split('.').pop();
-  cmDef.unit = cmDef.unit || sourceDef.unit || '%';
-  cmDef.refMin = cmDef.refMin != null ? cmDef.refMin : (sourceDef.refMin != null ? sourceDef.refMin : null);
-  cmDef.refMax = cmDef.refMax != null ? cmDef.refMax : (sourceDef.refMax != null ? sourceDef.refMax : null);
-  cmDef.icon = cmDef.icon || sourceDef.icon || SPECIALTY_MARKER_DEFS[oldKey]?.icon;
-  cmDef.categoryLabel = 'Spadia';
-  cmDef.group = 'Fatty Acids';
-  data.customMarkers[nextKey] = cmDef;
-}
-
-/**
- * @param {ProfileData} data
  * @param {any} entry
  * @param {string} oldKey
  * @param {string} nextKey
@@ -679,7 +660,7 @@ function _ensureSpadiaFattyAcidCustomMarker(data, oldKey, nextKey) {
  */
 function _remapSpadiaFattyAcidEntry(data, entry, oldKey, nextKey) {
   if (!renameLabEntryMarker(entry, oldKey, nextKey, { stamp: false })) return false;
-  _ensureSpadiaFattyAcidCustomMarker(data, oldKey, nextKey);
+  ensureProductFattyAcidCustomMarker(data, oldKey, nextKey);
   if (entry.date) {
     _copyDateScopedProfileMarkerData(data, oldKey, nextKey, entry.date);
   }
@@ -716,17 +697,23 @@ function _repairSpadiaFattyAcidKeys(data) {
       const oldKey = marker?.mappedKey?.startsWith('fattyAcids.') ? marker.mappedKey
         : marker?.suggestedKey?.startsWith('fattyAcids.') ? marker.suggestedKey
           : null;
-      const nextKey = remapKey(oldKey);
+      const productKey = marker?.mappedKey?.startsWith('spadiaFA.') ? marker.mappedKey
+        : marker?.suggestedKey?.startsWith('spadiaFA.') ? marker.suggestedKey
+          : null;
+      const nextKey = oldKey ? remapKey(oldKey) : productKey;
       if (!nextKey) continue;
-      const def = SPECIALTY_MARKER_DEFS[oldKey] || {};
+      const markerPart = nextKey.slice('spadiaFA.'.length);
+      const genericKey = oldKey || `fattyAcids.${markerPart}`;
+      const def = SPECIALTY_MARKER_DEFS[genericKey] || {};
       marker.mappedKey = nextKey;
       marker.suggestedKey = null;
       marker.suggestedName = marker.suggestedName || def.name || marker.rawName;
       marker.suggestedCategoryLabel = 'Spadia';
       marker.suggestedGroup = 'Fatty Acids';
       marker.matched = true;
+      ensureProductFattyAcidCustomMarker(data, genericKey, nextKey, marker);
+      if (!oldKey) continue;
       renamedKeys.set(oldKey, nextKey);
-      _ensureSpadiaFattyAcidCustomMarker(data, oldKey, nextKey);
       if (snap?.date) {
         _copyDateScopedProfileMarkerData(data, oldKey, nextKey, snap.date);
       }
@@ -758,5 +745,6 @@ export function repairProfileMarkerData(data) {
   _repairUnitSuffixedStandardMarkers(data);
   _repairNewlyStandardizedImports(data);
   _repairFractionStoredPercentImports(data);
+  repairSnapshotBackedProductFattyAcidMetadata(data);
   _repairSpadiaFattyAcidKeys(data);
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -119,6 +119,7 @@ const APP_SHELL = [
   '/js/import-drop-zone-runtime.js',
   '/js/ai-verdict-engine-runtime.js',
   '/js/ai-verdict-engine.js',
+  '/js/profile-fatty-acid-migrations.js',
   '/js/profile-marker-migrations.js',
   '/js/profile.js',
   '/js/profile-runtime.js',

--- a/tests/playwright/pdf-import-browser-coverage.spec.js
+++ b/tests/playwright/pdf-import-browser-coverage.spec.js
@@ -768,6 +768,55 @@ test('PDF import confirm flow covers preview persistence', async ({ page }) => {
         && imported.importHash === 'confirm-import-hash'
         && imported.sourceFiles?.includes('confirm-import.pdf') === true
         && review.getPendingImport() === null;
+
+      state.importedData = {
+        entries: [],
+        notes: [],
+        supplements: [],
+        customMarkers: {},
+        markerNotes: {},
+        markerValueNotes: {},
+        manualValues: {},
+        refOverrides: {},
+        importSnapshots: [{
+          id: 'snap-spadia-re-review',
+          fileName: 'Spadia Fatty Acids.pdf',
+          date: '2024-07-04',
+          testType: 'blood',
+          markers: [
+            {
+              rawName: 'Omega-3 Index',
+              value: 7.1,
+              unit: '%',
+              refMin: 8,
+              refMax: 12,
+              matched: true,
+              mappedKey: 'spadiaFA.omega3Index',
+              suggestedName: 'Omega-3 Index',
+              suggestedCategoryLabel: 'Spadia',
+              suggestedGroup: 'Fatty Acids',
+            },
+            {
+              rawName: 'Vitamin A',
+              value: 2.39,
+              unit: 'µmol/l',
+              matched: true,
+              mappedKey: 'vitamins.vitaminA',
+            },
+          ],
+        }],
+      };
+      pdfImport.openImportReviewFromSnapshot('snap-spadia-re-review');
+      await pdfImport.confirmImport();
+      const restoredSpadia = state.importedData.entries.find(entry => entry.date === '2024-07-04');
+      const restoredSpadiaDef = state.importedData.customMarkers['spadiaFA.omega3Index'];
+      outcomes.spadiaSnapshotReReviewRestoresVisibleMarkers =
+        restoredSpadia?.markers?.['spadiaFA.omega3Index'] === 7.1
+        && restoredSpadia?.markers?.['vitamins.vitaminA'] === 2.39
+        && restoredSpadia?.markerSources?.['spadiaFA.omega3Index']?.snapshotId === 'snap-spadia-re-review'
+        && restoredSpadiaDef?.name === 'Omega-3 Index'
+        && restoredSpadiaDef?.categoryLabel === 'Spadia'
+        && restoredSpadiaDef?.group === 'Fatty Acids';
     } finally {
       state.importedData = original.importedData;
       state.currentProfile = original.currentProfile;

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -85,6 +85,7 @@ assert('SW APP_SHELL includes settings provider bridge module', swAuditSrc.inclu
 assert('SW APP_SHELL includes PDF import review module', swAuditSrc.includes("'/js/pdf-import-review.js'"));
 assert('SW APP_SHELL includes PDF import review runtime module', swAuditSrc.includes("'/js/pdf-import-review-runtime.js'"));
 assert('SW APP_SHELL includes PDF import commit module', swAuditSrc.includes("'/js/pdf-import-commit.js'"));
+assert('SW APP_SHELL includes fatty-acid profile migration module', swAuditSrc.includes("'/js/profile-fatty-acid-migrations.js'"));
 assert('SW APP_SHELL includes modal lifecycle module', swAuditSrc.includes("'/js/modal-lifecycle.js'"));
 assert('SW APP_SHELL includes marker analysis module', swAuditSrc.includes("'/js/marker-analysis.js'"));
 assert('SW APP_SHELL includes cycle import modules',

--- a/tests/test-unit-import.js
+++ b/tests/test-unit-import.js
@@ -798,6 +798,94 @@ const importCssSrc = read('css/import.css');
     && savedSpadiaFA.markerValueNotes['fattyAcids.epaC20_5:2024-07-04'] === undefined
     && savedSpadiaFA.markerLabels['fattyAcids.epaC20_5'] === undefined);
 
+  const snapshotReadySpadiaFA = {
+    entries: [{
+      date: '2024-07-04',
+      markers: { 'spadiaFA.omega3Index': 7.1, 'vitamins.vitaminA': 2.39 },
+      markerSources: {
+        'spadiaFA.omega3Index': { file: 'Spadia Fatty Acids.pdf', snapshotId: 'snap_spadia_ready' },
+        'vitamins.vitaminA': { file: 'Spadia Fatty Acids.pdf', snapshotId: 'snap_spadia_ready' },
+      },
+    }],
+    customMarkers: {},
+    importSnapshots: [{
+      id: 'snap_spadia_ready',
+      fileName: 'Spadia Fatty Acids.pdf',
+      date: '2024-07-04',
+      markers: [
+        { rawName: 'Omega-3 Index', value: 7.1, unit: '%', mappedKey: 'spadiaFA.omega3Index', suggestedName: 'Omega-3 Index', suggestedCategoryLabel: 'Spadia', suggestedGroup: 'Fatty Acids', matched: true },
+        { rawName: 'Vitamin A', value: 2.39, unit: 'µmol/l', mappedKey: 'vitamins.vitaminA', matched: true },
+      ],
+    }],
+  };
+  migrateProfileData(snapshotReadySpadiaFA);
+  assert('Profile migration preserves snapshot-ready Spadia values in mixed reports when metadata is missing',
+    snapshotReadySpadiaFA.entries[0].markers['spadiaFA.omega3Index'] === 7.1
+    && snapshotReadySpadiaFA.entries[0].markers['vitamins.vitaminA'] === 2.39);
+  assert('Profile migration rebuilds missing custom marker metadata from snapshot-ready Spadia keys',
+    snapshotReadySpadiaFA.customMarkers['spadiaFA.omega3Index']?.name === 'Omega-3 Index'
+    && snapshotReadySpadiaFA.customMarkers['spadiaFA.omega3Index']?.unit === '%'
+    && snapshotReadySpadiaFA.customMarkers['spadiaFA.omega3Index']?.categoryLabel === 'Spadia'
+    && snapshotReadySpadiaFA.customMarkers['spadiaFA.omega3Index']?.group === 'Fatty Acids');
+
+  const productFAFixtures = [
+    ['zinzinoFA', 'ZinZino'],
+    ['omegaquantFA', 'OmegaQuant'],
+    ['metabolomixFA', 'Fatty Acids'],
+    ['fattyAcidsTest', 'Fatty Acids Test'],
+    ['nutriBalanceFA', 'Nutri Balance'],
+  ];
+  const snapshotBackedProductFA = { entries: [], customMarkers: {}, importSnapshots: [] };
+  for (let i = 0; i < productFAFixtures.length; i++) {
+    const [prefix, categoryLabel] = productFAFixtures[i];
+    const date = `2026-02-0${i + 1}`;
+    const snapshotId = `snap_product_fa_${i}`;
+    const key = `${prefix}.omega3Index`;
+    snapshotBackedProductFA.entries.push({
+      date,
+      markers: { [key]: 7 + i, 'vitamins.vitaminA': 2.39 },
+      markerSources: { [key]: { file: `${categoryLabel}.pdf`, snapshotId } },
+    });
+    snapshotBackedProductFA.importSnapshots.push({
+      id: snapshotId,
+      fileName: `${categoryLabel}.pdf`,
+      date,
+      markers: [{
+        rawName: 'Omega-3 Index',
+        value: 7 + i,
+        unit: '%',
+        mappedKey: key,
+        suggestedName: 'Omega-3 Index',
+        suggestedCategoryLabel: categoryLabel,
+        suggestedGroup: 'Fatty Acids',
+        matched: true,
+      }],
+    });
+  }
+  migrateProfileData(snapshotBackedProductFA);
+  assert('Profile migration preserves snapshot-backed values for every fatty-acid adapter prefix',
+    productFAFixtures.every(([prefix], i) =>
+      snapshotBackedProductFA.entries[i].markers[`${prefix}.omega3Index`] === 7 + i
+      && snapshotBackedProductFA.entries[i].markers['vitamins.vitaminA'] === 2.39));
+  assert('Profile migration rebuilds metadata for known and dynamic fatty-acid adapters',
+    productFAFixtures.every(([prefix, categoryLabel]) => {
+      const def = snapshotBackedProductFA.customMarkers[`${prefix}.omega3Index`];
+      return def?.name === 'Omega-3 Index'
+        && def?.unit === '%'
+        && def?.categoryLabel === categoryLabel
+        && def?.group === 'Fatty Acids';
+    }));
+
+  const unprovenCorruptFA = {
+    entries: [{ date: '2026-02-10', markers: { 'accidentalFA.glucose': 5.2, 'vitamins.vitaminA': 2.39 } }],
+    customMarkers: {},
+    importSnapshots: [],
+  };
+  migrateProfileData(unprovenCorruptFA);
+  assert('Profile migration still removes unproven FA-prefixed blood-marker corruption',
+    unprovenCorruptFA.entries[0].markers['accidentalFA.glucose'] === undefined
+    && unprovenCorruptFA.entries[0].markers['vitamins.vitaminA'] === 2.39);
+
   const savedGenericFA = {
     entries: [{
       date: '2024-07-04',

--- a/tests/test-wearables-dom.js
+++ b/tests/test-wearables-dom.js
@@ -39,6 +39,11 @@ return (async function() {
   const reg = await import('../js/wearable-adapters.js');
   const wearables = await import('../js/wearables.js');
   const views = await import('../js/views.js');
+  const testToday = reg.isoDay();
+  const testDay1 = reg.daysAgoIso(1);
+  const testDay2 = reg.daysAgoIso(2);
+  const testDay3 = reg.daysAgoIso(3);
+  const testDay4 = reg.daysAgoIso(4);
 
   state.importedData = state.importedData || {};
   const TEST_PROFILE = state.currentProfile || ('__test-wearables-dom-' + Math.random().toString(36).slice(2, 8));
@@ -52,9 +57,9 @@ return (async function() {
   const stripHost = document.createElement('div');
   try {
     state.importedData.wearableSummary = {
-      sources: { oura: { connectedSince: '2026-01-01', lastSyncAt: Date.now(), coverageDays: 5 } },
+      sources: { oura: { connectedSince: testDay4, lastSyncAt: Date.now(), coverageDays: 5 } },
       metrics: {
-        hrv_rmssd: { primarySource: 'oura', latest: 42, latestDate: '2026-04-22', baseline: 40, baselineP25: 36, baselineP75: 44, rolling: { d7: 42, d30: 40, d90: 40 }, trend30d: 'rising', weekly: [38, 40, 42] },
+        hrv_rmssd: { primarySource: 'oura', latest: 42, latestDate: testToday, baseline: 40, baselineP25: 36, baselineP75: 44, rolling: { d7: 42, d30: 40, d90: 40 }, trend30d: 'rising', weekly: [38, 40, 42] },
       },
     };
     stripHost.innerHTML = wearables.renderWearableStrip();
@@ -76,17 +81,17 @@ return (async function() {
   // ═══════════════════════════════════════
   console.log('%c A. Detail Modal ', 'font-weight:bold;color:#f59e0b');
   const detailSummary = {
-    sources: { oura: { connectedSince: '2026-01-01', lastSyncAt: Date.now(), coverageDays: 5 } },
+    sources: { oura: { connectedSince: testDay4, lastSyncAt: Date.now(), coverageDays: 5 } },
     metrics: {
-      hrv_rmssd: { primarySource: 'oura', latest: 42, latestDate: '2026-04-22', baseline: 40, baselineP25: 36, baselineP75: 44, rolling: { d7: 42, d30: 40, d90: 40 }, trend30d: 'rising', weekly: [38, 40, 42] },
-      activity_score: { primarySource: 'oura', latest: 0, latestDate: '2026-04-22', baseline: 0, baselineP25: 0, baselineP75: 0, rolling: { d7: 0, d30: 0, d90: 0 }, trend30d: 'flat', weekly: [0,0,0,0,0] },
+      hrv_rmssd: { primarySource: 'oura', latest: 42, latestDate: testToday, baseline: 40, baselineP25: 36, baselineP75: 44, rolling: { d7: 42, d30: 40, d90: 40 }, trend30d: 'rising', weekly: [38, 40, 42] },
+      activity_score: { primarySource: 'oura', latest: 0, latestDate: testToday, baseline: 0, baselineP25: 0, baselineP75: 0, rolling: { d7: 0, d30: 0, d90: 0 }, trend30d: 'flat', weekly: [0,0,0,0,0] },
     },
   };
   state.importedData.wearableSummary = detailSummary;
   await store.upsertDailyBatch(TEST_PROFILE, [
-    { source: 'oura', date: '2026-04-20', hrv_rmssd: 40, activity_score: 0 },
-    { source: 'oura', date: '2026-04-21', hrv_rmssd: 41, activity_score: 0 },
-    { source: 'oura', date: '2026-04-22', hrv_rmssd: 42, activity_score: 0 },
+    { source: 'oura', date: testDay2, hrv_rmssd: 40, activity_score: 0 },
+    { source: 'oura', date: testDay1, hrv_rmssd: 41, activity_score: 0 },
+    { source: 'oura', date: testToday, hrv_rmssd: 42, activity_score: 0 },
   ]);
 
   await wearables.openWearableDetail('hrv_rmssd');
@@ -130,16 +135,16 @@ return (async function() {
   console.log('%c A2. Blood Pressure Modal Pairing ', 'font-weight:bold;color:#f59e0b');
   localStorage.setItem('wearable-detail-range', '90d');
   state.importedData.wearableSummary = {
-    sources: { manual: { connectedSince: '2026-04-20', lastSyncAt: Date.now(), coverageDays: 3 } },
+    sources: { manual: { connectedSince: testDay2, lastSyncAt: Date.now(), coverageDays: 3 } },
     metrics: {
-      bp_systolic: { primarySource: 'manual', latest: 120, latestDate: '2026-04-22', baseline: 121, baselineP25: 118, baselineP75: 123, rolling: { d7: 120, d30: 121, d90: 121 }, trend30d: 'flat', weekly: [121, 120] },
-      bp_diastolic: { primarySource: 'manual', latest: 80, latestDate: '2026-04-22', baseline: 79, baselineP25: 76, baselineP75: 82, rolling: { d7: 80, d30: 79, d90: 79 }, trend30d: 'flat', weekly: [79, 80] },
+      bp_systolic: { primarySource: 'manual', latest: 120, latestDate: testToday, baseline: 121, baselineP25: 118, baselineP75: 123, rolling: { d7: 120, d30: 121, d90: 121 }, trend30d: 'flat', weekly: [121, 120] },
+      bp_diastolic: { primarySource: 'manual', latest: 80, latestDate: testToday, baseline: 79, baselineP25: 76, baselineP75: 82, rolling: { d7: 80, d30: 79, d90: 79 }, trend30d: 'flat', weekly: [79, 80] },
     },
   };
   await store.upsertDailyBatch(TEST_PROFILE, [
-    { source: 'manual', date: '2026-04-20', bp_systolic: 122, bp_diastolic: 81 },
-    { source: 'manual', date: '2026-04-21', bp_systolic: 121, bp_diastolic: 79 },
-    { source: 'manual', date: '2026-04-22', bp_systolic: 120, bp_diastolic: 80, note: 'after walk', tags: ['rested'] },
+    { source: 'manual', date: testDay2, bp_systolic: 122, bp_diastolic: 81 },
+    { source: 'manual', date: testDay1, bp_systolic: 121, bp_diastolic: 79 },
+    { source: 'manual', date: testToday, bp_systolic: 120, bp_diastolic: 80, note: 'after walk', tags: ['rested'] },
   ]);
   await wearables.openWearableDetail('bp_systolic');
   await waitFor(() => state?.chartInstances?.modal?.data?.datasets?.some(d => /Diastolic/.test(d?.label || '')));
@@ -164,19 +169,19 @@ return (async function() {
   await store.clearSource(TEST_PROFILE, 'withings');
   state.importedData.wearableSummary = {
     sources: {
-      withings: { connectedSince: '2026-06-20', lastSyncAt: Date.now(), coverageDays: 2 },
-      manual: { connectedSince: '2026-06-20', lastSyncAt: Date.now(), coverageDays: 1 },
+      withings: { connectedSince: testDay4, lastSyncAt: Date.now(), coverageDays: 2 },
+      manual: { connectedSince: testDay4, lastSyncAt: Date.now(), coverageDays: 1 },
     },
     metrics: {
-      bp_systolic: { primarySource: 'withings', latest: 130, latestDate: '2026-06-24', baseline: 126, baselineP25: 124, baselineP75: 130, rolling: { d7: 127, d30: 126, d90: 126 }, trend30d: 'flat', weekly: [126, 127] },
-      bp_diastolic: { primarySource: 'manual', latest: 80, latestDate: '2026-06-20', baseline: 80, baselineP25: 78, baselineP75: 82, rolling: { d7: 80, d30: 80, d90: 80 }, trend30d: 'flat', weekly: [80] },
+      bp_systolic: { primarySource: 'withings', latest: 130, latestDate: testToday, baseline: 126, baselineP25: 124, baselineP75: 130, rolling: { d7: 127, d30: 126, d90: 126 }, trend30d: 'flat', weekly: [126, 127] },
+      bp_diastolic: { primarySource: 'manual', latest: 80, latestDate: testDay4, baseline: 80, baselineP25: 78, baselineP75: 82, rolling: { d7: 80, d30: 80, d90: 80 }, trend30d: 'flat', weekly: [80] },
     },
   };
   await store.upsertDailyBatch(TEST_PROFILE, [
-    { source: 'withings', date: '2026-06-20', bp_systolic: 124 },
-    { source: 'withings', date: '2026-06-24', bp_systolic: 130 },
-    { source: 'manual', date: '2026-06-20', bp_diastolic: 80 },
-    { source: 'manual', date: '2026-06-22', bp_diastolic: 78 },
+    { source: 'withings', date: testDay4, bp_systolic: 124 },
+    { source: 'withings', date: testToday, bp_systolic: 130 },
+    { source: 'manual', date: testDay4, bp_diastolic: 80 },
+    { source: 'manual', date: testDay2, bp_diastolic: 78 },
   ]);
   await wearables.openWearableDetail('bp_systolic');
   await waitFor(() => state?.chartInstances?.modal?.data?.datasets?.some(d => /^Diastolic/.test(d?.label || '')));
@@ -202,19 +207,19 @@ return (async function() {
   await store.clearSource(TEST_PROFILE, 'withings');
   state.importedData.wearableSummary = {
     sources: {
-      withings: { connectedSince: '2026-06-20', lastSyncAt: Date.now(), coverageDays: 0 },
-      manual: { connectedSince: '2026-06-20', lastSyncAt: Date.now(), coverageDays: 2 },
+      withings: { connectedSince: testDay4, lastSyncAt: Date.now(), coverageDays: 0 },
+      manual: { connectedSince: testDay4, lastSyncAt: Date.now(), coverageDays: 2 },
     },
     metrics: {
-      bp_systolic: { primarySource: 'withings', latest: 125, latestDate: '2026-06-24', baseline: 121, baselineP25: 119, baselineP75: 123, rolling: { d7: 121, d30: 121, d90: 121 }, trend30d: 'flat', weekly: [] },
-      bp_diastolic: { primarySource: 'manual', latest: 79, latestDate: '2026-06-22', baseline: 79, baselineP25: 77, baselineP75: 81, rolling: { d7: 79, d30: 79, d90: 79 }, trend30d: 'flat', weekly: [] },
+      bp_systolic: { primarySource: 'withings', latest: 125, latestDate: testToday, baseline: 121, baselineP25: 119, baselineP75: 123, rolling: { d7: 121, d30: 121, d90: 121 }, trend30d: 'flat', weekly: [] },
+      bp_diastolic: { primarySource: 'manual', latest: 79, latestDate: testDay2, baseline: 79, baselineP25: 77, baselineP75: 81, rolling: { d7: 79, d30: 79, d90: 79 }, trend30d: 'flat', weekly: [] },
     },
   };
   await store.upsertDailyBatch(TEST_PROFILE, [
-    { source: 'withings', date: '2026-06-20', bp_systolic: 124 },
-    { source: 'manual', date: '2026-06-20', bp_diastolic: 80 },
-    { source: 'manual', date: '2026-06-21', bp_systolic: 122, bp_diastolic: 80 },
-    { source: 'manual', date: '2026-06-22', bp_systolic: 121, bp_diastolic: 79 },
+    { source: 'withings', date: testDay4, bp_systolic: 124 },
+    { source: 'manual', date: testDay4, bp_diastolic: 80 },
+    { source: 'manual', date: testDay3, bp_systolic: 122, bp_diastolic: 80 },
+    { source: 'manual', date: testDay2, bp_systolic: 121, bp_diastolic: 79 },
   ]);
   await wearables.openWearableDetail('bp_systolic');
   await waitFor(() => state?.chartInstances?.modal?.data?.datasets?.some(d => /^Diastolic \(Manual/.test(d?.label || '')));
@@ -236,17 +241,17 @@ return (async function() {
   await store.clearSource(TEST_PROFILE, 'withings');
   state.importedData.wearableSummary = {
     sources: {
-      withings: { connectedSince: '2026-06-20', lastSyncAt: Date.now(), coverageDays: 1 },
-      manual: { connectedSince: '2026-06-20', lastSyncAt: Date.now(), coverageDays: 1 },
+      withings: { connectedSince: testDay4, lastSyncAt: Date.now(), coverageDays: 1 },
+      manual: { connectedSince: testDay4, lastSyncAt: Date.now(), coverageDays: 1 },
     },
     metrics: {
-      bp_systolic: { primarySource: 'withings', latest: 130, latestDate: '2026-06-24', baseline: 130, baselineP25: 128, baselineP75: 132, rolling: { d7: 130, d30: 130, d90: 130 }, trend30d: 'flat', weekly: [] },
-      bp_diastolic: { primarySource: 'manual', latest: 78, latestDate: '2026-06-22', baseline: 78, baselineP25: 76, baselineP75: 80, rolling: { d7: 78, d30: 78, d90: 78 }, trend30d: 'flat', weekly: [] },
+      bp_systolic: { primarySource: 'withings', latest: 130, latestDate: testToday, baseline: 130, baselineP25: 128, baselineP75: 132, rolling: { d7: 130, d30: 130, d90: 130 }, trend30d: 'flat', weekly: [] },
+      bp_diastolic: { primarySource: 'manual', latest: 78, latestDate: testDay2, baseline: 78, baselineP25: 76, baselineP75: 80, rolling: { d7: 78, d30: 78, d90: 78 }, trend30d: 'flat', weekly: [] },
     },
   };
   await store.upsertDailyBatch(TEST_PROFILE, [
-    { source: 'withings', date: '2026-06-24', bp_systolic: 130 },
-    { source: 'manual', date: '2026-06-22', bp_diastolic: 78 },
+    { source: 'withings', date: testToday, bp_systolic: 130 },
+    { source: 'manual', date: testDay2, bp_diastolic: 78 },
   ]);
   await wearables.openWearableDetail('bp_systolic');
   await waitFor(() => /No same-date pair/.test(document.getElementById('detail-modal')?.textContent || ''));
@@ -267,17 +272,17 @@ return (async function() {
   await store.clearSource(TEST_PROFILE, 'withings');
   state.importedData.wearableSummary = {
     sources: {
-      withings: { connectedSince: '2026-06-20', lastSyncAt: Date.now(), coverageDays: 0 },
-      manual: { connectedSince: '2026-06-20', lastSyncAt: Date.now(), coverageDays: 2 },
+      withings: { connectedSince: testDay4, lastSyncAt: Date.now(), coverageDays: 0 },
+      manual: { connectedSince: testDay4, lastSyncAt: Date.now(), coverageDays: 2 },
     },
     metrics: {
-      bp_systolic: { primarySource: 'withings', latest: 125, latestDate: '2026-06-24', baseline: 121, baselineP25: 119, baselineP75: 123, rolling: { d7: 121, d30: 121, d90: 121 }, trend30d: 'flat', weekly: [] },
-      bp_diastolic: { primarySource: 'withings', latest: 79, latestDate: '2026-06-22', baseline: 79, baselineP25: 77, baselineP75: 81, rolling: { d7: 79, d30: 79, d90: 79 }, trend30d: 'flat', weekly: [] },
+      bp_systolic: { primarySource: 'withings', latest: 125, latestDate: testToday, baseline: 121, baselineP25: 119, baselineP75: 123, rolling: { d7: 121, d30: 121, d90: 121 }, trend30d: 'flat', weekly: [] },
+      bp_diastolic: { primarySource: 'withings', latest: 79, latestDate: testDay2, baseline: 79, baselineP25: 77, baselineP75: 81, rolling: { d7: 79, d30: 79, d90: 79 }, trend30d: 'flat', weekly: [] },
     },
   };
   await store.upsertDailyBatch(TEST_PROFILE, [
-    { source: 'manual', date: '2026-06-21', bp_systolic: 122, bp_diastolic: 80 },
-    { source: 'manual', date: '2026-06-22', bp_systolic: 121, bp_diastolic: 79 },
+    { source: 'manual', date: testDay3, bp_systolic: 122, bp_diastolic: 80 },
+    { source: 'manual', date: testDay2, bp_systolic: 121, bp_diastolic: 79 },
   ]);
   await wearables.openWearableDetail('bp_systolic');
   await waitFor(() => state?.chartInstances?.modal?.data?.datasets?.some(d => /^Manual systolic$/.test(d?.label || '')));
@@ -322,13 +327,13 @@ return (async function() {
   // divergence where the modal's inline formatV fell through to .toFixed(1).
   console.log('%c C. SpO2 Modal Parity ', 'font-weight:bold;color:#f59e0b');
   state.importedData.wearableSummary = {
-    sources: { oura: { connectedSince: '2026-01-01', lastSyncAt: Date.now(), coverageDays: 10 } },
+    sources: { oura: { connectedSince: testDay4, lastSyncAt: Date.now(), coverageDays: 10 } },
     metrics: {
-      spo2_avg: { primarySource: 'oura', latest: 97, latestDate: '2026-04-22', baseline: 96, baselineP25: 95, baselineP75: 98, rolling: { d7: 97, d30: 97, d90: 96 }, trend30d: 'flat', weekly: [96, 96, 97, 97, 97] },
+      spo2_avg: { primarySource: 'oura', latest: 97, latestDate: testToday, baseline: 96, baselineP25: 95, baselineP75: 98, rolling: { d7: 97, d30: 97, d90: 96 }, trend30d: 'flat', weekly: [96, 96, 97, 97, 97] },
     },
   };
   await store.upsertDailyBatch(TEST_PROFILE, [
-    { source: 'oura', date: '2026-04-22', spo2_avg: 97 },
+    { source: 'oura', date: testToday, spo2_avg: 97 },
   ]);
   await wearables.openWearableDetail('spo2_avg');
   await new Promise(r => setTimeout(r, 60));
@@ -342,9 +347,8 @@ return (async function() {
   // ═══════════════════════════════════════
   console.log('%c D. Partial-Day Chart Marker ', 'font-weight:bold;color:#f59e0b');
   localStorage.setItem('wearable-detail-range', '90d');
-  const todayISO = reg.isoDay();
-  const yesterday = new Date(); yesterday.setDate(yesterday.getDate() - 1);
-  const yesterdayISO = reg.isoDay(yesterday);
+  const todayISO = testToday;
+  const yesterdayISO = testDay1;
   state.importedData.wearableSummary = {
     sources: { oura: { connectedSince: yesterdayISO, lastSyncAt: Date.now(), coverageDays: 2 } },
     metrics: {
@@ -459,14 +463,14 @@ return (async function() {
     wearableSummary: {
       summaryUpdatedAt: new Date().toISOString(),
       sources: {
-        oura:   { connectedSince: '2026-01-01', lastSyncAt: Date.now(), coverageDays: 5 },
-        manual: { connectedSince: '2026-01-01', lastSyncAt: Date.now(), coverageDays: 1 },
+        oura:   { connectedSince: testDay4, lastSyncAt: Date.now(), coverageDays: 5 },
+        manual: { connectedSince: testDay4, lastSyncAt: Date.now(), coverageDays: 1 },
       },
       metrics: {
-        hrv_rmssd: { primarySource: 'oura', latest: 38, latestDate: '2026-04-23',
+        hrv_rmssd: { primarySource: 'oura', latest: 38, latestDate: testToday,
           baseline: 36, baselineP25: 32, baselineP75: 40,
           rolling: { d7: 37, d30: 36, d90: 36 }, trend30d: 'flat', weekly: [36, 37, 38] },
-        rhr: { primarySource: 'manual', latest: 62, latestDate: '2026-04-23',
+        rhr: { primarySource: 'manual', latest: 62, latestDate: testToday,
           baseline: 62, baselineP25: 62, baselineP75: 62,
           rolling: { d7: 62, d30: 62, d90: 62 }, trend30d: 'flat', weekly: [62] },
       },

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -203,6 +203,7 @@
     "js/pdf-import.js",
     "js/pdfjs-loader.js",
     "js/pii.js",
+    "js/profile-fatty-acid-migrations.js",
     "js/profile-marker-migrations.js",
     "js/profile-share.js",
     "js/profile.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.299';
+self.APP_VERSION = '1.10.301';


### PR DESCRIPTION
## What changed

- restore missing custom-marker metadata for snapshot-backed product fatty-acid imports
- cover Spadia, ZinZino, OmegaQuant, Metabolomix, Fatty Acids Test, and dynamic `*FA` adapter keys
- recreate definitions when a saved import is confirmed again, while retaining cleanup of unproven corrupted FA-prefixed blood markers
- register the migration in the service-worker app shell and check-JS project
- make rolling-window wearable browser fixtures use relative dates so CI does not expire over time
- bump the app cache version to `1.10.301`

## Root cause

Product-specific fatty-acid keys depend on custom-marker metadata for sidebar and dashboard discovery. When that metadata was absent, profile migration treated mixed-report keys as malformed and removed them even though the values and import snapshot still existed. Re-saving an opened snapshot also did not recreate metadata for already-matched custom keys.

## Validation

- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
- `npm test` — 399 passed
- full `./run-tests.sh` — 351/352 browser tests passed before the unrelated expired-date fixture was corrected
- corrected wearables browser fixture — 1 passed
- fatty-acid import unit tests — 149 passed
- targeted PDF import snapshot browser regression — passed
- module verification, audit checks, and `git diff --check` — passed