### PR TITLE
Decouple API models from discovery

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -12,8 +12,8 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | Modules | 462 |
 | Internal import edges | 2058 |
 | Dynamic internal edges | 63 |
-| Modules participating in cycles | 49 |
-| Cyclic components | 3 |
+| Modules participating in cycles | 44 |
+| Cyclic components | 2 |
 | Largest cyclic component | 40 |
 | Computed dynamic imports | 2 |
 
@@ -64,13 +64,7 @@ These are existing debt, not approved architecture. CI prevents new modules from
 
 </details>
 
-<details><summary>Component 2 — 5 modules</summary>
-
-[`js/api-models.js`](js/api-models.js), [`js/api-openai-compatible.js`](js/api-openai-compatible.js), [`js/local-ai-discovery.js`](js/local-ai-discovery.js), [`js/local-ai-provider-openai-compatible.js`](js/local-ai-provider-openai-compatible.js), [`js/local-ai-provider-registry.js`](js/local-ai-provider-registry.js)
-
-</details>
-
-<details><summary>Component 3 — 4 modules</summary>
+<details><summary>Component 2 — 4 modules</summary>
 
 [`js/pdf-import-commit.js`](js/pdf-import-commit.js), [`js/pdf-import-persistence.js`](js/pdf-import-persistence.js), [`js/pdf-import-review-runtime.js`](js/pdf-import-review-runtime.js), [`js/pdf-import-review.js`](js/pdf-import-review.js)
 
@@ -105,7 +99,7 @@ Native browser modules shipped with the static application.
 
 - [`js/api-custom.js`](js/api-custom.js) → [`js/api-models.js`](js/api-models.js), [`js/api-openai-compatible.js`](js/api-openai-compatible.js), [`js/api-provider-storage.js`](js/api-provider-storage.js)
 - [`js/api-local.js`](js/api-local.js) → [`js/api-provider-storage.js`](js/api-provider-storage.js), [`js/local-ai-discovery.js`](js/local-ai-discovery.js), [`js/local-ai-lifecycle.js`](js/local-ai-lifecycle.js), [`js/local-ai-provider-registry.js`](js/local-ai-provider-registry.js)
-- [`js/api-models.js`](js/api-models.js) → [`js/api-provider-storage.js`](js/api-provider-storage.js), [`js/local-ai-discovery.js`](js/local-ai-discovery.js), [`js/schema.js`](js/schema.js)
+- [`js/api-models.js`](js/api-models.js) → [`js/api-provider-storage.js`](js/api-provider-storage.js), [`js/local-ai-provider-shared.js`](js/local-ai-provider-shared.js), [`js/schema.js`](js/schema.js)
 - [`js/api-openai-compatible.js`](js/api-openai-compatible.js) → [`js/api-models.js`](js/api-models.js), [`js/api-provider-storage.js`](js/api-provider-storage.js), [`js/api-runtime.js`](js/api-runtime.js), [`js/api-transport.js`](js/api-transport.js), [`js/local-ai-provider-shared.js`](js/local-ai-provider-shared.js), [`js/utils.js`](js/utils.js)
 - [`js/api-openrouter-oauth.js`](js/api-openrouter-oauth.js) → [`js/api-provider-storage.js`](js/api-provider-storage.js), [`js/api-runtime.js`](js/api-runtime.js)
 - [`js/api-openrouter.js`](js/api-openrouter.js) → [`js/api-openai-compatible.js`](js/api-openai-compatible.js), [`js/api-provider-storage.js`](js/api-provider-storage.js), [`js/api-runtime.js`](js/api-runtime.js)

--- a/js/api-models.js
+++ b/js/api-models.js
@@ -2,7 +2,7 @@
 // api-models.js - Provider model catalogs, pricing, and capability helpers.
 
 import { getModelPricing } from './schema.js';
-import { isCloudModel } from './local-ai-discovery.js';
+import { isCloudModel } from './local-ai-provider-shared.js';
 import {
   getAIProvider,
   getOllamaMainModel,

--- a/scripts/architecture-cycle-baseline.json
+++ b/scripts/architecture-cycle-baseline.json
@@ -1,10 +1,8 @@
 {
   "schemaVersion": 1,
-  "maxCyclicModules": 49,
+  "maxCyclicModules": 44,
   "maxLargestCyclicComponent": 40,
   "allowedCyclicModules": [
-    "js/api-models.js",
-    "js/api-openai-compatible.js",
     "js/backup-cycle.js",
     "js/backup.js",
     "js/biology-score-context-ai.js",
@@ -15,9 +13,6 @@
     "js/data.js",
     "js/lab-context-wearables.js",
     "js/lab-context.js",
-    "js/local-ai-discovery.js",
-    "js/local-ai-provider-openai-compatible.js",
-    "js/local-ai-provider-registry.js",
     "js/pdf-import-commit.js",
     "js/pdf-import-persistence.js",
     "js/pdf-import-review-runtime.js",

--- a/tests/test-openrouter.js
+++ b/tests/test-openrouter.js
@@ -54,6 +54,9 @@ assert('getOpenRouterModelDisplay exists', apiProviderStorageSrc.includes('funct
 assert('api.js re-exports OpenRouter model helpers', apiSrc.includes("from './api-models.js'"));
 assert('fetchOpenRouterModels exists', apiModelsSrc.includes('function fetchOpenRouterModels('));
 assert('validateOpenRouterKey exists', apiModelsSrc.includes('function validateOpenRouterKey('));
+assert('API model pricing reads cloud classification from pure provider helpers',
+  apiModelsSrc.includes("from './local-ai-provider-shared.js'")
+    && !apiModelsSrc.includes("from './local-ai-discovery.js'"));
 assert('callOpenRouterAPI exists', apiOpenRouterSrc.includes('function callOpenRouterAPI('));
 assert('extraHeaders in helper signature', apiOpenAICompatibleSrc.includes('extraHeaders = {}'));
 assert('extraHeaders spread in fetch headers', apiOpenAICompatibleSrc.includes('...extraHeaders'));
@@ -293,6 +296,9 @@ else localStorage.removeItem('labcharts-openrouter-pricing');
 const ollamaPricing = api.renderModelPricingHint('ollama', '');
 assert('Local AI pricing avoids claiming remote or cloud servers are free',
   ollamaPricing.includes('configured server') && !ollamaPricing.includes('Free'));
+const cloudOllamaPricing = api.renderModelPricingHint('ollama', 'qwen3:cloud');
+assert('Ollama cloud model pricing retains the provider-terms warning',
+  cloudOllamaPricing.includes('Cloud model') && cloudOllamaPricing.includes('provider terms'));
 
 // ─── 12. Key removal clears pricing cache ───
 console.log('\n12. Key removal clears pricing cache');

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.332';
+self.APP_VERSION = '1.10.333';


### PR DESCRIPTION
## Summary

- import cloud-model classification directly from the pure Local AI provider helper
- preserve pricing behavior with source and runtime regression assertions
- remove the five-module Local AI cycle, reducing cyclic modules from 49 to 44 and cyclic components from 3 to 2
- regenerate the module map, ratchet the architecture baseline, and bump the app cache version to 1.10.333

## Validation

- `PORT=8193 ./run-tests.sh` — 470 Vitest tests, 378 Chromium tests, 472 responsive-theme assertions, plus architecture/vendor/origin checks
- `PORT=8192 npm run test:firefox` — 3 passed
- focused provider Chromium coverage — 5 passed
- OpenRouter/provider assertions — 162 + 40 passed
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
- `npm run architecture:check`