### PR TITLE
Add function coverage ratchet

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v7
@@ -63,8 +63,8 @@ jobs:
       - name: Run Firefox smoke suite
         run: npm run test:firefox
 
-      - name: Run test suite
-        run: SKIP_TYPECHECK=1 ./run-tests.sh
+      - name: Run test suite with coverage ratchet
+        run: COVERAGE=1 SKIP_TYPECHECK=1 ./run-tests.sh
 
       - name: Upload test logs on failure
         if: failure()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,11 +22,13 @@ Prerequisites: a modern browser (Chrome or Firefox), Node.js for the dev server,
 
 ```bash
 ./run-tests.sh
+COVERAGE=1 ./run-tests.sh
 npx playwright install firefox
 npm run test:firefox
 ```
 
 `./run-tests.sh` auto-starts a server, runs Vitest, the origin guard, and the full Chromium Playwright suite. The Firefox command runs a focused cross-browser check of startup, demo data, navigation, settings, JSON round trips, and offline app-shell readiness. Exit code 0 = all pass. If you add a feature or fix a bug, add assertions to the relevant test file. See the [Testing developer doc](https://docs.getbased.health/developers/testing) for how the harness works.
+`COVERAGE=1 ./run-tests.sh` additionally enforces the combined function-coverage minimum in `scripts/coverage-baseline.json`. Raise that committed minimum when coverage improves; `COVERAGE_MIN` may temporarily demand a stricter local threshold but cannot weaken the repository baseline.
 
 If you add, remove, rename, or rewire a runtime module, regenerate and inspect the file map:
 

--- a/README.md
+++ b/README.md
@@ -127,9 +127,11 @@ npm run quality
 npm test
 npm run test:firefox
 ./run-tests.sh
+COVERAGE=1 ./run-tests.sh
 ```
 
 `./run-tests.sh` runs both type checkers, verifies the architecture map, vendored browser assets, and static module graph, starts an isolated local server, runs the Node/Vitest tests, checks the dev-server origin guard, and runs Playwright browser assertions.
+`COVERAGE=1 ./run-tests.sh` also combines Vitest and Playwright V8 function coverage and enforces the committed ratchet in `scripts/coverage-baseline.json`; CI runs this mode on every change.
 `npm run test:firefox` runs the focused Firefox critical-flow suite; install its browser binary once with `npx playwright install firefox`.
 
 ## Tech stack

--- a/plans/code-quality-audit-2026-07-21.md
+++ b/plans/code-quality-audit-2026-07-21.md
@@ -103,6 +103,13 @@ baseline. CI has no positive coverage threshold, Playwright runs only Chromium,
 and the axe test can skip when its CDN download fails. `js/data-wipe.js`, a
 high-consequence path, measured 0% function coverage.
 
+Remediation status: **addressed after the audit**. The destructive data-wipe
+path now has focused behavioral coverage, axe is installed locally and cannot
+silently skip, a Firefox critical-flow smoke suite runs in CI, and the full
+Vitest/Playwright coverage run now enforces a committed 67.0% combined function
+coverage floor. The fresh reference measurement is 67.23%; the floor is a
+ratchet to raise as meaningful coverage is added.
+
 ### 5. Supply-chain visibility
 
 Vendored dependencies are integrity checked, but most are outside Dependabot
@@ -118,7 +125,7 @@ current dependency-vulnerability state was not verified.
 3. Add route/feature lazy loading and CI budgets for request count, transferred
    bytes, and decoded bytes.
 4. Vendor axe locally, fail when it cannot run, add a Firefox smoke suite, and
-   ratchet function coverage upward.
+   ratchet function coverage upward. **Completed in follow-up changes.**
 5. Add linting and stricter type checking incrementally; lower large-file
    baselines rather than preserving them.
 6. Add automated SBOM/CVE monitoring for vendored libraries.

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -99,7 +99,5 @@ else
   PLAYWRIGHT_REUSE_SERVER=1 PORT=$PORT npm run test:playwright || exit 1
 fi
 if [ "$COVERAGE_ENABLED" = "1" ]; then
-  : "${COVERAGE_MIN:=0}"
-  export COVERAGE_MIN
   INCLUDE_VITEST_COVERAGE=1 REQUIRE_PLAYWRIGHT_COVERAGE_SHARDS=1 PLAYWRIGHT_COVERAGE_DIR="$DIR/tests/.playwright-coverage" PORT=$PORT node "$DIR/scripts/playwright-coverage.mjs" || exit 1
 fi

--- a/scripts/coverage-baseline.json
+++ b/scripts/coverage-baseline.json
@@ -1,0 +1,7 @@
+{
+  "minimumFunctionPct": 67.0,
+  "referenceFunctionPct": 67.23,
+  "referenceCommit": "dd49ab62",
+  "measuredAt": "2026-07-21",
+  "metric": "combined Vitest/Node and Playwright V8 function coverage"
+}

--- a/scripts/coverage-gate.mjs
+++ b/scripts/coverage-gate.mjs
@@ -1,0 +1,55 @@
+function parsePercentage(value, label) {
+  const percentage = Number.parseFloat(String(value));
+  if (!Number.isFinite(percentage) || percentage <= 0 || percentage > 100) {
+    throw new Error(`${label} must be a number greater than 0 and at most 100.`);
+  }
+  return percentage;
+}
+
+export function resolveCoverageMinimum({ baseline, envValue = '' } = {}) {
+  const baselineMinimum = parsePercentage(
+    baseline?.minimumFunctionPct,
+    'coverage baseline minimumFunctionPct',
+  );
+  const overrideText = String(envValue || '').trim();
+  if (!overrideText) {
+    return {
+      minimum: baselineMinimum,
+      baselineMinimum,
+      source: 'scripts/coverage-baseline.json',
+    };
+  }
+
+  const overrideMinimum = parsePercentage(overrideText, 'COVERAGE_MIN');
+  if (overrideMinimum < baselineMinimum) {
+    throw new Error(
+      `COVERAGE_MIN=${overrideMinimum} cannot lower the committed coverage baseline of ${baselineMinimum}.`,
+    );
+  }
+  return {
+    minimum: overrideMinimum,
+    baselineMinimum,
+    source: 'COVERAGE_MIN',
+  };
+}
+
+export function enforceFunctionCoverage(actualFunctionPct, gate) {
+  const actual = Number(actualFunctionPct);
+  if (!Number.isFinite(actual) || actual < 0 || actual > 100) {
+    throw new Error('Measured function coverage must be a number from 0 to 100.');
+  }
+  if (!gate || !Number.isFinite(gate.minimum)) {
+    throw new Error('A valid function coverage gate is required.');
+  }
+  if (actual + Number.EPSILON < gate.minimum) {
+    throw new Error(
+      `Coverage gate failed: function coverage ${actual.toFixed(2)}% is below `
+      + `${gate.minimum.toFixed(2)}% (${gate.source}).`,
+    );
+  }
+  return {
+    actual,
+    minimum: gate.minimum,
+    margin: actual - gate.minimum,
+  };
+}

--- a/scripts/playwright-coverage.mjs
+++ b/scripts/playwright-coverage.mjs
@@ -10,12 +10,14 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { chromium } from 'playwright';
 import { runBrowserScript } from '../tests/playwright/browser-script-runner.js';
+import { enforceFunctionCoverage, resolveCoverageMinimum } from './coverage-gate.mjs';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const PORT = process.env.PORT || '8000';
 const BASE_URL = `http://127.0.0.1:${PORT}`;
 const chromiumExecutable = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE;
 const jsonPath = path.join(repoRoot, 'tests', '.coverage.json');
+const coverageBaselinePath = path.join(repoRoot, 'scripts', 'coverage-baseline.json');
 const playwrightCoverageDir = process.env.PLAYWRIGHT_COVERAGE_DIR ||
   path.join(repoRoot, 'tests', '.playwright-coverage');
 const vitestCoveragePath = process.env.VITEST_COVERAGE_JSON ||
@@ -360,10 +362,16 @@ function readPlaywrightCoverageShards() {
 }
 
 function enforceCoverageGate(report) {
-  const minPct = Number.parseFloat(process.env.COVERAGE_MIN || '0');
-  if (Number.isFinite(minPct) && minPct > 0 && report.globalFnPct < minPct) {
-    throw new Error(`Coverage gate failed: function coverage ${report.globalFnPct.toFixed(2)}% is below COVERAGE_MIN=${minPct}.`);
-  }
+  const baseline = JSON.parse(fs.readFileSync(coverageBaselinePath, 'utf8'));
+  const gate = resolveCoverageMinimum({
+    baseline,
+    envValue: process.env.COVERAGE_MIN,
+  });
+  const result = enforceFunctionCoverage(report.globalFnPct, gate);
+  console.log(
+    `Coverage ratchet passed: ${result.actual.toFixed(2)}% functions `
+    + `>= ${result.minimum.toFixed(2)}% (${gate.source}; +${result.margin.toFixed(2)}pt).`,
+  );
 }
 
 function writeCoverageReport(entries, fixtures, options = {}) {

--- a/tests/coverage-gate.test.js
+++ b/tests/coverage-gate.test.js
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  enforceFunctionCoverage,
+  resolveCoverageMinimum,
+} from '../scripts/coverage-gate.mjs';
+
+const BASELINE = { minimumFunctionPct: 67 };
+
+describe('coverage ratchet', () => {
+  it('uses the committed minimum by default', () => {
+    expect(resolveCoverageMinimum({ baseline: BASELINE })).toEqual({
+      minimum: 67,
+      baselineMinimum: 67,
+      source: 'scripts/coverage-baseline.json',
+    });
+  });
+
+  it('accepts an environment override that raises the minimum', () => {
+    expect(resolveCoverageMinimum({ baseline: BASELINE, envValue: '67.25' })).toEqual({
+      minimum: 67.25,
+      baselineMinimum: 67,
+      source: 'COVERAGE_MIN',
+    });
+  });
+
+  it('refuses overrides that weaken the committed baseline', () => {
+    expect(() => resolveCoverageMinimum({ baseline: BASELINE, envValue: '60' }))
+      .toThrow('cannot lower the committed coverage baseline');
+  });
+
+  it('rejects missing or invalid baseline values', () => {
+    expect(() => resolveCoverageMinimum({ baseline: {} }))
+      .toThrow('coverage baseline minimumFunctionPct');
+    expect(() => resolveCoverageMinimum({ baseline: { minimumFunctionPct: 101 } }))
+      .toThrow('coverage baseline minimumFunctionPct');
+  });
+
+  it('passes at the minimum and reports the available margin', () => {
+    const gate = resolveCoverageMinimum({ baseline: BASELINE });
+    const result = enforceFunctionCoverage(67.23, gate);
+    expect(result.actual).toBe(67.23);
+    expect(result.minimum).toBe(67);
+    expect(result.margin).toBeCloseTo(0.23);
+    expect(() => enforceFunctionCoverage(67, gate)).not.toThrow();
+  });
+
+  it('fails below the minimum with an actionable message', () => {
+    const gate = resolveCoverageMinimum({ baseline: BASELINE });
+    expect(() => enforceFunctionCoverage(66.99, gate))
+      .toThrow('function coverage 66.99% is below 67.00%');
+  });
+});


### PR DESCRIPTION
## Summary

- run the combined Vitest and Playwright V8 coverage suite in CI
- enforce a committed 67.0% combined function-coverage floor that overrides may only raise
- add focused tests for the coverage gate and document the contributor workflow
- record the completed audit remediation and fresh 67.23% reference measurement

## Why

The code-quality audit found that coverage was measured but not enforced, so regressions could silently lower it. This adds a conservative ratchet that prevents backsliding while leaving a small margin for environment variance. The baseline can be raised as meaningful behavioral tests are added.

## Impact

CI now runs `COVERAGE=1 ./run-tests.sh` on every pull request and push to `main`. A change fails when combined function coverage drops below 67.0%. `COVERAGE_MIN` remains available for stricter local checks but cannot weaken the committed floor.

## Validation

- `COVERAGE=1 ./run-tests.sh`
  - 460 Vitest tests passed
  - 18 origin-guard tests passed
  - 376 Chromium tests passed
  - 472 responsive-theme assertions passed
  - combined function coverage: 67.23%
- `npm test -- tests/coverage-gate.test.js` — 6 passed
- `npm run quality` — 11 passed
- type checking, checkJs, architecture, vendor, and module verification passed