### PR TITLE
Align and harden marker chart timelines

### DIFF
--- a/css/category-views.css
+++ b/css/category-views.css
@@ -263,26 +263,22 @@
 .chart-values {
   display: grid;
   grid-template-columns: repeat(var(--chart-value-count, 4), minmax(0, 1fr));
-  gap: 6px;
+  column-gap: 6px;
+  row-gap: 7px;
   margin-top: 10px;
   padding-top: 10px;
   border-top: 1px solid var(--border);
   overflow: hidden;
   min-height: 54px;
 }
-.chart-values.chart-values-positioned {
-  display: block;
-  position: relative;
-}
-.chart-values.chart-values-positioned .chart-value-item {
-  position: absolute;
-  top: 10px;
-  left: var(--chart-value-x, 50%);
-  width: min(82px, 27%);
-  transform: translateX(-50%);
-}
-.chart-values.chart-values-positioned .chart-value-item.chart-value-collided {
-  visibility: hidden;
+.chart-values-label {
+  grid-column: 1 / -1;
+  color: var(--text-muted);
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  line-height: 1;
+  text-transform: uppercase;
 }
 .chart-value-item {
   min-width: 0;

--- a/css/category-views.css
+++ b/css/category-views.css
@@ -111,7 +111,7 @@
 .chart-card:hover { border-color: color-mix(in srgb, var(--accent) 72%, var(--border)); transform: translateY(-1px); box-shadow: var(--shadow-glow); }
 .chart-card-header {
   display: flex; align-items: flex-start; justify-content: space-between; margin-bottom: 10px; gap: 12px;
-  min-height: 42px;
+  min-height: 28px;
 }
 .chart-card-title-block,
 .chart-card-header > div:first-child {
@@ -131,27 +131,6 @@
   word-break: normal;
   white-space: normal;
   min-width: 0;
-}
-.chart-card-meta {
-  display: flex;
-  align-items: center;
-  flex-wrap: nowrap;
-  gap: 5px 8px;
-  overflow: hidden;
-  min-height: 18px;
-  margin-top: 3px;
-}
-.chart-card-unit {
-  flex: 0 0 auto;
-}
-.chart-card-range {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  color: var(--text-muted);
-  font-family: var(--font-mono);
-  font-size: 10.5px;
 }
 .chart-card-tips-host {
   display: inline-flex;
@@ -179,7 +158,6 @@
   font-size: 15px;
   font-weight: 700;
 }
-.chart-card-unit { font-size: 12px; color: var(--text-muted); }
 .chart-card-status {
   font-family: var(--font-mono); font-size: 11px; font-weight: 700; padding: 3px 9px; border-radius: 20px;
 }
@@ -302,15 +280,7 @@
 .chart-value-num.val-high::before { content: "\25B2 "; font-size: 0.65em; }
 .chart-value-num.val-low { color: var(--yellow); }
 .chart-value-num.val-low::before { content: "\25BC "; font-size: 0.65em; }
-.chart-ref-range {
-  margin-top: 8px;
-  color: var(--text-muted);
-  font-family: var(--font-mono);
-  font-size: 10.5px;
-  text-align: center;
-}
 .chart-value-num.val-missing { color: var(--text-muted); }
-.chart-ref-range { font-size: 11px; color: var(--text-muted); margin-top: 8px; text-align: center; }
 .chart-card-trend {
   font-size: 11px; font-weight: 600; margin-left: 8px; white-space: nowrap;
 }

--- a/css/category-views.css
+++ b/css/category-views.css
@@ -109,6 +109,17 @@
   flex-direction: column;
 }
 .chart-card:hover { border-color: color-mix(in srgb, var(--accent) 72%, var(--border)); transform: translateY(-1px); box-shadow: var(--shadow-glow); }
+.chart-card:has(> .chart-card-main:focus-visible) {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.chart-card-main {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  flex-direction: column;
+  outline: none;
+}
 .chart-card-header {
   display: flex; align-items: flex-start; justify-content: space-between; margin-bottom: 10px; gap: 12px;
   min-height: 28px;
@@ -165,6 +176,7 @@
 .status-high { background: var(--red-bg); color: var(--red); border: 1px solid color-mix(in srgb, var(--red) 20%, transparent); animation: statusPulse 0.6s ease 0.3s; }
 .status-low { background: var(--yellow-bg); color: var(--yellow); border: 1px solid color-mix(in srgb, var(--yellow) 20%, transparent); animation: statusPulse 0.6s ease 0.3s; }
 .status-missing { background: var(--bg-hover); color: var(--text-muted); }
+.status-unrated { background: var(--bg-hover); color: var(--text-muted); border: 1px solid var(--border); }
 .chart-card-status.status-normal,
 .chart-card-status.status-high,
 .chart-card-status.status-low,
@@ -174,6 +186,7 @@
 .chart-card-status.status-normal { color: var(--green); }
 .chart-card-status.status-high { color: var(--red); }
 .chart-card-status.status-low { color: var(--yellow); }
+.chart-card-status.status-unrated { color: var(--text-muted); }
 @keyframes statusPulse { 0% { transform: scale(1); } 50% { transform: scale(1.1); } 100% { transform: scale(1); } }
 .chart-card-snapshot {
   display: grid;
@@ -188,7 +201,7 @@
   background: color-mix(in srgb, var(--bg-secondary) 36%, transparent);
 }
 .chart-card-snapshot-label,
-.chart-card-snapshot-side span {
+.chart-card-range-row > span {
   display: block;
   color: var(--text-muted);
   font-family: var(--font-mono);
@@ -212,6 +225,7 @@
 .chart-card-latest-value.val-normal { color: var(--green); }
 .chart-card-latest-value.val-high { color: var(--red); }
 .chart-card-latest-value.val-low { color: var(--yellow); }
+.chart-card-latest-value.val-unrated { color: var(--text-primary); }
 .chart-card-snapshot-meta {
   display: block;
   margin-top: 4px;
@@ -226,7 +240,8 @@
   min-width: 0;
   text-align: right;
 }
-.chart-card-snapshot-side strong {
+.chart-card-range-row + .chart-card-range-row { margin-top: 5px; }
+.chart-card-range-row > strong {
   display: block;
   margin-top: 4px;
   color: var(--text-primary);
@@ -247,13 +262,27 @@
 }
 .chart-values {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(var(--chart-value-count, 4), minmax(0, 1fr));
   gap: 6px;
   margin-top: 10px;
   padding-top: 10px;
   border-top: 1px solid var(--border);
   overflow: hidden;
   min-height: 54px;
+}
+.chart-values.chart-values-positioned {
+  display: block;
+  position: relative;
+}
+.chart-values.chart-values-positioned .chart-value-item {
+  position: absolute;
+  top: 10px;
+  left: var(--chart-value-x, 50%);
+  width: min(82px, 27%);
+  transform: translateX(-50%);
+}
+.chart-values.chart-values-positioned .chart-value-item.chart-value-collided {
+  visibility: hidden;
 }
 .chart-value-item {
   min-width: 0;
@@ -281,9 +310,28 @@
 .chart-value-num.val-low { color: var(--yellow); }
 .chart-value-num.val-low::before { content: "\25BC "; font-size: 0.65em; }
 .chart-value-num.val-missing { color: var(--text-muted); }
+.chart-value-num.val-unrated { color: var(--text-secondary); }
 .chart-card-trend {
   font-size: 11px; font-weight: 600; margin-left: 8px; white-space: nowrap;
 }
+.chart-card-gap-section { margin-top: 16px; }
+.chart-card-gap-section > p { color: var(--text-secondary); font-size: 13px; margin-bottom: 8px; }
+.chart-card-gap-list { display: flex; flex-wrap: wrap; gap: 8px; }
+.chart-card-add {
+  display: inline-flex;
+  flex: 0 0 auto;
+  width: auto;
+  min-height: auto;
+  height: auto;
+  flex-direction: row;
+  align-items: center;
+  padding: 12px 16px;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+}
+.chart-card-add > span:first-child { color: var(--text-secondary); }
+.chart-card-add > span:last-child { margin-left: 6px; color: var(--text-muted); font-size: 11px; }
 
 .gb-table-shell {
   --gb-table-scroll-x: 0px;
@@ -703,6 +751,21 @@
   .alert-card { flex-wrap: wrap; padding: 10px 12px; gap: 8px; }
   .alert-ref { width: auto; text-align: left; }
   .corr-dropdown { min-width: 100%; }
+}
+
+@media (max-width: 360px) {
+  .chart-card-snapshot { grid-template-columns: minmax(0, 1fr); }
+  .chart-card-snapshot-side {
+    padding-top: 8px;
+    border-top: 1px solid var(--border);
+    text-align: left;
+  }
+  .chart-card-range-row {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 10px;
+  }
 }
 
 @media (pointer: coarse) {

--- a/css/context-profile.css
+++ b/css/context-profile.css
@@ -866,9 +866,10 @@
   font-size: 9px; font-weight: 600; letter-spacing: 0.05em; color: var(--accent);
   padding: 1px 5px; border-radius: 4px; border: 1px solid color-mix(in srgb, var(--accent) 40%, transparent);
   white-space: nowrap; flex-shrink: 0; cursor: pointer; transition: all 0.15s;
-  margin-left: 6px; vertical-align: middle;
+  margin-left: 6px; vertical-align: middle; background: transparent; font-family: inherit; line-height: inherit;
 }
 .ctx-tips-badge:hover { background: color-mix(in srgb, var(--accent) 15%, transparent); border-color: var(--accent); }
+.ctx-tips-badge:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 /* Tips modal */
 .ctx-tips-modal-header { font-size: 16px; font-weight: 600; color: var(--text-primary); margin-bottom: 16px; }
 .ctx-tip-slot { margin-bottom: 16px; padding-bottom: 16px; border-bottom: 1px solid var(--border); }

--- a/css/marker-detail-modal.css
+++ b/css/marker-detail-modal.css
@@ -125,6 +125,7 @@
 .gb-detail-status-normal { color: var(--green); border-color: color-mix(in srgb, var(--green) 45%, var(--border)); }
 .gb-detail-status-high { color: var(--red); border-color: color-mix(in srgb, var(--red) 45%, var(--border)); }
 .gb-detail-status-low { color: var(--yellow); border-color: color-mix(in srgb, var(--yellow) 45%, var(--border)); }
+.gb-detail-status-unrated { color: var(--text-muted); }
 .marker-detail-modal .marker-description,
 .marker-detail-modal .gb-detail-summary,
 .marker-detail-modal .gb-range-band,
@@ -269,6 +270,7 @@
 .marker-detail-modal .stat-card-value.val-normal { color: var(--green); }
 .marker-detail-modal .stat-card-value.val-high { color: var(--red); }
 .marker-detail-modal .stat-card-value.val-low { color: var(--yellow); }
+.marker-detail-modal .stat-card-value.val-unrated { color: var(--text-primary); }
 .marker-detail-modal .stat-card-meta {
   margin-top: 7px;
   color: var(--text-secondary);
@@ -613,7 +615,17 @@
 }
 .marker-detail-modal .stat-card-range-controls .ref-editable {
   white-space: nowrap;
+  padding: 2px 7px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  background: transparent;
+  font: inherit;
+  cursor: pointer;
 }
+.marker-detail-modal .stat-card-range-controls .ref-editable:hover { color: var(--accent); border-color: var(--accent); }
+.marker-detail-modal .stat-card-range-controls .ref-editable-optimal { color: var(--green); }
+.marker-detail-modal .gb-detail-section-label > span { margin-left: 5px; color: var(--text-muted); font-size: 10px; font-weight: 500; }
 .marker-detail-modal .marker-history-list {
   grid-template-columns: 1fr;
   gap: 8px;

--- a/js/category-page-view.js
+++ b/js/category-page-view.js
@@ -7,6 +7,7 @@ import {
   getActiveData,
   filterDatesByRange,
   destroyAllCharts,
+  dataActionAttrs,
   renderDateRangeFilter,
   renderChartLayersDropdown,
 } from './data.js';
@@ -98,7 +99,46 @@ export function installCategoryPageActionDelegates(root = typeof document !== 'u
 
 if (typeof document !== 'undefined') installCategoryPageActionDelegates();
 
-function markerHasData(m) { return m.values?.some(v => v !== null) ?? false; }
+function markerHasData(m) { return m.values?.some(v => v !== null && v !== undefined) ?? false; }
+
+function selectedRangeLabel() {
+  return state.dateRangeFilter === '3m' ? 'the last 3 months'
+    : state.dateRangeFilter === '6m' ? 'the last 6 months'
+    : state.dateRangeFilter === '1y' ? 'the last year'
+    : 'all time';
+}
+
+function renderNoResultsInRange(cat, categoryKey) {
+  return `<div class="empty-state"><div class="empty-state-icon empty-state-icon-category">${renderCategoryGlyph(categoryKey, cat.label, { large: true })}</div>
+    <h3>No results in ${escapeHTML(selectedRangeLabel())}</h3>
+    <p>This category has older results. Choose a longer range or show the complete history.</p>
+    <button type="button" class="range-btn" ${dataActionAttrs('set-date-range', { range: 'all' })}>Show all results</button></div>`;
+}
+
+function renderMarkerDataGapSections(allEntries, rawCat, categoryKey) {
+  const withoutVisibleData = allEntries.filter(([, marker]) => !markerHasData(marker));
+  if (!withoutVisibleData.length) return '';
+  const outsideRange = [];
+  const neverRecorded = [];
+  for (const entry of withoutVisibleData) {
+    const [key] = entry;
+    if (state.dateRangeFilter !== 'all' && markerHasData(rawCat?.markers?.[key])) outsideRange.push(entry);
+    else neverRecorded.push(entry);
+  }
+  const renderSection = (entries, heading, suffix) => {
+    if (!entries.length) return '';
+    let html = `<div class="chart-card-gap-section"><p>${escapeHTML(heading)}</p><div class="chart-card-gap-list">`;
+    for (const [key, marker] of entries) {
+      if (!safeMarkerId(key)) continue;
+      const id = categoryKey + '_' + key;
+      html += `<button type="button" class="chart-card chart-card-add" aria-label="Open ${escapeAttr(marker.name)} details" ${markerDetailActionAttrs('show-detail-modal', { id })}>
+        <span>${escapeHTML(marker.name)}</span><span>${escapeHTML(suffix)}</span></button>`;
+    }
+    return html + `</div></div>`;
+  };
+  return renderSection(outsideRange, `Results outside ${selectedRangeLabel()}`, 'view history')
+    + renderSection(neverRecorded, 'No data yet', '+ add value');
+}
 
 function sortCategoryChartEntries(entries, categoryKey) {
   const preserved = state._preserveCategoryCardOrder;
@@ -114,16 +154,16 @@ function sortCategoryChartEntries(entries, categoryKey) {
   // by status (out-of-range before normal).
   const catalogSlots = getCategoryPageCatalogSlots();
   const hasSlot = (k) => catalogSlots?.[categoryKey + '.' + k] ? 0 : 1;
-  const statusOrder = { high: 0, low: 0, normal: 1, missing: 2 };
+  const statusOrder = { high: 0, low: 0, normal: 1, unrated: 2, missing: 3 };
   entries.sort(([ka, a], [kb, b]) => {
     const slotDiff = hasSlot(ka) - hasSlot(kb);
     if (slotDiff !== 0) return slotDiff;
     const ai = getLatestValueIndex(a.values), bi = getLatestValueIndex(b.values);
     const ar = ai !== -1 ? getEffectiveRangeForDate(a, ai) : { min: null, max: null };
     const br = bi !== -1 ? getEffectiveRangeForDate(b, bi) : { min: null, max: null };
-    const as = ai !== -1 ? getStatus(a.values[ai], ar.min, ar.max) : 'missing';
-    const bs = bi !== -1 ? getStatus(b.values[bi], br.min, br.max) : 'missing';
-    return (statusOrder[as] ?? 2) - (statusOrder[bs] ?? 2);
+    const as = ai === -1 ? 'missing' : (ar.min == null && ar.max == null) ? 'unrated' : getStatus(a.values[ai], ar.min, ar.max);
+    const bs = bi === -1 ? 'missing' : (br.min == null && br.max == null) ? 'unrated' : getStatus(b.values[bi], br.min, br.max);
+    return (statusOrder[as] ?? 3) - (statusOrder[bs] ?? 3);
   });
 }
 
@@ -135,12 +175,16 @@ export function showCategory(categoryKey, preData) {
   // Ensure catalog is preloaded for sorting and rec links
   primeCategoryPageCatalogCache();
   const rawData = preData || getActiveData();
-  const data = filterDatesByRange(rawData);
+  const data = filterDatesByRange(rawData, { fallbackToAll: false });
   const cat = data.categories[categoryKey];
+  const rawCat = rawData.categories[categoryKey];
   const main = document.getElementById("main-content");
   const allEntries = Object.entries(cat.markers).filter(([, m]) => !m.hidden);
   const withData = allEntries.filter(([, m]) => markerHasData(m));
-  const countLabel = withData.length < allEntries.length ? `${withData.length} of ${allEntries.length} biomarkers with data` : `${allEntries.length} biomarkers tracked`;
+  const rawWithData = Object.values(rawCat?.markers || {}).filter(markerHasData).length;
+  const countLabel = state.dateRangeFilter !== 'all'
+    ? `${withData.length} of ${allEntries.length} biomarkers with results in ${selectedRangeLabel()}`
+    : withData.length < allEntries.length ? `${withData.length} of ${allEntries.length} biomarkers with data` : `${allEntries.length} biomarkers tracked`;
   const renameBtn = ` <span class="ref-edited-badge" role="button" tabindex="0" aria-label="Rename category" title="Rename category" ${categoryPageActionAttrs('rename-category', { category: categoryKey })} style="cursor:pointer;font-size:12px">rename</span>`;
   let html = `<div class="category-header"><h2>${renderCategoryGlyph(categoryKey, cat.label)}<span class="category-title-text">${escapeHTML(cat.label)}</span>${renameBtn}</h2>
     <p>${countLabel}</p></div>`;
@@ -156,8 +200,10 @@ export function showCategory(categoryKey, preData) {
 
   html += `<div id="view-content">`;
   if (withData.length === 0) {
-    html += `<div class="empty-state"><div class="empty-state-icon empty-state-icon-category">${renderCategoryGlyph(categoryKey, cat.label, { large: true })}</div>
-      <h3>No Data Available</h3><p>Import lab results containing ${escapeHTML(cat.label.toLowerCase())} markers to see data here.</p></div>`;
+    html += state.dateRangeFilter !== 'all' && rawWithData > 0
+      ? renderNoResultsInRange(cat, categoryKey)
+      : `<div class="empty-state"><div class="empty-state-icon empty-state-icon-category">${renderCategoryGlyph(categoryKey, cat.label, { large: true })}</div>
+        <h3>No Data Available</h3><p>Import lab results containing ${escapeHTML(cat.label.toLowerCase())} markers to see data here.</p></div>`;
   } else if (cat.singleDate) {
     html += renderFattyAcidsView(cat, categoryKey);
   } else {
@@ -167,22 +213,10 @@ export function showCategory(categoryKey, preData) {
       // Skip legacy customMarkers with unsafe keys — they can't be safely
       // embedded in inline-onclick handlers.
       if (!safeMarkerId(key)) continue;
-      html += renderChartCard(categoryKey + "_" + key, marker, data.dateLabels);
+      html += renderChartCard(categoryKey + "_" + key, marker, data.dateLabels, data.dates);
     }
     html += `</div>`;
-    // Show empty markers (no data yet) as clickable cards
-    const noData = allEntries.filter(([, m]) => !markerHasData(m));
-    if (noData.length > 0) {
-      html += `<div style="margin-top:16px"><p style="color:var(--text-secondary);font-size:13px;margin-bottom:8px">No data yet</p><div style="display:flex;flex-wrap:wrap;gap:8px">`;
-      for (const [key, marker] of noData) {
-        if (!safeMarkerId(key)) continue;
-        const id = categoryKey + '_' + key;
-        html += `<div class="chart-card" role="button" tabindex="0" aria-label="Add value for ${escapeHTML(marker.name)}" ${markerDetailActionAttrs('show-detail-modal', { id })} style="cursor:pointer;padding:12px 16px;min-height:auto;flex:0 0 auto">
-          <span style="color:var(--text-secondary)">${escapeHTML(marker.name)}</span>
-          <span style="color:var(--text-muted);font-size:11px;margin-left:6px">+ add value</span></div>`;
-      }
-      html += `</div></div>`;
-    }
+    html += renderMarkerDataGapSections(allEntries, rawCat, categoryKey);
   }
   html += `</div>`;
   main.innerHTML = html;
@@ -201,7 +235,7 @@ export function showCategory(categoryKey, preData) {
       createLineChart(categoryKey + "_" + key, marker, data.dateLabels, data.dates, data.phaseLabels);
     }
   }
-  loadChartCardRecs();
+  void loadChartCardRecs();
 }
 
 export function switchView(view, categoryKey, btn) {
@@ -220,8 +254,9 @@ export function switchView(view, categoryKey, btn) {
   btn.setAttribute('tabindex', '0');
   destroyAllCharts();
   const rawData = getActiveData();
-  const data = filterDatesByRange(rawData);
+  const data = filterDatesByRange(rawData, { fallbackToAll: false });
   const cat = data.categories[categoryKey];
+  const rawCat = rawData.categories[categoryKey];
   const container = document.getElementById("view-content");
   // Pre-sanitize date labels at the call boundary — CodeQL's taint analysis
   // (js/xss-through-dom) doesn't trace sanitizers across function calls, so
@@ -230,6 +265,12 @@ export function switchView(view, categoryKey, btn) {
   // because renderers treat them as values and escape at the attribute/text
   // boundary where needed.
   const safeLabels = Array.isArray(data.dateLabels) ? data.dateLabels.map(escapeHTML) : data.dateLabels;
+  const categoryHasVisibleData = Object.values(cat.markers || {}).some(markerHasData);
+  const categoryHasHistoricalData = Object.values(rawCat?.markers || {}).some(markerHasData);
+  if (state.dateRangeFilter !== 'all' && !categoryHasVisibleData && categoryHasHistoricalData) {
+    container.innerHTML = renderNoResultsInRange(cat, categoryKey);
+    return;
+  }
   if (view === "table") {
     container.innerHTML = renderTableView(cat, safeLabels, categoryKey, data.dates);
   } else if (view === "heatmap") {
@@ -242,15 +283,25 @@ export function switchView(view, categoryKey, btn) {
       // Per-key safety check skips legacy customMarkers with unsafe keys so
       // they never reach inline-onclick handlers in renderChartCard.
       const withData = Object.entries(cat.markers).filter(([key, m]) => markerHasData(m) && safeMarkerId(key));
+      if (withData.length === 0) {
+        container.innerHTML = state.dateRangeFilter !== 'all' && categoryHasHistoricalData
+          ? renderNoResultsInRange(cat, categoryKey)
+          : `<div class="empty-state"><h3>No Data Available</h3><p>Import lab results to see marker charts here.</p></div>`;
+        return;
+      }
+      sortCategoryChartEntries(withData, categoryKey);
       let html = `<div class="charts-grid">`;
       for (const [key, marker] of withData) {
-        html += renderChartCard(categoryKey + "_" + key, marker, data.dateLabels);
+        html += renderChartCard(categoryKey + "_" + key, marker, data.dateLabels, data.dates);
       }
       html += `</div>`;
+      const allEntries = Object.entries(cat.markers).filter(([, marker]) => !marker.hidden);
+      html += renderMarkerDataGapSections(allEntries, rawCat, categoryKey);
       container.innerHTML = html;
       for (const [key, marker] of withData) {
         createLineChart(categoryKey + "_" + key, marker, data.dateLabels, data.dates, data.phaseLabels);
       }
+      void loadChartCardRecs();
     }
   }
 }

--- a/js/category-view-renderers.js
+++ b/js/category-view-renderers.js
@@ -4,7 +4,7 @@
 import { state } from './state.js';
 import { escapeHTML, escapeAttr, getStatus, formatValue, getTrend, safeMarkerId } from './utils.js';
 import { getChartColors } from './theme.js';
-import { ensureChartJs } from './charts.js';
+import { ensureChartJs, formatChartTickValue } from './charts.js';
 import { createChartRuntime, hasChartRuntime } from './charts-runtime.js';
 import { getEffectiveRange, getEffectiveRangeForDate, getLatestValueIndex, statusIcon } from './marker-analysis.js';
 import { markerDetailActionAttrs } from './marker-detail-actions.js';
@@ -85,9 +85,13 @@ export function renderChartCard(id, marker, dateLabels) {
   const fmtRange = (min, max) => `${min != null ? formatValue(min) : '–'} – ${max != null ? formatValue(max) : '–'}`;
   const effectiveRange = getEffectiveRange(marker);
   const rangeLabel = state.rangeMode === 'optimal' && (marker.optimalMin != null || marker.optimalMax != null) ? 'Optimal' : 'Reference';
-  const rangeSummary = effectiveRange.min != null || effectiveRange.max != null
-    ? `${rangeLabel}: ${fmtRange(effectiveRange.min, effectiveRange.max)}`
-    : 'No range set';
+  const showBothRanges = state.rangeMode === 'both'
+    && (marker.optimalMin != null || marker.optimalMax != null)
+    && (marker.refMin != null || marker.refMax != null);
+  const snapshotRangeLabel = showBothRanges ? 'Reference / Optimal' : rangeLabel;
+  const snapshotRangeValue = showBothRanges
+    ? `${escapeHTML(fmtRange(marker.refMin, marker.refMax))}<br>${escapeHTML(fmtRange(marker.optimalMin, marker.optimalMax))}`
+    : escapeHTML(fmtRange(effectiveRange.min, effectiveRange.max));
   const latestDateLabel = latestIdx !== -1 ? (labels[latestIdx] || 'Latest') : 'No value';
   const latestDisplay = latestVal !== null ? formatValue(latestVal) : '—';
   const latestUnit = marker.unit || '';
@@ -102,10 +106,6 @@ export function renderChartCard(id, marker, dateLabels) {
           <span class="chart-card-title-text">${escapeHTML(markerName)}</span>
           <span class="chart-card-tips-host" id="chart-rec-${id}"></span>
         </div>
-        <div class="chart-card-meta">
-          <span class="chart-card-unit">${escapeHTML(latestUnit || 'unitless')}</span>
-          <span class="chart-card-range">${escapeHTML(rangeSummary)}${latestUnit ? ` ${escapeHTML(latestUnit)}` : ''}</span>
-        </div>
       </div>
       <div class="chart-card-state"><span class="chart-card-status status-${status}">${sIcon ? sIcon + ' ' : ''}${statusLabel}</span>${trendBadge}</div>
     </div>
@@ -116,22 +116,17 @@ export function renderChartCard(id, marker, dateLabels) {
         <span class="chart-card-snapshot-meta">${escapeHTML(latestMeta)}</span>
       </div>
       <div class="chart-card-snapshot-side">
-        <span>${escapeHTML(rangeLabel)}</span>
-        <strong>${escapeHTML(fmtRange(effectiveRange.min, effectiveRange.max))}</strong>
+        <span>${snapshotRangeLabel}</span>
+        <strong>${snapshotRangeValue}</strong>
       </div>
     </div>
     <div class="chart-container"><canvas id="chart-${id}"></canvas></div>
     <div class="chart-values">`;
-  // Trim leading/trailing nulls to match chart trimming, then show the most
-  // recent points only so category cards stay scannable.
-  let valStart = 0, valEnd = marker.values.length - 1;
-  if (!marker.singlePoint && marker.values.length > 1) {
-    valStart = marker.values.findIndex(v => v !== null);
-    if (valStart < 0) valStart = 0;
-    while (valEnd > valStart && marker.values[valEnd] === null) valEnd--;
-  }
+  // Show only actual observations so missing dates do not consume summary slots.
   const visibleValueIndexes = [];
-  for (let i = valStart; i <= valEnd; i++) visibleValueIndexes.push(i);
+  for (let i = 0; i < marker.values.length; i++) {
+    if (marker.values[i] !== null) visibleValueIndexes.push(i);
+  }
   const compactValueIndexes = visibleValueIndexes.length > 4 ? visibleValueIndexes.slice(-4) : visibleValueIndexes;
   for (const i of compactValueIndexes) {
     const v = marker.values[i];
@@ -140,15 +135,7 @@ export function renderChartCard(id, marker, dateLabels) {
     html += `<div class="chart-value-item"><div class="chart-value-date">${labels[i] || ''}</div>
       <div class="chart-value-num val-${s}">${v !== null ? formatValue(v) : "—"}</div></div>`;
   }
-  let rangeHtml = '';
-  if (state.rangeMode === 'both' && (marker.optimalMin != null || marker.optimalMax != null) && (marker.refMin != null || marker.refMax != null)) {
-    rangeHtml = `<div class="chart-ref-range">Ref: ${fmtRange(marker.refMin, marker.refMax)} · <span style="color:var(--green)">Optimal: ${fmtRange(marker.optimalMin, marker.optimalMax)}</span> ${escapeHTML(marker.unit)}</div>`;
-  } else {
-    const r = getEffectiveRange(marker);
-    const rangeLabel = state.rangeMode === 'optimal' && (marker.optimalMin != null || marker.optimalMax != null) ? 'Optimal' : 'Reference';
-    rangeHtml = r.min != null || r.max != null ? `<div class="chart-ref-range">${rangeLabel}: ${fmtRange(r.min, r.max)} ${escapeHTML(marker.unit)}</div>` : '';
-  }
-  html += `</div>${rangeHtml}</div>`;
+  html += `</div></div>`;
   return html;
 }
 
@@ -323,7 +310,7 @@ export function renderFattyAcidsCharts(cat) {
     ]},
     options: { responsive:true, maintainAspectRatio:false,
       plugins: { legend:{display:false}, tooltip:{ backgroundColor:tc.tooltipBg, titleColor:tc.tooltipTitle, bodyColor:tc.tooltipBody, borderColor:tc.tooltipBorder, borderWidth:1 }},
-      scales: { x:{ticks:{color:tc.tickColor,font:{size:10},maxRotation:45},grid:{display:false}}, y:{ticks:{color:tc.tickColor},grid:{color:tc.gridColor}} }
+      scales: { x:{ticks:{color:tc.tickColor,font:{size:10},maxRotation:45},grid:{display:false}}, y:{ticks:{color:tc.tickColor,callback:formatChartTickValue},grid:{color:tc.gridColor}} }
     }
   });
   if (chart) state.chartInstances["fa-bar"] = chart;

--- a/js/category-view-renderers.js
+++ b/js/category-view-renderers.js
@@ -184,14 +184,15 @@ export function renderChartCard(id, marker, dateLabels, chartDates = []) {
       </div>
     </div>
     <div class="chart-container"><canvas id="chart-${id}" aria-hidden="true"></canvas></div>
-    <div class="chart-values" style="--chart-value-count:${Math.max(1, compactValueIndexes.length)}">`;
+    <div class="chart-values" role="list" aria-label="Recent results" style="--chart-value-count:${Math.max(1, compactValueIndexes.length)}">
+      <span class="chart-values-label" aria-hidden="true">Recent results</span>`;
   for (const i of compactValueIndexes) {
     const v = marker.values[i];
     const ri = getEffectiveRangeForDate(marker, i);
     const s = markerValueStatus(v, ri);
     const itemDateLabel = displayDateLabel(i, false);
     const fullDateLabel = exactObservationLabel(chartDates[i], labels[i] || '', true);
-    html += `<div class="chart-value-item" data-chart-value-index="${i}"><div class="chart-value-date" title="${escapeAttr(fullDateLabel)}">${escapeHTML(itemDateLabel)}</div>
+    html += `<div class="chart-value-item" role="listitem"><div class="chart-value-date" title="${escapeAttr(fullDateLabel)}">${escapeHTML(itemDateLabel)}</div>
       <div class="chart-value-num val-${s}">${v !== null ? formatValue(v) : "—"}</div></div>`;
   }
   html += `</div></div></div>`;

--- a/js/category-view-renderers.js
+++ b/js/category-view-renderers.js
@@ -65,7 +65,33 @@ function renderSemanticRangeRail(value, minValue, maxValue, status, style = '') 
   </div>`;
 }
 
-export function renderChartCard(id, marker, dateLabels) {
+function hasRangeBounds(range) {
+  return range?.min != null || range?.max != null;
+}
+
+function markerValueStatus(value, range) {
+  if (value === null || value === undefined) return 'missing';
+  return hasRangeBounds(range) ? getStatus(value, range.min, range.max) : 'unrated';
+}
+
+function formatPhaseRangeLabel(phaseLabel) {
+  if (!phaseLabel) return 'Phase range';
+  const readable = String(phaseLabel).replace(/[_-]+/g, ' ');
+  return `${readable.charAt(0).toUpperCase()}${readable.slice(1)} range`;
+}
+
+function exactObservationLabel(isoDate, fallback, includeYear = true) {
+  if (typeof isoDate !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(isoDate)) return fallback;
+  const date = new Date(`${isoDate}T00:00:00`);
+  if (Number.isNaN(date.getTime())) return fallback;
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    ...(includeYear ? { year: 'numeric' } : {}),
+  });
+}
+
+export function renderChartCard(id, marker, dateLabels, chartDates = []) {
   // id is interpolated into delegated data attributes and DOM ids below.
   // Single chokepoint guard for every caller (dashboard, showCategory,
   // switchView).
@@ -74,32 +100,69 @@ export function renderChartCard(id, marker, dateLabels) {
   const latestIdx = getLatestValueIndex(marker.values);
   const latestVal = latestIdx !== -1 ? marker.values[latestIdx] : null;
   const lr = getEffectiveRangeForDate(marker, latestIdx);
-  const status = latestVal !== null ? getStatus(latestVal, lr.min, lr.max) : "missing";
-  const statusLabel = status === "normal" ? "Normal" : status === "high" ? "High" : status === "low" ? "Low" : "N/A";
+  const status = markerValueStatus(latestVal, lr);
+  const statusLabel = status === "normal" ? "Normal" : status === "high" ? "High" : status === "low" ? "Low" : status === 'unrated' ? 'No range' : "N/A";
   const sIcon = statusIcon(status);
 
   const trend = getTrend(marker.values, lr.min, lr.max);
-  const trendBadge = trend.cls !== 'trend-stable' || trend.arrow !== '—' ? `<span class="chart-card-trend ${trend.cls}">${trend.arrow}</span>` : '';
+  const trendBadge = trend.arrow !== '—'
+    ? `<span class="chart-card-trend ${trend.cls}" aria-label="${escapeAttr(trend.label)}" title="${escapeAttr(trend.label)}">${escapeHTML(trend.arrow)}</span>`
+    : '';
   const markerName = marker.name || '';
   const labels = marker.singlePoint ? [marker.singleDateLabel || "N/A"] : dateLabels;
   const fmtRange = (min, max) => `${min != null ? formatValue(min) : '–'} – ${max != null ? formatValue(max) : '–'}`;
   const effectiveRange = getEffectiveRange(marker);
-  const rangeLabel = state.rangeMode === 'optimal' && (marker.optimalMin != null || marker.optimalMax != null) ? 'Optimal' : 'Reference';
-  const showBothRanges = state.rangeMode === 'both'
-    && (marker.optimalMin != null || marker.optimalMax != null)
-    && (marker.refMin != null || marker.refMax != null);
-  const snapshotRangeLabel = showBothRanges ? 'Reference / Optimal' : rangeLabel;
-  const snapshotRangeValue = showBothRanges
-    ? `${escapeHTML(fmtRange(marker.refMin, marker.refMax))}<br>${escapeHTML(fmtRange(marker.optimalMin, marker.optimalMax))}`
-    : escapeHTML(fmtRange(effectiveRange.min, effectiveRange.max));
-  const latestDateLabel = latestIdx !== -1 ? (labels[latestIdx] || 'Latest') : 'No value';
+  const latestPhaseRange = latestIdx !== -1 ? marker.phaseRefRanges?.[latestIdx] : null;
+  const rangeRows = [];
+  if (hasRangeBounds(latestPhaseRange)) {
+    rangeRows.push({
+      label: formatPhaseRangeLabel(marker.phaseLabels?.[latestIdx]),
+      value: fmtRange(lr.min, lr.max),
+    });
+  } else if (state.rangeMode === 'both') {
+    if (marker.refMin != null || marker.refMax != null) {
+      rangeRows.push({ label: 'Reference', value: fmtRange(marker.refMin, marker.refMax) });
+    }
+    if (marker.optimalMin != null || marker.optimalMax != null) {
+      rangeRows.push({ label: 'Optimal', value: fmtRange(marker.optimalMin, marker.optimalMax) });
+    }
+  } else if (hasRangeBounds(effectiveRange)) {
+    const rangeLabel = state.rangeMode === 'optimal' && (marker.optimalMin != null || marker.optimalMax != null) ? 'Optimal' : 'Reference';
+    rangeRows.push({ label: rangeLabel, value: fmtRange(effectiveRange.min, effectiveRange.max) });
+  }
+  if (rangeRows.length === 0) rangeRows.push({ label: 'Range', value: 'Not set' });
+
+  // Show only actual observations so missing dates do not consume summary slots.
+  const visibleValueIndexes = [];
+  for (let i = 0; i < marker.values.length; i++) {
+    if (marker.values[i] !== null && marker.values[i] !== undefined) visibleValueIndexes.push(i);
+  }
+  const compactValueIndexes = visibleValueIndexes.length > 4 ? visibleValueIndexes.slice(-4) : visibleValueIndexes;
+  const labelCounts = new Map();
+  for (const i of visibleValueIndexes) {
+    const label = labels[i] || '';
+    labelCounts.set(label, (labelCounts.get(label) || 0) + 1);
+  }
+  const displayDateLabel = (index, includeYear) => {
+    const fallback = labels[index] || '';
+    return labelCounts.get(fallback) > 1
+      ? exactObservationLabel(chartDates[index], fallback, includeYear)
+      : fallback;
+  };
+
+  const latestDateLabel = latestIdx !== -1 ? (displayDateLabel(latestIdx, true) || 'Latest') : 'No value';
   const latestDisplay = latestVal !== null ? formatValue(latestVal) : '—';
   const latestUnit = marker.unit || '';
   const latestMeta = latestVal !== null
     ? `${latestDateLabel}${latestUnit ? ' · ' + latestUnit : ''}`
     : 'Add a value to start the trend';
+  const rangeAria = rangeRows.map(row => `${row.label} ${row.value}`).join('; ');
+  const cardLabel = latestVal !== null
+    ? `${markerName}. ${statusLabel}. Latest ${latestDisplay}${latestUnit ? ` ${latestUnit}` : ''}, ${latestDateLabel}. ${rangeAria}.${trendBadge ? ` ${trend.label}.` : ''}`
+    : `${markerName}. No values. ${rangeAria}.`;
+  const detailAttrs = markerDetailActionAttrs('show-detail-modal', { id });
 
-  let html = `<div class="chart-card chart-card-${status}" role="button" tabindex="0" aria-label="${escapeAttr(markerName + ' - ' + statusLabel)}" ${markerDetailActionAttrs('show-detail-modal', { id })}>
+  let html = `<div class="chart-card chart-card-${status}" ${detailAttrs}>
     <div class="chart-card-header">
       <div class="chart-card-title-block">
         <div class="chart-card-title" title="${escapeAttr(markerName)}">
@@ -109,33 +172,29 @@ export function renderChartCard(id, marker, dateLabels) {
       </div>
       <div class="chart-card-state"><span class="chart-card-status status-${status}">${sIcon ? sIcon + ' ' : ''}${statusLabel}</span>${trendBadge}</div>
     </div>
+    <div class="chart-card-main" role="button" tabindex="0" aria-label="${escapeAttr(cardLabel)}" ${detailAttrs}>
     <div class="chart-card-snapshot">
       <div>
         <span class="chart-card-snapshot-label">Latest</span>
         <strong class="chart-card-latest-value val-${status}">${escapeHTML(latestDisplay)}</strong>
         <span class="chart-card-snapshot-meta">${escapeHTML(latestMeta)}</span>
       </div>
-      <div class="chart-card-snapshot-side">
-        <span>${snapshotRangeLabel}</span>
-        <strong>${snapshotRangeValue}</strong>
+      <div class="chart-card-snapshot-side" aria-label="${escapeAttr(rangeAria)}">
+        ${rangeRows.map(row => `<div class="chart-card-range-row"><span>${escapeHTML(row.label)}</span><strong>${escapeHTML(row.value)}</strong></div>`).join('')}
       </div>
     </div>
-    <div class="chart-container"><canvas id="chart-${id}"></canvas></div>
-    <div class="chart-values">`;
-  // Show only actual observations so missing dates do not consume summary slots.
-  const visibleValueIndexes = [];
-  for (let i = 0; i < marker.values.length; i++) {
-    if (marker.values[i] !== null) visibleValueIndexes.push(i);
-  }
-  const compactValueIndexes = visibleValueIndexes.length > 4 ? visibleValueIndexes.slice(-4) : visibleValueIndexes;
+    <div class="chart-container"><canvas id="chart-${id}" aria-hidden="true"></canvas></div>
+    <div class="chart-values" style="--chart-value-count:${Math.max(1, compactValueIndexes.length)}">`;
   for (const i of compactValueIndexes) {
     const v = marker.values[i];
     const ri = getEffectiveRangeForDate(marker, i);
-    const s = v !== null ? getStatus(v, ri.min, ri.max) : "missing";
-    html += `<div class="chart-value-item"><div class="chart-value-date">${labels[i] || ''}</div>
+    const s = markerValueStatus(v, ri);
+    const itemDateLabel = displayDateLabel(i, false);
+    const fullDateLabel = exactObservationLabel(chartDates[i], labels[i] || '', true);
+    html += `<div class="chart-value-item" data-chart-value-index="${i}"><div class="chart-value-date" title="${escapeAttr(fullDateLabel)}">${escapeHTML(itemDateLabel)}</div>
       <div class="chart-value-num val-${s}">${v !== null ? formatValue(v) : "—"}</div></div>`;
   }
-  html += `</div></div>`;
+  html += `</div></div></div>`;
   return html;
 }
 

--- a/js/changelog.js
+++ b/js/changelog.js
@@ -11,6 +11,14 @@ const changelogDelegateRoots = new WeakSet();
 
 const CHANGELOG = [
   {
+    version: '1.10.305', date: '2026-07-20', title: 'Clearer lab trends at a glance',
+    items: [
+      '<b>A consistent timeline across lab charts.</b> Your selected timeframe sets the start and end for every marker, making trends easy to compare.',
+      '<b>Recent results in one place.</b> Each marker card highlights the latest reading and up to four recent measurements.',
+      '<b>Clear marker context.</b> Status, ranges, and trends are presented consistently across cards, dashboards, and marker details.',
+    ]
+  },
+  {
     version: '1.10.185', date: '2026-07-14', title: 'Biology Scores stay unlocked',
     items: [
       '<b>Biology Scores no longer relock after app or health-context updates.</b> Once you complete the context check, scores stay visible and changed context appears as a refresh recommendation.',

--- a/js/chart-card-recs.js
+++ b/js/chart-card-recs.js
@@ -17,10 +17,12 @@ export async function loadChartCardRecs() {
     const slotKey = id.replace('_', '.');
     const slot = catalog.slots[slotKey];
     if (!slot) continue;
-    const badge = document.createElement('span');
+    const badge = document.createElement('button');
+    badge.type = 'button';
     badge.className = 'ctx-tips-badge';
     badge.textContent = 'Tips';
     badge.title = 'What can help';
+    badge.setAttribute('aria-label', `Open actionable tips for ${id.replaceAll('_', ' ')}`);
     badge.onclick = e => {
       e.stopPropagation();
       showDetailModal(id, { scrollToRec: true });

--- a/js/charts.js
+++ b/js/charts.js
@@ -5,6 +5,7 @@ import { state } from './state.js';
 import { getStatus, formatValue, loadScriptOnce } from './utils.js';
 import { getChartColors } from './theme.js';
 import { getEffectiveRange, getEffectiveRangeForDate, getPhaseRefEnvelope } from './marker-analysis.js';
+import { getLabDateRangeBounds } from './lab-date-range.js';
 import {
   createChartRuntime,
   getChartConstructorRuntime,
@@ -19,6 +20,17 @@ const CHART_DATE_ADAPTER_SRC = '/vendor/chartjs-adapter-native.js';
 
 let _chartJsLoad = null;
 let _chartDateAdapterLoad = null;
+
+/**
+ * Keep Chart.js floating-point tick artifacts out of user-facing labels.
+ * @param {unknown} value
+ * @returns {string}
+ */
+export function formatChartTickValue(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return String(value ?? '');
+  return String(Number(numeric.toPrecision(12)));
+}
 
 export function isChartDateAdapterReady() {
   return isChartDateAdapterReadyRuntime();
@@ -481,7 +493,16 @@ export function createLineChart(id, marker, dateLabels, chartDates, phaseLabels)
   let values = marker.values;
   let valid = values.filter(v => v !== null);
   if (valid.length === 0) return;
-  const useTimeScale = !marker.singlePoint && valid.length > 1;
+  const timelineBounds = marker.singlePoint
+    ? null
+    : getLabDateRangeBounds(chartDates, state.dateRangeFilter);
+  const useTimeScale = !!timelineBounds;
+  if (useTimeScale && !isChartDateAdapterReady()) {
+    ensureChartJs().then(() => {
+      if (document.getElementById("chart-" + id)) createLineChart(id, marker, dateLabels, chartDates, phaseLabels);
+    }).catch(() => {});
+    return;
+  }
   // Trim leading/trailing nulls for category scale (time scale handles gaps proportionally)
   let trimOffset = 0;
   if (!useTimeScale && !marker.singlePoint && values.length > 1) {
@@ -494,19 +515,6 @@ export function createLineChart(id, marker, dateLabels, chartDates, phaseLabels)
       dates = dates.slice(first, last + 1);
       if (chartDates) chartDates = chartDates.slice(first, last + 1);
       if (phaseLabels) phaseLabels = phaseLabels.slice(first, last + 1);
-    }
-  }
-
-  // Extend chart to today so supplements/notes after last lab date are visible (skip if <30 days)
-  if (!marker.singlePoint && chartDates && chartDates.length > 0) {
-    const today = new Date().toISOString().slice(0, 10);
-    const lastDate = chartDates[chartDates.length - 1];
-    const daysSince = Math.round((new Date(today).getTime() - new Date(lastDate + 'T00:00:00').getTime()) / 86400000);
-    if (daysSince >= 30) {
-      chartDates = [...chartDates, today];
-      dates = [...dates, 'Today'];
-      values = [...values, null];
-      if (phaseLabels) phaseLabels = [...phaseLabels, null];
     }
   }
 
@@ -542,8 +550,9 @@ export function createLineChart(id, marker, dateLabels, chartDates, phaseLabels)
     ptStatuses.push(s);
   }
   const rawDates = chartDates || [];
-  const chartNotes = marker.singlePoint ? [] : getNotesForChart(rawDates);
-  const chartSupps = marker.singlePoint ? [] : getSupplementsForChart(rawDates);
+  const visibleRangeDates = timelineBounds ? [timelineBounds.min, timelineBounds.max] : rawDates;
+  const chartNotes = marker.singlePoint ? [] : getNotesForChart(visibleRangeDates);
+  const chartSupps = marker.singlePoint ? [] : getSupplementsForChart(visibleRangeDates);
   const datasets = /** @type {Array<Record<string, any>>} */ ([{
     data: values, borderColor: tc.lineColor, backgroundColor: tc.lineFill,
     borderWidth: 2.5, pointBackgroundColor: ptColors, pointBorderColor: ptColors,
@@ -561,6 +570,9 @@ export function createLineChart(id, marker, dateLabels, chartDates, phaseLabels)
   const chartLabels = useTimeScale ? rawDates : dates;
   const xScale = useTimeScale
     ? { type: 'time',
+        display: false,
+        min: timelineBounds.min,
+        max: timelineBounds.max,
         time: { tooltipFormat: 'MMM d, yyyy', displayFormats: { day: 'MMM d, yyyy', month: 'MMM yyyy', year: 'yyyy' } },
         // `source: 'labels'` forces a tick at every datapoint, which
         // collides at "Dec 2025 / Jan 2026" zoom levels — adjacent
@@ -571,7 +583,7 @@ export function createLineChart(id, marker, dateLabels, chartDates, phaseLabels)
         // and the day-precision is still in the tooltip on hover.
         ticks: { color: tc.tickColor, font: { size: 11 }, maxTicksLimit: 6, autoSkip: true, maxRotation: 0 },
         grid: { display: false } }
-    : { ticks: { color: tc.tickColor, font: { size: 11 }, maxRotation: 0, autoSkip: true }, grid: { display: false } };
+    : { display: false, ticks: { color: tc.tickColor, font: { size: 11 }, maxRotation: 0, autoSkip: true }, grid: { display: false } };
   state.chartInstances[id] = createChartRuntime(/** @type {HTMLCanvasElement} */ (canvas), {
     type: "line",
     data: { labels: chartLabels, datasets },
@@ -581,12 +593,12 @@ export function createLineChart(id, marker, dateLabels, chartDates, phaseLabels)
           callbacks:{ label:(c)=>`${c.dataset.label ? c.dataset.label + ': ' : ''}${formatValue(c.parsed.y)} ${marker.unit}`, afterLabel:(c)=> { if (c.datasetIndex !== 0) return ''; const di = c.dataIndex; const oi = di + trimOffset; const pr = getEffectiveRangeForDate(marker, oi); const phaseLabel = marker.phaseLabels && marker.phaseLabels[oi]; const lines = []; if (phaseLabel) lines.push(`Phase: ${phaseLabel}`); if (pr.min != null || pr.max != null) { const rl = phaseLabel ? 'Phase ref' : (state.rangeMode === 'optimal' && marker.optimalMin != null ? 'Optimal' : 'Ref'); const rMin = pr.min != null ? formatValue(pr.min) : '–'; const rMax = pr.max != null ? formatValue(pr.max) : '–'; lines.push(`${rl}: ${rMin} \u2013 ${rMax}`); } return lines.join('\n'); } }},
         refBand: (() => { const env = getPhaseRefEnvelope(marker); if (state.rangeMode === 'both') return { refMin: marker.refMin, refMax: marker.refMax }; if (env) return { refMin: env.min, refMax: env.max }; return { refMin: chartRange.min, refMax: chartRange.max }; })(),
         optimalBand: state.rangeMode === 'both' && (marker.optimalMin != null || marker.optimalMax != null) ? { optimalMin: marker.optimalMin, optimalMax: marker.optimalMax } : false,
-        noteAnnotations: chartNotes.length ? { notes: chartNotes, chartDates: rawDates } : false,
-        supplementBars: chartSupps.length ? { supplements: chartSupps, chartDates: rawDates } : false,
+        noteAnnotations: chartNotes.length ? { notes: chartNotes, chartDates: visibleRangeDates } : false,
+        supplementBars: chartSupps.length ? { supplements: chartSupps, chartDates: visibleRangeDates } : false,
         phaseBands: (phaseLabels && phaseLabels.some(p => p) && state.phaseOverlayMode === 'on') ? { phases: phaseLabels, chartDates: rawDates } : false},
       layout: { padding: { top: chartSupps.length ? chartSupps.length * 14 + 6 : 0 } },
       scales: { x: xScale,
-        y:{min:minV-pad, max:maxV+pad, ticks:{color:tc.tickColor,font:{size:10}}, grid:{color:tc.gridColor}}}
+        y:{min:minV-pad, max:maxV+pad, ticks:{color:tc.tickColor,font:{size:10},callback:formatChartTickValue}, grid:{color:tc.gridColor}}}
     },
     plugins: [phaseBandPlugin, refBandPlugin, optimalBandPlugin, noteAnnotationPlugin, supplementBarPlugin]
   });

--- a/js/charts.js
+++ b/js/charts.js
@@ -479,6 +479,63 @@ export const phaseBandPlugin = {
   }
 };
 
+// Keep the compact observation labels below marker charts tied to the actual
+// point coordinates. The row renders a grid as a no-JS fallback; once Chart.js
+// has laid out the time scale, this plugin replaces those slots with measured
+// positions and hides older labels that would collide. The latest label always
+// wins a collision so the summary remains useful on narrow cards.
+function positionChartValueLabels(chart, options = {}) {
+  const card = chart.canvas?.closest?.('.chart-card');
+  const row = card?.querySelector?.('.chart-values');
+  if (!row) return;
+  const items = Array.from(row.querySelectorAll('.chart-value-item'));
+  if (!items.length) return;
+  const meta = chart.getDatasetMeta?.(0);
+  if (!meta?.data) return;
+
+  row.classList.add('chart-values-positioned');
+  const rowWidth = row.clientWidth || chart.width || 0;
+  const chartWidth = chart.width || chart.canvas?.getBoundingClientRect?.().width || rowWidth;
+  if (!(rowWidth > 0) || !(chartWidth > 0)) return;
+  const trimOffset = Number(options.trimOffset) || 0;
+  const positioned = [];
+
+  for (const item of items) {
+    item.classList.remove('chart-value-collided');
+    const originalIndex = Number(item.dataset.chartValueIndex);
+    const point = meta.data[originalIndex - trimOffset];
+    if (!point || !Number.isFinite(point.x)) {
+      item.classList.add('chart-value-collided');
+      continue;
+    }
+    const width = Math.min(item.getBoundingClientRect().width || 82, rowWidth);
+    const rawCenter = (point.x / chartWidth) * rowWidth;
+    const center = Math.max(width / 2, Math.min(rowWidth - width / 2, rawCenter));
+    item.style.setProperty('--chart-value-x', `${center}px`);
+    positioned.push({ item, center, width });
+  }
+
+  const accepted = [];
+  for (let i = positioned.length - 1; i >= 0; i--) {
+    const candidate = positioned[i];
+    const collides = accepted.some(existing =>
+      Math.abs(existing.center - candidate.center) < (existing.width + candidate.width) / 2 + 4
+    );
+    if (collides) candidate.item.classList.add('chart-value-collided');
+    else accepted.push(candidate);
+  }
+}
+
+export const chartValueLabelsPlugin = {
+  id: 'chartValueLabels',
+  afterUpdate(chart, _args, options = {}) {
+    positionChartValueLabels(chart, options);
+  },
+  afterRender(chart, _args, options = {}) {
+    positionChartValueLabels(chart, options);
+  },
+};
+
 export function createLineChart(id, marker, dateLabels, chartDates, phaseLabels) {
   const canvas = document.getElementById("chart-" + id);
   if (!canvas) return;
@@ -491,7 +548,7 @@ export function createLineChart(id, marker, dateLabels, chartDates, phaseLabels)
   const tc = getChartColors();
   let dates = marker.singlePoint ? [marker.singleDateLabel || "N/A"] : dateLabels;
   let values = marker.values;
-  let valid = values.filter(v => v !== null);
+  let valid = values.filter(v => v !== null && v !== undefined);
   if (valid.length === 0) return;
   const timelineBounds = marker.singlePoint
     ? null
@@ -538,14 +595,16 @@ export function createLineChart(id, marker, dateLabels, chartDates, phaseLabels)
   const minV = Math.min(...allValid, refMinSafe, optMinSafe);
   const maxV = Math.max(...allValid, refMaxSafe, optMaxSafe);
   const pad = (maxV - minV) * 0.15 || 1;
+  const axisMin = minV >= 0 ? Math.max(0, minV - pad) : minV - pad;
   const chartRange = getEffectiveRange(marker);
   const ptColors = []; const ptStyles = []; const ptStatuses = [];
   for (let i = 0; i < values.length; i++) {
     const v = values[i];
-    if (v === null) { ptColors.push("transparent"); ptStyles.push('circle'); ptStatuses.push('missing'); continue; }
+    if (v === null || v === undefined) { ptColors.push("transparent"); ptStyles.push('circle'); ptStatuses.push('missing'); continue; }
     const r = getEffectiveRangeForDate(marker, i + trimOffset);
-    const s = getStatus(v, r.min, r.max);
-    ptColors.push(s==="normal"?tc.green:s==="high"?tc.red:tc.yellow);
+    const hasRange = r.min != null || r.max != null;
+    const s = hasRange ? getStatus(v, r.min, r.max) : 'unrated';
+    ptColors.push(s==="normal"?tc.green:s==="high"?tc.red:s==="low"?tc.yellow:tc.tickColor);
     ptStyles.push('circle');
     ptStatuses.push(s);
   }
@@ -595,12 +654,13 @@ export function createLineChart(id, marker, dateLabels, chartDates, phaseLabels)
         optimalBand: state.rangeMode === 'both' && (marker.optimalMin != null || marker.optimalMax != null) ? { optimalMin: marker.optimalMin, optimalMax: marker.optimalMax } : false,
         noteAnnotations: chartNotes.length ? { notes: chartNotes, chartDates: visibleRangeDates } : false,
         supplementBars: chartSupps.length ? { supplements: chartSupps, chartDates: visibleRangeDates } : false,
-        phaseBands: (phaseLabels && phaseLabels.some(p => p) && state.phaseOverlayMode === 'on') ? { phases: phaseLabels, chartDates: rawDates } : false},
+        phaseBands: (phaseLabels && phaseLabels.some(p => p) && state.phaseOverlayMode === 'on') ? { phases: phaseLabels, chartDates: rawDates } : false,
+        chartValueLabels: { trimOffset }},
       layout: { padding: { top: chartSupps.length ? chartSupps.length * 14 + 6 : 0 } },
       scales: { x: xScale,
-        y:{min:minV-pad, max:maxV+pad, ticks:{color:tc.tickColor,font:{size:10},callback:formatChartTickValue}, grid:{color:tc.gridColor}}}
+        y:{min:axisMin, max:maxV+pad, ticks:{color:tc.tickColor,font:{size:10},callback:formatChartTickValue}, grid:{color:tc.gridColor}}}
     },
-    plugins: [phaseBandPlugin, refBandPlugin, optimalBandPlugin, noteAnnotationPlugin, supplementBarPlugin]
+    plugins: [phaseBandPlugin, refBandPlugin, optimalBandPlugin, noteAnnotationPlugin, supplementBarPlugin, chartValueLabelsPlugin]
   });
 }
 
@@ -608,6 +668,7 @@ function getStatusChartColor(status, tc) {
   if (status === 'normal') return tc.green;
   if (status === 'high') return tc.red;
   if (status === 'low') return tc.yellow;
+  if (status === 'unrated') return tc.tickColor;
   return 'transparent';
 }
 

--- a/js/charts.js
+++ b/js/charts.js
@@ -479,63 +479,6 @@ export const phaseBandPlugin = {
   }
 };
 
-// Keep the compact observation labels below marker charts tied to the actual
-// point coordinates. The row renders a grid as a no-JS fallback; once Chart.js
-// has laid out the time scale, this plugin replaces those slots with measured
-// positions and hides older labels that would collide. The latest label always
-// wins a collision so the summary remains useful on narrow cards.
-function positionChartValueLabels(chart, options = {}) {
-  const card = chart.canvas?.closest?.('.chart-card');
-  const row = card?.querySelector?.('.chart-values');
-  if (!row) return;
-  const items = Array.from(row.querySelectorAll('.chart-value-item'));
-  if (!items.length) return;
-  const meta = chart.getDatasetMeta?.(0);
-  if (!meta?.data) return;
-
-  row.classList.add('chart-values-positioned');
-  const rowWidth = row.clientWidth || chart.width || 0;
-  const chartWidth = chart.width || chart.canvas?.getBoundingClientRect?.().width || rowWidth;
-  if (!(rowWidth > 0) || !(chartWidth > 0)) return;
-  const trimOffset = Number(options.trimOffset) || 0;
-  const positioned = [];
-
-  for (const item of items) {
-    item.classList.remove('chart-value-collided');
-    const originalIndex = Number(item.dataset.chartValueIndex);
-    const point = meta.data[originalIndex - trimOffset];
-    if (!point || !Number.isFinite(point.x)) {
-      item.classList.add('chart-value-collided');
-      continue;
-    }
-    const width = Math.min(item.getBoundingClientRect().width || 82, rowWidth);
-    const rawCenter = (point.x / chartWidth) * rowWidth;
-    const center = Math.max(width / 2, Math.min(rowWidth - width / 2, rawCenter));
-    item.style.setProperty('--chart-value-x', `${center}px`);
-    positioned.push({ item, center, width });
-  }
-
-  const accepted = [];
-  for (let i = positioned.length - 1; i >= 0; i--) {
-    const candidate = positioned[i];
-    const collides = accepted.some(existing =>
-      Math.abs(existing.center - candidate.center) < (existing.width + candidate.width) / 2 + 4
-    );
-    if (collides) candidate.item.classList.add('chart-value-collided');
-    else accepted.push(candidate);
-  }
-}
-
-export const chartValueLabelsPlugin = {
-  id: 'chartValueLabels',
-  afterUpdate(chart, _args, options = {}) {
-    positionChartValueLabels(chart, options);
-  },
-  afterRender(chart, _args, options = {}) {
-    positionChartValueLabels(chart, options);
-  },
-};
-
 export function createLineChart(id, marker, dateLabels, chartDates, phaseLabels) {
   const canvas = document.getElementById("chart-" + id);
   if (!canvas) return;
@@ -654,13 +597,12 @@ export function createLineChart(id, marker, dateLabels, chartDates, phaseLabels)
         optimalBand: state.rangeMode === 'both' && (marker.optimalMin != null || marker.optimalMax != null) ? { optimalMin: marker.optimalMin, optimalMax: marker.optimalMax } : false,
         noteAnnotations: chartNotes.length ? { notes: chartNotes, chartDates: visibleRangeDates } : false,
         supplementBars: chartSupps.length ? { supplements: chartSupps, chartDates: visibleRangeDates } : false,
-        phaseBands: (phaseLabels && phaseLabels.some(p => p) && state.phaseOverlayMode === 'on') ? { phases: phaseLabels, chartDates: rawDates } : false,
-        chartValueLabels: { trimOffset }},
+        phaseBands: (phaseLabels && phaseLabels.some(p => p) && state.phaseOverlayMode === 'on') ? { phases: phaseLabels, chartDates: rawDates } : false},
       layout: { padding: { top: chartSupps.length ? chartSupps.length * 14 + 6 : 0 } },
       scales: { x: xScale,
         y:{min:axisMin, max:maxV+pad, ticks:{color:tc.tickColor,font:{size:10},callback:formatChartTickValue}, grid:{color:tc.gridColor}}}
     },
-    plugins: [phaseBandPlugin, refBandPlugin, optimalBandPlugin, noteAnnotationPlugin, supplementBarPlugin, chartValueLabelsPlugin]
+    plugins: [phaseBandPlugin, refBandPlugin, optimalBandPlugin, noteAnnotationPlugin, supplementBarPlugin]
   });
 }
 

--- a/js/compare-correlations.js
+++ b/js/compare-correlations.js
@@ -7,7 +7,7 @@ import { escapeHTML, escapeAttr, getStatus, formatValue } from './utils.js';
 import { getChartColors } from './theme.js';
 import { getActiveData } from './data.js';
 import { getEffectiveRange, getEffectiveRangeForDate } from './marker-analysis.js';
-import { ensureChartJs, getNotesForChart, getSupplementsForChart, refBandPlugin, noteAnnotationPlugin, supplementBarPlugin } from './charts.js';
+import { ensureChartJs, formatChartTickValue, getNotesForChart, getSupplementsForChart, refBandPlugin, noteAnnotationPlugin, supplementBarPlugin } from './charts.js';
 import { createChartRuntime, hasChartRuntime } from './charts-runtime.js';
 
 /** @type {{ askAIAboutCorrelations: () => void, renderTableColgroup: (cols: string[]) => string, renderScrollableTableShell: (...args: any[]) => string, renderCategoryGlyph: (...args: any[]) => string }} */
@@ -422,7 +422,7 @@ export function renderCorrelationChart() {
       layout: { padding: { top: (function() { const s = getSupplementsForChart(data.dates); return s.length ? s.length * 14 + 6 : 0; })() } },
       scales: {
         x: { ticks: { color: tc.tickColor, font: { size: 11 } }, grid: { display: false } },
-        y: { min: minY, max: maxY, ticks: { color: tc.tickColor, font: { size: 10 }, callback: v => v + '%' }, grid: { color: tc.gridColor } }
+        y: { min: minY, max: maxY, ticks: { color: tc.tickColor, font: { size: 10 }, callback: v => `${formatChartTickValue(v)}%` }, grid: { color: tc.gridColor } }
       }
     },
     plugins: [refBandPlugin, noteAnnotationPlugin, supplementBarPlugin]

--- a/js/dashboard-lab-widget-renderers.js
+++ b/js/dashboard-lab-widget-renderers.js
@@ -29,7 +29,7 @@ export function createDashboardLabWidgetRenderers(deps) {
     const keyMarkers = getKeyTrendMarkers(filteredData);
     const trendAlerts = detectTrendAlerts(filteredData);
     const trendMarkerIds = new Set(trendAlerts.map(a => a.id));
-    const allFlags = getAllFlaggedMarkers(data);
+    const allFlags = getAllFlaggedMarkers(filteredData);
     const criticalFlags = allFlags.filter(f => {
       if (trendMarkerIds.has(f.id)) return false;
       const refRange = f.refMax - f.refMin;

--- a/js/data.js
+++ b/js/data.js
@@ -808,14 +808,17 @@ export function applyUnitConversion(data) {
 // ═══════════════════════════════════════════════
 export function filterDatesByRange(data, options = {}) {
   if (state.dateRangeFilter === 'all') return data;
-  const fallbackToAll = options.fallbackToAll !== false;
+  // A selected timeframe must stay truthful. Callers may explicitly request
+  // the legacy all-history fallback, but UI surfaces default to an honest
+  // empty range and can offer "Show all results" themselves.
+  const fallbackToAll = options.fallbackToAll === true;
   const bounds = getLabDateRangeBounds(data.dates, state.dateRangeFilter, new Date(), { fallbackToAll: false });
   if (!bounds) return data;
   const indices = [];
   for (let i = 0; i < data.dates.length; i++) {
     if (data.dates[i] >= bounds.min && data.dates[i] <= bounds.max) indices.push(i);
   }
-  if (indices.length === 0 && fallbackToAll) return data; // fallback: show all if no dates in range
+  if (indices.length === 0 && fallbackToAll) return data;
   const filteredDates = new Set(indices.map(i => data.dates[i]));
   const filtered = {
     dates: indices.map(i => data.dates[i]),

--- a/js/data.js
+++ b/js/data.js
@@ -10,6 +10,7 @@ import { encryptedSetItem, broadcastDataChanged, scheduleAutoBackup } from './cr
 import { onDataSaved } from './sync.js';
 import { recalculateLabEntryHOMAIR } from './lab-entry.js';
 import { scheduleUtilsAfterNextPaint } from './utils-runtime.js';
+import { getLabDateRangeBounds } from './lab-date-range.js';
 import {
   countFlagged,
   detectTrendAlerts,
@@ -808,13 +809,11 @@ export function applyUnitConversion(data) {
 export function filterDatesByRange(data, options = {}) {
   if (state.dateRangeFilter === 'all') return data;
   const fallbackToAll = options.fallbackToAll !== false;
-  const months = state.dateRangeFilter === '3m' ? 3 : state.dateRangeFilter === '6m' ? 6 : 12;
-  const cutoff = new Date();
-  cutoff.setMonth(cutoff.getMonth() - months);
-  const cutoffStr = cutoff.toISOString().slice(0, 10);
+  const bounds = getLabDateRangeBounds(data.dates, state.dateRangeFilter, new Date(), { fallbackToAll: false });
+  if (!bounds) return data;
   const indices = [];
   for (let i = 0; i < data.dates.length; i++) {
-    if (data.dates[i] >= cutoffStr) indices.push(i);
+    if (data.dates[i] >= bounds.min && data.dates[i] <= bounds.max) indices.push(i);
   }
   if (indices.length === 0 && fallbackToAll) return data; // fallback: show all if no dates in range
   const filteredDates = new Set(indices.map(i => data.dates[i]));
@@ -835,7 +834,7 @@ export function filterDatesByRange(data, options = {}) {
       if (marker.singlePoint || cat.singlePoint) {
         // Hide single-point markers whose date is outside the filtered range
         const spDate = marker.singleDate || cat.singleDate;
-        if (spDate && spDate < cutoffStr) {
+        if (spDate && (spDate < bounds.min || spDate > bounds.max)) {
           filteredCat.markers[mKey] = { ...marker, values: [null], singleDate: null };
         } else {
           filteredCat.markers[mKey] = marker;

--- a/js/lab-date-range.js
+++ b/js/lab-date-range.js
@@ -1,0 +1,78 @@
+// @ts-check
+// lab-date-range.js - Shared visible bounds for lab timeline charts and filters.
+
+const RANGE_MONTHS = {
+  '3m': 3,
+  '6m': 6,
+  '1y': 12,
+};
+
+/**
+ * @param {unknown} value
+ * @returns {value is string}
+ */
+function isIsoDate(value) {
+  if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  return !Number.isNaN(new Date(`${value}T00:00:00Z`).getTime());
+}
+
+/**
+ * @param {Date} date
+ * @returns {string}
+ */
+function isoDate(date) {
+  return date.toISOString().slice(0, 10);
+}
+
+/**
+ * Subtract whole calendar months while clamping end-of-month dates.
+ * @param {Date} date
+ * @param {number} months
+ * @returns {Date}
+ */
+function subtractUtcMonths(date, months) {
+  const result = new Date(date.getTime());
+  const day = result.getUTCDate();
+  result.setUTCDate(1);
+  result.setUTCMonth(result.getUTCMonth() - months);
+  const lastDay = new Date(Date.UTC(result.getUTCFullYear(), result.getUTCMonth() + 1, 0)).getUTCDate();
+  result.setUTCDate(Math.min(day, lastDay));
+  return result;
+}
+
+/**
+ * Resolve the shared x-axis window for lab timelines.
+ * Rolling ranges span their calendar cutoff through today. "All" spans the
+ * earliest real lab date through today, preserving post-lab annotation space
+ * without adding a synthetic null datapoint. When a rolling range contains no
+ * dates, the default mirrors filterDatesByRange's existing all-data fallback.
+ *
+ * @param {unknown} dates
+ * @param {string} [range]
+ * @param {Date} [now]
+ * @param {{ fallbackToAll?: boolean }} [options]
+ * @returns {{ min: string, max: string } | null}
+ */
+export function getLabDateRangeBounds(dates, range = 'all', now = new Date(), options = {}) {
+  const validDates = Array.isArray(dates)
+    ? [...new Set(dates.filter(isIsoDate))].sort()
+    : [];
+  const today = isoDate(now);
+  const months = RANGE_MONTHS[range];
+
+  if (months) {
+    const rollingBounds = {
+      min: isoDate(subtractUtcMonths(now, months)),
+      max: today,
+    };
+    const hasDateInRange = validDates.some(date => date >= rollingBounds.min && date <= rollingBounds.max);
+    if (hasDateInRange || options.fallbackToAll === false || validDates.length === 0) return rollingBounds;
+  }
+
+  if (validDates.length === 0) return null;
+  const earliest = validDates[0];
+  const latest = validDates[validDates.length - 1];
+  const max = latest > today ? latest : today;
+  if (earliest < max) return { min: earliest, max };
+  return { min: isoDate(subtractUtcMonths(new Date(`${earliest}T12:00:00Z`), 1)), max };
+}

--- a/js/marker-analysis.js
+++ b/js/marker-analysis.js
@@ -39,7 +39,7 @@ export function getPhaseRefEnvelope(marker) {
 }
 
 export function getLatestValueIndex(values) {
-  for (let i = values.length - 1; i >= 0; i--) if (values[i] !== null) return i;
+  for (let i = values.length - 1; i >= 0; i--) if (values[i] !== null && values[i] !== undefined) return i;
   return -1;
 }
 

--- a/js/marker-detail-modal.js
+++ b/js/marker-detail-modal.js
@@ -299,18 +299,16 @@ export function showDetailModal(id, opts = {}) {
   const hiddenHistoryCount = modalPoints.length - visibleHistoryPoints.length;
   const latestPoint = modalPoints[modalPoints.length - 1] || null;
   const prevPoint = modalPoints.length > 1 ? modalPoints[modalPoints.length - 2] : null;
-  const firstPoint = modalPoints[0] || null;
   const latestRange = latestPoint ? getEffectiveRangeForDate(marker, latestPoint.i) : r;
-  const latestStatus = latestPoint ? getStatus(latestPoint.v, latestRange.min, latestRange.max) : 'missing';
+  const latestHasRange = latestRange.min != null || latestRange.max != null;
+  const latestStatus = latestPoint ? (latestHasRange ? getStatus(latestPoint.v, latestRange.min, latestRange.max) : 'unrated') : 'missing';
   const statusText = latestStatus === 'normal' ? 'In range'
     : latestStatus === 'high' ? 'Above range'
     : latestStatus === 'low' ? 'Below range'
+    : latestStatus === 'unrated' ? 'No range'
     : 'No value';
   const deltaFromPrev = latestPoint && prevPoint && Number(prevPoint.v) !== 0
     ? (((Number(latestPoint.v) - Number(prevPoint.v)) / Number(prevPoint.v)) * 100)
-    : null;
-  const deltaFromFirst = latestPoint && firstPoint && Number(firstPoint.v) !== 0
-    ? (((Number(latestPoint.v) - Number(firstPoint.v)) / Number(firstPoint.v)) * 100)
     : null;
   const latestUnit = marker.unit || '';
   const latestDisplay = latestPoint ? formatValue(latestPoint.v) : '—';
@@ -319,11 +317,39 @@ export function showDetailModal(id, opts = {}) {
   const referenceMinDisplay = hasReferenceRange && marker.refMin != null ? formatValue(marker.refMin) : latestRange.min != null ? formatValue(latestRange.min) : '—';
   const referenceMaxDisplay = hasReferenceRange && marker.refMax != null ? formatValue(marker.refMax) : latestRange.max != null ? formatValue(latestRange.max) : '—';
   const referenceDisplay = `${referenceMinDisplay}–${referenceMaxDisplay} ${latestUnit}`.trim();
-  const referenceMetaLabel = hasReferenceRange ? 'Ref' : 'Range';
-  const hasOptimalRange = marker.optimalMin != null && marker.optimalMax != null;
+  const referenceMetaLabel = hasReferenceRange ? 'Reference' : 'Range';
+  const hasOptimalRange = marker.optimalMin != null || marker.optimalMax != null;
   const optimalDisplay = `${marker.optimalMin != null ? formatValue(marker.optimalMin) : '—'}–${marker.optimalMax != null ? formatValue(marker.optimalMax) : '—'} ${latestUnit}`.trim();
-  const rangeMainDisplay = hasOptimalRange ? optimalDisplay : referenceDisplay;
-  const rangeMainLabel = hasOptimalRange ? 'optimal' : referenceMetaLabel.toLowerCase();
+  const latestPhaseRange = latestPoint ? marker.phaseRefRanges?.[latestPoint.i] : null;
+  const latestPhaseLabel = latestPoint ? marker.phaseLabels?.[latestPoint.i] : null;
+  const hasLatestPhaseRange = latestPhaseRange?.min != null || latestPhaseRange?.max != null;
+  const phaseDisplay = `${latestRange.min != null ? formatValue(latestRange.min) : '—'}–${latestRange.max != null ? formatValue(latestRange.max) : '—'} ${latestUnit}`.trim();
+  let rangeMainDisplay = 'Not set';
+  let rangeMainLabel = 'range';
+  let rangeSecondaryDisplay = '';
+  let rangeSecondaryLabel = '';
+  if (hasLatestPhaseRange) {
+    rangeMainDisplay = phaseDisplay;
+    rangeMainLabel = latestPhaseLabel ? `${latestPhaseLabel} range` : 'phase range';
+  } else if (state.rangeMode === 'both') {
+    if (hasReferenceRange) {
+      rangeMainDisplay = referenceDisplay;
+      rangeMainLabel = 'reference';
+      if (hasOptimalRange) {
+        rangeSecondaryDisplay = optimalDisplay;
+        rangeSecondaryLabel = 'Optimal';
+      }
+    } else if (hasOptimalRange) {
+      rangeMainDisplay = optimalDisplay;
+      rangeMainLabel = 'optimal';
+    }
+  } else if (state.rangeMode === 'optimal' && hasOptimalRange) {
+    rangeMainDisplay = optimalDisplay;
+    rangeMainLabel = 'optimal';
+  } else if (hasReferenceRange) {
+    rangeMainDisplay = referenceDisplay;
+    rangeMainLabel = referenceMetaLabel.toLowerCase();
+  }
   const clampPct = value => Math.max(0, Math.min(100, value));
   const numericOrNull = value => {
     if (value === null || value === undefined || value === '') return null;
@@ -342,9 +368,10 @@ export function showDetailModal(id, opts = {}) {
     const baseMin = refMin ?? effMin;
     const baseMax = refMax ?? effMax;
     if (baseMin == null || baseMax == null || Number(baseMax) === Number(baseMin)) return '';
-    const hasOptimalBand = optMin != null && optMax != null;
-    const goodMin = hasOptimalBand ? Math.min(optMin, optMax) : Math.min(baseMin, baseMax);
-    const goodMax = hasOptimalBand ? Math.max(optMin, optMax) : Math.max(baseMin, baseMax);
+    const usePhaseBand = hasLatestPhaseRange && effMin != null && effMax != null;
+    const useOptimalBand = !usePhaseBand && state.rangeMode !== 'reference' && optMin != null && optMax != null;
+    const goodMin = usePhaseBand ? Math.min(effMin, effMax) : useOptimalBand ? Math.min(optMin, optMax) : Math.min(baseMin, baseMax);
+    const goodMax = usePhaseBand ? Math.max(effMin, effMax) : useOptimalBand ? Math.max(optMin, optMax) : Math.max(baseMin, baseMax);
     let min = Math.min(baseMin, baseMax);
     let max = Math.max(baseMin, baseMax);
     const goodSpan = goodMax - goodMin;
@@ -392,9 +419,8 @@ export function showDetailModal(id, opts = {}) {
     const hasLabStash = type === 'optimal' ? 'labOptimalMin' in overrides : 'labRefMin' in overrides;
     const badgeTitle = source === 'manual' ? (hasLabStash ? 'Manually edited — click to revert to lab range' : 'Manually edited — click to revert to default') : 'Custom range from your lab — click to revert to default';
     const editedBadge = isEdited ? ` <span class="ref-edited-badge" role="button" tabindex="0" aria-label="${badgeTitle}" title="${badgeTitle}" ${markerDetailActionAttrs('revert-ref-range', { id, type })}>${badgeLabel} \u00d7</span>` : '';
-    const displayMin = min != null ? min : '–';
-    const displayMax = max != null ? max : '–';
-    return ` &middot; ${type === 'optimal' ? '<span style="color:var(--green)">' : ''}${label}: <span class="ref-editable" role="button" tabindex="0" aria-label="Edit ${label} range" ${markerDetailActionAttrs('edit-ref-range', { id, type })} title="Click to edit">${displayMin} \u2013 ${displayMax}</span>${editedBadge}${type === 'optimal' ? '</span>' : ''}`;
+    const currentRange = `${min != null ? min : '–'} to ${max != null ? max : '–'}`;
+    return ` &middot; <button type="button" class="ref-editable${type === 'optimal' ? ' ref-editable-optimal' : ''}" aria-label="Edit ${label} range, currently ${escapeAttr(currentRange)}" ${markerDetailActionAttrs('edit-ref-range', { id, type })}>Edit ${label.toLowerCase()}</button>${editedBadge}`;
   };
   const isCustom = !!state.importedData?.customMarkers?.[dotKey];
   const hasRef = marker.refMin != null || marker.refMax != null;
@@ -475,20 +501,23 @@ export function showDetailModal(id, opts = {}) {
       <div class="stat-card">
         <div class="stat-card-label">Ranges</div>
         <div class="stat-card-value stat-card-value-range">${escapeHTML(rangeMainDisplay)} <span>${escapeHTML(rangeMainLabel)}</span></div>
-        <div class="stat-card-meta">${escapeHTML(referenceMetaLabel)} ${escapeHTML(referenceDisplay)}${deltaFromFirst != null ? ` · ${deltaFromFirst >= 0 ? '+' : ''}${deltaFromFirst.toFixed(1)}% vs first` : ''}</div>
+        ${rangeSecondaryDisplay
+          ? `<div class="stat-card-meta">${escapeHTML(rangeSecondaryLabel)} ${escapeHTML(rangeSecondaryDisplay)}</div>`
+          : hasLatestPhaseRange ? `<div class="stat-card-meta">Used for the latest status</div>` : ''}
         ${rangeCardControls ? `<div class="stat-card-range-controls">${rangeCardControls}</div>` : ''}
       </div>
     </div>
     ${rangeBandHtml}
     <div class="gb-detail-section-label">Trend</div>
     <div class="modal-chart"><canvas id="chart-modal"></canvas></div>
-    <div class="gb-detail-section-label">History</div>
+    <div class="gb-detail-section-label">History <span>All time</span></div>
     <div class="modal-values-grid marker-history-list">`;
   for (const point of visibleHistoryPoints) {
     const { v, i } = point;
     const ri = getEffectiveRangeForDate(marker, i);
-    const s = getStatus(v, ri.min, ri.max);
-    const sl = s==="normal"?"\u2713 In Range":s==="high"?"\u25B2 Above Range":s==="low"?"\u25BC Below Range":"Unknown";
+    const hasPointRange = ri.min != null || ri.max != null;
+    const s = hasPointRange ? getStatus(v, ri.min, ri.max) : 'unrated';
+    const sl = s==="normal"?"\u2713 In Range":s==="high"?"\u25B2 Above Range":s==="low"?"\u25BC Below Range":s === 'unrated' ? 'No range' : "Unknown";
     const phaseLabel = marker.phaseLabels && marker.phaseLabels[i];
     const phaseInfo = phaseLabel ? `<div class="mv-phase">${phaseLabel} \u2022 ${formatValue(ri.min)}\u2013${formatValue(ri.max)}</div>` : '';
     const rawDate = marker.singlePoint ? null : data.dates[i];
@@ -759,7 +788,7 @@ export function showDetailModal(id, opts = {}) {
   // Async-fill recommendation section (unified: genetics + actionable tips)
   if (shouldRenderRecommendations) {
     const _latestVal = marker.values?.filter(v => v !== null).pop();
-    const _markerStatus = _latestVal != null ? getStatus(_latestVal, r.min, r.max) : 'missing';
+    const _markerStatus = latestStatus === 'unrated' ? 'missing' : latestStatus;
     renderRecommendationSectionRuntime(id.replace('_','.'), { label: 'What can help', maxProducts: 3, inlineSNPs: _inlineSNPs, markerStatus: _markerStatus })
       .then(h => {
         const el = document.getElementById('rec-modal-' + id);

--- a/js/utils.js
+++ b/js/utils.js
@@ -303,13 +303,18 @@ export function getRangePosition(value, refMin, refMax) {
 // arrow; loose enough that a single decimal-place rounding doesn't.
 const STABLE_TREND_PCT = 2;
 export function getTrend(values, refMin, refMax) {
-  const nn = values.filter(v=>v!==null);
-  if (nn.length<2) return {arrow:"\u2014",cls:"trend-stable"};
+  const nn = values.filter(v=>v!==null && v!==undefined);
+  if (nn.length<2) return {arrow:"\u2014",cls:"trend-stable",label:"No previous result"};
   const prev = nn[nn.length-2];
-  if (prev === 0) return {arrow:"→",cls:"trend-stable"};
   const curr = nn[nn.length-1];
+  if (prev === 0) {
+    if (curr === 0) return {arrow:"Stable",cls:"trend-stable",label:"Stable versus previous result"};
+    return {arrow:"Changed",cls:"trend-stable",label:"Changed versus previous result; percentage unavailable because the previous value was zero"};
+  }
   const pct = ((curr-prev)/prev)*100;
-  if (Math.abs(pct)<STABLE_TREND_PCT) return {arrow:"\u2192",cls:"trend-stable"};
+  if (Math.abs(pct)<STABLE_TREND_PCT) {
+    return {arrow:"Stable",cls:"trend-stable",label:`Stable versus previous result (${pct >= 0 ? '+' : ''}${pct.toFixed(1)}%)`};
+  }
   const dir = pct > 0 ? 'up' : 'down';
   const arrow = pct > 0 ? `\u2191 +${pct.toFixed(1)}%` : `\u2193 ${pct.toFixed(1)}%`;
   // Color based on whether change is good or bad relative to ref range
@@ -318,7 +323,8 @@ export function getTrend(values, refMin, refMax) {
   if (status === 'high') quality = dir === 'down' ? 'good' : 'bad';
   else if (status === 'low') quality = dir === 'up' ? 'good' : 'bad';
   else quality = 'neutral';
-  return {arrow, cls:`trend-${dir} trend-${quality}`};
+  const label = `${pct > 0 ? 'Increased' : 'Decreased'} ${Math.abs(pct).toFixed(1)}% versus previous result`;
+  return {arrow, cls:`trend-${dir} trend-${quality}`, label};
 }
 
 export function formatValue(v) {

--- a/js/wearables-bp-detail-chart.js
+++ b/js/wearables-bp-detail-chart.js
@@ -2,7 +2,7 @@
 
 import { state } from './state.js';
 import { adapterById, isMetricValueMeaningful } from './wearable-adapters.js';
-import { ensureChartJs, isChartDateAdapterReady } from './charts.js';
+import { ensureChartJs, formatChartTickValue, isChartDateAdapterReady } from './charts.js';
 import { createChartRuntime, hasChartRuntime } from './charts-runtime.js';
 import { getChartColors } from './theme.js';
 import { formatValue, shortDate } from './wearables-formatters.js';
@@ -165,7 +165,7 @@ export function renderBloodPressureChart(canvas, canon, m, systolicSeries, diast
         },
         y: {
           min: ymin - pad, max: ymax + pad,
-          ticks: { color: tc.tickColor, font: { size: 10 } },
+          ticks: { color: tc.tickColor, font: { size: 10 }, callback: formatChartTickValue },
           grid: { color: tc.gridColor },
         },
       },

--- a/js/wearables-detail-modal.js
+++ b/js/wearables-detail-modal.js
@@ -13,7 +13,7 @@ import { getActiveProfileId } from './profile.js';
 import { getDailyRange } from './wearables-store.js';
 import { MANUAL_METRICS } from './wearables-manual.js';
 import { getChartColors } from './theme.js';
-import { ensureChartJs, isChartDateAdapterReady } from './charts.js';
+import { ensureChartJs, formatChartTickValue, isChartDateAdapterReady } from './charts.js';
 import { formatValue, shortDate } from './wearables-formatters.js';
 import { _collectActiveChips, _renderNoteField, _renderTagChips, inputValueById, inputValueFromElement } from './wearables-manual-form-ui.js';
 import { renderBloodPressureChart } from './wearables-bp-detail-chart.js';
@@ -632,7 +632,7 @@ function renderWearableChart(canvas, canon, m, series, manualSeries = []) {
         },
         y: {
           min: ymin - pad, max: ymax + pad,
-          ticks: { color: tc.tickColor, font: { size: 10 } },
+          ticks: { color: tc.tickColor, font: { size: 10 }, callback: formatChartTickValue },
           grid: { color: tc.gridColor },
         },
       },

--- a/service-worker.js
+++ b/service-worker.js
@@ -119,6 +119,7 @@ const APP_SHELL = [
   '/js/import-drop-zone-runtime.js',
   '/js/ai-verdict-engine-runtime.js',
   '/js/ai-verdict-engine.js',
+  '/js/lab-date-range.js',
   '/js/profile-fatty-acid-migrations.js',
   '/js/profile-marker-migrations.js',
   '/js/profile.js',

--- a/tests/lab-date-range.test.js
+++ b/tests/lab-date-range.test.js
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { getLabDateRangeBounds } from '../js/lab-date-range.js';
+
+const NOW = new Date('2026-07-20T12:00:00Z');
+
+describe('lab timeline date-range bounds', () => {
+  it('uses the selected rolling window when it contains lab dates', () => {
+    expect(getLabDateRangeBounds(['2026-05-02'], '3m', NOW)).toEqual({
+      min: '2026-04-20',
+      max: '2026-07-20',
+    });
+    expect(getLabDateRangeBounds(['2026-02-02'], '6m', NOW)).toEqual({
+      min: '2026-01-20',
+      max: '2026-07-20',
+    });
+    expect(getLabDateRangeBounds(['2025-08-02'], '1y', NOW)).toEqual({
+      min: '2025-07-20',
+      max: '2026-07-20',
+    });
+  });
+
+  it('clamps calendar-month cutoffs at the end of shorter months', () => {
+    const monthEnd = new Date('2026-05-31T12:00:00Z');
+    expect(getLabDateRangeBounds([], '3m', monthEnd, { fallbackToAll: false })).toEqual({
+      min: '2026-02-28',
+      max: '2026-05-31',
+    });
+  });
+
+  it('uses the earliest real date through today for All', () => {
+    expect(getLabDateRangeBounds(['2026-03-10', 'bad', '2025-11-04'], 'all', NOW)).toEqual({
+      min: '2025-11-04',
+      max: '2026-07-20',
+    });
+  });
+
+  it('mirrors the existing all-data fallback when a rolling window is empty', () => {
+    expect(getLabDateRangeBounds(['2024-01-10', '2024-03-10'], '3m', NOW)).toEqual({
+      min: '2024-01-10',
+      max: '2026-07-20',
+    });
+    expect(getLabDateRangeBounds(
+      ['2024-01-10', '2024-03-10'],
+      '3m',
+      NOW,
+      { fallbackToAll: false },
+    )).toEqual({
+      min: '2026-04-20',
+      max: '2026-07-20',
+    });
+  });
+
+  it('pads a one-date All window without adding another observation', () => {
+    expect(getLabDateRangeBounds(['2026-07-20'], 'all', NOW)).toEqual({
+      min: '2026-06-20',
+      max: '2026-07-20',
+    });
+  });
+
+  it('returns no All bounds when there are no valid dates', () => {
+    expect(getLabDateRangeBounds(['bad'], 'all', NOW)).toBeNull();
+  });
+});

--- a/tests/playwright/category-view-renderers-browser-coverage.spec.js
+++ b/tests/playwright/category-view-renderers-browser-coverage.spec.js
@@ -83,7 +83,9 @@ test('category view renderers browser coverage exercises chart table heatmap and
         && !card.querySelector('.chart-card-unit')
         && card.querySelector('.chart-card-snapshot-meta')?.textContent === 'May 1 · mg/dL'
         && card.querySelectorAll('.chart-value-item').length === 4
-        && [...card.querySelectorAll('.chart-value-item')].map(el => el.getAttribute('data-chart-value-index')).join('|') === '0|2|3|4'
+        && card.querySelector('.chart-values')?.getAttribute('aria-label') === 'Recent results'
+        && card.querySelector('.chart-values-label')?.textContent === 'Recent results'
+        && [...card.querySelectorAll('.chart-value-date')].map(el => el.textContent).join('|') === 'Jan 1|Mar 1|Apr 1|May 1'
         && ![...card.querySelectorAll('.chart-value-date')].some(el => el.textContent === 'Feb 1')
         && !card.querySelector('.chart-value-num.val-missing')
         && !card.querySelector('.chart-card-range, .chart-ref-range')

--- a/tests/playwright/category-view-renderers-browser-coverage.spec.js
+++ b/tests/playwright/category-view-renderers-browser-coverage.spec.js
@@ -74,6 +74,15 @@ test('category view renderers browser coverage exercises chart table heatmap and
         && !card.hasAttribute('onclick')
         && card.querySelector('.chart-card-title-text')?.textContent === 'ApoB <script>'
         && card.querySelector('.chart-card-latest-value')?.textContent === '90'
+        && !card.querySelector('.chart-card-unit')
+        && card.querySelector('.chart-card-snapshot-meta')?.textContent === 'May 1 · mg/dL'
+        && card.querySelectorAll('.chart-value-item').length === 4
+        && ![...card.querySelectorAll('.chart-value-date')].some(el => el.textContent === 'Feb 1')
+        && !card.querySelector('.chart-value-num.val-missing')
+        && !card.querySelector('.chart-card-range, .chart-ref-range')
+        && card.querySelector('.chart-card-snapshot-side > span')?.textContent === 'Reference / Optimal'
+        && card.querySelector('.chart-card-snapshot-side > strong')?.textContent.includes('60 – 100')
+        && card.querySelector('.chart-card-snapshot-side > strong')?.textContent.includes('60 – 90')
         && card.querySelector('#chart-rec-lipids_apob')
         && !card.querySelector('script');
       outcomes.chartCardRejectsUnsafeIds =

--- a/tests/playwright/category-view-renderers-browser-coverage.spec.js
+++ b/tests/playwright/category-view-renderers-browser-coverage.spec.js
@@ -64,27 +64,68 @@ test('category view renderers browser coverage exercises chart table heatmap and
       state.markerRegistry = {};
       state.chartInstances = {};
 
-      fixture.innerHTML = renderers.renderChartCard('lipids_apob', apoBMarker, dateLabels);
+      fixture.innerHTML = renderers.renderChartCard('lipids_apob', apoBMarker, dateLabels, dates);
       const card = fixture.querySelector('.chart-card');
+      const cardMain = card?.querySelector('.chart-card-main');
       outcomes.chartCardEscapesMarkerStoresRegistryAndShowsLatest =
         state.markerRegistry.lipids_apob === apoBMarker
-        && card?.getAttribute('aria-label') === 'ApoB <script> - Normal'
+        && card?.getAttribute('role') == null
+        && cardMain?.getAttribute('role') === 'button'
+        && cardMain.getAttribute('tabindex') === '0'
+        && cardMain.getAttribute('aria-label')?.includes('ApoB <script>. Normal. Latest 90 mg/dL, May 1.')
         && card.getAttribute('data-marker-detail-action') === 'show-detail-modal'
         && card.getAttribute('data-marker-detail-id') === 'lipids_apob'
+        && cardMain.getAttribute('data-marker-detail-action') === 'show-detail-modal'
         && !card.hasAttribute('onclick')
         && card.querySelector('.chart-card-title-text')?.textContent === 'ApoB <script>'
         && card.querySelector('.chart-card-latest-value')?.textContent === '90'
+        && card.querySelector('canvas')?.getAttribute('aria-hidden') === 'true'
         && !card.querySelector('.chart-card-unit')
         && card.querySelector('.chart-card-snapshot-meta')?.textContent === 'May 1 · mg/dL'
         && card.querySelectorAll('.chart-value-item').length === 4
+        && [...card.querySelectorAll('.chart-value-item')].map(el => el.getAttribute('data-chart-value-index')).join('|') === '0|2|3|4'
         && ![...card.querySelectorAll('.chart-value-date')].some(el => el.textContent === 'Feb 1')
         && !card.querySelector('.chart-value-num.val-missing')
         && !card.querySelector('.chart-card-range, .chart-ref-range')
-        && card.querySelector('.chart-card-snapshot-side > span')?.textContent === 'Reference / Optimal'
-        && card.querySelector('.chart-card-snapshot-side > strong')?.textContent.includes('60 – 100')
-        && card.querySelector('.chart-card-snapshot-side > strong')?.textContent.includes('60 – 90')
+        && [...card.querySelectorAll('.chart-card-range-row > span')].map(el => el.textContent).join('|') === 'Reference|Optimal'
+        && [...card.querySelectorAll('.chart-card-range-row > strong')].map(el => el.textContent).join('|') === '60 – 100|60 – 90'
         && card.querySelector('#chart-rec-lipids_apob')
         && !card.querySelector('script');
+
+      state.rangeMode = 'optimal';
+      const phaseMarker = {
+        name: 'Progesterone', unit: 'nmol/L', values: [17],
+        refMin: 0.18, refMax: 75.9, optimalMin: 14, optimalMax: 36,
+        phaseLabels: ['luteal'], phaseRefRanges: [{ min: 20, max: 30 }],
+      };
+      fixture.innerHTML = renderers.renderChartCard('hormones_progesterone', phaseMarker, ['May 2026'], ['2026-05-20']);
+      const phaseCard = fixture.querySelector('.chart-card');
+      outcomes.chartCardStatusAndDisplayedRangeUseSamePhaseBounds =
+        phaseCard?.classList.contains('chart-card-low')
+        && phaseCard.querySelector('.chart-card-status')?.textContent.includes('Low')
+        && phaseCard.querySelector('.chart-card-range-row > span')?.textContent === 'Luteal range'
+        && phaseCard.querySelector('.chart-card-range-row > strong')?.textContent === '20 – 30'
+        && phaseCard.querySelector('.chart-card-main')?.getAttribute('aria-label')?.includes('Luteal range 20 – 30');
+
+      const unratedMarker = { name: 'Unrated', unit: 'u', values: [1.2], refMin: null, refMax: null };
+      fixture.innerHTML = renderers.renderChartCard('custom_unrated', unratedMarker, ['May 2026'], ['2026-05-20']);
+      const unratedCard = fixture.querySelector('.chart-card');
+      outcomes.chartCardDoesNotCallAValueNormalWithoutARange =
+        unratedCard?.classList.contains('chart-card-unrated')
+        && unratedCard.querySelector('.chart-card-status')?.textContent === 'No range'
+        && unratedCard.querySelector('.chart-card-range-row > strong')?.textContent === 'Not set'
+        && unratedCard.querySelector('.chart-value-num')?.classList.contains('val-unrated');
+
+      fixture.innerHTML = renderers.renderChartCard('lipids_duplicate_dates', {
+        ...apoBMarker,
+        name: 'Duplicate month dates',
+        values: [80, 90],
+      }, ['May 2026', 'May 2026'], ['2026-05-01', '2026-05-20']);
+      outcomes.chartCardDisambiguatesMultipleResultsInTheSameMonth =
+        [...fixture.querySelectorAll('.chart-value-date')].map(el => el.textContent).join('|') === 'May 1|May 20'
+        && fixture.querySelector('.chart-card-snapshot-meta')?.textContent === 'May 20, 2026 · mg/dL';
+
+      state.rangeMode = 'both';
       outcomes.chartCardRejectsUnsafeIds =
         renderers.renderChartCard('lipids_bad"id', apoBMarker, dateLabels) === '';
 
@@ -230,6 +271,9 @@ test('category view renderers browser coverage exercises chart table heatmap and
 
   const expectedOutcomeKeys = [
     'chartCardEscapesMarkerStoresRegistryAndShowsLatest',
+    'chartCardStatusAndDisplayedRangeUseSamePhaseBounds',
+    'chartCardDoesNotCallAValueNormalWithoutARange',
+    'chartCardDisambiguatesMultipleResultsInTheSameMonth',
     'chartCardRejectsUnsafeIds',
     'scrollableTableShellClampsWidthEscapesColsAndSyncsScroll',
     'tableViewFiltersEmptyMarkersEscapesNamesAndAddsManualEntryCells',

--- a/tests/playwright/chart-card-recs-browser-coverage.spec.js
+++ b/tests/playwright/chart-card-recs-browser-coverage.spec.js
@@ -103,6 +103,7 @@ test('chart card recommendation browser coverage handles badges reorder clicks a
     await chartCardRecs.loadChartCardRecs();
     outcomes.badgesRenderForMatchingSlotsAndReorderWithinEachGrid =
       badgeTexts().join('|') === 'Tips|Tips|Tips'
+      && [...document.querySelectorAll('.ctx-tips-badge')].every(badge => badge.tagName === 'BUTTON' && badge.tabIndex === 0 && badge.getAttribute('aria-label')?.startsWith('Open actionable tips'))
       && document.querySelector('#chart-rec-missing_marker .ctx-tips-badge') == null
       && cardOrder('primary-grid').join('|') === 'card-apob|card-glucose|card-empty'
       && cardOrder('secondary-grid').join('|') === 'card-secondary-rec|card-secondary-empty';

--- a/tests/playwright/charts-browser-coverage.spec.js
+++ b/tests/playwright/charts-browser-coverage.spec.js
@@ -198,6 +198,36 @@ test('charts browser coverage exercises annotation supplement and theme callback
       && suppChart.ctx.calls.some(call => call[0] === 'createLinearGradient')
       && suppChart.ctx.calls.some(call => call[0] === 'fillText' && String(call[1]).includes('Magnesium'));
 
+    const card = document.createElement('div');
+    card.className = 'chart-card';
+    card.innerHTML = `<canvas></canvas><div class="chart-values" style="display:block;width:300px">
+      <div class="chart-value-item" data-chart-value-index="0" style="width:60px"></div>
+      <div class="chart-value-item" data-chart-value-index="1" style="width:60px"></div>
+      <div class="chart-value-item" data-chart-value-index="2" style="width:60px"></div>
+    </div>`;
+    document.body.appendChild(card);
+    const positionChart = {
+      canvas: card.querySelector('canvas'),
+      width: 300,
+      getDatasetMeta: () => ({ data: [{ x: 10 }, { x: 150 }, { x: 295 }] }),
+    };
+    charts.chartValueLabelsPlugin.afterRender(positionChart, {}, { trimOffset: 0 });
+    const positionedItems = [...card.querySelectorAll('.chart-value-item')];
+    const positionedXs = positionedItems.map(item => parseFloat(item.style.getPropertyValue('--chart-value-x')));
+    outcomes.chartValueLabelsFollowPointCoordinatesAndClampToCardEdges =
+      card.querySelector('.chart-values')?.classList.contains('chart-values-positioned')
+      && positionedXs[0] >= 30
+      && positionedXs[1] === 150
+      && positionedXs[2] <= 270
+      && positionedItems.every(item => !item.classList.contains('chart-value-collided'));
+
+    positionChart.getDatasetMeta = () => ({ data: [{ x: 200 }, { x: 215 }, { x: 230 }] });
+    charts.chartValueLabelsPlugin.afterRender(positionChart, {}, { trimOffset: 0 });
+    outcomes.chartValueLabelCollisionsKeepNewestObservationVisible =
+      positionedItems[2].classList.contains('chart-value-collided') === false
+      && positionedItems.slice(0, 2).some(item => item.classList.contains('chart-value-collided'));
+    card.remove();
+
     const captured = {};
     const singlePointCaptured = {};
     const canvas = document.createElement('canvas');
@@ -224,7 +254,7 @@ test('charts browser coverage exercises annotation supplement and theme callback
         name: 'Coverage Marker',
         unit: 'mg/L',
         values: [1.2, 4.5, 2.2],
-        refMin: 1,
+        refMin: 0.17,
         refMax: 3,
         optimalMin: 1.5,
         optimalMax: 2.5,
@@ -259,7 +289,8 @@ test('charts browser coverage exercises annotation supplement and theme callback
       && afterLabelText.includes('Phase ref:')
       && chronoAfterLabelText === ''
       && yTickCallback(1.000000000000009) === '1'
-      && yTickCallback(449.6) === '449.6';
+      && yTickCallback(449.6) === '449.6'
+      && captured.config.options.scales.y.min === 0;
     outcomes.createLineChartTooltipCallbacksFormatValuesAndRanges = tooltipCallbacksOk || {
       labelText,
       afterLabelText,
@@ -291,7 +322,7 @@ test('charts browser coverage exercises annotation supplement and theme callback
       },
       data: {
         datasets: [
-          { borderColor: '', backgroundColor: '', pointBackgroundColor: [], pointBorderColor: [], _gbPointStatuses: ['normal', 'high', 'low', 'missing'] },
+          { borderColor: '', backgroundColor: '', pointBackgroundColor: [], pointBorderColor: [], _gbPointStatuses: ['normal', 'high', 'low', 'unrated', 'missing'] },
           { label: 'Chronological Age', borderColor: '' },
         ],
       },
@@ -306,7 +337,7 @@ test('charts browser coverage exercises annotation supplement and theme callback
       && themedChart.options.scales.x.ticks.color === '#94a3b8'
       && themedChart.options.scales.y.grid.color === '#475569'
       && themedChart.data.datasets[0].borderColor === '#38bdf8'
-      && themedChart.data.datasets[0].pointBackgroundColor.join('|') === '#22c55e|#ef4444|#eab308|transparent'
+      && themedChart.data.datasets[0].pointBackgroundColor.join('|') === '#22c55e|#ef4444|#eab308|#94a3b8|transparent'
       && themedChart.data.datasets[1].borderColor === '#94a3b8';
 
     return outcomes;

--- a/tests/playwright/charts-browser-coverage.spec.js
+++ b/tests/playwright/charts-browser-coverage.spec.js
@@ -14,9 +14,10 @@ test('charts browser coverage exercises annotation supplement and theme callback
   await openBlankPage(page);
 
   const results = await page.evaluate(async ({ chartsUrl }) => {
-    const [{ state }, charts] = await Promise.all([
+    const [{ state }, charts, { getLabDateRangeBounds }] = await Promise.all([
       import('/js/state.js'),
       import(chartsUrl),
+      import('/js/lab-date-range.js'),
     ]);
     const outcomes = {};
 
@@ -198,15 +199,25 @@ test('charts browser coverage exercises annotation supplement and theme callback
       && suppChart.ctx.calls.some(call => call[0] === 'fillText' && String(call[1]).includes('Magnesium'));
 
     const captured = {};
+    const singlePointCaptured = {};
     const canvas = document.createElement('canvas');
     canvas.id = 'chart-coverage-marker';
     document.body.appendChild(canvas);
+    const singlePointCanvas = document.createElement('canvas');
+    singlePointCanvas.id = 'chart-range-single-point';
+    document.body.appendChild(singlePointCanvas);
     const originalChart = window.Chart;
+    const originalDateAdapterReady = window.__labChartDateAdapterLoaded;
+    window.__labChartDateAdapterLoaded = true;
     window.Chart = function ChartStub(canvasArg, config) {
-      captured.canvas = canvasArg;
-      captured.config = config;
+      const target = canvasArg === singlePointCanvas ? singlePointCaptured : captured;
+      target.canvas = canvasArg;
+      target.config = config;
       return { canvas: canvasArg, options: config.options, data: config.data, update: () => {} };
     };
+    const originalDateRange = state.dateRangeFilter;
+    let expectedSinglePointBounds = null;
+    let singlePointDate = null;
     try {
       state.rangeMode = 'optimal';
       charts.createLineChart('coverage-marker', {
@@ -219,24 +230,53 @@ test('charts browser coverage exercises annotation supplement and theme callback
         optimalMax: 2.5,
         phaseLabels: ['Follicular', 'Luteal', 'Luteal'],
       }, ['Jan', 'Feb', 'Mar'], ['2026-01-01', '2026-02-01', '2026-03-01'], ['follicular', 'luteal', 'luteal']);
+
+      state.dateRangeFilter = '3m';
+      const recent = new Date();
+      recent.setUTCMonth(recent.getUTCMonth() - 1);
+      singlePointDate = recent.toISOString().slice(0, 10);
+      expectedSinglePointBounds = getLabDateRangeBounds([singlePointDate], '3m');
+      charts.createLineChart('range-single-point', {
+        name: 'Single Result Marker',
+        unit: 'mg/L',
+        values: [2.2],
+        refMin: 1,
+        refMax: 3,
+      }, ['Only result'], [singlePointDate]);
     } finally {
+      state.dateRangeFilter = originalDateRange;
       window.Chart = originalChart;
+      window.__labChartDateAdapterLoaded = originalDateAdapterReady;
     }
     const callbacks = captured.config.options.plugins.tooltip.callbacks;
     const labelText = callbacks.label({ dataset: captured.config.data.datasets[0], parsed: { y: 4.5 } });
     const afterLabelText = callbacks.afterLabel({ datasetIndex: 0, dataIndex: 1 });
     const chronoAfterLabelText = callbacks.afterLabel({ datasetIndex: 1, dataIndex: 1 });
+    const yTickCallback = captured.config.options.scales.y.ticks.callback;
     const tooltipCallbacksOk = captured.canvas === canvas
       && labelText === '4.50 mg/L'
       && afterLabelText.includes('Phase: Luteal')
       && afterLabelText.includes('Phase ref:')
-      && chronoAfterLabelText === '';
+      && chronoAfterLabelText === ''
+      && yTickCallback(1.000000000000009) === '1'
+      && yTickCallback(449.6) === '449.6';
     outcomes.createLineChartTooltipCallbacksFormatValuesAndRanges = tooltipCallbacksOk || {
       labelText,
       afterLabelText,
       chronoAfterLabelText,
       capturedCanvas: captured.canvas === canvas,
     };
+    outcomes.singlePointLabTimelineUsesSharedBoundsWithoutSyntheticDates =
+      singlePointCaptured.canvas === singlePointCanvas
+      && singlePointCaptured.config?.options?.scales?.x?.type === 'time'
+      && singlePointCaptured.config?.options?.scales?.x?.display === false
+      && singlePointCaptured.config?.options?.scales?.x?.min === expectedSinglePointBounds?.min
+      && singlePointCaptured.config?.options?.scales?.x?.max === expectedSinglePointBounds?.max
+      && singlePointCaptured.config?.data?.labels?.length === 1
+      && singlePointCaptured.config?.data?.labels?.[0] === singlePointDate
+      && singlePointCaptured.config?.data?.datasets?.[0]?.data?.length === 1
+      && singlePointCaptured.config?.data?.datasets?.[0]?.data?.[0] === 2.2
+      && !singlePointCaptured.config?.data?.labels?.includes('Today');
 
     const themedChart = {
       options: {

--- a/tests/playwright/charts-browser-coverage.spec.js
+++ b/tests/playwright/charts-browser-coverage.spec.js
@@ -198,36 +198,6 @@ test('charts browser coverage exercises annotation supplement and theme callback
       && suppChart.ctx.calls.some(call => call[0] === 'createLinearGradient')
       && suppChart.ctx.calls.some(call => call[0] === 'fillText' && String(call[1]).includes('Magnesium'));
 
-    const card = document.createElement('div');
-    card.className = 'chart-card';
-    card.innerHTML = `<canvas></canvas><div class="chart-values" style="display:block;width:300px">
-      <div class="chart-value-item" data-chart-value-index="0" style="width:60px"></div>
-      <div class="chart-value-item" data-chart-value-index="1" style="width:60px"></div>
-      <div class="chart-value-item" data-chart-value-index="2" style="width:60px"></div>
-    </div>`;
-    document.body.appendChild(card);
-    const positionChart = {
-      canvas: card.querySelector('canvas'),
-      width: 300,
-      getDatasetMeta: () => ({ data: [{ x: 10 }, { x: 150 }, { x: 295 }] }),
-    };
-    charts.chartValueLabelsPlugin.afterRender(positionChart, {}, { trimOffset: 0 });
-    const positionedItems = [...card.querySelectorAll('.chart-value-item')];
-    const positionedXs = positionedItems.map(item => parseFloat(item.style.getPropertyValue('--chart-value-x')));
-    outcomes.chartValueLabelsFollowPointCoordinatesAndClampToCardEdges =
-      card.querySelector('.chart-values')?.classList.contains('chart-values-positioned')
-      && positionedXs[0] >= 30
-      && positionedXs[1] === 150
-      && positionedXs[2] <= 270
-      && positionedItems.every(item => !item.classList.contains('chart-value-collided'));
-
-    positionChart.getDatasetMeta = () => ({ data: [{ x: 200 }, { x: 215 }, { x: 230 }] });
-    charts.chartValueLabelsPlugin.afterRender(positionChart, {}, { trimOffset: 0 });
-    outcomes.chartValueLabelCollisionsKeepNewestObservationVisible =
-      positionedItems[2].classList.contains('chart-value-collided') === false
-      && positionedItems.slice(0, 2).some(item => item.classList.contains('chart-value-collided'));
-    card.remove();
-
     const captured = {};
     const singlePointCaptured = {};
     const canvas = document.createElement('canvas');

--- a/tests/playwright/compare-correlations-browser-coverage.spec.js
+++ b/tests/playwright/compare-correlations-browser-coverage.spec.js
@@ -318,6 +318,7 @@ test('correlations browser contract filters markers toggles chips and builds cha
         dataIndex: 1,
         parsed: { y: firstDataset?.data?.[1] },
       });
+      const yTickLabel = firstChart?.config?.options?.scales?.y?.ticks?.callback?.(1.000000000000009);
       outcomes.secondMarkerBuildsNormalizedChart =
         state.selectedCorrelationMarkers.length === 2
         && document.getElementById('corr-chart-container')?.style.display === 'block'
@@ -329,6 +330,7 @@ test('correlations browser contract filters markers toggles chips and builds cha
         && Math.abs(firstDataset.data[1] - expectedLdlPct) < 0.001
         && String(tooltipLabel).includes('LDL Cholesterol')
         && String(tooltipLabel).includes('mmol')
+        && yTickLabel === '1%'
         && firstChart.config.options.plugins.refBand.refMin === 0
         && firstChart.config.options.plugins.refBand.refMax === 100
         && firstChart.config.plugins.length === 3;

--- a/tests/playwright/marker-detail-browser-coverage.spec.js
+++ b/tests/playwright/marker-detail-browser-coverage.spec.js
@@ -772,11 +772,30 @@ test('marker detail modal covers default deps descriptions alt units and bio age
         && detailText.includes('coverage-lab.pdf')
         && !!detail?.querySelector('.gb-detail-pin-btn[aria-pressed="false"]')
         && detailText.includes('rec proteins.albumin');
+      outcomes.detailModalBothModeLabelsEachRangeAndUsesNativeEditButtons =
+        detail?.querySelector('.stat-card-value-range')?.textContent.includes('reference')
+        && detail.querySelector('.stat-card:nth-child(2) .stat-card-meta')?.textContent.includes('Optimal')
+        && [...detail.querySelectorAll('.stat-card-range-controls .ref-editable')].every(control => control.tagName === 'BUTTON')
+        && detailText.includes('History All time');
 
-      detail?.querySelector('[data-marker-detail-action="quick-pin"]')?.click();
-      detail?.querySelector('[data-marker-detail-action="rename-marker"]')?.click();
-      detail?.querySelector('[data-marker-detail-action="revert-marker-name"]')?.click();
-      detail?.querySelector('[data-marker-detail-action="ask-ai"]')?.click();
+      state.rangeMode = 'reference';
+      modal.showDetailModal(albuminId);
+      await wait(20);
+      const referenceDetail = document.getElementById('detail-modal');
+      outcomes.detailModalReferenceModeUsesReferenceAsThePrimaryRange =
+        referenceDetail?.querySelector('.stat-card-value-range')?.textContent.includes('reference')
+        && !referenceDetail.querySelector('.stat-card-value-range')?.textContent.includes('optimal');
+      outcomes.detailModalReferenceModeOmitsOptimalSecondaryRange =
+        !referenceDetail?.querySelector('.stat-card:nth-child(2) .stat-card-meta')?.textContent.includes('Optimal');
+      state.rangeMode = 'both';
+      modal.showDetailModal(albuminId);
+      await wait(20);
+
+      const restoredDetail = document.getElementById('detail-modal');
+      restoredDetail?.querySelector('[data-marker-detail-action="quick-pin"]')?.click();
+      restoredDetail?.querySelector('[data-marker-detail-action="rename-marker"]')?.click();
+      restoredDetail?.querySelector('[data-marker-detail-action="revert-marker-name"]')?.click();
+      restoredDetail?.querySelector('[data-marker-detail-action="ask-ai"]')?.click();
       outcomes.defaultDelegatesCallInjectedMarkerActions =
         calls.some(call => call[0] === 'pin' && call[1] === albuminId)
         && calls.some(call => call[0] === 'rename' && call[1] === albuminId)

--- a/tests/test-a11y-phase3.js
+++ b/tests/test-a11y-phase3.js
@@ -41,8 +41,9 @@ console.log('=== Phase 3 A11y Tests ===\n');
   const onboardingViewSrc = read('/js/onboarding-view.js');
   const markerDetailSrc = read('/js/marker-detail-modal.js');
   const dashboardLabRenderersSrc = read('/js/dashboard-lab-widget-renderers.js');
-  assert('chart-card has role and tabindex',
-    categoryViewRenderersSrc.match(/<div class="chart-card[^"]*" role="button" tabindex="0"/));
+  assert('chart-card body has role and tabindex without nesting the Tips control',
+    categoryViewRenderersSrc.includes('class="chart-card-main" role="button" tabindex="0"')
+      && categoryViewRenderersSrc.includes('class="chart-card-tips-host"'));
   assert('trend-alert-card has role and tabindex',
     dashboardLabRenderersSrc.includes('class="trend-alert-card ${cls}" role="button" tabindex="0"'));
   assert('alert-card (critical) has role and tabindex',
@@ -55,8 +56,8 @@ console.log('=== Phase 3 A11y Tests ===\n');
     categoryViewRenderersSrc.match(/heatmap-\$\{s\}" role="button" tabindex="0"/));
   assert('fa-card has role+tabindex',
     categoryViewRenderersSrc.includes('class="fa-card" role="button" tabindex="0"'));
-  assert('ref-editable span has role+tabindex',
-    markerDetailSrc.includes('class="ref-editable" role="button" tabindex="0"'));
+  assert('range edit control is a native button',
+    markerDetailSrc.includes('type="button" class="ref-editable'));
   assert('focus-card refresh has aria-label and delegated action',
     focusCardSrc.includes('class="focus-card-refresh"') &&
     focusCardSrc.includes('aria-label="Regenerate insight"') &&

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -85,6 +85,7 @@ assert('SW APP_SHELL includes settings provider bridge module', swAuditSrc.inclu
 assert('SW APP_SHELL includes PDF import review module', swAuditSrc.includes("'/js/pdf-import-review.js'"));
 assert('SW APP_SHELL includes PDF import review runtime module', swAuditSrc.includes("'/js/pdf-import-review-runtime.js'"));
 assert('SW APP_SHELL includes PDF import commit module', swAuditSrc.includes("'/js/pdf-import-commit.js'"));
+assert('SW APP_SHELL includes lab date range module', swAuditSrc.includes("'/js/lab-date-range.js'"));
 assert('SW APP_SHELL includes fatty-acid profile migration module', swAuditSrc.includes("'/js/profile-fatty-acid-migrations.js'"));
 assert('SW APP_SHELL includes modal lifecycle module', swAuditSrc.includes("'/js/modal-lifecycle.js'"));
 assert('SW APP_SHELL includes marker analysis module', swAuditSrc.includes("'/js/marker-analysis.js'"));

--- a/tests/test-biology-scores.js
+++ b/tests/test-biology-scores.js
@@ -689,6 +689,12 @@ const savedRangeForBiologyScores = state.dateRangeFilter;
 const oldOnlyData = { ...data, dates: ['2025-01-01'], dateLabels: ['Jan 2025'] };
 state.dateRangeFilter = '3m';
 const strictOldOnly = filterDatesByRange(oldOnlyData, { fallbackToAll: false });
+const defaultOldOnly = filterDatesByRange(oldOnlyData);
+assert('filterDatesByRange defaults to an honest empty timeframe instead of silently showing all history',
+  defaultOldOnly.dates.length === 0
+    && Object.values(defaultOldOnly.categories).every(cat =>
+      Object.values(cat.markers || {}).every(marker => marker.singlePoint || marker.values.length === 0)
+    ));
 const contextFilteredData = {
   dates: ['2025-01-01', '2026-06-01'],
   dateLabels: ['Jan 2025', 'Jun 2026'],

--- a/tests/test-changelog.js
+++ b/tests/test-changelog.js
@@ -110,6 +110,11 @@ assert('version.js sets APP_VERSION', versionMatch !== null, versionMatch ? `'${
 assert('APP_VERSION is semver', versionMatch && /^\d+\.\d+\.\d+/.test(versionMatch[1]), versionMatch ? versionMatch[1] : '');
 const latestChangelogVersion = changelogSrc.match(/version:\s*'([^']+)'/)?.[1] || '';
 assert('APP_VERSION is at least latest changelog entry', appVersion && latestChangelogVersion && semverGte(appVersion, latestChangelogVersion), `${appVersion} < ${latestChangelogVersion}`);
+assert('latest changelog gives a simple high-level lab chart overview',
+  /version:\s*'1\.10\.305'[\s\S]{0,500}Clearer lab trends at a glance/.test(changelogSrc)
+    && /version:\s*'1\.10\.305'[\s\S]{0,1200}A consistent timeline across lab charts/.test(changelogSrc)
+    && /version:\s*'1\.10\.305'[\s\S]{0,1200}Recent results in one place/.test(changelogSrc)
+    && /version:\s*'1\.10\.305'[\s\S]{0,1200}Clear marker context/.test(changelogSrc));
 assert('latest changelog explains private AI reliability and Venice limits in user-readable terms',
   /version:\s*'1\.10\.177'[\s\S]{0,1800}Long private replies can finish normally/.test(changelogSrc)
     && /version:\s*'1\.10\.177'[\s\S]{0,1800}Reasoning-heavy models no longer leave an empty chat/.test(changelogSrc)

--- a/tests/test-data-pipeline.js
+++ b/tests/test-data-pipeline.js
@@ -245,7 +245,8 @@ const dataModule = await import('../js/data.js');
   assert('filterDatesByRange "1y" has dates', Array.isArray(filtered1y.dates));
   assert('filterDatesByRange "1y" has <= all dates', filtered1y.dates.length <= allData.dates.length);
 
-  // Fallback: if no dates in range, show all
+  // Empty selected windows remain empty unless a caller explicitly opts into
+  // the legacy all-history fallback.
   S.dateRangeFilter = '3m';
   const oldData = {
     dates: ['2020-01-01'],
@@ -255,8 +256,11 @@ const dataModule = await import('../js/data.js');
     }}}
   };
   const oldFiltered = dataModule.filterDatesByRange(oldData);
-  assert('filterDatesByRange falls back to all when no dates in range', oldFiltered.dates.length === 1,
+  assert('filterDatesByRange keeps an empty selected timeframe truthful', oldFiltered.dates.length === 0,
     `got ${oldFiltered.dates.length}`);
+  const oldFallback = dataModule.filterDatesByRange(oldData, { fallbackToAll: true });
+  assert('filterDatesByRange still supports an explicit all-history fallback', oldFallback.dates.length === 1,
+    `got ${oldFallback.dates.length}`);
 
   S.dateRangeFilter = 'all';
 

--- a/tests/test-trend-alerts.js
+++ b/tests/test-trend-alerts.js
@@ -27,7 +27,7 @@ function assert(name, condition, detail) {
 
 console.log('=== Trend Alerts & Status Tests ===\n');
 
-const { linearRegression, getStatus } = await import('../js/utils.js');
+const { linearRegression, getStatus, getTrend } = await import('../js/utils.js');
 const { detectTrendAlerts, getKeyTrendMarkers, getEffectiveRange } = await import('../js/marker-analysis.js');
 
   // =======================================
@@ -100,6 +100,15 @@ const { detectTrendAlerts, getKeyTrendMarkers, getEffectiveRange } = await impor
   assert('Only refMax, value below = normal', getStatus(3, null, 10) === 'normal');
   assert('Only refMax, value above = high', getStatus(15, null, 10) === 'high');
   assert('Zero value, within range = normal', getStatus(0, -1, 1) === 'normal');
+  const stableTrend = getTrend([100, 101], 80, 120);
+  const fallingTrend = getTrend([100, 90], 80, 120);
+  const zeroBaselineTrend = getTrend([0, 5], 0, 10);
+  assert('stable marker change uses clear text instead of an unexplained arrow',
+    stableTrend.arrow === 'Stable' && stableTrend.label.includes('versus previous result'));
+  assert('non-stable marker change exposes an accessible previous-result label',
+    fallingTrend.arrow === '↓ -10.0%' && fallingTrend.label === 'Decreased 10.0% versus previous result');
+  assert('zero-baseline marker change explains why no percentage is shown',
+    zeroBaselineTrend.arrow === 'Changed' && zeroBaselineTrend.label.includes('previous value was zero'));
 
   // =======================================
   // 6. detectTrendAlerts — sudden change (high)

--- a/tests/test-v1-6-shipped.js
+++ b/tests/test-v1-6-shipped.js
@@ -589,7 +589,7 @@ const _origProfileSex = state ? state.profileSex : null;
       /\.chart-card-snapshot\s*\{/.test(cssSrc)
       && /\.chart-container\s*\{[^\}]*height:\s*150px/.test(cssSrc)
       && /\.chart-values\s*\{[\s\S]{0,160}grid-template-columns:\s*repeat\(var\(--chart-value-count/.test(cssSrc)
-      && /\.chart-values\.chart-values-positioned/.test(cssSrc));
+      && /\.chart-values-label\s*\{/.test(cssSrc));
     assert('category-page-view.js: returning to Charts restores tips and sorted card order',
       /sortCategoryChartEntries\(withData, categoryKey\)[\s\S]{0,900}loadChartCardRecs\(\)/.test(categoryPageViewSrc));
     assert('chart-card-recs.js: tips nudge does not cover open marker modal',

--- a/tests/test-v1-6-shipped.js
+++ b/tests/test-v1-6-shipped.js
@@ -588,7 +588,10 @@ const _origProfileSex = state ? state.profileSex : null;
     assert('styles.css: marker cards are compact summary-first cards',
       /\.chart-card-snapshot\s*\{/.test(cssSrc)
       && /\.chart-container\s*\{[^\}]*height:\s*150px/.test(cssSrc)
-      && /\.chart-values\s*\{[\s\S]{0,140}grid-template-columns:\s*repeat\(4/.test(cssSrc));
+      && /\.chart-values\s*\{[\s\S]{0,160}grid-template-columns:\s*repeat\(var\(--chart-value-count/.test(cssSrc)
+      && /\.chart-values\.chart-values-positioned/.test(cssSrc));
+    assert('category-page-view.js: returning to Charts restores tips and sorted card order',
+      /sortCategoryChartEntries\(withData, categoryKey\)[\s\S]{0,900}loadChartCardRecs\(\)/.test(categoryPageViewSrc));
     assert('chart-card-recs.js: tips nudge does not cover open marker modal',
       /const modalOpen\s*=\s*!!document\.querySelector\('\.modal-overlay\.show'\)/.test(chartCardRecsSrc)
       && /recLinks\.length > 0 && !modalOpen/.test(chartCardRecsSrc));
@@ -649,14 +652,16 @@ const _origProfileSex = state ? state.profileSex : null;
       /const refMin\s*=\s*numericOrNull\(marker\.refMin\)/.test(markerDetailSrc)
       && /const effMin\s*=\s*numericOrNull\(latestRange\.min\)/.test(markerDetailSrc)
       && /const baseMin\s*=\s*refMin \?\? effMin/.test(markerDetailSrc)
-      && /const hasOptimalBand\s*=\s*optMin != null && optMax != null/.test(markerDetailSrc)
-      && /const goodMin\s*=\s*hasOptimalBand \? Math\.min\(optMin, optMax\) : Math\.min\(baseMin, baseMax\)/.test(markerDetailSrc)
+      && /const usePhaseBand\s*=\s*hasLatestPhaseRange/.test(markerDetailSrc)
+      && /const useOptimalBand\s*=\s*!usePhaseBand && state\.rangeMode !== 'reference'/.test(markerDetailSrc)
+      && /const goodMin\s*=\s*usePhaseBand \? Math\.min\(effMin, effMax\) : useOptimalBand/.test(markerDetailSrc)
       && /const zonePad\s*=\s*goodSpan \* 0\.1/.test(markerDetailSrc)
       && /for \(const value of \[goodMin, goodMax, latestValue\]\)/.test(markerDetailSrc)
       && /if \(latestValue >= max\) max \+= span \* 0\.08/.test(markerDetailSrc)
       && /const referenceDisplay\s*=/.test(markerDetailSrc)
-      && /const referenceMetaLabel\s*=\s*hasReferenceRange \? 'Ref' : 'Range'/.test(markerDetailSrc)
-      && /const rangeMainDisplay\s*=\s*hasOptimalRange \? optimalDisplay : referenceDisplay/.test(markerDetailSrc));
+      && /const referenceMetaLabel\s*=\s*hasReferenceRange \? 'Reference' : 'Range'/.test(markerDetailSrc)
+      && /let rangeMainDisplay\s*=\s*'Not set'/.test(markerDetailSrc)
+      && /state\.rangeMode === 'optimal'[\s\S]{0,400}else if \(hasReferenceRange\) \{\s*rangeMainDisplay = referenceDisplay/.test(markerDetailSrc));
     assert('marker-detail-modal.js/styles.css: marker range band colors non-optimal zones',
       /gb-range-band-zone-low/.test(markerDetailSrc)
       && /gb-range-band-zone-high/.test(markerDetailSrc)

--- a/tests/test-v1-6-shipped.js
+++ b/tests/test-v1-6-shipped.js
@@ -584,7 +584,7 @@ const _origProfileSex = state ? state.profileSex : null;
     assert('styles.css: marker cards stretch to preserve row alignment',
       /\.charts-grid\s*\{[\s\S]{0,220}align-items:\s*stretch/.test(cssSrc)
       && /\.chart-card\s*\{[\s\S]{0,260}height:\s*100%/.test(cssSrc)
-      && /\.chart-card-meta\s*\{[\s\S]{0,180}flex-wrap:\s*nowrap/.test(cssSrc));
+      && /\.chart-card-title-block,[\s\S]{0,140}flex:\s*1/.test(cssSrc));
     assert('styles.css: marker cards are compact summary-first cards',
       /\.chart-card-snapshot\s*\{/.test(cssSrc)
       && /\.chart-container\s*\{[^\}]*height:\s*150px/.test(cssSrc)

--- a/tests/test-wearables-dom.js
+++ b/tests/test-wearables-dom.js
@@ -109,6 +109,8 @@ return (async function() {
   assert('Chart primary dataset carries 3 dated points',
     modalChart?.data?.datasets?.[0]?.data?.filter(p => p?.x && typeof p?.y === 'number')?.length === 3);
   assert('Chart x-axis is time type', modalChart?.options?.scales?.x?.type === 'time');
+  assert('Wearable y-axis hides floating-point tick artifacts',
+    modalChart?.options?.scales?.y?.ticks?.callback?.(1.000000000000009) === '1');
   const rangeButtons = Array.from(document.querySelectorAll('#detail-modal .wearable-detail-range .ctx-btn-option'));
   assert('Detail modal renders 90d / 6m / 1y / All range buttons',
     rangeButtons.map(b => b.textContent.trim()).join('|') === '90d|6m|1y|All');
@@ -161,6 +163,8 @@ return (async function() {
     !bpLabels.some(l => /^Manual diastolic$/.test(l)), bpLabels.join('|'));
   assert('BP diastolic dataset has 3 dated points',
     bpChart?.data?.datasets?.find(d => /^Diastolic/.test(d.label))?.data?.length === 3);
+  assert('Blood-pressure y-axis hides floating-point tick artifacts',
+    bpChart?.options?.scales?.y?.ticks?.callback?.(1.000000000000009) === '1');
   assert('BP manual entries preserve paired sys/dia row value',
     !!document.querySelector('#detail-modal .wearable-manual-entry-val')?.textContent?.includes('120/80'));
   views.closeModal();

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -129,6 +129,7 @@
     "js/import-review-row-actions.js",
     "js/lab-context.js",
     "js/lab-context-wearables.js",
+    "js/lab-date-range.js",
     "js/lens-actions.js",
     "js/lens-cache.js",
     "js/lens-knowledge-base-ui.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.301';
+self.APP_VERSION = '1.10.302';

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.303';
+self.APP_VERSION = '1.10.304';

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.302';
+self.APP_VERSION = '1.10.303';

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.304';
+self.APP_VERSION = '1.10.305';


### PR DESCRIPTION
## Summary

- anchor lab-marker charts to the selected timeframe through shared date-range bounds, including single-result charts
- remove empty/generated x-axis dates while preserving real chronological spacing in the plot
- show the latest four actual observations in a predictable, labeled recent-results strip
- make marker-card range, status, trend, filtering, and detail-modal behavior consistent and accessible
- harden specialty-marker recovery and date-range consumers uncovered during the audit

## Root cause

Marker charts and related views derived their timeline bounds and compact labels independently. Single-point charts could therefore lose the selected timeframe context, while summary labels alternated between acting like an axis and acting like recent history. Missing values and range fallbacks also produced inconsistent card, dashboard, and modal states.

## Impact

All marker charts now share the selected range boundaries, sparse data remains visually honest, and the compact history area consistently shows up to four real results without empty dates or collision-based disappearance.

## Validation

- `./run-tests.sh`
- 405/405 Vitest tests passed
- 352/352 Playwright tests passed
- 472/472 responsive theme checks passed

Closes #1234