### PR TITLE
Fix PWA offline reliability

### DIFF
--- a/js/changelog.js
+++ b/js/changelog.js
@@ -11,6 +11,13 @@ const changelogDelegateRoots = new WeakSet();
 
 const CHANGELOG = [
   {
+    version: '1.10.317', date: '2026-07-20', title: 'More reliable offline use',
+    items: [
+      '<b>The installed app now opens reliably without a connection.</b> Required app files and fonts are kept together for offline use, and interrupted installations resume safely.',
+      '<b>Your downloaded Knowledge Base models survive app updates.</b> Updating getbased no longer clears caches owned by the local research engine.',
+    ]
+  },
+  {
     version: '1.10.316', date: '2026-07-20', title: 'Better Local AI and model comparisons',
     items: [
       '<b>Local AI setup is clearer and more reliable.</b> getbased now works more smoothly with LM Studio, Ollama, and other compatible servers, with better connection details, model guidance, and memory handling.',

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,6 @@
   "start_url": "/app",
   "scope": "/app",
   "display": "standalone",
-  "orientation": "portrait-primary",
   "categories": ["health", "productivity", "medical"],
   "background_color": "#0f1117",
   "theme_color": "#0a0a12",

--- a/service-worker.js
+++ b/service-worker.js
@@ -78,6 +78,7 @@ const APP_SHELL = [
   '/js/app-event-listeners.js',
   '/js/context-card-dashboard-ai-runtime.js',
   '/js/startup-orchestrator.js',
+  '/js/legal-consent.js',
   '/js/schema.js',
   '/js/schema-environment.js',
   '/js/constants.js',
@@ -125,12 +126,17 @@ const APP_SHELL = [
   '/js/import-drop-zone-runtime.js',
   '/js/ai-verdict-engine-runtime.js',
   '/js/ai-verdict-engine.js',
+  '/js/ai-action-delegates.js',
+  '/js/health-goals-utils.js',
   '/js/lab-date-range.js',
   '/js/profile-fatty-acid-migrations.js',
   '/js/profile-marker-migrations.js',
   '/js/profile.js',
   '/js/profile-runtime.js',
+  '/js/profile-share.js',
   '/js/data.js',
+  '/js/lab-entry.js',
+  '/js/lab-entry-mutations.js',
   '/js/marker-analysis.js',
   '/js/blob-storage.js',
   '/js/local-ai-discovery.js',
@@ -155,6 +161,7 @@ const APP_SHELL = [
   '/js/cycle-runtime.js',
   '/js/context-cards.js',
   '/js/context-cards-runtime.js',
+  '/js/context-card-health-dots.js',
   '/js/context-source-registry.js',
   '/js/context-card-summaries.js',
   '/js/context-card-editor-ui.js',
@@ -209,12 +216,14 @@ const APP_SHELL = [
   '/js/chat-discussion-picker.js',
   '/js/chat-discussion-ui.js',
   '/js/chat-onboarding.js',
+  '/js/chat-onboarding-host-bindings.js',
   '/js/chat-empty-state.js',
   '/js/chat-runtime.js',
   '/js/chat-render-runtime.js',
   '/js/chat-render.js',
   '/js/chat-send.js',
   '/js/chat-send-runtime.js',
+  '/js/chat-message-action-attrs.js',
   '/js/chat-icons.js',
   '/js/chat-personalities.js',
   '/js/chat-history.js',
@@ -538,6 +547,61 @@ const APP_SHELL = [
   '/vendor/evolu/sqlite3-worker1-bundler-friendly.mjs',
   '/vendor/evolu/sqlite3.wasm',
   '/vendor/fonts/fonts.css',
+  '/vendor/fonts/inter-400.woff2',
+  '/vendor/fonts/inter-400-2.woff2',
+  '/vendor/fonts/inter-400-3.woff2',
+  '/vendor/fonts/inter-400-4.woff2',
+  '/vendor/fonts/inter-400-5.woff2',
+  '/vendor/fonts/inter-400-6.woff2',
+  '/vendor/fonts/inter-400-7.woff2',
+  '/vendor/fonts/inter-500.woff2',
+  '/vendor/fonts/inter-500-2.woff2',
+  '/vendor/fonts/inter-500-3.woff2',
+  '/vendor/fonts/inter-500-4.woff2',
+  '/vendor/fonts/inter-500-5.woff2',
+  '/vendor/fonts/inter-500-6.woff2',
+  '/vendor/fonts/inter-500-7.woff2',
+  '/vendor/fonts/inter-600.woff2',
+  '/vendor/fonts/inter-600-2.woff2',
+  '/vendor/fonts/inter-600-3.woff2',
+  '/vendor/fonts/inter-600-4.woff2',
+  '/vendor/fonts/inter-600-5.woff2',
+  '/vendor/fonts/inter-600-6.woff2',
+  '/vendor/fonts/inter-600-7.woff2',
+  '/vendor/fonts/inter-700.woff2',
+  '/vendor/fonts/inter-700-2.woff2',
+  '/vendor/fonts/inter-700-3.woff2',
+  '/vendor/fonts/inter-700-4.woff2',
+  '/vendor/fonts/inter-700-5.woff2',
+  '/vendor/fonts/inter-700-6.woff2',
+  '/vendor/fonts/inter-700-7.woff2',
+  '/vendor/fonts/jetbrains-mono-500.woff2',
+  '/vendor/fonts/jetbrains-mono-500-2.woff2',
+  '/vendor/fonts/jetbrains-mono-500-3.woff2',
+  '/vendor/fonts/jetbrains-mono-500-4.woff2',
+  '/vendor/fonts/jetbrains-mono-500-5.woff2',
+  '/vendor/fonts/jetbrains-mono-500-6.woff2',
+  '/vendor/fonts/jetbrains-mono-600.woff2',
+  '/vendor/fonts/jetbrains-mono-600-2.woff2',
+  '/vendor/fonts/jetbrains-mono-600-3.woff2',
+  '/vendor/fonts/jetbrains-mono-600-4.woff2',
+  '/vendor/fonts/jetbrains-mono-600-5.woff2',
+  '/vendor/fonts/jetbrains-mono-600-6.woff2',
+  '/vendor/fonts/jetbrains-mono-700.woff2',
+  '/vendor/fonts/jetbrains-mono-700-2.woff2',
+  '/vendor/fonts/jetbrains-mono-700-3.woff2',
+  '/vendor/fonts/jetbrains-mono-700-4.woff2',
+  '/vendor/fonts/jetbrains-mono-700-5.woff2',
+  '/vendor/fonts/jetbrains-mono-700-6.woff2',
+  '/vendor/fonts/outfit-500.woff2',
+  '/vendor/fonts/outfit-500-2.woff2',
+  '/vendor/fonts/outfit-600.woff2',
+  '/vendor/fonts/outfit-600-2.woff2',
+  '/vendor/fonts/outfit-700.woff2',
+  '/vendor/fonts/outfit-700-2.woff2',
+  '/vendor/fonts/vt323-400.woff2',
+  '/vendor/fonts/vt323-400-2.woff2',
+  '/vendor/fonts/vt323-400-3.woff2',
   '/data/recommendations.json',
   '/data/light-device-presets.json',
   '/data/mito-compounds.json',
@@ -550,6 +614,55 @@ const APP_SHELL = [
   '/data/import-benchmark-reference-us-v2.gold.json',
   '/data/emf-assessment-template.html',
 ];
+
+// Store successful responses one-by-one instead of using Cache.addAll(). If a
+// large install is interrupted, the next install attempt can resume from the
+// entries already written. The install still rejects when any required entry
+// cannot be fetched, so an incomplete app shell is never allowed to activate.
+const PRECACHE_CONCURRENCY = 12;
+const PRECACHE_ATTEMPTS = 3;
+
+async function cacheAppShellEntry(cache, url) {
+  if (await cache.match(url)) return;
+
+  let lastError = null;
+  for (let attempt = 1; attempt <= PRECACHE_ATTEMPTS; attempt += 1) {
+    try {
+      const response = await fetch(url, { cache: 'reload' });
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      await cache.put(url, response);
+      return;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw new Error(`Failed to precache ${url}: ${lastError?.message || 'network error'}`);
+}
+
+async function precacheAppShell(cache) {
+  let nextIndex = 0;
+  const failures = [];
+
+  async function cacheNextEntries() {
+    while (nextIndex < APP_SHELL.length) {
+      const url = APP_SHELL[nextIndex];
+      nextIndex += 1;
+      try {
+        await cacheAppShellEntry(cache, url);
+      } catch (error) {
+        failures.push(error);
+      }
+    }
+  }
+
+  const workerCount = Math.min(PRECACHE_CONCURRENCY, APP_SHELL.length);
+  await Promise.all(Array.from({ length: workerCount }, () => cacheNextEntries()));
+  if (failures.length) {
+    const detail = failures.slice(0, 3).map((error) => error.message).join('; ');
+    throw new Error(`App shell precache failed for ${failures.length} resource(s): ${detail}`);
+  }
+}
 
 function cacheResponse(request, response) {
   if (!response || response.status === 206 || !response.ok) return Promise.resolve();
@@ -602,7 +715,7 @@ function isLocalOrPrivateHost(hostname) {
 self.addEventListener('install', (event) => {
   event.waitUntil(
     resolveCacheName().then((name) =>
-      caches.open(name).then((cache) => cache.addAll(APP_SHELL))
+      caches.open(name).then((cache) => precacheAppShell(cache))
     )
   );
 });
@@ -627,11 +740,12 @@ self.addEventListener('activate', (event) => {
   event.waitUntil(
     resolveCacheName().then((name) =>
       caches.keys().then((keys) =>
-        Promise.all(keys.filter((k) => k !== name).map((k) => caches.delete(k)))
+        Promise.all(keys
+          .filter((k) => k.startsWith('labcharts-v') && k !== name)
+          .map((k) => caches.delete(k)))
       )
-    )
+    ).then(() => self.clients.claim())
   );
-  self.clients.claim();
 });
 
 // Fetch: route-based caching strategies

--- a/tests/playwright/pwa-offline.spec.js
+++ b/tests/playwright/pwa-offline.spec.js
@@ -1,0 +1,63 @@
+import { expect, test } from './coverage-fixture.js';
+
+test.use({ serviceWorkers: 'allow' });
+
+test('installed PWA completes a cache-only cold offline relaunch', async ({ page }, testInfo) => {
+  testInfo.setTimeout(120_000);
+  const failedStaticRequests = [];
+  let recordFailures = false;
+
+  page.on('requestfailed', (request) => {
+    if (!recordFailures) return;
+    const url = new URL(request.url());
+    const isSameOriginStatic = url.origin === new URL(page.url()).origin
+      && /\.(?:css|js|mjs|woff2|json|svg|png|wasm|pdf)$/.test(url.pathname);
+    if (isSameOriginStatic) {
+      failedStaticRequests.push({ url: url.pathname, error: request.failure()?.errorText || '' });
+    }
+  });
+
+  await page.goto('/app?dev-sw=1', { waitUntil: 'networkidle' });
+  await page.evaluate(async () => {
+    await navigator.serviceWorker.ready;
+    if (navigator.serviceWorker.controller) return;
+    await Promise.race([
+      new Promise((resolve) => {
+        navigator.serviceWorker.addEventListener('controllerchange', resolve, { once: true });
+      }),
+      new Promise((_, reject) => {
+        setTimeout(() => reject(new Error('service worker did not claim the app')), 20_000);
+      }),
+    ]);
+  });
+
+  const installed = await page.evaluate(async () => {
+    const cacheNames = await caches.keys();
+    const appCacheName = cacheNames.find((name) => name.startsWith('labcharts-v')) || '';
+    const appCache = await caches.open(appCacheName);
+    const cachedPaths = (await appCache.keys()).map((request) => new URL(request.url).pathname);
+    return {
+      appCacheName,
+      cachedPaths,
+      controlled: !!navigator.serviceWorker.controller,
+    };
+  });
+  expect(installed.controlled).toBe(true);
+  expect(installed.appCacheName).toContain('labcharts-v');
+  expect(installed.cachedPaths).toContain('/js/legal-consent.js');
+  expect(installed.cachedPaths).toContain('/js/profile-share.js');
+  expect(installed.cachedPaths).toContain('/js/chat-onboarding-host-bindings.js');
+  expect(installed.cachedPaths).toContain('/vendor/fonts/inter-400-7.woff2');
+
+  const client = await page.context().newCDPSession(page);
+  await client.send('Network.enable');
+  await client.send('Network.clearBrowserCache');
+  await page.context().setOffline(true);
+  recordFailures = true;
+
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await expect(page.locator('#main-content')).toContainText('Welcome to getbased', { timeout: 20_000 });
+  await page.waitForTimeout(500);
+  expect(failedStaticRequests).toEqual([]);
+  await expect.poll(() => page.evaluate(() => !!navigator.serviceWorker.controller)).toBe(true);
+});

--- a/tests/service-worker-app-shell.test.js
+++ b/tests/service-worker-app-shell.test.js
@@ -1,0 +1,118 @@
+import { readFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const VIRTUAL_APP_SHELL_URLS = new Set(['/app']);
+
+function readRepoFile(url) {
+  return readFileSync(path.join(REPO_ROOT, url.replace(/^\//, '')), 'utf8');
+}
+
+function appShellEntries() {
+  const source = readRepoFile('/service-worker.js');
+  const body = source.match(/const APP_SHELL = \[([\s\S]*?)\n\];/)?.[1] || '';
+  return [...body.matchAll(/^\s*'([^']+)',\s*$/gm)].map((match) => match[1]);
+}
+
+function resolveLocalAsset(importerUrl, specifier) {
+  const clean = String(specifier || '').split(/[?#]/, 1)[0];
+  if (!clean || /^(?:[a-z]+:|\/\/|#)/i.test(clean)) return null;
+  if (clean.startsWith('/')) return path.posix.normalize(clean);
+  if (!clean.startsWith('.')) return null;
+  return path.posix.normalize(path.posix.join(path.posix.dirname(importerUrl), clean));
+}
+
+function moduleDependencies(moduleUrl) {
+  const source = readRepoFile(moduleUrl);
+  const specifiers = new Set();
+  const patterns = [
+    /\bfrom\s*['"]([^'"]+)['"]/g,
+    /\bimport\s*['"]([^'"]+)['"]/g,
+    /\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g,
+    /new\s+URL\(\s*['"]([^'"]+)['"]\s*,\s*import\.meta\.url\s*\)/g,
+  ];
+  for (const pattern of patterns) {
+    for (const match of source.matchAll(pattern)) specifiers.add(match[1]);
+  }
+  return [...specifiers]
+    .map((specifier) => resolveLocalAsset(moduleUrl, specifier))
+    .filter(Boolean);
+}
+
+function reachableAppModules() {
+  const index = readRepoFile('/index.html');
+  const entries = [...index.matchAll(/<script\b[^>]*\btype=['"]module['"][^>]*\bsrc=['"]([^'"]+)['"]/g)]
+    .map((match) => path.posix.normalize(`/${match[1].replace(/^\//, '')}`));
+  const reachable = new Set();
+  const missingFiles = [];
+
+  function visit(moduleUrl) {
+    if (reachable.has(moduleUrl)) return;
+    reachable.add(moduleUrl);
+    const filePath = path.join(REPO_ROOT, moduleUrl.replace(/^\//, ''));
+    if (!existsSync(filePath)) {
+      missingFiles.push(moduleUrl);
+      return;
+    }
+    for (const dependency of moduleDependencies(moduleUrl)) {
+      if (/\.(?:js|mjs)$/.test(dependency)) visit(dependency);
+    }
+  }
+
+  entries.forEach(visit);
+  return { entries, missingFiles, reachable: [...reachable].sort() };
+}
+
+function cssDependencies(cssUrl) {
+  const source = readRepoFile(cssUrl);
+  const dependencies = [];
+  const urlPattern = /url\(\s*(?:'([^']+)'|"([^"]+)"|([^)'"\s]+))\s*\)/g;
+  for (const match of source.matchAll(urlPattern)) {
+    const specifier = match[1] || match[2] || match[3] || '';
+    if (specifier.startsWith('data:')) continue;
+    const resolved = resolveLocalAsset(cssUrl, specifier);
+    if (resolved) dependencies.push(resolved);
+  }
+  return dependencies;
+}
+
+describe('service worker app-shell completeness', () => {
+  it('lists unique app-shell URLs that all resolve to local files', () => {
+    const entries = appShellEntries();
+    const duplicates = entries.filter((entry, index) => entries.indexOf(entry) !== index);
+    const missing = entries.filter((entry) => {
+      if (VIRTUAL_APP_SHELL_URLS.has(entry)) return false;
+      return !existsSync(path.join(REPO_ROOT, entry.replace(/^\//, '')));
+    });
+
+    expect(entries.length).toBeGreaterThan(0);
+    expect(duplicates).toEqual([]);
+    expect(missing).toEqual([]);
+  });
+
+  it('pre-caches the complete local ES-module and worker dependency graph', () => {
+    const cached = new Set(appShellEntries());
+    const { entries, missingFiles, reachable } = reachableAppModules();
+    const uncached = reachable.filter((moduleUrl) => !cached.has(moduleUrl));
+
+    expect(entries).toEqual(['/js/service-worker-update.js', '/js/main.js']);
+    expect(missingFiles).toEqual([]);
+    expect(uncached).toEqual([]);
+  });
+
+  it('pre-caches local files referenced by cached stylesheets', () => {
+    const entries = appShellEntries();
+    const cached = new Set(entries);
+    const stylesheetDependencies = entries
+      .filter((entry) => entry.endsWith('.css'))
+      .flatMap(cssDependencies);
+    const uncached = [...new Set(stylesheetDependencies)]
+      .filter((dependency) => !cached.has(dependency))
+      .sort();
+
+    expect(stylesheetDependencies.length).toBeGreaterThan(0);
+    expect(uncached).toEqual([]);
+  });
+});

--- a/tests/service-worker-runtime.test.js
+++ b/tests/service-worker-runtime.test.js
@@ -40,7 +40,11 @@ function makeCaches() {
     match: vi.fn(async (request) => {
       return matches.get(cacheKey(request));
     }),
-    keys: vi.fn(async () => ['labcharts-vold', 'labcharts-v9.9.9-deadbeef']),
+    keys: vi.fn(async () => [
+      'labcharts-vold',
+      'labcharts-v9.9.9-deadbeef',
+      'transformers-cache',
+    ]),
     delete: vi.fn(async () => true),
   };
   return { cache, caches, matches, opened };
@@ -70,7 +74,7 @@ async function loadServiceWorker({ hostname = 'preview.getbased.health', fetchIm
     APP_VERSION: '9.9.9',
     location: { hostname, origin: `https://${hostname}` },
     skipWaiting: vi.fn(),
-    clients: { claim: vi.fn() },
+    clients: { claim: vi.fn(async () => {}) },
     addEventListener: vi.fn((type, listener) => {
       listeners.set(type, listener);
     }),
@@ -110,7 +114,7 @@ afterEach(() => {
 });
 
 describe('service worker runtime cache behavior', () => {
-  it('pre-caches the app shell and deletes stale caches using preview commit-specific names', async () => {
+  it('pre-caches the app shell and deletes only stale app caches using preview commit-specific names', async () => {
     const { cache, caches, listeners, self } = await loadServiceWorker();
 
     expect(globalThis.importScripts).toHaveBeenCalledWith('/version.js');
@@ -123,10 +127,10 @@ describe('service worker runtime cache behavior', () => {
     await install.done();
 
     expect(caches.open).toHaveBeenCalledWith('labcharts-v9.9.9-deadbeef');
-    expect(cache.addAll).toHaveBeenCalled();
-    expect(cache.addAll.mock.calls[0][0]).toContain('/app');
-    expect(cache.addAll.mock.calls[0][0]).toContain('/js/main.js');
-    expect(cache.addAll.mock.calls[0][0]).toContain('/js/service-worker-update.js');
+    expect(cache.addAll).not.toHaveBeenCalled();
+    expect(cache.put).toHaveBeenCalledWith('/app', expect.any(Response));
+    expect(cache.put).toHaveBeenCalledWith('/js/main.js', expect.any(Response));
+    expect(cache.put).toHaveBeenCalledWith('/js/service-worker-update.js', expect.any(Response));
     expect(self.skipWaiting).not.toHaveBeenCalled();
 
     const activate = makeWaitEvent();
@@ -135,8 +139,68 @@ describe('service worker runtime cache behavior', () => {
 
     expect(caches.delete).toHaveBeenCalledWith('labcharts-vold');
     expect(caches.delete).not.toHaveBeenCalledWith('labcharts-v9.9.9-deadbeef');
+    expect(caches.delete).not.toHaveBeenCalledWith('transformers-cache');
     expect(self.clients.claim).toHaveBeenCalled();
     expect(globalThis.fetch).toHaveBeenCalledWith('/api/commit', { cache: 'no-store' });
+  });
+
+  it('resumes partial app-shell caches and retries transient entry failures', async () => {
+    let mainAttempts = 0;
+    const fetchImpl = vi.fn(async (request) => {
+      const href = typeof request === 'string' ? request : request.url;
+      if (href === '/api/commit') return jsonResponse({ sha: 'deadbeefcafebabe' });
+      if (href === '/js/main.js') {
+        mainAttempts += 1;
+        if (mainAttempts < 3) throw new Error('temporary network failure');
+      }
+      return new Response(`network:${href}`, { status: 200 });
+    });
+    const { listeners, matches } = await loadServiceWorker({ fetchImpl });
+    matches.set('/app', new Response('already-cached-app'));
+
+    const install = makeWaitEvent();
+    listeners.get('install')(install);
+    await install.done();
+
+    expect(mainAttempts).toBe(3);
+    expect(fetchImpl.mock.calls.some(([request]) => request === '/app')).toBe(false);
+    expect(matches.get('/app')).toBeDefined();
+    expect(matches.get('/js/main.js')).toBeDefined();
+  });
+
+  it('rejects installation when a required app-shell entry stays unavailable', async () => {
+    const fetchImpl = vi.fn(async (request) => {
+      const href = typeof request === 'string' ? request : request.url;
+      if (href === '/api/commit') return jsonResponse({ sha: 'deadbeefcafebabe' });
+      if (href === '/js/main.js') throw new Error('offline');
+      return new Response(`network:${href}`, { status: 200 });
+    });
+    const { listeners, matches } = await loadServiceWorker({ fetchImpl });
+
+    const install = makeWaitEvent();
+    listeners.get('install')(install);
+
+    await expect(install.done()).rejects.toThrow('Failed to precache /js/main.js');
+    expect(fetchImpl.mock.calls.filter(([request]) => request === '/js/main.js')).toHaveLength(3);
+    expect(matches.get('/styles.css')).toBeDefined();
+  });
+
+  it('keeps activation alive until clients are claimed', async () => {
+    const { listeners, self } = await loadServiceWorker();
+    let resolveClaim;
+    const claimPending = new Promise((resolve) => { resolveClaim = resolve; });
+    self.clients.claim.mockReturnValue(claimPending);
+
+    const activate = makeWaitEvent();
+    listeners.get('activate')(activate);
+    let completed = false;
+    const completion = activate.done().then(() => { completed = true; });
+
+    await vi.waitFor(() => expect(self.clients.claim).toHaveBeenCalled());
+    expect(completed).toBe(false);
+    resolveClaim();
+    await completion;
+    expect(completed).toBe(true);
   });
 
   it('uses network-first preview assets, navigation fallback, and network-only APIs', async () => {

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.316';
+self.APP_VERSION = '1.10.317';


### PR DESCRIPTION
## Summary

- make PWA app-shell installation resumable and retry transient asset failures
- cache the complete module and font dependency set for reliable cold offline launches
- preserve Knowledge Base and model caches during app updates, await client takeover, and allow installed-app rotation
- add structural, runtime, and real-browser cold-offline regression coverage
- bump the app version and add an end-user changelog entry

## Root cause

The service worker omitted reachable ES modules and font files from its app shell, used all-or-nothing bulk precaching, and deleted every origin cache during activation. This could leave cold offline launches blank and remove locally downloaded AI model data during updates.

## Validation

- `./run-tests.sh`
  - 131 verification tests
  - 437 Vitest tests
  - 18 origin-policy tests
  - 376 Playwright tests
  - 472 theme/responsive checks
- `git diff --check`