### PR TITLE
Inject cycle storage crypto

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -10,11 +10,11 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | Metric | Current |
 | --- | ---: |
 | Modules | 462 |
-| Internal import edges | 2059 |
-| Dynamic internal edges | 62 |
-| Modules participating in cycles | 22 |
+| Internal import edges | 2058 |
+| Dynamic internal edges | 60 |
+| Modules participating in cycles | 20 |
 | Cyclic components | 2 |
-| Largest cyclic component | 19 |
+| Largest cyclic component | 17 |
 | Computed dynamic imports | 2 |
 
 ## Enforced source boundaries
@@ -45,8 +45,8 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 | [`js/modal-lifecycle.js`](js/modal-lifecycle.js) | 51 | [`js/sync-configure.js`](js/sync-configure.js) | 24 |
 | [`js/profile.js`](js/profile.js) | 50 | [`js/pdf-import.js`](js/pdf-import.js) | 23 |
 | [`js/schema.js`](js/schema.js) | 30 | [`js/chat-send.js`](js/chat-send.js) | 22 |
-| [`js/crypto.js`](js/crypto.js) | 29 | [`js/views.js`](js/views.js) | 20 |
-| [`js/data-merge.js`](js/data-merge.js) | 29 | [`js/wearables-connect.js`](js/wearables-connect.js) | 20 |
+| [`js/data-merge.js`](js/data-merge.js) | 29 | [`js/views.js`](js/views.js) | 20 |
+| [`js/crypto.js`](js/crypto.js) | 28 | [`js/wearables-connect.js`](js/wearables-connect.js) | 20 |
 | [`js/marker-analysis.js`](js/marker-analysis.js) | 18 | [`js/biology-scores.js`](js/biology-scores.js) | 19 |
 | [`js/utils-runtime.js`](js/utils-runtime.js) | 18 | [`js/profile.js`](js/profile.js) | 18 |
 | [`js/constants.js`](js/constants.js) | 17 | [`js/sun.js`](js/sun.js) | 18 |
@@ -58,9 +58,9 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 
 These are existing debt, not approved architecture. CI prevents new modules from joining a cycle and prevents the cycle budgets from increasing.
 
-<details><summary>Component 1 — 19 modules</summary>
+<details><summary>Component 1 — 17 modules</summary>
 
-[`js/backup-cycle.js`](js/backup-cycle.js), [`js/backup.js`](js/backup.js), [`js/crypto.js`](js/crypto.js), [`js/cycle-store.js`](js/cycle-store.js), [`js/data.js`](js/data.js), [`js/profile.js`](js/profile.js), [`js/sync-actions.js`](js/sync-actions.js), [`js/sync-chat-apply.js`](js/sync-chat-apply.js), [`js/sync-cutover.js`](js/sync-cutover.js), [`js/sync-payload-collectors.js`](js/sync-payload-collectors.js), [`js/sync-payload.js`](js/sync-payload.js), [`js/sync-save-hooks.js`](js/sync-save-hooks.js), [`js/sync-storage-cleanup.js`](js/sync-storage-cleanup.js), [`js/sync-tombstones.js`](js/sync-tombstones.js), [`js/sync.js`](js/sync.js), [`js/wearables-connect.js`](js/wearables-connect.js), [`js/wearables-manual.js`](js/wearables-manual.js), [`js/wearables-store.js`](js/wearables-store.js), [`js/wearables-summary.js`](js/wearables-summary.js)
+[`js/backup.js`](js/backup.js), [`js/crypto.js`](js/crypto.js), [`js/data.js`](js/data.js), [`js/profile.js`](js/profile.js), [`js/sync-actions.js`](js/sync-actions.js), [`js/sync-chat-apply.js`](js/sync-chat-apply.js), [`js/sync-cutover.js`](js/sync-cutover.js), [`js/sync-payload-collectors.js`](js/sync-payload-collectors.js), [`js/sync-payload.js`](js/sync-payload.js), [`js/sync-save-hooks.js`](js/sync-save-hooks.js), [`js/sync-storage-cleanup.js`](js/sync-storage-cleanup.js), [`js/sync-tombstones.js`](js/sync-tombstones.js), [`js/sync.js`](js/sync.js), [`js/wearables-connect.js`](js/wearables-connect.js), [`js/wearables-manual.js`](js/wearables-manual.js), [`js/wearables-store.js`](js/wearables-store.js), [`js/wearables-summary.js`](js/wearables-summary.js)
 
 </details>
 
@@ -296,7 +296,7 @@ Native browser modules shipped with the static application.
 <details><summary><code>crypto</code> family — 2 modules</summary>
 
 - [`js/crypto-key-cache.js`](js/crypto-key-cache.js) → no in-scope imports
