### PR TITLE
Speed up app updates

### DIFF
--- a/css/app-shell.css
+++ b/css/app-shell.css
@@ -151,14 +151,25 @@
   box-shadow: 0 8px 28px rgba(0, 0, 0, 0.32);
   animation: analytics-consent-in 0.25s ease-out;
 }
-.version-update-body { display: flex; gap: 8px; align-items: center; font-size: 12px; color: var(--text-secondary); line-height: 1.45; flex: 1 1 240px; min-width: 0; }
+.version-update-body { display: grid; gap: 6px; font-size: 12px; color: var(--text-secondary); line-height: 1.45; flex: 1 1 240px; min-width: 0; }
 .version-update-body strong { color: var(--text-primary); }
+.version-update-copy-row { display: flex; gap: 12px; align-items: center; justify-content: space-between; min-width: 0; }
+.version-update-copy { min-width: 0; }
+.version-update-percent { flex: 0 0 auto; color: var(--accent); font-family: var(--font-mono); font-size: 10px; font-weight: 700; font-variant-numeric: tabular-nums; }
+.version-update-progress[hidden], .version-update-actions[hidden] { display: none; }
+.version-update-progress { display: grid; gap: 4px; width: 100%; }
+.version-update-progress-track { height: 7px; overflow: hidden; border: 1px solid color-mix(in srgb, var(--accent) 34%, var(--border)); border-radius: 999px; background: color-mix(in srgb, var(--accent) 7%, var(--bg-secondary)); }
+.version-update-progress-fill { display: block; width: 0; height: 100%; border-radius: inherit; background: linear-gradient(90deg, color-mix(in srgb, var(--accent) 72%, var(--green)), var(--accent)); box-shadow: 0 0 10px color-mix(in srgb, var(--accent) 35%, transparent); transition: width .2s ease; }
+.version-update-progress-meta { overflow: hidden; color: var(--text-muted); font-family: var(--font-mono); font-size: 8px; font-variant-numeric: tabular-nums; text-overflow: ellipsis; white-space: nowrap; }
 .version-update-actions { display: flex; gap: 6px; flex: 0 0 auto; }
 .version-update-btn { font-size: 12px; padding: 4px 12px; border-radius: 6px; border: 1px solid var(--border); background: transparent; color: var(--text-secondary); cursor: pointer; transition: background 0.15s, border-color 0.15s, color 0.15s; }
 .version-update-btn:hover { background: var(--bg-elevated, rgba(255,255,255,0.04)); color: var(--text-primary); border-color: var(--text-muted); }
 .version-update-btn-primary { background: var(--accent); border-color: var(--accent); color: var(--on-accent); }
 .version-update-btn-primary:hover { filter: brightness(1.08); background: var(--accent); color: var(--on-accent); }
 body.analytics-consent-visible .version-update-banner { bottom: 78px; }
