### PR TITLE
Add Firefox smoke coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@
 #   - Node-side tests (native-dialog guard, lens-local-utils, dev-server
 #     origin guard)
 #   - Playwright-driven web-app suite
+#   - Focused Firefox smoke coverage for critical browser flows
 
 name: Tests
 
@@ -46,18 +47,21 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key: playwright-browsers-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
           restore-keys: |
-            playwright-${{ runner.os }}-
+            playwright-browsers-${{ runner.os }}-
 
-      - name: Install Playwright Chromium
-        run: npx playwright install --with-deps chromium
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium firefox
 
       - name: Resolve catalog file (fetch from private source if creds set, else use stub)
         env:
           CATALOG_FETCH_URL: ${{ secrets.CATALOG_FETCH_URL }}
           CATALOG_FETCH_TOKEN: ${{ secrets.CATALOG_FETCH_TOKEN }}
         run: node scripts/fetch-catalog.mjs
+
+      - name: Run Firefox smoke suite
+        run: npm run test:firefox
 
       - name: Run test suite
         run: SKIP_TYPECHECK=1 ./run-tests.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,9 +22,11 @@ Prerequisites: a modern browser (Chrome or Firefox), Node.js for the dev server,
 
 ```bash
 ./run-tests.sh
+npx playwright install firefox
+npm run test:firefox
 ```
 