-- [`js/crypto.js`](js/crypto.js) → [`js/backup.js`](js/backup.js), [`js/blob-storage.js`](js/blob-storage.js), [`js/cashu-wallet-store.js`](js/cashu-wallet-store.js) *(dynamic)*, [`js/crypto-key-cache.js`](js/crypto-key-cache.js), [`js/cycle-store.js`](js/cycle-store.js) *(dynamic)*, [`js/data-merge.js`](js/data-merge.js), [`js/data-wipe.js`](js/data-wipe.js) *(dynamic)*, [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js), [`js/wearables-store.js`](js/wearables-store.js) *(dynamic)*
+- [`js/crypto.js`](js/crypto.js) → [`js/backup.js`](js/backup.js), [`js/blob-storage.js`](js/blob-storage.js), [`js/cashu-wallet-store.js`](js/cashu-wallet-store.js) *(dynamic)*, [`js/crypto-key-cache.js`](js/crypto-key-cache.js), [`js/cycle-store.js`](js/cycle-store.js), [`js/data-merge.js`](js/data-merge.js), [`js/data-wipe.js`](js/data-wipe.js) *(dynamic)*, [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js), [`js/wearables-store.js`](js/wearables-store.js) *(dynamic)*
 
 </details>
 
@@ -306,7 +306,7 @@ Native browser modules shipped with the static application.
 - [`js/cycle-import-file.js`](js/cycle-import-file.js) → no in-scope imports
 - [`js/cycle-import.js`](js/cycle-import.js) → [`js/context-cards-runtime.js`](js/context-cards-runtime.js), [`js/cycle-import-adapters.js`](js/cycle-import-adapters.js), [`js/cycle-import-file.js`](js/cycle-import-file.js), [`js/cycle-runtime.js`](js/cycle-runtime.js), [`js/cycle-store.js`](js/cycle-store.js), [`js/cycle-summary.js`](js/cycle-summary.js), [`js/cycle.js`](js/cycle.js) *(dynamic)*, [`js/data-merge.js`](js/data-merge.js), [`js/data.js`](js/data.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/tour.js`](js/tour.js), [`js/utils.js`](js/utils.js), [`js/wearables-apple-health.js`](js/wearables-apple-health.js) *(dynamic)*
 - [`js/cycle-runtime.js`](js/cycle-runtime.js) → no in-scope imports
-- [`js/cycle-store.js`](js/cycle-store.js) → [`js/crypto.js`](js/crypto.js) *(dynamic)*
+- [`js/cycle-store.js`](js/cycle-store.js) → no in-scope imports
 - [`js/cycle-summary.js`](js/cycle-summary.js) → no in-scope imports
 - [`js/cycle.js`](js/cycle.js) → [`js/constants.js`](js/constants.js), [`js/context-cards-runtime.js`](js/context-cards-runtime.js), [`js/cycle-import.js`](js/cycle-import.js), [`js/cycle-runtime.js`](js/cycle-runtime.js), [`js/cycle-summary.js`](js/cycle-summary.js), [`js/data.js`](js/data.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/state.js`](js/state.js), [`js/tour.js`](js/tour.js), [`js/utils.js`](js/utils.js)
 

--- a/js/crypto.js
+++ b/js/crypto.js
@@ -7,6 +7,7 @@ import { profileStorageKey } from './profile.js';
 import { getBlob, setBlob, deleteBlob, shouldUseBlob } from './blob-storage.js';
 import { ensureImportedArray } from './data-merge.js';
 import { clearKeyCache, getCachedKey, updateKeyCache } from './crypto-key-cache.js';
+import { configureCycleStoreCrypto } from './cycle-store.js';
 
 export { getCachedKey, updateKeyCache } from './crypto-key-cache.js';
 
@@ -304,6 +305,13 @@ export function isEncryptedObject(o) {
   return o && typeof o === 'object' && o._enc === 'v1' &&
          o.iv instanceof Uint8Array && o.ct instanceof Uint8Array;
 }
+
+configureCycleStoreCrypto({
+  getEncryptionEnabled,
+  encryptObject,
+  isEncryptedObject,
+  decryptObject,
+});
 
 // TEST-ONLY: injects a freshly-derived key so behavioral tests can drive
 // the encrypt/decrypt round-trip without going through the passphrase

--- a/js/cycle-store.js
+++ b/js/cycle-store.js
@@ -20,6 +20,35 @@ const STORE_META = 'meta';
 
 const _dbPromises = new Map();
 
