### PR TITLE
Inject startup reconciliation

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -12,9 +12,9 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | Modules | 462 |
 | Internal import edges | 2059 |
 | Dynamic internal edges | 62 |
-| Modules participating in cycles | 24 |
+| Modules participating in cycles | 22 |
 | Cyclic components | 2 |
-| Largest cyclic component | 21 |
+| Largest cyclic component | 19 |
 | Computed dynamic imports | 2 |
 
 ## Enforced source boundaries
@@ -42,8 +42,8 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 | [`js/state.js`](js/state.js) | 145 | [`js/app-light-sun-modules.js`](js/app-light-sun-modules.js) | 27 |
 | [`js/data.js`](js/data.js) | 74 | [`js/dashboard-view-composition.js`](js/dashboard-view-composition.js) | 24 |
 | [`js/api.js`](js/api.js) | 63 | [`js/settings.js`](js/settings.js) | 24 |
-| [`js/modal-lifecycle.js`](js/modal-lifecycle.js) | 51 | [`js/pdf-import.js`](js/pdf-import.js) | 23 |
-| [`js/profile.js`](js/profile.js) | 50 | [`js/sync-configure.js`](js/sync-configure.js) | 23 |
+| [`js/modal-lifecycle.js`](js/modal-lifecycle.js) | 51 | [`js/sync-configure.js`](js/sync-configure.js) | 24 |
+| [`js/profile.js`](js/profile.js) | 50 | [`js/pdf-import.js`](js/pdf-import.js) | 23 |
 | [`js/schema.js`](js/schema.js) | 30 | [`js/chat-send.js`](js/chat-send.js) | 22 |
 | [`js/crypto.js`](js/crypto.js) | 29 | [`js/views.js`](js/views.js) | 20 |
 | [`js/data-merge.js`](js/data-merge.js) | 29 | [`js/wearables-connect.js`](js/wearables-connect.js) | 20 |
@@ -58,9 +58,9 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 
 These are existing debt, not approved architecture. CI prevents new modules from joining a cycle and prevents the cycle budgets from increasing.
 
-<details><summary>Component 1 — 21 modules</summary>
+<details><summary>Component 1 — 19 modules</summary>
 
-[`js/backup-cycle.js`](js/backup-cycle.js), [`js/backup.js`](js/backup.js), [`js/crypto.js`](js/crypto.js), [`js/cycle-store.js`](js/cycle-store.js), [`js/data.js`](js/data.js), [`js/profile.js`](js/profile.js), [`js/sync-actions.js`](js/sync-actions.js), [`js/sync-chat-apply.js`](js/sync-chat-apply.js), [`js/sync-cutover.js`](js/sync-cutover.js), [`js/sync-init.js`](js/sync-init.js), [`js/sync-payload-collectors.js`](js/sync-payload-collectors.js), [`js/sync-payload.js`](js/sync-payload.js), [`js/sync-reconcile.js`](js/sync-reconcile.js), [`js/sync-save-hooks.js`](js/sync-save-hooks.js), [`js/sync-storage-cleanup.js`](js/sync-storage-cleanup.js), [`js/sync-tombstones.js`](js/sync-tombstones.js), [`js/sync.js`](js/sync.js), [`js/wearables-connect.js`](js/wearables-connect.js), [`js/wearables-manual.js`](js/wearables-manual.js), [`js/wearables-store.js`](js/wearables-store.js), [`js/wearables-summary.js`](js/wearables-summary.js)
+[`js/backup-cycle.js`](js/backup-cycle.js), [`js/backup.js`](js/backup.js), [`js/crypto.js`](js/crypto.js), [`js/cycle-store.js`](js/cycle-store.js), [`js/data.js`](js/data.js), [`js/profile.js`](js/profile.js), [`js/sync-actions.js`](js/sync-actions.js), [`js/sync-chat-apply.js`](js/sync-chat-apply.js), [`js/sync-cutover.js`](js/sync-cutover.js), [`js/sync-payload-collectors.js`](js/sync-payload-collectors.js), [`js/sync-payload.js`](js/sync-payload.js), [`js/sync-save-hooks.js`](js/sync-save-hooks.js), [`js/sync-storage-cleanup.js`](js/sync-storage-cleanup.js), [`js/sync-tombstones.js`](js/sync-tombstones.js), [`js/sync.js`](js/sync.js), [`js/wearables-connect.js`](js/wearables-connect.js), [`js/wearables-manual.js`](js/wearables-manual.js), [`js/wearables-store.js`](js/wearables-store.js), [`js/wearables-summary.js`](js/wearables-summary.js)
 
 </details>
 