+@media (prefers-reduced-motion: reduce) {
+  .version-update-progress-fill { transition: none; }
+}
 
 /* Terms/Privacy acceptance gate */
 .modal-overlay.legal-consent-overlay {

--- a/js/changelog.js
+++ b/js/changelog.js
@@ -11,6 +11,12 @@ const changelogDelegateRoots = new WeakSet();
 
 const CHANGELOG = [
   {
+    version: '1.10.320', date: '2026-07-21', title: 'Faster, clearer app updates',
+    items: [
+      '<b>App updates finish faster and show their progress.</b> The update banner now displays a themed progress bar, percentage, file count, and elapsed time while the complete offline app is refreshed.',
+    ]
+  },
+  {
     version: '1.10.318', date: '2026-07-20', title: 'Clearer marker measurements',
     items: [
       '<b>Marker values are easier to read at a glance.</b> Units now sit beside the latest result and its reference or optimal range, while the measurement date stays clearly separated below.',

--- a/js/service-worker-update.js
+++ b/js/service-worker-update.js
@@ -7,6 +7,7 @@ const DEV_SW_QUERY_RE = /(?:^|[?&])dev-sw=1(?:&|$)/;
 const UPDATE_CHECK_INTERVAL_MS = 5 * 60 * 1000;
 const VERSION_CHECK_URL = '/version.js?update-check=1';
 const LAST_VERSION_CHECK_KEY = 'labcharts-version-update-last-check';
+const PRECACHE_PROGRESS_MESSAGE = 'PRECACHE_PROGRESS';
 const APP_VERSION_RE = /\bAPP_VERSION\s*=\s*(['"])([^'"]+)\1/;
 
 let pendingRegistration = null;
@@ -17,6 +18,10 @@ let updateRequested = false;
 let updateInstallPending = false;
 let reloadAvailable = false;
 let lastUpdateCheckAt = 0;
+let updateProgressCompleted = 0;
+let updateProgressTotal = 0;
+let updateProgressStartedAt = 0;
+let updateProgressTimer = null;
 
 /**
  * @returns {(Window & { caches?: CacheStorage }) | null}
@@ -76,6 +81,33 @@ let reloadPage = () => {
   getDefaultServiceWorkerWindow()?.location.reload();
 };
 
+function stopUpdateProgressTimer() {
+  if (updateProgressTimer == null) return;
+  getDefaultServiceWorkerWindow()?.clearInterval?.(updateProgressTimer);
+  updateProgressTimer = null;
+}
+
+function resetUpdateProgress() {
+  stopUpdateProgressTimer();
+  updateProgressCompleted = 0;
+  updateProgressTotal = 0;
+  updateProgressStartedAt = 0;
+}
+
+function startUpdateProgress() {
+  resetUpdateProgress();
+  updateProgressStartedAt = Date.now();
+  const win = getDefaultServiceWorkerWindow();
+  updateProgressTimer = win?.setInterval?.(() => {
+    if (!updateInstallPending) {
+      stopUpdateProgressTimer();
+      return;
+    }
+    const banner = document.getElementById(UPDATE_BANNER_ID);
+    if (banner) renderVersionUpdateBanner(banner);
+  }, 1000) ?? null;
+}
+
 export function isDevServiceWorkerHost(hostname) {
   if (!hostname) return false;
   return hostname === 'localhost'
@@ -108,6 +140,7 @@ function removeBanner() {
 
 export function hideVersionUpdateBanner() {
   reloadAvailable = false;
+  resetUpdateProgress();
   removeBanner();
 }
 
@@ -129,7 +162,16 @@ export function showVersionUpdateBanner(registration) {
     banner.setAttribute('aria-live', 'polite');
     banner.innerHTML = `
       <div class="version-update-body">
-        <span class="version-update-copy"><strong>New version available.</strong> Update when you are ready.</span>
+        <div class="version-update-copy-row">
+          <span class="version-update-copy"><strong>New version available.</strong> Update when you are ready.</span>
+          <span class="version-update-percent" hidden>0%</span>
+        </div>
+        <div class="version-update-progress" hidden>
+          <div class="version-update-progress-track" role="progressbar" aria-label="App update progress" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+            <span class="version-update-progress-fill"></span>
+          </div>
+          <span class="version-update-progress-meta">Preparing app files…</span>
+        </div>
       </div>
       <div class="version-update-actions">
         <button type="button" class="version-update-btn version-update-btn-primary" ${UPDATE_ACTION_ATTR}="apply">Update</button>
@@ -149,7 +191,23 @@ function renderVersionUpdateBanner(banner) {
   const copy = banner.querySelector('.version-update-copy');
   const primaryButton = banner.querySelector(`[${UPDATE_ACTION_ATTR}="apply"]`);
   const dismissButton = banner.querySelector(`[${UPDATE_ACTION_ATTR}="dismiss"]`);
+  const actions = banner.querySelector('.version-update-actions');
+  const percentCopy = banner.querySelector('.version-update-percent');
+  const progress = banner.querySelector('.version-update-progress');
+  const progressTrack = banner.querySelector('.version-update-progress-track');
+  const progressFill = banner.querySelector('.version-update-progress-fill');
+  const progressMeta = banner.querySelector('.version-update-progress-meta');
+
+  const showInstallingLayout = (visible) => {
+    if (actions instanceof HTMLElement) actions.hidden = visible;
+    if (percentCopy instanceof HTMLElement) percentCopy.hidden = !visible;
+    if (progress instanceof HTMLElement) progress.hidden = !visible;
+  };
+
   if (reloadAvailable) {
+    showInstallingLayout(false);
+    banner.setAttribute('aria-live', 'polite');
+    banner.setAttribute('aria-busy', 'false');
     if (copy) copy.innerHTML = '<strong>New version installed.</strong> Reload when you are ready.';
     if (primaryButton) primaryButton.textContent = 'Reload';
     if (primaryButton) primaryButton.disabled = false;
@@ -159,7 +217,33 @@ function renderVersionUpdateBanner(banner) {
   }
 
   if (updateInstallPending) {
-    if (copy) copy.innerHTML = '<strong>Installing update…</strong> The app will reload when it is ready.';
+    showInstallingLayout(true);
+    banner.setAttribute('aria-live', 'off');
+    banner.setAttribute('aria-busy', 'true');
+    const completed = Math.max(0, Math.min(updateProgressCompleted, updateProgressTotal || updateProgressCompleted));
+    const total = Math.max(0, updateProgressTotal);
+    const percent = total > 0 ? Math.min(100, Math.round((completed / total) * 100)) : 0;
+    const elapsedSeconds = updateProgressStartedAt
+      ? Math.max(0, Math.round((Date.now() - updateProgressStartedAt) / 1000))
+      : 0;
+    const finishedCaching = total > 0 && completed >= total;
+    if (copy) copy.innerHTML = finishedCaching
+      ? '<strong>Finalizing update…</strong> The app will reload when it is ready.'
+      : '<strong>Installing update…</strong> The app will reload when it is ready.';
+    if (percentCopy) percentCopy.textContent = `${percent}%`;
+    if (progressFill instanceof HTMLElement) progressFill.style.width = `${percent}%`;
+    if (progressTrack) {
+      progressTrack.setAttribute('aria-valuenow', String(percent));
+      progressTrack.setAttribute('aria-valuetext', total > 0
+        ? `${completed} of ${total} app files cached`
+        : 'Preparing app files');
+    }
+    if (progressMeta) {
+      const elapsedCopy = elapsedSeconds > 0 ? ` · ${elapsedSeconds}s` : '';
+      progressMeta.textContent = total > 0
+        ? `${completed} of ${total} files cached${elapsedCopy}`
+        : `Preparing app files${elapsedCopy}`;
+    }
     if (primaryButton) primaryButton.textContent = 'Installing…';
     if (primaryButton) primaryButton.disabled = true;
     if (dismissButton) dismissButton.disabled = true;
@@ -167,6 +251,9 @@ function renderVersionUpdateBanner(banner) {
     return;
   }
 
+  showInstallingLayout(false);
+  banner.setAttribute('aria-live', 'polite');
+  banner.setAttribute('aria-busy', 'false');
   if (copy) copy.innerHTML = '<strong>New version available.</strong> Update when you are ready.';
   if (primaryButton) primaryButton.textContent = 'Update';
   if (primaryButton) primaryButton.disabled = false;
@@ -215,6 +302,7 @@ export function applyPendingServiceWorkerUpdate(registration = pendingRegistrati
   updateRequested = true;
   updateInstallPending = true;
   dismissedAvailableVersion = '';
+  startUpdateProgress();
   showVersionUpdateBanner(registration);
 
   if (registration.installing) return true;
@@ -231,11 +319,13 @@ export function applyPendingServiceWorkerUpdate(registration = pendingRegistrati
     if (!registration.installing) {
       updateRequested = false;
       updateInstallPending = false;
+      resetUpdateProgress();
       showVersionUpdateBanner(registration);
     }
   }).catch(() => {
     updateRequested = false;
     updateInstallPending = false;
+    resetUpdateProgress();
     showVersionUpdateBanner(registration);
   });
   return true;
@@ -271,6 +361,7 @@ export function watchServiceWorkerRegistration(
       if (installingWorker.state === 'redundant' && updateInstallPending) {
         updateRequested = false;
         updateInstallPending = false;
+        resetUpdateProgress();
         showVersionUpdateBanner(registration);
       }
     });
@@ -384,6 +475,16 @@ export async function registerServiceWorkerUpdates({
     const registration = await serviceWorkerContainer.register('/service-worker.js', { updateViaCache: 'none' });
     reloadPage = () => win.location.reload();
     let refreshing = false;
+    serviceWorkerContainer.addEventListener('message', (event) => {
+      if (event?.data?.type !== PRECACHE_PROGRESS_MESSAGE || !updateInstallPending) return;
+      const total = Math.max(0, Math.round(Number(event.data.total) || 0));
+      const completed = Math.max(0, Math.min(total, Math.round(Number(event.data.completed) || 0)));
+      if (total <= 0) return;
+      updateProgressCompleted = completed;
+      updateProgressTotal = total;
+      const banner = document.getElementById(UPDATE_BANNER_ID);
+      if (banner) renderVersionUpdateBanner(banner);
+    });
     serviceWorkerContainer.addEventListener('controllerchange', () => {
       if (refreshing) return;
       if (!updateRequested) {

--- a/service-worker.js
+++ b/service-worker.js
@@ -619,8 +619,25 @@ const APP_SHELL = [
 // large install is interrupted, the next install attempt can resume from the
 // entries already written. The install still rejects when any required entry
 // cannot be fetched, so an incomplete app shell is never allowed to activate.
-const PRECACHE_CONCURRENCY = 12;
+const PRECACHE_CONCURRENCY = 48;
 const PRECACHE_ATTEMPTS = 3;
+const PRECACHE_PROGRESS_MESSAGE = 'PRECACHE_PROGRESS';
+let lastPrecacheProgressPercent = -1;
+
+async function reportPrecacheProgress(completed, total, { force = false } = {}) {
+  const percent = total > 0 ? Math.floor((completed / total) * 100) : 0;
+  if (!force && percent <= lastPrecacheProgressPercent) return;
+  lastPrecacheProgressPercent = percent;
+  if (typeof self.clients?.matchAll !== 'function') return;
+
+  try {
+    const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+    const message = { type: PRECACHE_PROGRESS_MESSAGE, completed, total };
+    clients.forEach((client) => client.postMessage(message));
+  } catch {
+    // Progress is optional; caching must continue even if no client is reachable.
+  }
+}
 
 async function cacheAppShellEntry(cache, url) {
   if (await cache.match(url)) return;
@@ -642,7 +659,10 @@ async function cacheAppShellEntry(cache, url) {
 
 async function precacheAppShell(cache) {
   let nextIndex = 0;
+  let cachedCount = 0;
   const failures = [];
+  lastPrecacheProgressPercent = -1;
+  await reportPrecacheProgress(0, APP_SHELL.length, { force: true });
 
   async function cacheNextEntries() {
     while (nextIndex < APP_SHELL.length) {
@@ -650,6 +670,8 @@ async function precacheAppShell(cache) {
       nextIndex += 1;
       try {
         await cacheAppShellEntry(cache, url);
+        cachedCount += 1;
+        await reportPrecacheProgress(cachedCount, APP_SHELL.length);
       } catch (error) {
         failures.push(error);
       }
@@ -658,6 +680,7 @@ async function precacheAppShell(cache) {
 
   const workerCount = Math.min(PRECACHE_CONCURRENCY, APP_SHELL.length);
   await Promise.all(Array.from({ length: workerCount }, () => cacheNextEntries()));
+  await reportPrecacheProgress(cachedCount, APP_SHELL.length, { force: true });
   if (failures.length) {
     const detail = failures.slice(0, 3).map((error) => error.message).join('; ');
     throw new Error(`App shell precache failed for ${failures.length} resource(s): ${detail}`);

--- a/tests/service-worker-runtime.test.js
+++ b/tests/service-worker-runtime.test.js
@@ -70,11 +70,15 @@ function makeFetchEvent(url, init = {}) {
 async function loadServiceWorker({ hostname = 'preview.getbased.health', fetchImpl } = {}) {
   const listeners = new Map();
   const { cache, caches, matches, opened } = makeCaches();
+  const progressClient = { postMessage: vi.fn() };
   const self = {
     APP_VERSION: '9.9.9',
     location: { hostname, origin: `https://${hostname}` },
     skipWaiting: vi.fn(),
-    clients: { claim: vi.fn(async () => {}) },
+    clients: {
+      claim: vi.fn(async () => {}),
+      matchAll: vi.fn(async () => [progressClient]),
+    },
     addEventListener: vi.fn((type, listener) => {
       listeners.set(type, listener);
     }),
@@ -95,7 +99,7 @@ async function loadServiceWorker({ hostname = 'preview.getbased.health', fetchIm
 
   vi.resetModules();
   await import('../service-worker.js');
-  return { cache, caches, listeners, matches, opened, self };
+  return { cache, caches, listeners, matches, opened, progressClient, self };
 }
 
 beforeEach(() => {
@@ -115,7 +119,7 @@ afterEach(() => {
 
 describe('service worker runtime cache behavior', () => {
   it('pre-caches the app shell and deletes only stale app caches using preview commit-specific names', async () => {
-    const { cache, caches, listeners, self } = await loadServiceWorker();
+    const { cache, caches, listeners, progressClient, self } = await loadServiceWorker();
 
     expect(globalThis.importScripts).toHaveBeenCalledWith('/version.js');
     expect(listeners.has('install')).toBe(true);
@@ -132,6 +136,14 @@ describe('service worker runtime cache behavior', () => {
     expect(cache.put).toHaveBeenCalledWith('/js/main.js', expect.any(Response));
     expect(cache.put).toHaveBeenCalledWith('/js/service-worker-update.js', expect.any(Response));
     expect(self.skipWaiting).not.toHaveBeenCalled();
+    const progressMessages = progressClient.postMessage.mock.calls
+      .map(([message]) => message)
+      .filter((message) => message.type === 'PRECACHE_PROGRESS');
+    expect(progressMessages[0]).toMatchObject({ completed: 0, total: expect.any(Number) });
+    expect(progressMessages.at(-1)).toMatchObject({
+      completed: progressMessages[0].total,
+      total: progressMessages[0].total,
+    });
 
     const activate = makeWaitEvent();
     listeners.get('activate')(activate);
@@ -166,6 +178,34 @@ describe('service worker runtime cache behavior', () => {
     expect(fetchImpl.mock.calls.some(([request]) => request === '/app')).toBe(false);
     expect(matches.get('/app')).toBeDefined();
     expect(matches.get('/js/main.js')).toBeDefined();
+  });
+
+  it('uses bounded high-concurrency precaching', async () => {
+    let activeFetches = 0;
+    let maxActiveFetches = 0;
+    let releaseFetches;
+    const fetchGate = new Promise((resolve) => { releaseFetches = resolve; });
+    const fetchImpl = vi.fn(async (request) => {
+      activeFetches += 1;
+      maxActiveFetches = Math.max(maxActiveFetches, activeFetches);
+      await fetchGate;
+      activeFetches -= 1;
+      return new Response(`network:${request}`, { status: 200 });
+    });
+    const { listeners } = await loadServiceWorker({
+      hostname: 'app.getbased.health',
+      fetchImpl,
+    });
+
+    const install = makeWaitEvent();
+    listeners.get('install')(install);
+    const completion = install.done();
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(48));
+    expect(maxActiveFetches).toBe(48);
+
+    releaseFetches();
+    await completion;
+    expect(maxActiveFetches).toBe(48);
   });
 
   it('rejects installation when a required app-shell entry stays unavailable', async () => {

--- a/tests/service-worker-update.test.js
+++ b/tests/service-worker-update.test.js
@@ -181,6 +181,66 @@ describe('service worker update prompt', () => {
     expect(document.getElementById('version-update-banner')).toBeNull();
   });
 
+  it('renders themed, accessible install progress from service-worker messages', async () => {
+    const { checkForAppVersionUpdate, registerServiceWorkerUpdates } = serviceWorkerUpdate;
+    let onMessage = null;
+    let resolveUpdate;
+    const updatePending = new Promise((resolve) => { resolveUpdate = resolve; });
+    const registration = {
+      waiting: null,
+      installing: null,
+      addEventListener: vi.fn(),
+      update: vi.fn(() => updatePending),
+    };
+    const win = {
+      APP_VERSION: '1.2.3',
+      fetch: vi.fn(async () => new Response("self.APP_VERSION = '1.2.3';")),
+      location: { hostname: 'getbased.health', search: '', reload: vi.fn() },
+      localStorage: { getItem: vi.fn(() => null), setItem: vi.fn() },
+      performance: { getEntriesByType: vi.fn(() => [{ type: 'navigate' }]) },
+      document: { visibilityState: 'visible', addEventListener: vi.fn() },
+      addEventListener: vi.fn(),
+      setInterval: vi.fn(() => 7),
+      clearInterval: vi.fn(),
+    };
+    const serviceWorkerContainer = {
+      controller: {},
+      register: vi.fn(async () => registration),
+      addEventListener: vi.fn((type, listener) => {
+        if (type === 'message') onMessage = listener;
+      }),
+    };
+
+    await registerServiceWorkerUpdates({ win, serviceWorkerContainer, cacheStorage: null });
+    await checkForAppVersionUpdate(registration, serviceWorkerContainer, win, {
+      force: true,
+      fetchImpl: vi.fn(async () => new Response("self.APP_VERSION = '1.2.4';")),
+    });
+
+    document.querySelector('[data-version-update-action="apply"]').click();
+    expect(onMessage).toEqual(expect.any(Function));
+    onMessage({ data: { type: 'PRECACHE_PROGRESS', completed: 293, total: 586 } });
+
+    const banner = document.getElementById('version-update-banner');
+    const track = banner.querySelector('.version-update-progress-track');
+    expect(banner.querySelector('.version-update-percent').textContent).toBe('50%');
+    expect(banner.querySelector('.version-update-progress-fill').style.width).toBe('50%');
+    expect(banner.querySelector('.version-update-progress-meta').textContent).toContain('293 of 586 files cached');
+    expect(track.getAttribute('role')).toBe('progressbar');
+    expect(track.getAttribute('aria-valuenow')).toBe('50');
+    expect(track.getAttribute('aria-valuetext')).toBe('293 of 586 app files cached');
+    expect(banner.getAttribute('aria-live')).toBe('off');
+    expect(banner.getAttribute('aria-busy')).toBe('true');
+    expect(banner.querySelector('.version-update-actions').hidden).toBe(true);
+
+    onMessage({ data: { type: 'PRECACHE_PROGRESS', completed: 586, total: 586 } });
+    expect(banner.textContent).toContain('Finalizing update');
+    expect(banner.querySelector('.version-update-percent').textContent).toBe('100%');
+
+    resolveUpdate();
+    await updatePending;
+  });
+
   it('shares the version-check throttle across tabs while allowing forced reload checks', async () => {
     const { checkForAppVersionUpdate } = serviceWorkerUpdate;
     const stored = new Map();

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.319';
+self.APP_VERSION = '1.10.320';


### PR DESCRIPTION
## Summary

- increase app-shell precache concurrency from 12 to 48 while preserving per-file retries and atomic activation
- report service-worker cache progress to open clients
- show a responsive, theme-aware progress bar with percentage, file count, and elapsed time in the update banner
- add reduced-motion and accessibility handling, bump the app version to `1.10.320`, and document the improvement in What's New

## Root cause

The production app refreshes a 586-file, 14.34 MiB offline shell for every new version. The offline-reliability change bounded that work to 12 concurrent requests, which made production installation take about nine seconds in a measured run. During that time the UI only displayed a static “Installing…” message, making a healthy update look stuck.

## Impact

Updates retain the complete offline shell, retry behavior, and user-controlled atomic activation. The higher bounded concurrency reduces install latency, while progress feedback makes slower connections visibly active on desktop and mobile.

## Validation

- both TypeScript/checkJs passes
- quality, architecture, vendor, and static-module guardrails
- 24 focused service-worker/update tests
- 454 Vitest tests
- 18 dev-server origin-guard tests
- 376 Chromium Playwright tests, including cache-only cold offline relaunch
- 472 responsive-theme assertions
- 3 Firefox smoke tests
- desktop and mobile visual inspection
