### PR TITLE
Move sync parsing to payload codec

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -12,9 +12,9 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | Modules | 462 |
 | Internal import edges | 2058 |
 | Dynamic internal edges | 63 |
-| Modules participating in cycles | 40 |
+| Modules participating in cycles | 37 |
 | Cyclic components | 1 |
-| Largest cyclic component | 40 |
+| Largest cyclic component | 37 |
 | Computed dynamic imports | 2 |
 
 ## Enforced source boundaries
@@ -58,9 +58,9 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 
 These are existing debt, not approved architecture. CI prevents new modules from joining a cycle and prevents the cycle budgets from increasing.
 
-<details><summary>Component 1 — 40 modules</summary>
+<details><summary>Component 1 — 37 modules</summary>
 
-[`js/backup-cycle.js`](js/backup-cycle.js), [`js/backup.js`](js/backup.js), [`js/biology-score-context-ai.js`](js/biology-score-context-ai.js), [`js/crypto.js`](js/crypto.js), [`js/cycle-import.js`](js/cycle-import.js), [`js/cycle-store.js`](js/cycle-store.js), [`js/cycle.js`](js/cycle.js), [`js/data.js`](js/data.js), [`js/lab-context-wearables.js`](js/lab-context-wearables.js), [`js/lab-context.js`](js/lab-context.js), [`js/profile.js`](js/profile.js), [`js/supplement-impact.js`](js/supplement-impact.js), [`js/sync-actions.js`](js/sync-actions.js), [`js/sync-apply.js`](js/sync-apply.js), [`js/sync-chat-apply.js`](js/sync-chat-apply.js), [`js/sync-configure.js`](js/sync-configure.js), [`js/sync-cutover.js`](js/sync-cutover.js), [`js/sync-diagnose-ui.js`](js/sync-diagnose-ui.js), [`js/sync-diagnostics-snapshot.js`](js/sync-diagnostics-snapshot.js), [`js/sync-diagnostics.js`](js/sync-diagnostics.js), [`js/sync-init.js`](js/sync-init.js), [`js/sync-lifecycle.js`](js/sync-lifecycle.js), [`js/sync-messenger.js`](js/sync-messenger.js), [`js/sync-payload-collectors.js`](js/sync-payload-collectors.js), [`js/sync-payload.js`](js/sync-payload.js), [`js/sync-pull-active-refresh.js`](js/sync-pull-active-refresh.js), [`js/sync-pull-merge.js`](js/sync-pull-merge.js), [`js/sync-pull.js`](js/sync-pull.js), [`js/sync-push.js`](js/sync-push.js), [`js/sync-reconcile.js`](js/sync-reconcile.js), [`js/sync-save-hooks.js`](js/sync-save-hooks.js), [`js/sync-storage-cleanup.js`](js/sync-storage-cleanup.js), [`js/sync-tombstones.js`](js/sync-tombstones.js), [`js/sync.js`](js/sync.js), [`js/tour.js`](js/tour.js), [`js/wearables-apple-health.js`](js/wearables-apple-health.js), [`js/wearables-connect.js`](js/wearables-connect.js), [`js/wearables-manual.js`](js/wearables-manual.js), [`js/wearables-store.js`](js/wearables-store.js), [`js/wearables-summary.js`](js/wearables-summary.js)
+[`js/backup-cycle.js`](js/backup-cycle.js), [`js/backup.js`](js/backup.js), [`js/biology-score-context-ai.js`](js/biology-score-context-ai.js), [`js/crypto.js`](js/crypto.js), [`js/cycle-import.js`](js/cycle-import.js), [`js/cycle-store.js`](js/cycle-store.js), [`js/cycle.js`](js/cycle.js), [`js/data.js`](js/data.js), [`js/lab-context-wearables.js`](js/lab-context-wearables.js), [`js/lab-context.js`](js/lab-context.js), [`js/profile.js`](js/profile.js), [`js/supplement-impact.js`](js/supplement-impact.js), [`js/sync-actions.js`](js/sync-actions.js), [`js/sync-apply.js`](js/sync-apply.js), [`js/sync-chat-apply.js`](js/sync-chat-apply.js), [`js/sync-configure.js`](js/sync-configure.js), [`js/sync-cutover.js`](js/sync-cutover.js), [`js/sync-init.js`](js/sync-init.js), [`js/sync-lifecycle.js`](js/sync-lifecycle.js), [`js/sync-messenger.js`](js/sync-messenger.js), [`js/sync-payload-collectors.js`](js/sync-payload-collectors.js), [`js/sync-payload.js`](js/sync-payload.js), [`js/sync-pull-active-refresh.js`](js/sync-pull-active-refresh.js), [`js/sync-pull-merge.js`](js/sync-pull-merge.js), [`js/sync-pull.js`](js/sync-pull.js), [`js/sync-push.js`](js/sync-push.js), [`js/sync-reconcile.js`](js/sync-reconcile.js), [`js/sync-save-hooks.js`](js/sync-save-hooks.js), [`js/sync-storage-cleanup.js`](js/sync-storage-cleanup.js), [`js/sync-tombstones.js`](js/sync-tombstones.js), [`js/sync.js`](js/sync.js), [`js/tour.js`](js/tour.js), [`js/wearables-apple-health.js`](js/wearables-apple-health.js), [`js/wearables-connect.js`](js/wearables-connect.js), [`js/wearables-manual.js`](js/wearables-manual.js), [`js/wearables-store.js`](js/wearables-store.js), [`js/wearables-summary.js`](js/wearables-summary.js)
 
 </details>
 