@@ -766,7 +766,7 @@ Native browser modules shipped with the static application.
 - [`js/sync-actions.js`](js/sync-actions.js) → [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/sync-messenger.js`](js/sync-messenger.js), [`js/sync-save-hooks.js`](js/sync-save-hooks.js), [`js/sync-state.js`](js/sync-state.js), [`js/sync-storage-cleanup.js`](js/sync-storage-cleanup.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-apply.js`](js/sync-apply.js) → [`js/crypto.js`](js/crypto.js), [`js/sync-chat-apply.js`](js/sync-chat-apply.js), [`js/sync-payload-collectors.js`](js/sync-payload-collectors.js), [`js/sync-runtime.js`](js/sync-runtime.js)
 - [`js/sync-chat-apply.js`](js/sync-chat-apply.js) → [`js/crypto.js`](js/crypto.js), [`js/state.js`](js/state.js), [`js/sync-payload-collectors.js`](js/sync-payload-collectors.js), [`js/sync-state.js`](js/sync-state.js), [`js/utils.js`](js/utils.js)
-- [`js/sync-configure.js`](js/sync-configure.js) → [`js/lab-context.js`](js/lab-context.js), [`js/sync-actions.js`](js/sync-actions.js), [`js/sync-cutover.js`](js/sync-cutover.js), [`js/sync-delta.js`](js/sync-delta.js), [`js/sync-diagnose-ui.js`](js/sync-diagnose-ui.js), [`js/sync-diagnostics.js`](js/sync-diagnostics.js), [`js/sync-environment.js`](js/sync-environment.js), [`js/sync-identity.js`](js/sync-identity.js), [`js/sync-messenger.js`](js/sync-messenger.js), [`js/sync-pull.js`](js/sync-pull.js), [`js/sync-push.js`](js/sync-push.js), [`js/sync-reconcile.js`](js/sync-reconcile.js), [`js/sync-recovery.js`](js/sync-recovery.js), [`js/sync-relay-health.js`](js/sync-relay-health.js), [`js/sync-runtime.js`](js/sync-runtime.js), [`js/sync-save-hooks.js`](js/sync-save-hooks.js), [`js/sync-settings-state.js`](js/sync-settings-state.js), [`js/sync-state.js`](js/sync-state.js), [`js/sync-storage-cleanup.js`](js/sync-storage-cleanup.js), [`js/sync-subscriptions.js`](js/sync-subscriptions.js), [`js/sync-tombstones.js`](js/sync-tombstones.js), [`js/sync-ui.js`](js/sync-ui.js), [`js/utils.js`](js/utils.js)
+- [`js/sync-configure.js`](js/sync-configure.js) → [`js/lab-context.js`](js/lab-context.js), [`js/sync-actions.js`](js/sync-actions.js), [`js/sync-cutover.js`](js/sync-cutover.js), [`js/sync-delta.js`](js/sync-delta.js), [`js/sync-diagnose-ui.js`](js/sync-diagnose-ui.js), [`js/sync-diagnostics.js`](js/sync-diagnostics.js), [`js/sync-environment.js`](js/sync-environment.js), [`js/sync-identity.js`](js/sync-identity.js), [`js/sync-init.js`](js/sync-init.js), [`js/sync-messenger.js`](js/sync-messenger.js), [`js/sync-pull.js`](js/sync-pull.js), [`js/sync-push.js`](js/sync-push.js), [`js/sync-reconcile.js`](js/sync-reconcile.js), [`js/sync-recovery.js`](js/sync-recovery.js), [`js/sync-relay-health.js`](js/sync-relay-health.js), [`js/sync-runtime.js`](js/sync-runtime.js), [`js/sync-save-hooks.js`](js/sync-save-hooks.js), [`js/sync-settings-state.js`](js/sync-settings-state.js), [`js/sync-state.js`](js/sync-state.js), [`js/sync-storage-cleanup.js`](js/sync-storage-cleanup.js), [`js/sync-subscriptions.js`](js/sync-subscriptions.js), [`js/sync-tombstones.js`](js/sync-tombstones.js), [`js/sync-ui.js`](js/sync-ui.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-cutover.js`](js/sync-cutover.js) → [`js/sync-delta.js`](js/sync-delta.js), [`js/sync-payload.js`](js/sync-payload.js)
 - [`js/sync-delta-array-merge.js`](js/sync-delta-array-merge.js) → [`js/data-merge.js`](js/data-merge.js), [`js/sync-delta-observability.js`](js/sync-delta-observability.js), [`js/sync-delta-registry.js`](js/sync-delta-registry.js), [`js/sync-delta-row-codec.js`](js/sync-delta-row-codec.js)
 - [`js/sync-delta-array-planner.js`](js/sync-delta-array-planner.js) → [`js/sync-delta-planner-context.js`](js/sync-delta-planner-context.js), [`js/sync-delta-registry.js`](js/sync-delta-registry.js), [`js/sync-delta-snapshot.js`](js/sync-delta-snapshot.js), [`js/sync-payload-codec.js`](js/sync-payload-codec.js)
@@ -805,7 +805,7 @@ Native browser modules shipped with the static application.
 - [`js/sync-disable-cleanup.js`](js/sync-disable-cleanup.js) → no in-scope imports
 - [`js/sync-environment.js`](js/sync-environment.js) → [`js/utils-runtime.js`](js/utils-runtime.js)
 - [`js/sync-identity.js`](js/sync-identity.js) → [`js/sync-disable-cleanup.js`](js/sync-disable-cleanup.js), [`js/sync-runtime.js`](js/sync-runtime.js), [`js/utils.js`](js/utils.js)
-- [`js/sync-init.js`](js/sync-init.js) → [`js/sync-environment.js`](js/sync-environment.js), [`js/sync-reconcile.js`](js/sync-reconcile.js), [`js/sync-recovery.js`](js/sync-recovery.js), [`js/sync-runtime.js`](js/sync-runtime.js), [`js/sync-schema.js`](js/sync-schema.js), [`js/sync-settings-state.js`](js/sync-settings-state.js), [`js/sync-subscriptions.js`](js/sync-subscriptions.js), [`js/utils.js`](js/utils.js)
+- [`js/sync-init.js`](js/sync-init.js) → [`js/sync-environment.js`](js/sync-environment.js), [`js/sync-recovery.js`](js/sync-recovery.js), [`js/sync-runtime.js`](js/sync-runtime.js), [`js/sync-schema.js`](js/sync-schema.js), [`js/sync-settings-state.js`](js/sync-settings-state.js), [`js/sync-subscriptions.js`](js/sync-subscriptions.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-lifecycle.js`](js/sync-lifecycle.js) → [`js/sync-actions.js`](js/sync-actions.js), [`js/sync-disable-cleanup.js`](js/sync-disable-cleanup.js), [`js/sync-environment.js`](js/sync-environment.js), [`js/sync-init.js`](js/sync-init.js), [`js/sync-pull.js`](js/sync-pull.js), [`js/sync-runtime.js`](js/sync-runtime.js), [`js/sync-save-hooks.js`](js/sync-save-hooks.js), [`js/sync-settings-state.js`](js/sync-settings-state.js), [`js/sync-state.js`](js/sync-state.js), [`js/sync-subscriptions.js`](js/sync-subscriptions.js), [`js/sync-ui.js`](js/sync-ui.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-messenger.js`](js/sync-messenger.js) → [`js/state.js`](js/state.js), [`js/utils-runtime.js`](js/utils-runtime.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-payload-codec.js`](js/sync-payload-codec.js) → no in-scope imports

