### PR TITLE
Fix and cover profile sharing

### DIFF
--- a/api/share.js
+++ b/api/share.js
@@ -412,7 +412,11 @@ async function handleDelete(req) {
       return jsonResponse(req, 403, { error: 'This link can only be stopped from the browser that created it.' });
     }
   }
-  await del(path, options);
+  try {
+    await del(path, options);
+  } catch (err) {
+    return jsonResponse(req, 500, { error: err?.message || 'Could not stop sharing link.' });
+  }
   return jsonResponse(req, 200, { ok: true });
 }
 

--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -127,6 +127,7 @@ import {
   configureShellChatImageDeps,
   configureShellChatThreadDeps,
   configureShellNavDeps,
+  configureShellProfileShareDeps,
 } from './shell-actions.js';
 import { configureStartupUIDeps } from './startup-ui.js';
 import { configureSyncPull } from './sync-pull.js';
@@ -257,6 +258,7 @@ configureShellChatActionDeps({
 configureShellChatImageDeps({ toggleHDMode });
 configureShellChatThreadDeps({ createNewThread, filterThreadList, toggleThreadRail });
 configureShellNavDeps({ closeMobileSidebar, toggleMobileSidebar });
+configureShellProfileShareDeps({ openProfileShareModal });
 configureStartupUIDeps({
   getInitialView,
   initChatImageHandlers,

--- a/js/profile-share.js
+++ b/js/profile-share.js
@@ -240,7 +240,12 @@ export async function decryptProfileShareEnvelope(envelope, secret) {
   const iterations = Number(kdf.iterations);
   if (!Number.isInteger(iterations) || iterations < PROFILE_SHARE_MIN_KDF_ITERATIONS) throw new Error('Invalid shared profile encryption settings.');
   const key = await deriveShareKey(shareSecret, salt, iterations);
-  const plaintextBytes = new Uint8Array(await getCrypto().subtle.decrypt({ name: 'AES-GCM', iv }, key, ciphertext));
+  let plaintextBytes;
+  try {
+    plaintextBytes = new Uint8Array(await getCrypto().subtle.decrypt({ name: 'AES-GCM', iv }, key, ciphertext));
+  } catch {
+    throw new Error('Could not decrypt shared profile.');
+  }
   const jsonText = await decompressJsonBytes(plaintextBytes, envelope.compression);
   return validateClientExportObject(JSON.parse(jsonText));
 }
@@ -283,12 +288,17 @@ async function deleteProfileShareEnvelope(id, manageToken = '') {
 function readShareRecords() {
   if (typeof localStorage === 'undefined') return [];
   let parsed = [];
+  let shouldRewrite = false;
   try {
     parsed = JSON.parse(localStorage.getItem(SHARE_RECORDS_KEY) || '[]');
   } catch {
     parsed = [];
+    shouldRewrite = true;
   }
-  if (!Array.isArray(parsed)) parsed = [];
+  if (!Array.isArray(parsed)) {
+    parsed = [];
+    shouldRewrite = true;
+  }
   const now = Date.now();
   const records = parsed
     .filter(record => record && typeof record === 'object')
@@ -301,8 +311,9 @@ function readShareRecords() {
       manageToken: String(record.manageToken || ''),
       createdAt: String(record.createdAt || ''),
       expiresAt: String(record.expiresAt || ''),
-    }));
-  if (records.length !== parsed.length) writeShareRecords(records);
+    }))
+    .slice(0, 50);
+  if (shouldRewrite || records.length !== parsed.length) writeShareRecords(records);
   return records;
 }
 

--- a/js/shell-actions.js
+++ b/js/shell-actions.js
@@ -8,6 +8,9 @@ import { getSettingsModuleFunction } from './settings-runtime-bridge.js';
 let shellDelegatesInstalled = false;
 const shellImportDeps = { handleImportStatusClick, isImportRunning };
 const shellFeedbackDeps = { openFeedbackModal };