-Auto-starts a server, runs Vitest, the origin guard, and the Playwright browser suite. Exit code 0 = all pass. If you add a feature or fix a bug, add assertions to the relevant test file. See the [Testing developer doc](https://docs.getbased.health/developers/testing) for how the harness works.
+`./run-tests.sh` auto-starts a server, runs Vitest, the origin guard, and the full Chromium Playwright suite. The Firefox command runs a focused cross-browser check of startup, demo data, navigation, settings, JSON round trips, and offline app-shell readiness. Exit code 0 = all pass. If you add a feature or fix a bug, add assertions to the relevant test file. See the [Testing developer doc](https://docs.getbased.health/developers/testing) for how the harness works.
 
 If you add, remove, rename, or rewire a runtime module, regenerate and inspect the file map:
 

--- a/README.md
+++ b/README.md
@@ -125,10 +125,12 @@ npm run architecture:check
 npm run vendor:check
 npm run quality
 npm test
+npm run test:firefox
 ./run-tests.sh
 ```
 
 `./run-tests.sh` runs both type checkers, verifies the architecture map, vendored browser assets, and static module graph, starts an isolated local server, runs the Node/Vitest tests, checks the dev-server origin guard, and runs Playwright browser assertions.
+`npm run test:firefox` runs the focused Firefox critical-flow suite; install its browser binary once with `npx playwright install firefox`.
 
 ## Tech stack
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dev-server": "node dev-server.js",
     "quality": "node scripts/quality-guardrails.mjs",
     "test": "vitest run",
+    "test:firefox": "playwright test --config=playwright.firefox.config.js",
     "test:playwright": "playwright test",
     "typecheck": "tsc -p tsconfig.json",
     "typecheck:checkjs": "tsc -p tsconfig.checkjs.json",

--- a/playwright.firefox.config.js
+++ b/playwright.firefox.config.js
@@ -1,0 +1,20 @@
+import { defineConfig, devices } from '@playwright/test';
+import baseConfig from './playwright.config.js';
+
+const { launchOptions: _chromiumLaunchOptions, ...sharedUse } = baseConfig.use || {};
+
+export default defineConfig({
+  ...baseConfig,
+  testDir: './tests/firefox',
+  outputDir: process.env.PLAYWRIGHT_FIREFOX_OUTPUT_DIR || '/tmp/getbased-firefox-results',
+  fullyParallel: false,
+  workers: 1,
+  timeout: 60_000,
+  use: sharedUse,
+  projects: [
+    {
+      name: 'firefox-smoke',
+      use: { ...devices['Desktop Firefox'] },
+    },
+  ],
+});

--- a/tests/firefox/smoke.spec.js
+++ b/tests/firefox/smoke.spec.js
@@ -1,0 +1,173 @@
+import { expect, test } from '../playwright/coverage-fixture.js';
+
+test.use({ serviceWorkers: 'allow' });
+
+async function openApp(page, path = '/app') {
+  const pageErrors = [];
+  page.on('pageerror', error => pageErrors.push(error.message));
+  await page.addInitScript(() => {
+    const profileId = localStorage.getItem('labcharts-active-profile') || 'default';
+    localStorage.setItem(`labcharts-${profileId}-emptyTour`, 'completed');
+    localStorage.setItem(`labcharts-${profileId}-tour`, 'completed');
+  });
+  await page.goto(path, { waitUntil: 'load' });
+  await page.waitForFunction(async () => {
+    const { state } = await import('/js/state.js');
+    return !!state && !!document.getElementById('main-content');
+  });
+  await page.evaluate(async () => {
+    localStorage.setItem('labcharts-changelog-seen', window.APP_VERSION || 'test');
+    window.endTour?.();
+    (await import('/js/chat-panel.js')).closeChatPanel();
+    document.getElementById('tour-overlay')?.remove();
+    document.getElementById('tour-spotlight')?.remove();
+    document.getElementById('tour-tooltip')?.remove();
+    (await import('/js/changelog.js')).closeChangelog();
+  });
+  return pageErrors;
+}
+
+test('loads demo data and supports core navigation and settings', async ({ browserName, page }) => {
+  expect(browserName).toBe('firefox');
+  const pageErrors = await openApp(page);
+
+  await page.evaluate(async () => {
+    await (await import('/js/export.js')).loadDemoData('female');
+  });
+  await page.waitForFunction(async () => {
+    const [{ state }, { getProfiles }] = await Promise.all([
+      import('/js/state.js'),
+      import('/js/profile.js'),
+    ]);
+    const profile = getProfiles().find(item => item.id === state.currentProfile);
+    return profile?.name === 'Demo Sarah' && state.importedData?.entries?.length > 0;
+  }, null, { timeout: 30_000 });
+
+  await page.evaluate(async () => {
+    const { state } = await import('/js/state.js');
+    const profileId = state.currentProfile;
+    localStorage.setItem(`labcharts-${profileId}-emptyTour`, 'completed');
+    localStorage.setItem(`labcharts-${profileId}-tour`, 'completed');
+    window.endTour?.();
+    document.getElementById('tour-overlay')?.remove();
+    document.getElementById('tour-spotlight')?.remove();
+    document.getElementById('tour-tooltip')?.remove();
+  });
+
+  await page.locator('#sidebar-nav .nav-item[data-category="labs"]').click();
+  await expect.poll(() => page.evaluate(async () => (await import('/js/state.js')).state.currentView)).toBe('labs');
+  await expect(page.locator('.lens-page-widgets[data-lens-route="labs"]')).toBeVisible();
+
+  await page.evaluate(async () => (await import('/js/chat-panel.js')).closeChatPanel());
+  await expect(page.locator('#chat-panel')).not.toHaveClass(/\bopen\b/);
+  await page.locator('.settings-btn').click();
+  await expect(page.locator('#settings-modal-overlay')).toHaveClass(/\bshow\b/);
+  await page.locator('[data-settings-tab="privacy"]').click();
+  await expect(page.locator('[data-tab-panel="privacy"]')).toHaveClass(/\bactive\b/);
+  expect(pageErrors).toEqual([]);
+});
+
+test('round-trips a profile through browser JSON APIs', async ({ browserName, page }) => {
+  expect(browserName).toBe('firefox');
+  const pageErrors = await openApp(page);
+
+  const result = await page.evaluate(async () => {
+    const [{ state }, dataModule, exportModule, profileModule] = await Promise.all([
+      import('/js/state.js'),
+      import('/js/data.js'),
+      import('/js/export.js'),
+      import('/js/profile.js'),
+    ]);
+    const demo = await fetch('/data/demo-male.json', { cache: 'no-store' }).then(response => response.json());
+    state.importedData = demo;
+    state.profileSex = 'male';
+    state.profileDob = '1987-11-22';
+    await dataModule.saveImportedData();
+
+    const exported = await exportModule.buildClientExportObject(state.currentProfile, false);
+    exported.profile.name = 'Firefox Round Trip';
+    const sampleEntry = exported.entries.find(entry => entry?.date && Object.keys(entry.markers || {}).length > 0);
+    const sampleKey = Object.keys(sampleEntry?.markers || {})[0] || '';
+    const sampleValue = sampleEntry?.markers?.[sampleKey];
+
+    const file = new File([JSON.stringify(exported)], 'firefox-smoke.json', {
+      type: 'application/json',
+    });
+    await exportModule.importDataJSON(file);
+
+    const importedEntry = state.importedData.entries.find(entry => entry.date === sampleEntry?.date);
+    const activeProfile = profileModule.getProfiles().find(profile => profile.id === state.currentProfile);
+    return {
+      exportVersion: exported.version,
+      exportedEntries: exported.entries.length,
+      importedEntries: state.importedData.entries.length,
+      importedProfileName: activeProfile?.name || '',
+      sampleValue,
+      importedSampleValue: importedEntry?.markers?.[sampleKey],
+      fileReaderAvailable: typeof FileReader === 'function',
+    };
+  });
+
+  expect(result).toMatchObject({
+    exportVersion: 2,
+    importedProfileName: 'Firefox Round Trip',
+    fileReaderAvailable: true,
+  });
+  expect(result.exportedEntries).toBeGreaterThan(0);
+  expect(result.importedEntries).toBeGreaterThan(0);
+  expect(result.importedSampleValue).toEqual(result.sampleValue);
+  expect(pageErrors).toEqual([]);
+});
+
+test('installs a readable app shell for offline use', async ({ browserName, context, page }) => {
+  expect(browserName).toBe('firefox');
+  const pageErrors = await openApp(page, '/app?dev-sw=1');
+
+  await page.evaluate(async () => {
+    await navigator.serviceWorker.ready;
+    if (navigator.serviceWorker.controller) return;
+    await Promise.race([
+      new Promise(resolve => {
+        navigator.serviceWorker.addEventListener('controllerchange', resolve, { once: true });
+      }),
+      new Promise((_, reject) => {
+        setTimeout(() => reject(new Error('service worker did not claim the app')), 20_000);
+      }),
+    ]);
+  });
+  await expect.poll(() => page.evaluate(() => !!navigator.serviceWorker.controller)).toBe(true);
+
+  await context.setOffline(true);
+  const cached = await page.evaluate(async () => {
+    const cacheNames = await caches.keys();
+    const appCacheName = cacheNames.find(name => name.startsWith('labcharts-v')) || '';
+    const appCache = await caches.open(appCacheName);
+    const requiredPaths = [
+      '/index.html',
+      '/styles.css',
+      '/js/main.js',
+      '/js/legal-consent.js',
+      '/vendor/fonts/inter-400-7.woff2',
+    ];
+    const entries = await Promise.all(requiredPaths.map(async path => {
+      const response = await appCache.match(path);
+      return { path, available: !!response && response.ok };
+    }));
+    return {
+      appCacheName,
+      entries,
+      offline: navigator.onLine === false,
+    };
+  });
+
+  expect(cached.appCacheName).toContain('labcharts-v');
+  expect(cached.entries).toEqual([
+    { path: '/index.html', available: true },
+    { path: '/styles.css', available: true },
+    { path: '/js/main.js', available: true },
+    { path: '/js/legal-consent.js', available: true },
+    { path: '/vendor/fonts/inter-400-7.woff2', available: true },
+  ]);
+  expect(cached.offline).toBe(true);
+  expect(pageErrors).toEqual([]);
+});


### PR DESCRIPTION
## Summary

- add a focused, single-worker Firefox Playwright configuration
- cover demo loading/navigation/settings, browser JSON import/export, and offline app-shell readiness
- install and cache Firefox alongside Chromium in CI, then run the smoke suite before the full regression suite
- document the local Firefox command for contributors

## Why

CI previously exercised the browser app only in Chromium. This adds targeted Firefox coverage for the browser APIs and critical flows most likely to differ across engines without multiplying the full 376-test browser suite.

## Impact

No production app files or runtime behavior changed, so no cache-version bump is required.

## Validation

- `npm run test:firefox` — 3 passed
- `npm run quality` — 11 passed
- `./run-tests.sh` — 452 Vitest tests, 18 origin-guard tests, 376 Chromium Playwright tests, and 472 responsive-theme assertions passed