--- a/js/sync-configure.js
+++ b/js/sync-configure.js
@@ -21,7 +21,8 @@ import {
 import { bindSyncSaveHookEvents, configureSyncSaveHooks } from './sync-save-hooks.js';
 import { configureSyncPush, isSyncPushInFlight, pushProfile } from './sync-push.js';
 import { configureSyncRecovery } from './sync-recovery.js';
-import { configureSyncReconcile } from './sync-reconcile.js';
+import { configureSyncInit } from './sync-init.js';
+import { configureSyncReconcile, reconcileLocalStorageWithEvolu } from './sync-reconcile.js';
 import {
   disablePhase2Cutover, enablePhase2Cutover, isPhase2CutoverEnabled,
 } from './sync-cutover.js';
@@ -179,4 +180,6 @@ export function configureSyncModules({ enableSync, disableSync } = {}) {
     pushProfile,
     debug: dbg,
   });
+
+  configureSyncInit({ reconcileLocalStorageWithEvolu });
 }

--- a/js/sync-init.js
+++ b/js/sync-init.js
@@ -6,7 +6,6 @@ import { createSyncQueries, createSyncSchema } from './sync-schema.js';
 import { getSyncBlocker, getSyncRelay } from './sync-environment.js';
 import { primeSyncState, setSyncEnabled } from './sync-settings-state.js';
 import { bindSyncRecoveryEvents } from './sync-recovery.js';