@@ -793,7 +793,7 @@ Native browser modules shipped with the static application.
 - [`js/sync-diagnose-runtime.js`](js/sync-diagnose-runtime.js) → [`js/utils.js`](js/utils.js)
 - [`js/sync-diagnose-ui.js`](js/sync-diagnose-ui.js) → [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/sync-diagnose-actions.js`](js/sync-diagnose-actions.js), [`js/sync-diagnose-render.js`](js/sync-diagnose-render.js), [`js/sync-diagnostics.js`](js/sync-diagnostics.js), [`js/sync-relay-health.js`](js/sync-relay-health.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-diagnostics-context.js`](js/sync-diagnostics-context.js) → no in-scope imports
-- [`js/sync-diagnostics-snapshot.js`](js/sync-diagnostics-snapshot.js) → [`js/state.js`](js/state.js), [`js/sync-delta.js`](js/sync-delta.js), [`js/sync-diagnostics-context.js`](js/sync-diagnostics-context.js), [`js/sync-environment.js`](js/sync-environment.js), [`js/sync-payload.js`](js/sync-payload.js), [`js/sync-state.js`](js/sync-state.js), [`js/utils.js`](js/utils.js)
+- [`js/sync-diagnostics-snapshot.js`](js/sync-diagnostics-snapshot.js) → [`js/state.js`](js/state.js), [`js/sync-delta.js`](js/sync-delta.js), [`js/sync-diagnostics-context.js`](js/sync-diagnostics-context.js), [`js/sync-environment.js`](js/sync-environment.js), [`js/sync-payload-codec.js`](js/sync-payload-codec.js), [`js/sync-state.js`](js/sync-state.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-diagnostics-text.js`](js/sync-diagnostics-text.js) → no in-scope imports
 - [`js/sync-diagnostics.js`](js/sync-diagnostics.js) → [`js/sync-diagnostics-context.js`](js/sync-diagnostics-context.js), [`js/sync-diagnostics-snapshot.js`](js/sync-diagnostics-snapshot.js), [`js/sync-diagnostics-text.js`](js/sync-diagnostics-text.js)
 - [`js/sync-disable-cleanup.js`](js/sync-disable-cleanup.js) → no in-scope imports

--- a/js/sync-diagnostics-snapshot.js
+++ b/js/sync-diagnostics-snapshot.js
@@ -5,7 +5,7 @@ import { state } from './state.js';
 import { isDebugMode } from './utils.js';
 import { getDeltaCutoverReadiness, getDeltaTelemetry } from './sync-delta.js';
 import { getSyncRelay } from './sync-environment.js';
-import { parseSyncPayload } from './sync-payload.js';
+import { parseSyncPayload } from './sync-payload-codec.js';
 import { logSyncEvent } from './sync-state.js';
 import {
   currentDiagnosticAppOwner,

--- a/js/sync-payload-codec.js
+++ b/js/sync-payload-codec.js
@@ -1,5 +1,5 @@
 // @ts-check
-// sync-payload-codec.js - Pure gzip and base64 helpers for sync wire payloads.
+// sync-payload-codec.js - Pure gzip, base64, and parsing helpers for sync wire payloads.
 
 /** @param {string} str */
 export async function _gzipString(str) {
@@ -51,4 +51,51 @@ export function _base64ToBytes(b64) {
   const out = new Uint8Array(s.length);
   for (let i = 0; i < s.length; i++) out[i] = s.charCodeAt(i);
   return out;
+}
+
+// 5 MB cap. Normal payloads are well under 1 MB, so this is already generous.
+export const MAX_SYNC_PAYLOAD_BYTES = 5_000_000;
+
+/** @param {string} dataJson */
+export async function parseSyncPayload(dataJson) {
+  if (typeof dataJson !== 'string' || dataJson.length > MAX_SYNC_PAYLOAD_BYTES) {
+    throw new Error('Invalid sync payload: bad type or too large');
+  }
+  let inner = dataJson;
+  if (dataJson.startsWith('GZ|v1|')) {
+    if (typeof DecompressionStream === 'undefined') {
+      throw new Error('Invalid sync payload: gzip envelope but no DecompressionStream');
+    }
+    const b64 = dataJson.slice(6);
+    const bytes = _base64ToBytes(b64);
+    inner = await _gunzipToStringCapped(bytes, MAX_SYNC_PAYLOAD_BYTES);
+  }
+  const parsed = JSON.parse(inner);
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('Invalid sync payload');
+  }
+  // Defence-in-depth: strip wearableConnections from any incoming blob,
+  // regardless of producer version.
+  /** @param {any} imp */
+  function safe(imp) {
+    if (!imp || typeof imp !== 'object') return imp;
+    if ('wearableConnections' in imp) {
+      const { wearableConnections: _drop, ...rest } = imp;
+      return rest;
+    }
+    return imp;
+  }
+  if (parsed._v === 4) {
+    return { importedData: null, profile: parsed.profile, aiSettings: parsed.aiSettings, chatData: parsed.chatData, displayPrefs: parsed.displayPrefs };
+  }
+  if (parsed._v === 3) {
+    return { importedData: safe(parsed.importedData), profile: parsed.profile, aiSettings: parsed.aiSettings, chatData: parsed.chatData, displayPrefs: parsed.displayPrefs };
+  }
+  if (parsed._v === 2) {
+    return { importedData: safe(parsed.importedData), profile: parsed.profile, aiSettings: parsed.aiSettings, chatData: null, displayPrefs: null };
+  }
+  if (parsed.entries || parsed.notes || parsed.supplements) {
+    return { importedData: safe(parsed), profile: null, aiSettings: null, chatData: null, displayPrefs: null };
+  }
+  throw new Error('Invalid sync payload: unknown shape');
 }

--- a/js/sync-payload.js
+++ b/js/sync-payload.js
@@ -6,7 +6,7 @@ import {
   collectAISettings, collectChatData, collectDisplayPrefs,
 } from './sync-payload-collectors.js';
 import {
-  _base64ToBytes, _bytesToBase64, _gzipString, _gunzipToStringCapped,
+  _bytesToBase64, _gzipString,
 } from './sync-payload-codec.js';
 
 export {
@@ -15,7 +15,7 @@ export {
 } from './sync-payload-collectors.js';
 export {
   _base64ToBytes, _bytesToBase64, _gzipString, _gunzipToStringCapped,
-  _PER_ROW_DECOMPRESSED_CAP_BYTES,
+  _PER_ROW_DECOMPRESSED_CAP_BYTES, MAX_SYNC_PAYLOAD_BYTES, parseSyncPayload,
 } from './sync-payload-codec.js';
 
 // Phase 2 cutover flag — when set, buildSyncPayload omits importedData
@@ -111,51 +111,4 @@ export function stripLocalOnlyProfileData(importedData) {
     ...rest
   } = importedData;
   return rest;
-}
-
-// 5 MB cap. Normal payloads are well under 1 MB, so this is already generous.
-export const MAX_SYNC_PAYLOAD_BYTES = 5_000_000;
-
-/** @param {string} dataJson */
-export async function parseSyncPayload(dataJson) {
-  if (typeof dataJson !== 'string' || dataJson.length > MAX_SYNC_PAYLOAD_BYTES) {
-    throw new Error('Invalid sync payload: bad type or too large');
-  }
-  let inner = dataJson;
-  if (dataJson.startsWith('GZ|v1|')) {
-    if (typeof DecompressionStream === 'undefined') {
-      throw new Error('Invalid sync payload: gzip envelope but no DecompressionStream');
-    }
-    const b64 = dataJson.slice(6);
-    const bytes = _base64ToBytes(b64);
-    inner = await _gunzipToStringCapped(bytes, MAX_SYNC_PAYLOAD_BYTES);
-  }
-  const parsed = JSON.parse(inner);
-  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    throw new Error('Invalid sync payload');
-  }
-  // Defence-in-depth: strip wearableConnections from any incoming blob,
-  // regardless of producer version.
-  /** @param {any} imp */
-  function safe(imp) {
-    if (!imp || typeof imp !== 'object') return imp;
-    if ('wearableConnections' in imp) {
-      const { wearableConnections: _drop, ...rest } = imp;
-      return rest;
-    }
-    return imp;
-  }
-  if (parsed._v === 4) {
-    return { importedData: null, profile: parsed.profile, aiSettings: parsed.aiSettings, chatData: parsed.chatData, displayPrefs: parsed.displayPrefs };
-  }
-  if (parsed._v === 3) {
-    return { importedData: safe(parsed.importedData), profile: parsed.profile, aiSettings: parsed.aiSettings, chatData: parsed.chatData, displayPrefs: parsed.displayPrefs };
-  }
-  if (parsed._v === 2) {
-    return { importedData: safe(parsed.importedData), profile: parsed.profile, aiSettings: parsed.aiSettings, chatData: null, displayPrefs: null };
-  }
-  if (parsed.entries || parsed.notes || parsed.supplements) {
-    return { importedData: safe(parsed), profile: null, aiSettings: null, chatData: null, displayPrefs: null };
-  }
-  throw new Error('Invalid sync payload: unknown shape');
 }

--- a/scripts/architecture-cycle-baseline.json
+++ b/scripts/architecture-cycle-baseline.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "maxCyclicModules": 40,
-  "maxLargestCyclicComponent": 40,
+  "maxCyclicModules": 37,
+  "maxLargestCyclicComponent": 37,
   "allowedCyclicModules": [
     "js/backup-cycle.js",
     "js/backup.js",
@@ -20,9 +20,6 @@
     "js/sync-chat-apply.js",
     "js/sync-configure.js",
     "js/sync-cutover.js",
-    "js/sync-diagnose-ui.js",
-    "js/sync-diagnostics-snapshot.js",
-    "js/sync-diagnostics.js",
     "js/sync-init.js",
     "js/sync-lifecycle.js",
     "js/sync-messenger.js",

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -1008,16 +1008,21 @@ await import('../js/settings.js');
   assert('buildSyncPayload includes chatData', syncPayloadSrc.includes('chatData'));
   assert('buildSyncPayload includes displayPrefs', syncPayloadSrc.includes('displayPrefs'));
 
-  assert('parseSyncPayload handles v3 format', syncPayloadSrc.includes('parsed._v === 3'));
-  assert('parseSyncPayload handles v2 compat', syncPayloadSrc.includes('parsed._v === 2'));
+  assert('sync-payload re-exports the pure inbound parser',
+    syncPayloadSrc.includes('MAX_SYNC_PAYLOAD_BYTES, parseSyncPayload'));
+  assert('sync diagnostics imports the pure inbound parser directly',
+    syncDiagnosticsSnapshotSrc.includes("from './sync-payload-codec.js'")
+      && !syncDiagnosticsSnapshotSrc.includes("from './sync-payload.js'"));
+  assert('parseSyncPayload handles v3 format', syncPayloadCodecSrc.includes('parsed._v === 3'));
+  assert('parseSyncPayload handles v2 compat', syncPayloadCodecSrc.includes('parsed._v === 2'));
   assert('parseSyncPayload has v1 backward compat (gated on importedData shape)',
-    syncPayloadSrc.includes('importedData: safe(parsed)'));
-  assert('parseSyncPayload validates payload size (5 MB cap)', syncPayloadSrc.includes('MAX_SYNC_PAYLOAD_BYTES'));
+    syncPayloadCodecSrc.includes('importedData: safe(parsed)'));
+  assert('parseSyncPayload validates payload size (5 MB cap)', syncPayloadCodecSrc.includes('MAX_SYNC_PAYLOAD_BYTES'));
   assert('parseSyncPayload strips wearableConnections from incoming blob (defence-in-depth)',
-    syncPayloadSrc.includes("'wearableConnections' in imp"));
+    syncPayloadCodecSrc.includes("'wearableConnections' in imp"));
   assert('parseSyncPayload v1 compat rejects unknown shapes',
-    syncPayloadSrc.includes("Invalid sync payload: unknown shape"));
-  assert('parseSyncPayload validates payload type', syncPayloadSrc.includes("typeof dataJson !== 'string'"));
+    syncPayloadCodecSrc.includes("Invalid sync payload: unknown shape"));
+  assert('parseSyncPayload validates payload type', syncPayloadCodecSrc.includes("typeof dataJson !== 'string'"));
 
   // v1.6.3: gzip envelope. Pushes >1 KB get compressed before storing
   // in Evolu's CRDT log; cuts the per-message size ~3× and pushes the
@@ -1025,10 +1030,10 @@ await import('../js/settings.js');
   assert('buildSyncPayload gzip envelope (>1 KB compressed)',
     /CompressionStream/.test(syncPayloadSrc) && /GZ\|v1\|/.test(syncPayloadSrc) && /inner\.length > 1024/.test(syncPayloadSrc));
   assert('parseSyncPayload detects + decompresses gzip envelope',
-    /dataJson\.startsWith\('GZ\|v1\|'\)/.test(syncPayloadSrc) && /DecompressionStream/.test(syncPayloadSrc));
+    /dataJson\.startsWith\('GZ\|v1\|'\)/.test(syncPayloadCodecSrc) && /DecompressionStream/.test(syncPayloadCodecSrc));
   assert('parseSyncPayload caps decompressed size via streaming cap (zip-bomb guard)',
-    /_gunzipToStringCapped\(bytes,\s*MAX_SYNC_PAYLOAD_BYTES\)/.test(syncPayloadSrc));
-  assert('parseSyncPayload is async (gzip decode)', /async function parseSyncPayload/.test(syncPayloadSrc));
+    /_gunzipToStringCapped\(bytes,\s*MAX_SYNC_PAYLOAD_BYTES\)/.test(syncPayloadCodecSrc));
+  assert('parseSyncPayload is async (gzip decode)', /async function parseSyncPayload/.test(syncPayloadCodecSrc));
 
   // v1.6.6: recovery from compaction-induced empty profileId column.
   // After /compact-owner drops the original `evolu.insert` from the
@@ -2336,7 +2341,7 @@ await import('../js/settings.js');
   assert('v4 payload omits importedData when cutover is on',
     /cutover\s*\?\s*4\s*:\s*3[\s\S]{0,500}cutover\s*\?\s*undefined\s*:\s*safeImported/.test(syncPayloadSrc));
   assert('parseSyncPayload handles _v: 4 (importedData=null sentinel)',
-    /parsed\._v\s*===\s*4[\s\S]{0,400}importedData:\s*null/.test(syncPayloadSrc));
+    /parsed\._v\s*===\s*4[\s\S]{0,400}importedData:\s*null/.test(syncPayloadCodecSrc));
   assert('Receive path treats v4 (importedData null) as legitimate, not malformed',
     /function isMalformedPulledImportedData[\s\S]{0,160}importedData\s*!==\s*null[\s\S]{0,160}!importedData/.test(syncPullMergeSrc));
   assert('Receive path uses local as baseline when v4 (no blob to merge)',
@@ -2483,7 +2488,7 @@ await import('../js/settings.js');
   // only gunzip entry point post-2026-05-10 audit (the bare
   // _gunzipToString wrapper was deleted as dead).
   assert('Blob path uses _gunzipToStringCapped with MAX_SYNC_PAYLOAD_BYTES',
-    /_gunzipToStringCapped\(bytes,\s*MAX_SYNC_PAYLOAD_BYTES\)/.test(syncPayloadSrc));
+    /_gunzipToStringCapped\(bytes,\s*MAX_SYNC_PAYLOAD_BYTES\)/.test(syncPayloadCodecSrc));
   assert('Dead _gunzipToString wrapper removed (only capped variant remains)',
     !/async function _gunzipToString\(bytes\)/.test(syncSrc + syncPayloadSrc + syncPayloadCodecSrc));
 
@@ -2617,9 +2622,9 @@ await import('../js/settings.js');
 
   // P1: parseSyncPayload now uses capped gunzip (decompression-bomb defence on blob path)
   assert('parseSyncPayload routes blob gunzip through _gunzipToStringCapped',
-    /parseSyncPayload[\s\S]{0,1500}_gunzipToStringCapped\(bytes,\s*MAX_SYNC_PAYLOAD_BYTES\)/.test(syncPayloadSrc));
+    /parseSyncPayload[\s\S]{0,1500}_gunzipToStringCapped\(bytes,\s*MAX_SYNC_PAYLOAD_BYTES\)/.test(syncPayloadCodecSrc));
   assert('parseSyncPayload no longer post-buffers via uncapped _gunzipToString',
-    !/parseSyncPayload[\s\S]{0,1000}inner\s*=\s*await _gunzipToString\(bytes\)/.test(syncPayloadSrc));
+    !/parseSyncPayload[\s\S]{0,1000}inner\s*=\s*await _gunzipToString\(bytes\)/.test(syncPayloadCodecSrc));
 
   // P1: -relay-bytes- and -relay-quota-warned cleared on owner change
   assert('disableSync clears -relay-bytes- keys on owner change',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.334';
+self.APP_VERSION = '1.10.335';


### PR DESCRIPTION
## Summary
- move pure inbound sync payload parsing and the 5 MB payload cap into the existing payload codec
- preserve the public sync-payload API through re-exports while letting diagnostics depend directly on the pure codec
- ratchet architecture cycle debt from 40 to 37 modules and bump the app cache version to 1.10.335

## Validation
- `./run-tests.sh` (470 Vitest, 18 origin-guard, 378 Chromium, 472 responsive-theme assertions)
- `npm run test:firefox` (3 passed)
- focused sync Chromium coverage (20 passed)
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
- `npm run architecture:check`
- targeted legacy sync assertions (832 passed)