+const shellProfileShareDeps = {
+  openProfileShareModal: (_profileId) => {},
+};
 const shellNavDeps = {
   closeMobileSidebar: () => {},
   toggleMobileSidebar: () => {},
@@ -42,6 +45,14 @@ export function configureShellImportDeps(deps = {}) {
 export function configureShellFeedbackDeps(deps = {}) {
   const previous = { ...shellFeedbackDeps };
   if (typeof deps.openFeedbackModal === 'function') shellFeedbackDeps.openFeedbackModal = deps.openFeedbackModal;
+  return previous;
+}
+
+export function configureShellProfileShareDeps(deps = {}) {
+  const previous = { ...shellProfileShareDeps };
+  if (typeof deps.openProfileShareModal === 'function') {
+    shellProfileShareDeps.openProfileShareModal = deps.openProfileShareModal;
+  }
   return previous;
 }
 
@@ -113,7 +124,7 @@ function runShellAction(action) {
     clickFileInput('pdf-input');
     return true;
   } else if (action === 'share-profile') {
-    callShellRuntime('openProfileShareModal');
+    shellProfileShareDeps.openProfileShareModal();
     return true;
   } else if (action === 'open-tweaks') {
     callShellRuntime('openTweaksPanel');

--- a/tests/api-network-runtime.test.js
+++ b/tests/api-network-runtime.test.js
@@ -82,7 +82,7 @@ function validEnvelope(overrides = {}) {
   };
 }
 
-function installBlobStoreMock({ conflictRateLimit = false } = {}) {
+function installBlobStoreMock({ conflictRateLimit = false, failDelete = false } = {}) {
   const store = new Map();
   const apiCalls = [];
   const directCalls = [];
@@ -95,6 +95,9 @@ function installBlobStoreMock({ conflictRateLimit = false } = {}) {
       apiCalls.push({ href, method, init });
 
       if (parsed.pathname.endsWith('/delete')) {
+        if (failDelete) {
+          return jsonResponse({ error: { code: 'upstream_error', message: 'blob delete unavailable' } }, { status: 503 });
+        }
         const { urls = [] } = JSON.parse(String(init.body || '{}'));
         for (const item of urls) {
           const path = String(item || '').replace(/^https:\/\/[^/]+\//, '');
@@ -284,6 +287,151 @@ describe('profile share API runtime behavior', () => {
       retryAfterSeconds: expect.any(Number),
     });
     expect(globalThis.fetch).toHaveBeenCalledTimes(20);
+  });
+
+  it('dynamically enforces every encrypted-envelope boundary before storing a share', async () => {
+    process.env.BLOB_READ_WRITE_TOKEN = 'vercel_blob_rw_store123_secret';
+    const { store } = installBlobStoreMock();
+    const id = 'shareBoundaryId012345678';
+    const manageTokenHash = 'a'.repeat(64);
+    const cases = [
+      {
+        label: 'invalid JSON',
+        request: () => makeShareRequest('POST', undefined, { rawBody: '{' }),
+        error: 'Invalid JSON body.',
+      },
+      {
+        label: 'missing envelope',
+        request: () => makeShareRequest('POST', { id, manageTokenHash, envelope: null }),
+        error: 'Missing encrypted profile payload.',
+      },
+      {
+        label: 'unsupported schema',
+        request: () => makeShareRequest('POST', {
+          id, manageTokenHash, envelope: validEnvelope({ schema: 'other' }),
+        }),
+        error: 'Unsupported encrypted profile payload.',
+      },
+      {
+        label: 'expired envelope',
+        request: () => makeShareRequest('POST', {
+          id,
+          manageTokenHash,
+          envelope: validEnvelope({ expiresAt: '2000-01-01T00:00:00.000Z' }),
+        }),
+        error: 'Share expiry must be in the future.',
+      },
+      {
+        label: 'excessive lifetime',
+        request: () => makeShareRequest('POST', {
+          id,
+          manageTokenHash,
+          envelope: validEnvelope({ expiresAt: new Date(Date.now() + 31 * 24 * 60 * 60 * 1000).toISOString() }),
+        }),
+        error: 'Share expiry cannot exceed 30 days.',
+      },
+      {
+        label: 'unsupported key derivation',
+        request: () => makeShareRequest('POST', {
+          id,
+          manageTokenHash,
+          envelope: validEnvelope({ kdf: { name: 'scrypt', hash: 'SHA-256', iterations: 100_000 } }),
+        }),
+        error: 'Unsupported key derivation.',
+      },
+      {
+        label: 'unsupported cipher',
+        request: () => makeShareRequest('POST', {
+          id,
+          manageTokenHash,
+          envelope: validEnvelope({ cipher: { name: 'AES-CBC', iv: 'profile-share-iv' } }),
+        }),
+        error: 'Unsupported cipher.',
+      },
+      {
+        label: 'empty ciphertext',
+        request: () => makeShareRequest('POST', {
+          id, manageTokenHash, envelope: validEnvelope({ ciphertext: '' }),
+        }),
+        error: 'Encrypted profile payload is empty.',
+      },
+      {
+        label: 'oversized ciphertext',
+        request: () => makeShareRequest('POST', {
+          id, manageTokenHash, envelope: validEnvelope({ ciphertext: 'a'.repeat(3_750_000) }),
+        }),
+        error: 'Encrypted profile payload is too large for link sharing.',
+      },
+    ];
+
+    for (const testCase of cases) {
+      const response = await shareHandler(testCase.request());
+      expect(response.status, testCase.label).toBe(400);
+      expect(await responseJson(response), testCase.label).toEqual({ error: testCase.error });
+    }
+    expect(Array.from(store.keys()).filter(path => path.startsWith('profile-shares/v1/'))).toEqual([]);
+  });
+
+  it('handles missing, expired, corrupt, duplicate, and unsupported-method records', async () => {
+    process.env.BLOB_READ_WRITE_TOKEN = 'vercel_blob_rw_store123_secret';
+    const { store } = installBlobStoreMock();
+    const id = 'shareRecordEdge0123456789';
+    const path = `profile-shares/v1/${id}.json`;
+    const manageTokenHash = 'b'.repeat(64);
+
+    const missingGet = await shareHandler(makeShareRequest('GET', undefined, { id }));
+    expect(missingGet.status).toBe(404);
+    expect(await responseJson(missingGet)).toEqual({ error: 'Shared profile not found.' });
+
+    const missingDelete = await shareHandler(makeShareRequest('DELETE', {}, { id }));
+    expect(missingDelete.status).toBe(200);
+    expect(await responseJson(missingDelete)).toEqual({ ok: true, missing: true });
+
+    store.set(path, '{invalid-record');
+    const corrupt = await shareHandler(makeShareRequest('GET', undefined, { id }));
+    expect(corrupt.status).toBe(500);
+
+    store.set(path, JSON.stringify({
+      id,
+      expiresAt: '2000-01-01T00:00:00.000Z',
+      manageTokenHash,
+      envelope: validEnvelope(),
+    }));
+    const expired = await shareHandler(makeShareRequest('GET', undefined, { id }));
+    expect(expired.status).toBe(410);
+    expect(await responseJson(expired)).toEqual({ error: 'Shared profile link has expired.' });
+    await vi.waitFor(() => expect(store.has(path)).toBe(false));
+
+    const createBody = { id, manageTokenHash, envelope: validEnvelope() };
+    const created = await shareHandler(makeShareRequest('POST', createBody));
+    expect(created.status).toBe(201);
+    const duplicate = await shareHandler(makeShareRequest('POST', createBody));
+    expect(duplicate.status).toBe(409);
+
+    const unsupported = await shareHandler(makeShareRequest('PATCH', undefined, { id }));
+    expect(unsupported.status).toBe(405);
+    expect(await responseJson(unsupported)).toEqual({ error: 'Method not allowed.' });
+  });
+
+  it('returns a JSON error and keeps the share record when Blob deletion fails', async () => {
+    process.env.BLOB_READ_WRITE_TOKEN = 'vercel_blob_rw_store123_secret';
+    const { store } = installBlobStoreMock({ failDelete: true });
+    const id = 'shareDeleteFailure01234567';
+    const manageToken = 'delete-failure-token';
+    const manageTokenHash = await sha256Hex(manageToken);
+    const path = `profile-shares/v1/${id}.json`;
+    store.set(path, JSON.stringify({
+      id,
+      expiresAt: validEnvelope().expiresAt,
+      manageTokenHash,
+      envelope: validEnvelope(),
+    }));
+
+    const response = await shareHandler(makeShareRequest('DELETE', { manageToken }, { id }));
+
+    expect(response.status).toBe(500);
+    expect(await responseJson(response)).toEqual({ error: 'blob delete unavailable' });
+    expect(store.has(path)).toBe(true);
   });
 });
 

--- a/tests/playwright/profile-share-browser-coverage.spec.js
+++ b/tests/playwright/profile-share-browser-coverage.spec.js
@@ -4,6 +4,70 @@ function moduleUrl(path) {
   return `${path}?profileShareCoverage=${Date.now()}-${Math.random().toString(36).slice(2)}`;
 }
 
+test('Share Profile entry points open the sharing modal', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('labcharts-default-emptyTour', 'completed');
+    localStorage.setItem('labcharts-default-tour', 'completed');
+    localStorage.setItem('labcharts-default-onboarded', 'dismissed');
+  });
+  await page.goto('/app', { waitUntil: 'networkidle' });
+
+  await page.evaluate(async () => {
+    const [{ closeChatPanel }, { endTour }] = await Promise.all([
+      import('/js/chat-panel.js'),
+      import('/js/tour.js'),
+    ]);
+    endTour({ openEmptyChat: false });
+    closeChatPanel();
+  });
+  await expect(page.locator('#tour-overlay')).toHaveCount(0);
+  await expect(page.locator('#chat-panel')).not.toHaveClass(/\bopen\b/);
+  await page.locator('[data-shell-action="share-profile"]').click();
+
+  await expect(page.locator('#profile-share-overlay')).toBeVisible();
+  await expect(page.locator('#profile-share-overlay [role="dialog"]')).toHaveAttribute('aria-label', 'Share Profile');
+  await expect(page.locator('#profile-share-overlay [data-profile-share-action="close"]').first()).toBeFocused();
+  await page.keyboard.press('Escape');
+  await expect(page.locator('#profile-share-overlay')).toHaveCount(0);
+  await expect(page.locator('[data-shell-action="share-profile"]')).toBeFocused();
+
+  await page.evaluate(async () => {
+    const { state } = await import('/js/state.js');
+    state.importedData = {
+      ...state.importedData,
+      entries: [{ date: '2026-07-20', markers: { metabolic: { glucose: 5.1 } } }],
+    };
+    const { openSettingsModal } = await import('/js/settings.js');
+    openSettingsModal('data');
+  });
+  await expect(page.locator('#settings-modal-overlay')).toBeVisible();
+  await page.locator('[data-settings-action="share-profile"]').click();
+  await expect(page.locator('#profile-share-overlay')).toBeVisible();
+  await page.locator('#profile-share-overlay [data-profile-share-action="close"]').first().click();
+  await expect(page.locator('#profile-share-overlay')).toHaveCount(0);
+
+  const profile = await page.evaluate(async () => {
+    const [{ state }, { closeSettingsModal }, { openClientList }] = await Promise.all([
+      import('/js/state.js'),
+      import('/js/settings.js'),
+      import('/js/client-list.js'),
+    ]);
+    closeSettingsModal();
+    openClientList();
+    return {
+      id: state.currentProfile,
+      name: state.profiles.find(item => item.id === state.currentProfile)?.name || 'Active profile',
+    };
+  });
+  await page.setViewportSize({ width: 390, height: 844 });
+  await expect(page.locator('#client-list-overlay')).toBeVisible();
+  await page.locator(`[data-cl-action="toggle-menu"][data-cl-profile-id="${profile.id}"]`).click();
+  await page.locator(`[data-cl-action="share-profile"][data-cl-profile-id="${profile.id}"]`).click();
+  await expect(page.locator('#client-list-overlay')).toBeHidden();
+  await expect(page.locator('#profile-share-overlay')).toBeVisible();
+  await expect(page.locator('.profile-share-intro-title')).toContainText(profile.name);
+});
+
 test('profile share modal creates copies and manages active encrypted links', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
 

--- a/tests/playwright/profile-share-edge-browser-coverage.spec.js
+++ b/tests/playwright/profile-share-edge-browser-coverage.spec.js
@@ -1,0 +1,426 @@
+import { expect, test } from './coverage-fixture.js';
+
+function moduleUrl(path) {
+  return `${path}?profileShareEdgeCoverage=${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+async function openIsolatedProfileSharePage(page) {
+  await page.route('**/profile-share-edge-browser-coverage', route => route.fulfill({
+    status: 200,
+    contentType: 'text/html',
+    body: `<!doctype html>
+      <html>
+        <body>
+          <button id="share-trigger" type="button">Share</button>
+          <div id="notification-container"></div>
+        </body>
+      </html>`,
+  }));
+  await page.route('**/js/profile.js*', route => route.fulfill({
+    status: 200,
+    contentType: 'application/javascript',
+    body: `
+      export function getProfiles() {
+        return [
+          { id: 'default', name: 'Edge Profile' },
+          { id: 'other-profile', name: 'Other Profile' },
+        ];
+      }
+    `,
+  }));
+  await page.route('**/js/export.js*', route => route.fulfill({
+    status: 200,
+    contentType: 'application/javascript',
+    body: `
+      export async function buildClientExportObject(profileId) {
+        if (window.__profileShareExportError) throw new Error(window.__profileShareExportError);
+        return {
+          version: 2,
+          profile: { id: profileId || 'default', name: 'Edge Profile' },
+          entries: [{ date: '2026-07-20', markers: { metabolic: { glucose: 5.1 } } }],
+        };
+      }
+      export async function importDataJSON(file) {
+        if (window.__profileShareImportError) throw new Error(window.__profileShareImportError);
+        const payload = JSON.parse(await file.text());
+        window.__profileShareImports = window.__profileShareImports || [];
+        window.__profileShareImports.push({ name: file.name, type: file.type, payload });
+        return true;
+      }
+    `,
+  }));
+  await page.goto('/profile-share-edge-browser-coverage', { waitUntil: 'load' });
+}
+
+test('profile share forms recover from create, load, decrypt, import, and delete failures', async ({ page }) => {
+  test.slow();
+  await openIsolatedProfileSharePage(page);
+
+  const results = await page.evaluate(async ({ shareUrl }) => {
+    const share = await import(shareUrl);
+    const outcomes = {};
+    const requests = [];
+    const originalFetch = window.fetch;
+    let mode = '';
+    const jsonResponse = (body, status = 200) => new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+    const waitFor = async (predicate, label, attempts = 160) => {
+      for (let attempt = 0; attempt < attempts; attempt += 1) {
+        if (predicate()) return;
+        await new Promise(resolve => setTimeout(resolve, 50));
+      }
+      throw new Error(`Timed out waiting for ${label}`);
+    };
+    const statusText = () => document.getElementById('profile-share-status')?.textContent || '';
+    const submit = action => document.querySelector(`[data-profile-share-action="${action}"]`);
+
+    try {
+      window.fetch = async (url, options = {}) => {
+        const href = String(url || '');
+        const method = String(options.method || 'GET').toUpperCase();
+        if (!href.startsWith('/api/share')) return originalFetch(url, options);
+        requests.push({ href, method, body: String(options.body || '') });
+        if (method === 'POST') return jsonResponse({ error: 'Share service unavailable.' }, 503);
+        if (method === 'DELETE') return jsonResponse({ error: 'Could not stop this test link.' }, 503);
+        if (mode === 'not-found') return jsonResponse({ error: 'Shared profile link has expired.' }, 410);
+        if (mode === 'missing-envelope') return jsonResponse({ id: 'missing-envelope' });
+        return jsonResponse({ envelope: window.__profileShareEnvelope });
+      };
+
+      share.openProfileShareModal('default');
+      const createPassword = document.getElementById('profile-share-password');
+      const consent = document.getElementById('profile-share-consent');
+      createPassword.value = 'short';
+      consent.checked = true;
+      submit('create')?.click();
+      await waitFor(() => statusText().includes('at least 12 characters'), 'short-password error');
+      outcomes.shortPasswordRecovers = statusText().includes('at least 12 characters')
+        && submit('create')?.textContent === 'Create Link'
+        && submit('create')?.disabled === false
+        && createPassword.disabled === false;
+
+      createPassword.value = 'correct-horse-create-1234';
+      submit('create')?.click();
+      await waitFor(() => statusText().includes('Share service unavailable'), 'create API error');
+      outcomes.createFailureRecovers = requests.filter(request => request.method === 'POST').length === 1
+        && statusText().includes('Share service unavailable')
+        && document.getElementById('profile-share-overlay') != null
+        && submit('create')?.textContent === 'Create Link'
+        && submit('create')?.disabled === false
+        && document.getElementById('profile-share-expires')?.disabled === false;
+
+      const password = 'correct-horse-load-1234';
+      window.__profileShareEnvelope = await share.encryptProfileShareEnvelope({
+        version: 2,
+        profile: { id: 'shared-profile', name: 'Shared Edge Profile' },
+        entries: [{ date: '2026-07-19', markers: {} }],
+      }, password, {
+        iterations: share.PROFILE_SHARE_MIN_KDF_ITERATIONS,
+        expiresAt: '2099-01-01T00:00:00.000Z',
+      });
+
+      const shareId = 'edgefailureprofile123456';
+      mode = 'not-found';
+      share.openSharedProfileImportModal(shareId);
+      const loadPassword = document.getElementById('profile-share-load-password');
+      loadPassword.value = password;
+      submit('load')?.click();
+      await waitFor(() => statusText().includes('expired'), 'expired-link API error');
+      outcomes.loadFailureRecovers = statusText().includes('expired')
+        && submit('load')?.textContent === 'Load Profile'
+        && submit('load')?.disabled === false
+        && loadPassword.disabled === false;
+
+      mode = 'missing-envelope';
+      const getCountBeforeMissing = requests.filter(request => request.method === 'GET').length;
+      submit('load')?.click();
+      await waitFor(() => requests.filter(request => request.method === 'GET').length > getCountBeforeMissing
+        && statusText().includes('payload is missing'), 'missing-envelope error');
+      outcomes.missingEnvelopeRecovers = statusText().includes('payload is missing')
+        && submit('load')?.disabled === false;
+
+      mode = 'envelope';
+      loadPassword.value = 'wrong-password-1234';
+      const getCountBeforeWrongPassword = requests.filter(request => request.method === 'GET').length;
+      submit('load')?.click();
+      await waitFor(() => requests.filter(request => request.method === 'GET').length > getCountBeforeWrongPassword
+        && statusText().includes('Check the password'), 'wrong-password error');
+      outcomes.wrongPasswordUsesSafeMessage = statusText() === 'Could not unlock shared profile. Check the password and try again.'
+        && submit('load')?.disabled === false;
+
+      window.__profileShareImportError = 'Import rejected by fixture.';
+      loadPassword.value = password;
+      const getCountBeforeImportError = requests.filter(request => request.method === 'GET').length;
+      submit('load')?.click();
+      await waitFor(() => requests.filter(request => request.method === 'GET').length > getCountBeforeImportError
+        && statusText().includes('Import rejected by fixture'), 'import error');
+      outcomes.importFailureRecovers = statusText().includes('Import rejected by fixture')
+        && document.getElementById('profile-share-overlay') != null
+        && submit('load')?.textContent === 'Load Profile'
+        && submit('load')?.disabled === false;
+
+      share.closeProfileShareModal();
+      localStorage.setItem('getbased-profile-shares-v1', JSON.stringify([{
+        id: shareId,
+        profileId: 'default',
+        profileName: 'Edge Profile',
+        shareUrl: `${location.origin}${location.pathname}#share/${shareId}`,
+        manageToken: 'correct-local-manage-token',
+        createdAt: new Date().toISOString(),
+        expiresAt: '2099-01-01T00:00:00.000Z',
+      }]));
+      share.openProfileShareModal('default');
+      const deleteButton = submit('delete-link');
+      deleteButton?.click();
+      await waitFor(() => statusText().includes('Could not stop this test link'), 'delete API error');
+      const deleteRequest = requests.find(request => request.method === 'DELETE');
+      outcomes.deleteFailureKeepsRecordAndRecovers = JSON.parse(
+        localStorage.getItem('getbased-profile-shares-v1') || '[]',
+      ).length === 1
+        && JSON.parse(deleteRequest?.body || '{}').manageToken === 'correct-local-manage-token'
+        && deleteButton?.textContent === 'Stop sharing'
+        && deleteButton?.disabled === false
+        && statusText().includes('Could not stop this test link');
+    } finally {
+      share.closeProfileShareModal();
+      window.fetch = originalFetch;
+      localStorage.removeItem('getbased-profile-shares-v1');
+      document.querySelectorAll('.notification-toast').forEach(element => element.remove());
+      delete window.__profileShareEnvelope;
+      delete window.__profileShareImportError;
+    }
+
+    return outcomes;
+  }, { shareUrl: moduleUrl('/js/profile-share.js') });
+
+  for (const [name, passed] of Object.entries(results)) {
+    expect(passed, name).toBe(true);
+  }
+});
+
+test('profile share local records are repaired, capped, scoped, and safe without a management token', async ({ page }) => {
+  await openIsolatedProfileSharePage(page);
+
+  const results = await page.evaluate(async ({ shareUrl }) => {
+    const share = await import(shareUrl);
+    const outcomes = {};
+    const originalFetch = window.fetch;
+    const waitFor = async (predicate, label) => {
+      for (let attempt = 0; attempt < 80; attempt += 1) {
+        if (predicate()) return;
+        await new Promise(resolve => setTimeout(resolve, 25));
+      }
+      throw new Error(`Timed out waiting for ${label}`);
+    };
+
+    try {
+      localStorage.setItem('getbased-profile-shares-v1', '{broken-json');
+      share.openProfileShareModal('default');
+      outcomes.repairsMalformedStorage = document.querySelector('.profile-share-active-empty') != null
+        && localStorage.getItem('getbased-profile-shares-v1') === '[]';
+      share.closeProfileShareModal();
+
+      const records = Array.from({ length: 55 }, (_, index) => {
+        const id = `record${String(index).padStart(18, '0')}`;
+        return {
+          id,
+          profileId: index % 2 === 0 ? 'default' : 'other-profile',
+          profileName: index % 2 === 0 ? 'Edge Profile' : 'Other Profile',
+          shareUrl: `${location.origin}${location.pathname}#share/${id}`,
+          manageToken: index === 0 ? '' : `manage-token-${index}`,
+          createdAt: new Date(Date.now() - index * 1000).toISOString(),
+          expiresAt: '2099-01-01T00:00:00.000Z',
+        };
+      });
+      records.push({ ...records[0], id: 'invalid' });
+      records.push({ ...records[0], id: 'expiredrecord123456789', expiresAt: '2000-01-01T00:00:00.000Z' });
+      localStorage.setItem('getbased-profile-shares-v1', JSON.stringify(records));
+
+      let deleteBody = null;
+      window.fetch = async (url, options = {}) => {
+        if (String(url || '').startsWith('/api/share') && String(options.method || '').toUpperCase() === 'DELETE') {
+          deleteBody = JSON.parse(String(options.body || '{}'));
+          return new Response(JSON.stringify({
+            error: 'This link can only be stopped from the browser that created it.',
+          }), { status: 403, headers: { 'Content-Type': 'application/json' } });
+        }
+        return originalFetch(url, options);
+      };
+
+      share.openProfileShareModal('default');
+      const stored = JSON.parse(localStorage.getItem('getbased-profile-shares-v1') || '[]');
+      const visibleRows = Array.from(document.querySelectorAll('.profile-share-active-row'));
+      outcomes.prunesAndCapsRecordsImmediately = stored.length === 50
+        && stored.every(record => record.id !== 'invalid' && record.expiresAt !== '2000-01-01T00:00:00.000Z')
+        && visibleRows.length === 25;
+      outcomes.scopesRecordsToSelectedProfile = visibleRows.every(row => {
+        const record = stored.find(item => item.id === row.dataset.profileShareRecord);
+        return record?.profileId === 'default';
+      });
+
+      const deleteButton = document.querySelector('[data-profile-share-action="delete-link"]');
+      deleteButton?.click();
+      await waitFor(() => document.getElementById('profile-share-status')?.dataset.status === 'error', 'missing-token delete error');
+      outcomes.missingManageTokenFailsSafely = deleteBody?.manageToken === ''
+        && JSON.parse(localStorage.getItem('getbased-profile-shares-v1') || '[]').length === 50
+        && deleteButton?.disabled === false
+        && deleteButton?.textContent === 'Stop sharing';
+    } finally {
+      share.closeProfileShareModal();
+      window.fetch = originalFetch;
+      localStorage.removeItem('getbased-profile-shares-v1');
+      document.querySelectorAll('.notification-toast').forEach(element => element.remove());
+    }
+
+    return outcomes;
+  }, { shareUrl: moduleUrl('/js/profile-share.js') });
+
+  for (const [name, passed] of Object.entries(results)) {
+    expect(passed, name).toBe(true);
+  }
+});
+
+test('profile share copy actions fall back when the Clipboard API is unavailable or rejects', async ({ page }) => {
+  await openIsolatedProfileSharePage(page);
+
+  const results = await page.evaluate(async ({ shareUrl }) => {
+    const share = await import(shareUrl);
+    const outcomes = {};
+    const descriptor = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+    const originalExecCommand = document.execCommand;
+    const waitFor = async (predicate, label) => {
+      for (let attempt = 0; attempt < 40; attempt += 1) {
+        if (predicate()) return;
+        await new Promise(resolve => setTimeout(resolve, 25));
+      }
+      throw new Error(`Timed out waiting for ${label}`);
+    };
+
+    try {
+      const id = 'clipboardrecord12345678';
+      const shareUrlValue = `${location.origin}${location.pathname}#share/${id}`;
+      localStorage.setItem('getbased-profile-shares-v1', JSON.stringify([{
+        id,
+        profileId: 'default',
+        profileName: 'Edge Profile',
+        shareUrl: shareUrlValue,
+        manageToken: 'clipboard-manage-token',
+        createdAt: new Date().toISOString(),
+        expiresAt: '2099-01-01T00:00:00.000Z',
+      }]));
+      let calls = 0;
+      let copySucceeds = true;
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: { writeText: async () => { throw new Error('permission denied'); } },
+      });
+      document.execCommand = command => {
+        if (command === 'copy') calls += 1;
+        return copySucceeds;
+      };
+
+      share.openProfileShareModal('default');
+      document.querySelector('[aria-label="Copy active link"]')?.click();
+      await waitFor(() => calls === 1, 'successful copy fallback');
+      outcomes.rejectedClipboardUsesFallback = Array.from(document.querySelectorAll('.notification-toast'))
+        .some(element => element.textContent?.includes('Link copied'))
+        && !document.querySelector('textarea');
+
+      document.querySelectorAll('.notification-toast').forEach(element => element.remove());
+      copySucceeds = false;
+      document.querySelector('[aria-label="Copy active link"]')?.click();
+      await waitFor(() => calls === 2, 'failed copy fallback');
+      outcomes.failedFallbackGivesManualCopyGuidance = Array.from(document.querySelectorAll('.notification-toast'))
+        .some(element => element.textContent?.includes('Select the field and copy manually'))
+        && !document.querySelector('textarea');
+    } finally {
+      share.closeProfileShareModal();
+      localStorage.removeItem('getbased-profile-shares-v1');
+      if (descriptor) Object.defineProperty(navigator, 'clipboard', descriptor);
+      else delete navigator.clipboard;
+      document.execCommand = originalExecCommand;
+      document.querySelectorAll('.notification-toast').forEach(element => element.remove());
+    }
+
+    return outcomes;
+  }, { shareUrl: moduleUrl('/js/profile-share.js') });
+
+  for (const [name, passed] of Object.entries(results)) {
+    expect(passed, name).toBe(true);
+  }
+});
+
+test('profile share completes a browser-to-dev-server create, load, import, and delete round trip', async ({ page }) => {
+  test.slow();
+  await openIsolatedProfileSharePage(page);
+
+  const results = await page.evaluate(async ({ shareUrl }) => {
+    const share = await import(shareUrl);
+    const outcomes = {};
+    const password = 'correct-horse-roundtrip-1234';
+    let cleanup = null;
+    const waitFor = async (predicate, label, attempts = 200) => {
+      for (let attempt = 0; attempt < attempts; attempt += 1) {
+        if (predicate()) return;
+        await new Promise(resolve => setTimeout(resolve, 50));
+      }
+      throw new Error(`Timed out waiting for ${label}`);
+    };
+
+    try {
+      localStorage.removeItem('getbased-profile-shares-v1');
+      share.openProfileShareModal('default');
+      document.getElementById('profile-share-password').value = password;
+      document.getElementById('profile-share-consent').checked = true;
+      document.querySelector('[data-profile-share-action="create"]')?.click();
+      await waitFor(() => document.getElementById('profile-share-link'), 'real share creation');
+
+      const records = JSON.parse(localStorage.getItem('getbased-profile-shares-v1') || '[]');
+      const record = records[0];
+      cleanup = record;
+      const createdResponse = await fetch(`/api/share?id=${encodeURIComponent(record.id)}`);
+      const createdBody = await createdResponse.json();
+      outcomes.realPostPersistsEncryptedEnvelope = createdResponse.status === 200
+        && createdBody.envelope?.schema === 'getbased-profile-share'
+        && !JSON.stringify(createdBody.envelope).includes('Edge Profile')
+        && !JSON.stringify(createdBody.envelope).includes(password);
+
+      share.closeProfileShareModal();
+      share.openSharedProfileImportModal(record.id);
+      document.getElementById('profile-share-load-password').value = password;
+      document.querySelector('[data-profile-share-action="load"]')?.click();
+      await waitFor(() => !document.getElementById('profile-share-overlay'), 'real share import');
+      outcomes.realGetDecryptsAndImports = window.__profileShareImports?.length === 1
+        && window.__profileShareImports[0].name === 'getbased-shared-profile.json'
+        && window.__profileShareImports[0].payload.profile.name === 'Edge Profile'
+        && window.__profileShareImports[0].payload.entries[0].markers.metabolic.glucose === 5.1;
+
+      share.openProfileShareModal('default');
+      document.querySelector(`[data-profile-share-record="${record.id}"] [data-profile-share-action="delete-link"]`)?.click();
+      await waitFor(() => document.querySelector('.profile-share-active-empty'), 'real share deletion');
+      const deletedResponse = await fetch(`/api/share?id=${encodeURIComponent(record.id)}`);
+      outcomes.realDeleteRemovesRemoteAndLocalRecord = deletedResponse.status === 404
+        && JSON.parse(localStorage.getItem('getbased-profile-shares-v1') || '[]').length === 0;
+      cleanup = null;
+    } finally {
+      share.closeProfileShareModal();
+      if (cleanup?.id) {
+        await fetch(`/api/share?id=${encodeURIComponent(cleanup.id)}`, {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ manageToken: cleanup.manageToken || '' }),
+        }).catch(() => {});
+      }
+      localStorage.removeItem('getbased-profile-shares-v1');
+      document.querySelectorAll('.notification-toast').forEach(element => element.remove());
+    }
+
+    return outcomes;
+  }, { shareUrl: moduleUrl('/js/profile-share.js') });
+
+  for (const [name, passed] of Object.entries(results)) {
+    expect(passed, name).toBe(true);
+  }
+});