+/**
+ * @typedef {{
+ *   getEncryptionEnabled: () => boolean,
+ *   encryptObject: (value: any) => Promise<any>,
+ *   isEncryptedObject: (value: any) => boolean,
+ *   decryptObject: (value: any) => Promise<any>,
+ * }} CycleStoreCryptoDeps
+ */
+
+/** @type {CycleStoreCryptoDeps} */
+const cycleStoreCryptoDeps = {
+  getEncryptionEnabled: () => {
+    try { return localStorage.getItem('labcharts-encryption-enabled') === 'true'; } catch { return false; }
+  },
+  encryptObject: async () => null,
+  isEncryptedObject: value => !!(value && typeof value === 'object' && value._enc === 'v1'),
+  decryptObject: async () => null,
+};
+
+/** @param {Partial<CycleStoreCryptoDeps>} [deps] */
+export function configureCycleStoreCrypto(deps = {}) {
+  const previous = { ...cycleStoreCryptoDeps };
+  if (typeof deps.getEncryptionEnabled === 'function') cycleStoreCryptoDeps.getEncryptionEnabled = deps.getEncryptionEnabled;
+  if (typeof deps.encryptObject === 'function') cycleStoreCryptoDeps.encryptObject = deps.encryptObject;
+  if (typeof deps.isEncryptedObject === 'function') cycleStoreCryptoDeps.isEncryptedObject = deps.isEncryptedObject;
+  if (typeof deps.decryptObject === 'function') cycleStoreCryptoDeps.decryptObject = deps.decryptObject;
+  return previous;
+}
+
 function dbNameFor(profileId) {
   return DB_PREFIX + (profileId || 'default');
 }
