### PR TITLE
Stabilize profile share browser test

### DIFF
--- a/tests/playwright/profile-share-browser-coverage.spec.js
+++ b/tests/playwright/profile-share-browser-coverage.spec.js
@@ -13,15 +13,21 @@ test('Share Profile entry points open the sharing modal', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'networkidle' });
 
   await page.evaluate(async () => {
-    const [{ closeChatPanel }, { endTour }] = await Promise.all([
-      import('/js/chat-panel.js'),
-      import('/js/tour.js'),
-    ]);
+    const { endTour } = await import('/js/tour.js');
     endTour({ openEmptyChat: false });
-    closeChatPanel();
   });
   await expect(page.locator('#tour-overlay')).toHaveCount(0);
-  await expect(page.locator('#chat-panel')).not.toHaveClass(/\bopen\b/);
+
+  // A returning desktop user with no chat history intentionally gets the
+  // onboarding panel after a short delay. Let that startup task settle before
+  // closing the panel so it cannot race the share-profile assertions below.
+  const chatPanel = page.locator('#chat-panel');
+  await expect(chatPanel).toHaveClass(/\bopen\b/);
+  await page.evaluate(async () => {
+    const { closeChatPanel } = await import('/js/chat-panel.js');
+    closeChatPanel();
+  });
+  await expect(chatPanel).not.toHaveClass(/\bopen\b/);
   await page.locator('[data-shell-action="share-profile"]').click();
 
   await expect(page.locator('#profile-share-overlay')).toBeVisible();


### PR DESCRIPTION
## Summary

- wait for the intentional returning-user chat onboarding auto-open before closing it
- prevent the delayed startup task from racing profile-sharing assertions
- keep the test synchronized on visible application state instead of a fixed sleep or retry

## Validation

- `PORT=8001 npx playwright test tests/playwright/profile-share-browser-coverage.spec.js --repeat-each=10` — 30 passed
- `./run-tests.sh` — 460 Vitest, 378 Chromium, and 472 theme/responsive assertions passed