--- a/tests/playwright/shell-actions-browser-coverage.spec.js
+++ b/tests/playwright/shell-actions-browser-coverage.spec.js
@@ -29,6 +29,9 @@ test('shell action delegates cover shell chat file input and keyboard actions', 
     const previousShellFeedbackDeps = shellActions.configureShellFeedbackDeps({
       openFeedbackModal: () => calls.push(['openFeedbackModal']),
     });
+    const previousShellProfileShareDeps = shellActions.configureShellProfileShareDeps({
+      openProfileShareModal: (...args) => calls.push(['openProfileShareModal', ...args]),
+    });
     const previousShellChatImageDeps = shellActions.configureShellChatImageDeps({
       toggleHDMode: () => calls.push(['toggleHDMode']),
     });
@@ -54,16 +57,10 @@ test('shell action delegates cover shell chat file input and keyboard actions', 
       toggleMobileSidebar: () => calls.push(['toggleMobileSidebar']),
       closeMobileSidebar: () => calls.push(['closeMobileSidebar']),
     });
-    const originalFns = {
-      openProfileShareModal: window.openProfileShareModal,
-    };
     const previousSettingsBridge = settingsBridge.configureSettingsModuleBridge({
       openTweaksPanel: (...args) => calls.push(['openTweaksPanel', ...args]),
       openSettingsModal: (...args) => calls.push(['openSettingsModal', ...args]),
     });
