### PR TITLE
Make accessibility scan offline reliable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@cashu/cashu-ts": "4.7.0",
         "@playwright/test": "^1.60.0",
         "@vitest/coverage-v8": "^4.1.8",
+        "axe-core": "4.10.0",
         "fake-indexeddb": "^6.2.5",
         "jsdom": "^29.1.1",
         "rolldown": "1.0.3",
@@ -1171,6 +1172,16 @@
       "license": "MIT",
       "dependencies": {
         "retry": "0.13.1"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.0.tgz",
+      "integrity": "sha512-Mr2ZakwQ7XUAjp7pAwQWRhhK8mQQ6JAaNWSjmjxil0R8BPioMtQsTLOolGYkji1rcL++3dCqZA3zWqpT+9Ew6g==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/bidi-js": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@cashu/cashu-ts": "4.7.0",
     "@playwright/test": "^1.60.0",
     "@vitest/coverage-v8": "^4.1.8",
+    "axe-core": "4.10.0",
     "fake-indexeddb": "^6.2.5",
     "jsdom": "^29.1.1",
     "rolldown": "1.0.3",

--- a/tests/.a11y-baseline.json
+++ b/tests/.a11y-baseline.json
@@ -4,5 +4,5 @@
   "serious": {},
   "moderate": {},
   "minor": {},
-  "_note": "Baseline counts of axe-core violations as of v1.7.135 after resolving the remaining serious color-contrast and nested-interactive findings. The CI gate fails when any critical/serious rule INCREASES vs these numbers. Refresh intentionally with `A11Y_REBASELINE=1 ./run-tests.sh` after verified fixes. _axeVersion pins the runtime axe-core load (cdnjs URL); rule renames across versions would otherwise look like a regression."
+  "_note": "Baseline counts of axe-core violations as of v1.7.135 after resolving the remaining serious color-contrast and nested-interactive findings. The CI gate fails when any critical/serious rule INCREASES vs these numbers. Refresh intentionally with `A11Y_REBASELINE=1 ./run-tests.sh` after verified fixes. _axeVersion pins the local axe-core dev dependency; rule renames across versions would otherwise look like a regression."
 }

--- a/tests/playwright/a11y-axe-browser.spec.js
+++ b/tests/playwright/a11y-axe-browser.spec.js
@@ -1,9 +1,16 @@
+import { createRequire } from 'node:module';
 import { test } from './coverage-fixture.js';
 import { runBrowserScript } from './browser-script-runner.js';