-import { reconcileLocalStorageWithEvolu } from './sync-reconcile.js';
 import { bindSyncSubscriptions, startRelayProbe } from './sync-subscriptions.js';
 import {
   getSyncAppOwner, getSyncEvolu, getSyncReloadUrlRuntime,
@@ -14,6 +13,20 @@ import {
   setSyncQueries, setSyncQueryLoadedPromise,
   setSyncReadyPromise,
 } from './sync-runtime.js';
+
+/** @type {() => Promise<any>} */
+let _reconcileLocalStorageWithEvolu = async () => {};
+
+/** @param {{ reconcileLocalStorageWithEvolu?: () => Promise<any> }} [deps] */
+export function configureSyncInit({ reconcileLocalStorageWithEvolu } = {}) {
+  if (typeof reconcileLocalStorageWithEvolu === 'function') {
+    _reconcileLocalStorageWithEvolu = reconcileLocalStorageWithEvolu;
+  }
+}
+
+function reconcileLocalStorageWithEvolu() {
+  return _reconcileLocalStorageWithEvolu();
+}
 
 /** @param {...any} args */
 function dbg(...args) { if (isDebugMode()) console.log('[sync]', ...args); }

--- a/scripts/architecture-cycle-baseline.json
+++ b/scripts/architecture-cycle-baseline.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "maxCyclicModules": 24,
-  "maxLargestCyclicComponent": 21,
+  "maxCyclicModules": 22,
+  "maxLargestCyclicComponent": 19,
   "allowedCyclicModules": [
     "js/backup-cycle.js",
     "js/backup.js",
@@ -14,10 +14,8 @@
     "js/sync-actions.js",
     "js/sync-chat-apply.js",
     "js/sync-cutover.js",
-    "js/sync-init.js",
     "js/sync-payload-collectors.js",
     "js/sync-payload.js",
-    "js/sync-reconcile.js",
     "js/sync-save-hooks.js",
     "js/sync-storage-cleanup.js",
     "js/sync-tombstones.js",

--- a/tests/playwright/sync-init-browser-coverage.spec.js
+++ b/tests/playwright/sync-init-browser-coverage.spec.js
@@ -216,6 +216,11 @@ test('sync init browser coverage creates Evolu runtime subscriptions and debug g
       localStorage.setItem('labcharts-debug', 'true');
       localStorage.setItem('labcharts-sync-relay', 'wss://relay.example/ws');
       window.__syncInitTrace = { rows: [{ profileId: 'debug-profile' }] };
+      init.configureSyncInit({
+        reconcileLocalStorageWithEvolu: async () => {
+          window.__syncInitTrace.reconciledCount = (window.__syncInitTrace.reconciledCount || 0) + 1;
+        },
+      });
       window.setTimeout = (fn, delay = 0, ...args) => {
         timeouts.push(delay);
         return original.setTimeout.call(window, fn, delay, ...args);
@@ -232,6 +237,8 @@ test('sync init browser coverage creates Evolu runtime subscriptions and debug g
       const profileQuery = runtime.getSyncProfileQuery();
       const tombstoneQuery = runtime.getSyncTombstoneQuery();
       const itemRowQuery = runtime.getSyncItemRowQuery();
+
+      outcomes.waitsToReconcileUntilReady = !trace.reconciledCount;
 
       outcomes.createsEvoluWithSchemaRelayAndDebug =
         trace.createdCount === 1
@@ -256,6 +263,8 @@ test('sync init browser coverage creates Evolu runtime subscriptions and debug g
         trace.loadedQueries.join(',') === '1,2,3'
         && runtime.getSyncAppOwner()?.id === 'owner-init'
         && runtime.getSyncAppOwnerError() === null;
+
+      outcomes.runsConfiguredReconciliationAfterReady = trace.reconciledCount === 1;
 
       outcomes.bindsSubscriptionsAndRelayProbe =
         trace.subscriptions.join(',') === '1,2,3'

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -3331,7 +3331,10 @@ await import('../js/settings.js');
   assert('reconcileLocalStorageWithEvolu defined',
     /export async function reconcileLocalStorageWithEvolu\(\)/.test(syncReconcileSrc));
   assert('Reconciliation runs on initSync after appOwner + queries are ready',
-    /Promise\.all\(\[readyPromise,\s*queryLoaded\]\)[\s\S]{0,300}reconcileLocalStorageWithEvolu/.test(syncInitSrc));
+    syncConfigureSrc.includes("from './sync-init.js'")
+      && syncConfigureSrc.includes('configureSyncInit({ reconcileLocalStorageWithEvolu });')
+      && !syncInitSrc.includes("from './sync-reconcile.js'")
+      && /Promise\.all\(\[readyPromise,\s*queryLoaded\]\)[\s\S]{0,300}reconcileLocalStorageWithEvolu/.test(syncInitSrc));
   assert('Reconciliation reads remote dataJson via parseSyncPayload',
     /reconcileLocalStorageWithEvolu[\s\S]{0,800}parseSyncPayload\(existing\.dataJson\)/.test(syncReconcileSrc));
   assert('Reconciliation routes through localHasRowsRemoteLacks (catches same-id timestamp drift)',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.337';
+self.APP_VERSION = '1.10.338';


### PR DESCRIPTION
## Summary

- inject startup reconciliation into `sync-init.js` from the sync composition root
- preserve the existing post-owner/post-query scheduling and error handling
- remove the reverse `sync-init.js` → `sync-reconcile.js` import
- ratchet architecture debt from 24 to 22 cyclic modules and the largest cycle from 21 to 19 modules
- bump the app cache version to 1.10.338

## Validation

- `npm run architecture:check`
- `npm run typecheck && npm run typecheck:checkjs && npm run quality`
- sync legacy contract suite (832 passed)
- focused Chromium startup/reconciliation/two-device sync coverage (14 passed)
- `npm run test:firefox` (3 passed)
- `PORT=8210 ./run-tests.sh` (131 static checks, 472 Vitest, 378 Chromium, 472 responsive-theme assertions)