-    const bind = (name) => {
-      window[name] = (...args) => calls.push([name, ...args]);
-    };
     const click = (selector) => {
       const event = new MouseEvent('click', { bubbles: true, cancelable: true });
       const result = document.querySelector(selector)?.dispatchEvent(event);
@@ -102,7 +99,6 @@ test('shell action delegates cover shell chat file input and keyboard actions', 
         <input id="websearch" type="checkbox" data-chat-change-action="set-websearch">
         <textarea id="message-input" data-chat-key-action="message-input"></textarea>
       `;
-      for (const name of Object.keys(originalFns)) bind(name);
       document.getElementById('pdf-input').addEventListener('click', () => calls.push(['pdf-input-click']));
       document.getElementById('chat-image-input').addEventListener('click', () => calls.push(['chat-image-input-click']));
 
@@ -206,14 +202,11 @@ test('shell action delegates cover shell chat file input and keyboard actions', 
       shellActions.configureShellNavDeps(previousShellNavDeps);
       shellActions.configureShellImportDeps(previousShellImportDeps);
       shellActions.configureShellFeedbackDeps(previousShellFeedbackDeps);
+      shellActions.configureShellProfileShareDeps(previousShellProfileShareDeps);
       shellActions.configureShellChatActionDeps(previousShellChatActionDeps);
       shellActions.configureShellChatImageDeps(previousShellChatImageDeps);
       shellActions.configureShellChatThreadDeps(previousShellChatThreadDeps);
       settingsBridge.configureSettingsModuleBridge(previousSettingsBridge);
-      for (const [name, value] of Object.entries(originalFns)) {
-        if (value === undefined) delete window[name];
-        else window[name] = value;
-      }
       document.body.innerHTML = '';
     }
 

--- a/tests/profile-share-client.test.js
+++ b/tests/profile-share-client.test.js
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  PROFILE_SHARE_KDF_ITERATIONS,
+  PROFILE_SHARE_MAX_DAYS,
+  PROFILE_SHARE_MAX_DECOMPRESSED_BYTES,
+  PROFILE_SHARE_MIN_KDF_ITERATIONS,
+  buildProfileShareUrl,
+  decryptProfileShareEnvelope,
+  encryptProfileShareEnvelope,
+  parseProfileShareIdFromLocation,
+} from '../js/profile-share.js';
+
+const SHARE_ID = 'abcdefghijklmnopqrstuvwx';
+const PASSWORD = 'correct-horse-client-1234';
+
+function sampleExport(overrides = {}) {
+  return {
+    version: 2,
+    profile: { id: 'profile-client-test', name: 'Client Test Profile' },
+    entries: [{ date: '2026-07-20', markers: { metabolic: { glucose: 5.1 } } }],
+    ...overrides,
+  };
+}
+
+function replaceGlobal(name, value) {
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, name);
+  Object.defineProperty(globalThis, name, { configurable: true, writable: true, value });
+  return () => {
+    if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+    else delete globalThis[name];
+  };
+}
+
+describe('profile share URL handling', () => {
+  it('builds a secret-free link on the current path and rejects invalid ids', () => {
+    const url = buildProfileShareUrl(SHARE_ID, {
+      origin: 'https://getbased.health',
+      pathname: '/app',
+      search: '?private=value',
+    });
+
+    expect(url).toBe(`https://getbased.health/app#share/${SHARE_ID}`);
+    expect(url).not.toMatch(/private|password|secret|key/i);
+    expect(() => buildProfileShareUrl('too-short')).toThrow('Invalid share id.');
+  });
+
+  it('parses current and legacy hash routes plus query links', () => {
+    expect(parseProfileShareIdFromLocation({
+      hash: `#share/${SHARE_ID}`,
+      href: `https://getbased.health/app#share/${SHARE_ID}`,
+    })).toBe(SHARE_ID);
+    expect(parseProfileShareIdFromLocation({
+      hash: `#share=${SHARE_ID}`,
+      href: `https://getbased.health/app#share=${SHARE_ID}`,
+    })).toBe(SHARE_ID);
+    expect(parseProfileShareIdFromLocation({
+      hash: '',
+      href: `https://getbased.health/app?share=${SHARE_ID}`,
+    })).toBe(SHARE_ID);
+  });
+
+  it('rejects malformed routes and gives a valid hash route precedence over a query id', () => {
+    const queryId = 'zyxwvutsrqponmlkjihg';
+    expect(parseProfileShareIdFromLocation({
+      hash: `#share/${SHARE_ID}`,
+      href: `https://getbased.health/app?share=${queryId}#share/${SHARE_ID}`,
+    })).toBe(SHARE_ID);
+    expect(parseProfileShareIdFromLocation({
+      hash: '#share/short',
+      href: 'not a URL',
+    })).toBe('');
+    expect(parseProfileShareIdFromLocation(null)).toBe('');
+  });
+});
+
+describe('profile share client-side validation', () => {
+  it('rejects invalid exports and short passwords before encrypting', async () => {
+    await expect(encryptProfileShareEnvelope(null, PASSWORD)).rejects.toThrow('Invalid shared profile.');
+    await expect(encryptProfileShareEnvelope(sampleExport({ version: 1 }), PASSWORD))
+      .rejects.toThrow('Unsupported shared profile version.');
+    await expect(encryptProfileShareEnvelope(sampleExport({ profile: {} }), PASSWORD))
+      .rejects.toThrow('Shared profile is missing profile metadata.');
+    await expect(encryptProfileShareEnvelope(sampleExport({ entries: null }), PASSWORD))
+      .rejects.toThrow('Shared profile is missing lab entries.');
+    await expect(encryptProfileShareEnvelope(sampleExport(), 'too-short'))
+      .rejects.toThrow('Use a password of at least 12 characters.');
+  });
+
+  it('enforces the KDF floor, default, and expiry bounds', async () => {
+    const before = Date.now();
+    const minimum = await encryptProfileShareEnvelope(sampleExport(), PASSWORD, {
+      iterations: 1,
+      expiresDays: -10,
+    });
+    const maximum = await encryptProfileShareEnvelope(sampleExport(), PASSWORD, {
+      iterations: Number.NaN,
+      expiresDays: 10_000,
+    });
+    const after = Date.now();
+
+    expect(minimum.kdf.iterations).toBe(PROFILE_SHARE_MIN_KDF_ITERATIONS);
+    expect(Date.parse(minimum.expiresAt)).toBeGreaterThanOrEqual(before + 24 * 60 * 60 * 1000);
+    expect(Date.parse(minimum.expiresAt)).toBeLessThanOrEqual(after + 24 * 60 * 60 * 1000);
+    expect(maximum.kdf.iterations).toBe(PROFILE_SHARE_KDF_ITERATIONS);
+    expect(Date.parse(maximum.expiresAt)).toBeGreaterThanOrEqual(
+      before + PROFILE_SHARE_MAX_DAYS * 24 * 60 * 60 * 1000,
+    );
+    expect(Date.parse(maximum.expiresAt)).toBeLessThanOrEqual(
+      after + PROFILE_SHARE_MAX_DAYS * 24 * 60 * 60 * 1000,
+    );
+  }, 20_000);
+
+  it('rejects expired, malformed, weak, and unsupported envelopes', async () => {
+    const envelope = await encryptProfileShareEnvelope(sampleExport(), PASSWORD, {
+      iterations: PROFILE_SHARE_MIN_KDF_ITERATIONS,
+      expiresAt: '2099-01-01T00:00:00.000Z',
+    });
+
+    await expect(decryptProfileShareEnvelope({ ...envelope, schema: 'other' }, PASSWORD))
+      .rejects.toThrow('Invalid shared profile link.');
+    await expect(decryptProfileShareEnvelope({ ...envelope, version: 2 }, PASSWORD))
+      .rejects.toThrow('Invalid shared profile link.');
+    await expect(decryptProfileShareEnvelope({ ...envelope, expiresAt: '2000-01-01T00:00:00.000Z' }, PASSWORD))
+      .rejects.toThrow('This shared profile link has expired.');
+    await expect(decryptProfileShareEnvelope({
+      ...envelope,
+      kdf: { ...envelope.kdf, name: 'scrypt' },
+    }, PASSWORD)).rejects.toThrow('Unsupported shared profile encryption.');
+    await expect(decryptProfileShareEnvelope({
+      ...envelope,
+      cipher: { ...envelope.cipher, name: 'AES-CBC' },
+    }, PASSWORD)).rejects.toThrow('Unsupported shared profile encryption.');
+    await expect(decryptProfileShareEnvelope({
+      ...envelope,
+      kdf: { ...envelope.kdf, iterations: PROFILE_SHARE_MIN_KDF_ITERATIONS - 1 },
+    }, PASSWORD)).rejects.toThrow('Invalid shared profile encryption settings.');
+    await expect(decryptProfileShareEnvelope({ ...envelope, compression: 'brotli' }, PASSWORD))
+      .rejects.toThrow('Unsupported share compression.');
+    await expect(decryptProfileShareEnvelope(envelope, 'wrong-password-1234'))
+      .rejects.toThrow('Could not decrypt shared profile.');
+  }, 20_000);
+
+  it('round-trips without compression support and explains missing gzip decompression support', async () => {
+    const restoreCompression = replaceGlobal('CompressionStream', undefined);
+    let plainEnvelope;
+    try {
+      plainEnvelope = await encryptProfileShareEnvelope(sampleExport(), PASSWORD, {
+        iterations: PROFILE_SHARE_MIN_KDF_ITERATIONS,
+        expiresAt: '2099-01-01T00:00:00.000Z',
+      });
+    } finally {
+      restoreCompression();
+    }
+    expect(plainEnvelope.compression).toBe('none');
+    await expect(decryptProfileShareEnvelope(plainEnvelope, PASSWORD))
+      .resolves.toMatchObject({ profile: { name: 'Client Test Profile' } });
+
+    const gzipEnvelope = await encryptProfileShareEnvelope(sampleExport(), PASSWORD, {
+      iterations: PROFILE_SHARE_MIN_KDF_ITERATIONS,
+      expiresAt: '2099-01-01T00:00:00.000Z',
+    });
+    expect(gzipEnvelope.compression).toBe('gzip');
+    const restoreDecompression = replaceGlobal('DecompressionStream', undefined);
+    try {
+      await expect(decryptProfileShareEnvelope(gzipEnvelope, PASSWORD))
+        .rejects.toThrow('This browser cannot decompress the shared profile.');
+    } finally {
+      restoreDecompression();
+    }
+  }, 20_000);
+
+  it('rejects gzip payloads that expand beyond the import limit', async () => {
+    const oversized = sampleExport({
+      profile: {
+        id: 'profile-client-test',
+        name: 'Oversized Profile',
+        notes: 'x'.repeat(PROFILE_SHARE_MAX_DECOMPRESSED_BYTES + 1024),
+      },
+      entries: [],
+    });
+    const envelope = await encryptProfileShareEnvelope(oversized, PASSWORD, {
+      iterations: PROFILE_SHARE_MIN_KDF_ITERATIONS,
+      expiresAt: '2099-01-01T00:00:00.000Z',
+    });
+
+    expect(envelope.compression).toBe('gzip');
+    await expect(decryptProfileShareEnvelope(envelope, PASSWORD))
+      .rejects.toThrow('Shared profile is too large to import.');
+  }, 30_000);
+});