+
+const require = createRequire(import.meta.url);
+const axeScriptPath = require.resolve('axe-core/axe.min.js');
 
 test('axe accessibility browser scan', async ({ page }, testInfo) => {
   testInfo.setTimeout(120_000);
   const rebaseline = process.env.A11Y_REBASELINE === '1' || process.env.A11Y_REBASELINE === 'true';
+
+  await page.addInitScript({ path: axeScriptPath });
+
   if (rebaseline) {
     await page.addInitScript(() => {
       window.A11Y_REBASELINE = true;

--- a/tests/playwright/a11y-axe-browser.spec.js
+++ b/tests/playwright/a11y-axe-browser.spec.js
@@ -1,9 +1,10 @@
 import { createRequire } from 'node:module';
-import { test } from './coverage-fixture.js';
+import { expect, test } from './coverage-fixture.js';
 import { runBrowserScript } from './browser-script-runner.js';
 
 const require = createRequire(import.meta.url);
 const axeScriptPath = require.resolve('axe-core/axe.min.js');
+const axeVersion = require('axe-core/package.json').version;
 
 test('axe accessibility browser scan', async ({ page }, testInfo) => {
   testInfo.setTimeout(120_000);
@@ -17,9 +18,13 @@ test('axe accessibility browser scan', async ({ page }, testInfo) => {
     });
   }
 
-  await runBrowserScript(page, 'tests/test-a11y-axe.js', {
+  const result = await runBrowserScript(page, 'tests/test-a11y-axe.js', {
     viewport: { width: 800, height: 600 },
     readyTimeout: 20_000,
     settleMs: 250,
   });
+
+  if (rebaseline) {
+    expect(result.returnValue?._axeVersion).toBe(axeVersion);
+  }
 });

--- a/tests/test-a11y-axe.js
+++ b/tests/test-a11y-axe.js
@@ -200,11 +200,12 @@ return (async () => {
       const r = await fetch(BASELINE_URL, { cache: 'no-store' });
       if (r.ok) baseline = await r.json();
     } catch (_) {}
-    // A version mismatch can rename rules and make the count comparison
-    // misleading, so require the baseline and runtime to agree.
-    if (baseline?._axeVersion && baseline._axeVersion !== window.axe.version) {
+    // A missing or mismatched version can make the count comparison
+    // misleading. Explicit rebaseline mode may repair old metadata.
+    if (baseline && !window.A11Y_REBASELINE
+        && baseline._axeVersion !== window.axe.version) {
       throw new Error(
-        `accessibility baseline pins axe ${baseline._axeVersion}; runtime is ${window.axe.version}`,
+        `accessibility baseline pins axe ${baseline._axeVersion || 'missing'}; runtime is ${window.axe.version}`,
       );
     }
 
@@ -219,11 +220,12 @@ return (async () => {
     // can pipe into the file by hand. CI sets A11Y_REBASELINE=1 only on
     // intentional baseline refresh.
     if (!baseline || window.A11Y_REBASELINE) {
+      const generatedBaseline = { _axeVersion: PINNED_AXE_VERSION, ...current };
       console.log('▶ [a11y/baseline] No baseline file found OR A11Y_REBASELINE=1.');
       console.log('▶ [a11y/baseline] Write this JSON to tests/.a11y-baseline.json to lock the gate:');
-      console.log('▶ ' + JSON.stringify(current));
+      console.log('▶ ' + JSON.stringify(generatedBaseline));
       assert('a11y baseline established (no regression check possible on first run)', true);
-      return;
+      return generatedBaseline;
     }
 
     // Regression check: per impact tier, per rule, current must be ≤ baseline.

--- a/tests/test-a11y-axe.js
+++ b/tests/test-a11y-axe.js
@@ -11,8 +11,8 @@
 //   • moderate / minor     → logged as info, doesn't fail (too easy to
 //                             over-block on rules where axe is opinionated)
 //
-// axe-core is loaded from cdnjs at runtime. Network unreachable → skip,
-// not fail (a11y testing without the scanner is meaningless).
+// axe-core is injected from the pinned local dev dependency. If that runtime
+// is missing or mismatched, the test fails instead of silently skipping.
 //
 // State pollution: this test runs DURING a session where many other tests
 // have left arbitrary state. We snapshot the importedData reference up
@@ -45,36 +45,21 @@ return (async () => {
   };
 
   try {
-    // ── 1. Load axe-core from cdnjs ─────────────────────────────────────
+    // ── 1. Verify the locally injected axe-core runtime ─────────────────
     // Pinned version. The baseline file's `_axeVersion` field is asserted
     // against this string below — a mismatched bump (e.g. 4.11) would
     // surface a rule rename as a false regression. If you bump axe, also
     // bump _axeVersion in tests/.a11y-baseline.json.
     const PINNED_AXE_VERSION = '4.10.0';
-    const AXE_URL = `https://cdnjs.cloudflare.com/ajax/libs/axe-core/${PINNED_AXE_VERSION}/axe.min.js`;
-    if (!window.axe) {
-      try {
-        await new Promise((resolve, reject) => {
-          const s = document.createElement('script');
-          s.src = AXE_URL;
-          s.onload = resolve;
-          s.onerror = () => reject(new Error(`failed to load axe-core from ${AXE_URL}`));
-          document.head.appendChild(s);
-          setTimeout(() => reject(new Error('axe-core load timed out after 10s')), 10000);
-        });
-      } catch (e) {
-        console.warn('[a11y] skipping: ' + e.message);
-        return;
-      }
-    }
     if (typeof window.axe?.run !== 'function') {
-      note('axe-core failed to expose axe.run — skipping');
-      return;
+      throw new Error('local axe-core failed to expose axe.run');
     }
-    assert('axe-core loaded', true);
-    if (window.axe.version && window.axe.version !== PINNED_AXE_VERSION) {
-      note(`axe-core version ${window.axe.version} differs from PINNED_AXE_VERSION ${PINNED_AXE_VERSION} — rule renames may show as false regressions`);
+    if (window.axe.version !== PINNED_AXE_VERSION) {
+      throw new Error(
+        `local axe-core version ${window.axe.version || 'unknown'} does not match pinned ${PINNED_AXE_VERSION}`,
+      );
     }
+    assert(`local axe-core ${PINNED_AXE_VERSION} loaded`, true);
 
     // ── 2. Demo data ────────────────────────────────────────────────────
     // Only load if the dashboard would otherwise be empty. loadDemoData is
@@ -215,13 +200,12 @@ return (async () => {
       const r = await fetch(BASELINE_URL, { cache: 'no-store' });
       if (r.ok) baseline = await r.json();
     } catch (_) {}
-    // axe rules sometimes get renamed across major versions. If the
-    // baseline was captured under a different runtime version than the
-    // one currently loaded, surface a hint — the regression check can
-    // still pass numerically while a rule has silently rotated names.
-    if (baseline?._axeVersion && window.axe?.version
-        && baseline._axeVersion !== window.axe.version) {
-      note(`baseline pins axe ${baseline._axeVersion}, runtime is ${window.axe.version} — refresh baseline if rule shapes drifted`);
+    // A version mismatch can rename rules and make the count comparison
+    // misleading, so require the baseline and runtime to agree.
+    if (baseline?._axeVersion && baseline._axeVersion !== window.axe.version) {
+      throw new Error(
+        `accessibility baseline pins axe ${baseline._axeVersion}; runtime is ${window.axe.version}`,
+      );
     }
 
     const current = { critical: {}, serious: {}, moderate: {}, minor: {} };


### PR DESCRIPTION
## Summary

- pin axe-core 4.10.0 as an exact development dependency
- inject axe from the local install before the accessibility browser scan
- fail when axe is missing or its runtime/baseline version does not match
- remove the CDN dependency and silent accessibility-test skip

## Why

The accessibility gate previously depended on cdnjs and silently skipped when the network or CDN was unavailable. This makes the scan deterministic and offline-capable without changing production app code.

## Validation

- focused axe Playwright scan: 1 passed
- Vitest: 38 files, 452 tests passed
- full runner preflight, origin guards, and theme-responsive checks passed
- Playwright: 375/376 passed; one unrelated import-benchmark test was blocked by the tour overlay and timed out, then passed on its exact targeted rerun in 2.0s

No app files were changed, so no cache-version bump is required.