@@ -95,13 +124,11 @@ function txPromise(tx) {
 }
 
 async function _encryptRowIfEnabled(row) {
-  let crypto;
-  try { crypto = await import('./crypto.js'); } catch { return row; }
-  if (!crypto.getEncryptionEnabled?.()) return row;
+  if (!cycleStoreCryptoDeps.getEncryptionEnabled()) return row;
   const identified = withObservationIdentity(row);
   const { source, date, importId, _payload, ...rest } = identified;
   if (_payload?._enc === 'v1') return identified;
-  const env = await crypto.encryptObject(rest);
+  const env = await cycleStoreCryptoDeps.encryptObject(rest);
   if (!env) {
     const e = new Error('Cycle storage is encrypted; unlock with your passphrase before importing cycle data.');
     /** @type {Error & { code?: string }} */ (e).code = 'session-locked';
@@ -112,10 +139,8 @@ async function _encryptRowIfEnabled(row) {
 
 async function _decryptRowIfWrapped(row) {
   if (!row || !row._payload) return row;
-  let crypto;
-  try { crypto = await import('./crypto.js'); } catch { return null; }
-  if (!crypto.isEncryptedObject?.(row._payload)) return row;
-  const decrypted = await crypto.decryptObject(row._payload).catch(() => null);
+  if (!cycleStoreCryptoDeps.isEncryptedObject(row._payload)) return row;
+  const decrypted = await cycleStoreCryptoDeps.decryptObject(row._payload).catch(() => null);
   if (!decrypted) return null;
   return {
     source: row.source,
@@ -126,12 +151,10 @@ async function _decryptRowIfWrapped(row) {
 }
 
 async function _encryptImportMetaIfEnabled(meta) {
-  let crypto;
-  try { crypto = await import('./crypto.js'); } catch { return meta; }
-  if (!crypto.getEncryptionEnabled?.()) return meta;
+  if (!cycleStoreCryptoDeps.getEncryptionEnabled()) return meta;
   const { importId, source, _payload, ...rest } = meta;
   if (_payload?._enc === 'v1') return meta;
-  const env = await crypto.encryptObject(rest);
+  const env = await cycleStoreCryptoDeps.encryptObject(rest);
   if (!env) {
     const e = new Error('Cycle storage is encrypted; unlock with your passphrase before importing cycle data.');
     /** @type {Error & { code?: string }} */ (e).code = 'session-locked';
@@ -142,10 +165,8 @@ async function _encryptImportMetaIfEnabled(meta) {
 
 async function _decryptImportMetaIfWrapped(meta) {
   if (!meta || !meta._payload) return meta;
-  let crypto;
-  try { crypto = await import('./crypto.js'); } catch { return null; }
-  if (!crypto.isEncryptedObject?.(meta._payload)) return meta;
-  const decrypted = await crypto.decryptObject(meta._payload).catch(() => null);
+  if (!cycleStoreCryptoDeps.isEncryptedObject(meta._payload)) return meta;
+  const decrypted = await cycleStoreCryptoDeps.decryptObject(meta._payload).catch(() => null);
   if (!decrypted) return null;
   return { importId: meta.importId, source: meta.source, ...decrypted };
 }

--- a/scripts/architecture-cycle-baseline.json
+++ b/scripts/architecture-cycle-baseline.json
@@ -1,13 +1,11 @@
 {
   "schemaVersion": 1,
-  "maxCyclicModules": 22,
-  "maxLargestCyclicComponent": 19,
+  "maxCyclicModules": 20,
+  "maxLargestCyclicComponent": 17,
   "allowedCyclicModules": [
-    "js/backup-cycle.js",
     "js/backup.js",
     "js/crypto.js",
     "js/cycle-import.js",
-    "js/cycle-store.js",
     "js/cycle.js",
     "js/data.js",
     "js/profile.js",

--- a/tests/cycle-import-phase1.test.js
+++ b/tests/cycle-import-phase1.test.js
@@ -26,6 +26,7 @@ import { createDefaultProfileData } from '../js/profile.js';
 import { state } from '../js/state.js';
 import {
   clearCycleImport,
+  configureCycleStoreCrypto,
   countCycleSource,
   deleteCycleDB,
   getAllCycleObservationsRaw,
@@ -237,6 +238,29 @@ describe('cycle import phase 1 primitives', () => {
       localStorage.removeItem('labcharts-encryption-enabled');
       if (previousTestFlag === undefined) delete globalThis.__WEARABLES_TEST;
       else globalThis.__WEARABLES_TEST = previousTestFlag;
+      await deleteCycleDB(profileId).catch(() => {});
+    }
+  });
+
+  it('fails closed when cycle encryption is enabled without an unlocked provider', async () => {
+    const profileId = 'cycle-encryption-provider-locked';
+    const previous = configureCycleStoreCrypto({
+      getEncryptionEnabled: () => true,
+      encryptObject: async () => null,
+      isEncryptedObject: value => value?._enc === 'v1',
+      decryptObject: async () => null,
+    });
+
+    try {
+      await expect(upsertCycleObservationBatch(profileId, [{
+        source: 'drip',
+        importId: 'locked-import',
+        date: '2026-01-01',
+        note: 'must not land as plaintext',
+      }])).rejects.toMatchObject({ code: 'session-locked' });
+      expect(await getAllCycleObservationsRaw(profileId)).toEqual([]);
+    } finally {
+      configureCycleStoreCrypto(previous);
       await deleteCycleDB(profileId).catch(() => {});
     }
   });

--- a/tests/test-crypto.js
+++ b/tests/test-crypto.js
@@ -56,6 +56,8 @@ const settingsModule = await import('../js/settings.js');
 await import('../js/chat.js');
 await import('../js/utils.js');
 const backupModule = await import('../js/backup.js');
+const cryptoStoreSrc = read('js/crypto.js');
+const cycleStoreSrc = read('js/cycle-store.js');
 
 // Seed a minimal profile registry — the app bootstraps one via
 // initProfilesCache() on page load; in Node we seed it so the section-15
@@ -85,6 +87,10 @@ assert('backup.exportEncryptedBackup module export exists', typeof backupModule.
 assert('backup.importEncryptedBackup module export exists', typeof backupModule.importEncryptedBackup === 'function');
 assert('window.exportEncryptedBackup stays module-only', !('exportEncryptedBackup' in window));
 assert('window.importEncryptedBackup stays module-only', !('importEncryptedBackup' in window));
+assert('cycle storage receives crypto providers without a reverse import',
+  cryptoStoreSrc.includes('configureCycleStoreCrypto({')
+    && cycleStoreSrc.includes('export function configureCycleStoreCrypto')
+    && !cycleStoreSrc.includes("import('./crypto.js')"));
 assert('profile.initProfilesCache exists', typeof profileModule.initProfilesCache === 'function');
 assert('window.initProfilesCache stays module-only', !('initProfilesCache' in window));
 

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.338';
+self.APP_VERSION = '1.10.339';


### PR DESCRIPTION
## Summary

- inject cycle IndexedDB crypto providers from the crypto owner
- remove four reverse lazy imports while preserving encrypted row and metadata behavior
- fail closed with `session-locked` when encryption is enabled without an unlocked provider
- ratchet cyclic modules from 22 to 20 and the largest component from 19 to 17
- bump the cache version to 1.10.339

## Validation

- `./run-tests.sh` (131 static checks, 473 Vitest tests, 378 Chromium tests, 472 responsive-theme tests)
- `npm run test:firefox` (3 tests)
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
- `npm run architecture:check`
- `git diff --check`