--- a/tests/test-dev-server-helpers.js
+++ b/tests/test-dev-server-helpers.js
@@ -541,6 +541,12 @@ assertThrows('profile envelope rejects missing payload',
 assertThrows('profile envelope rejects expired links',
   () => _validateProfileShareEnvelope(validProfileEnvelope({ expiresAt: new Date(Date.now() - 1000).toISOString() })),
   /future/);
+assertThrows('profile envelope rejects expiry beyond 30 days',
+  () => _validateProfileShareEnvelope(validProfileEnvelope({ expiresAt: new Date(Date.now() + 31 * 24 * 60 * 60 * 1000).toISOString() })),
+  /cannot exceed 30 days/);
+assertThrows('profile envelope rejects unsupported key derivation',
+  () => _validateProfileShareEnvelope(validProfileEnvelope({ kdf: { name: 'scrypt', hash: 'SHA-256', iterations: 100_000 } })),
+  /Unsupported key derivation/);
 assertThrows('profile envelope rejects weak KDF iterations',
   () => _validateProfileShareEnvelope(validProfileEnvelope({ kdf: { name: 'PBKDF2', hash: 'SHA-256', iterations: 99_999 } })),
   /PBKDF2 iterations/);
@@ -550,6 +556,9 @@ assertThrows('profile envelope rejects unsupported cipher',
 assertThrows('profile envelope rejects empty ciphertext',
   () => _validateProfileShareEnvelope(validProfileEnvelope({ ciphertext: '' })),
   /empty/);
+assertThrows('profile envelope rejects oversized ciphertext',
+  () => _validateProfileShareEnvelope(validProfileEnvelope({ ciphertext: 'x'.repeat(3_750_000) })),
+  /too large/);
 
 function invokeProfileShareDev(method, search = '', body, headers = {}) {
   return new Promise(resolve => {
@@ -595,6 +604,20 @@ function jsonBody(out) {
   const out = await invokeProfileShareDev('POST', '', 'not json');
   assert('profile share dev POST rejects invalid JSON',
     out.status === 400 && jsonBody(out).error === 'Invalid JSON body.',
+    JSON.stringify(out));
+}
+
+{
+  const out = await invokeProfileShareDev('POST', '', 'x'.repeat(3_750_000 + 8193));
+  assert('profile share dev POST rejects oversized request bodies before parsing',
+    out.status === 413 && /too large/.test(jsonBody(out).error || ''),
+    JSON.stringify({ status: out.status, body: out.body }));
+}
+
+{
+  const out = await invokeProfileShareDev('PATCH');
+  assert('profile share dev rejects unsupported methods',
+    out.status === 405 && /Method not allowed/.test(jsonBody(out).error || ''),
     JSON.stringify(out));
 }
 

--- a/tests/test-profile-share.js
+++ b/tests/test-profile-share.js
@@ -123,7 +123,8 @@ assert('Share modal lists and can stop links created on this device',
 assert('Share profile has a top-level header action',
   read('index.html').includes('data-shell-action="share-profile"') &&
   read('js/shell-actions.js').includes("action === 'share-profile'") &&
-  read('js/shell-actions.js').includes("callShellRuntime('openProfileShareModal')"));
+  read('js/shell-actions.js').includes('shellProfileShareDeps.openProfileShareModal()') &&
+  read('js/app-shell-hooks.js').includes('configureShellProfileShareDeps({ openProfileShareModal });'));
 assert('Mobile share path moves into client list menu',
   read('js/client-list.js').includes("label: 'Share Profile', action: 'share-profile'") &&
   read('js/client-list.js').includes('clientListRuntime.openProfileShareModal(id)') &&

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -73,6 +73,11 @@ assert('Feedback shell action uses its module dependency instead of a window loo
     && shellSrc.includes('shellFeedbackDeps.openFeedbackModal()')
     && !shellSrc.includes("callShellRuntime('openFeedbackModal')"));
 
+assert('Share Profile shell action uses its wired module dependency instead of a window lookup',
+  shellSrc.includes('shellProfileShareDeps.openProfileShareModal()')
+    && !shellSrc.includes("callShellRuntime('openProfileShareModal')")
+    && appShellHooksSrc.includes('configureShellProfileShareDeps({ openProfileShareModal });'));
+
 assert('Chat HD shell action uses its module dependency instead of a window lookup',
   shellSrc.includes('shellChatImageDeps.toggleHDMode()')
     && !shellSrc.includes("callShellRuntime('toggleHDMode')"));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.305';
+self.APP_VERSION = '1.10.306';


### PR DESCRIPTION
## Summary

- restore the header Share Profile action through an explicit module dependency
- make local share-record cleanup, decryption errors, and remote deletion failures deterministic
- comprehensively cover Share Profile entry points, encryption boundaries, UI recovery, storage hygiene, and API behavior
- add a real browser-to-local-API create, import, and delete round trip
- bump the app cache version to 1.10.306

## Impact

Share Profile now opens reliably from the header, Settings, and the mobile profile menu. Failure states recover without stranding controls, and malformed local records or upstream storage errors are handled predictably.

## Root cause

The header action still relied on a removed window-level runtime lookup, so its click handler silently had no callable Share Profile dependency.

## Validation

- `./run-tests.sh`
- 416 Vitest tests passed
- 18 dev-server origin tests passed
- 357 Playwright tests passed
- 472 responsive/theme checks passed inside the browser suite
- TypeScript checks, module verification, and vendor verification passed