### PR TITLE
Inject wearable storage crypto

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -10,11 +10,11 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | Metric | Current |
 | --- | ---: |
 | Modules | 462 |
-| Internal import edges | 2058 |
-| Dynamic internal edges | 60 |
-| Modules participating in cycles | 20 |
+| Internal import edges | 2057 |
+| Dynamic internal edges | 58 |
+| Modules participating in cycles | 19 |
 | Cyclic components | 2 |
-| Largest cyclic component | 17 |
+| Largest cyclic component | 16 |
 | Computed dynamic imports | 2 |
 
 ## Enforced source boundaries
@@ -46,7 +46,7 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 | [`js/profile.js`](js/profile.js) | 50 | [`js/pdf-import.js`](js/pdf-import.js) | 23 |
 | [`js/schema.js`](js/schema.js) | 30 | [`js/chat-send.js`](js/chat-send.js) | 22 |
 | [`js/data-merge.js`](js/data-merge.js) | 29 | [`js/views.js`](js/views.js) | 20 |
-| [`js/crypto.js`](js/crypto.js) | 28 | [`js/wearables-connect.js`](js/wearables-connect.js) | 20 |
+| [`js/crypto.js`](js/crypto.js) | 27 | [`js/wearables-connect.js`](js/wearables-connect.js) | 20 |
 | [`js/marker-analysis.js`](js/marker-analysis.js) | 18 | [`js/biology-scores.js`](js/biology-scores.js) | 19 |
 | [`js/utils-runtime.js`](js/utils-runtime.js) | 18 | [`js/profile.js`](js/profile.js) | 18 |
 | [`js/constants.js`](js/constants.js) | 17 | [`js/sun.js`](js/sun.js) | 18 |
@@ -58,9 +58,9 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 
 These are existing debt, not approved architecture. CI prevents new modules from joining a cycle and prevents the cycle budgets from increasing.
 
-<details><summary>Component 1 — 17 modules</summary>
+<details><summary>Component 1 — 16 modules</summary>
 
-[`js/backup.js`](js/backup.js), [`js/crypto.js`](js/crypto.js), [`js/data.js`](js/data.js), [`js/profile.js`](js/profile.js), [`js/sync-actions.js`](js/sync-actions.js), [`js/sync-chat-apply.js`](js/sync-chat-apply.js), [`js/sync-cutover.js`](js/sync-cutover.js), [`js/sync-payload-collectors.js`](js/sync-payload-collectors.js), [`js/sync-payload.js`](js/sync-payload.js), [`js/sync-save-hooks.js`](js/sync-save-hooks.js), [`js/sync-storage-cleanup.js`](js/sync-storage-cleanup.js), [`js/sync-tombstones.js`](js/sync-tombstones.js), [`js/sync.js`](js/sync.js), [`js/wearables-connect.js`](js/wearables-connect.js), [`js/wearables-manual.js`](js/wearables-manual.js), [`js/wearables-store.js`](js/wearables-store.js), [`js/wearables-summary.js`](js/wearables-summary.js)
+[`js/backup.js`](js/backup.js), [`js/crypto.js`](js/crypto.js), [`js/data.js`](js/data.js), [`js/profile.js`](js/profile.js), [`js/sync-actions.js`](js/sync-actions.js), [`js/sync-chat-apply.js`](js/sync-chat-apply.js), [`js/sync-cutover.js`](js/sync-cutover.js), [`js/sync-payload-collectors.js`](js/sync-payload-collectors.js), [`js/sync-payload.js`](js/sync-payload.js), [`js/sync-save-hooks.js`](js/sync-save-hooks.js), [`js/sync-storage-cleanup.js`](js/sync-storage-cleanup.js), [`js/sync-tombstones.js`](js/sync-tombstones.js), [`js/sync.js`](js/sync.js), [`js/wearables-connect.js`](js/wearables-connect.js), [`js/wearables-manual.js`](js/wearables-manual.js), [`js/wearables-summary.js`](js/wearables-summary.js)
 
 </details>
 
@@ -296,7 +296,7 @@ Native browser modules shipped with the static application.
 <details><summary><code>crypto</code> family — 2 modules</summary>
 
 - [`js/crypto-key-cache.js`](js/crypto-key-cache.js) → no in-scope imports
-- [`js/crypto.js`](js/crypto.js) → [`js/backup.js`](js/backup.js), [`js/blob-storage.js`](js/blob-storage.js), [`js/cashu-wallet-store.js`](js/cashu-wallet-store.js) *(dynamic)*, [`js/crypto-key-cache.js`](js/crypto-key-cache.js), [`js/cycle-store.js`](js/cycle-store.js), [`js/data-merge.js`](js/data-merge.js), [`js/data-wipe.js`](js/data-wipe.js) *(dynamic)*, [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js), [`js/wearables-store.js`](js/wearables-store.js) *(dynamic)*
+- [`js/crypto.js`](js/crypto.js) → [`js/backup.js`](js/backup.js), [`js/blob-storage.js`](js/blob-storage.js), [`js/cashu-wallet-store.js`](js/cashu-wallet-store.js) *(dynamic)*, [`js/crypto-key-cache.js`](js/crypto-key-cache.js), [`js/cycle-store.js`](js/cycle-store.js), [`js/data-merge.js`](js/data-merge.js), [`js/data-wipe.js`](js/data-wipe.js) *(dynamic)*, [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js), [`js/wearables-store.js`](js/wearables-store.js)
 
 </details>
 
@@ -911,7 +911,7 @@ Native browser modules shipped with the static application.
 - [`js/wearables-runtime.js`](js/wearables-runtime.js) → [`js/emf-runtime.js`](js/emf-runtime.js), [`js/settings-runtime-bridge.js`](js/settings-runtime-bridge.js)
 - [`js/wearables-settings-panel.js`](js/wearables-settings-panel.js) → [`js/brand-assets.js`](js/brand-assets.js), [`js/data.js`](js/data.js) *(dynamic)*, [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js), [`js/wearable-adapters.js`](js/wearable-adapters.js), [`js/wearables-apple-health.js`](js/wearables-apple-health.js) *(dynamic)*, [`js/wearables-connect.js`](js/wearables-connect.js), [`js/wearables-manual.js`](js/wearables-manual.js) *(dynamic)*, [`js/wearables-settings-runtime.js`](js/wearables-settings-runtime.js), [`js/wearables-store.js`](js/wearables-store.js) *(dynamic)*, [`js/wearables-summary.js`](js/wearables-summary.js)
 - [`js/wearables-settings-runtime.js`](js/wearables-settings-runtime.js) → [`js/settings-runtime-bridge.js`](js/settings-runtime-bridge.js), [`js/utils.js`](js/utils.js)
-- [`js/wearables-store.js`](js/wearables-store.js) → [`js/crypto.js`](js/crypto.js) *(dynamic)*
+- [`js/wearables-store.js`](js/wearables-store.js) → no in-scope imports
 - [`js/wearables-summary.js`](js/wearables-summary.js) → [`js/data-merge.js`](js/data-merge.js), [`js/data.js`](js/data.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js), [`js/wearable-adapters.js`](js/wearable-adapters.js), [`js/wearables-store.js`](js/wearables-store.js)
 - [`js/wearables-ultrahuman-auth.js`](js/wearables-ultrahuman-auth.js) → [`js/utils.js`](js/utils.js), [`js/wearables-auth-runtime.js`](js/wearables-auth-runtime.js)
 - [`js/wearables-ultrahuman.js`](js/wearables-ultrahuman.js) → [`js/utils.js`](js/utils.js)

--- a/js/crypto.js
+++ b/js/crypto.js
@@ -8,6 +8,7 @@ import { getBlob, setBlob, deleteBlob, shouldUseBlob } from './blob-storage.js';
 import { ensureImportedArray } from './data-merge.js';
 import { clearKeyCache, getCachedKey, updateKeyCache } from './crypto-key-cache.js';
 import { configureCycleStoreCrypto } from './cycle-store.js';
+import { configureWearablesStoreCrypto } from './wearables-store.js';
 
 export { getCachedKey, updateKeyCache } from './crypto-key-cache.js';
 
@@ -307,6 +308,13 @@ export function isEncryptedObject(o) {
 }
 
 configureCycleStoreCrypto({
+  getEncryptionEnabled,
+  encryptObject,
+  isEncryptedObject,
+  decryptObject,
+});
+
+configureWearablesStoreCrypto({
   getEncryptionEnabled,
   encryptObject,
   isEncryptedObject,

--- a/js/wearables-store.js
+++ b/js/wearables-store.js
@@ -21,6 +21,35 @@ const STORE_META = 'meta';
 
 const _dbPromises = new Map();
 
+/**
+ * @typedef {{
+ *   getEncryptionEnabled: () => boolean,
+ *   encryptObject: (value: any) => Promise<any>,
+ *   isEncryptedObject: (value: any) => boolean,
+ *   decryptObject: (value: any) => Promise<any>,
+ * }} WearablesStoreCryptoDeps
+ */
+
+/** @type {WearablesStoreCryptoDeps} */
+const wearablesStoreCryptoDeps = {
+  getEncryptionEnabled: () => {
+    try { return localStorage.getItem('labcharts-encryption-enabled') === 'true'; } catch { return false; }
+  },
+  encryptObject: async () => null,
+  isEncryptedObject: value => !!(value && typeof value === 'object' && value._enc === 'v1'),
+  decryptObject: async () => null,
+};
+
+/** @param {Partial<WearablesStoreCryptoDeps>} [deps] */
+export function configureWearablesStoreCrypto(deps = {}) {
+  const previous = { ...wearablesStoreCryptoDeps };
+  if (typeof deps.getEncryptionEnabled === 'function') wearablesStoreCryptoDeps.getEncryptionEnabled = deps.getEncryptionEnabled;
+  if (typeof deps.encryptObject === 'function') wearablesStoreCryptoDeps.encryptObject = deps.encryptObject;
+  if (typeof deps.isEncryptedObject === 'function') wearablesStoreCryptoDeps.isEncryptedObject = deps.isEncryptedObject;
+  if (typeof deps.decryptObject === 'function') wearablesStoreCryptoDeps.decryptObject = deps.decryptObject;
+  return previous;
+}
+
 function dbNameFor(profileId) {
   // Fall back to 'default' so a missing profile id still gets a valid db name.
   return DB_PREFIX + (profileId || 'default');
@@ -87,16 +116,14 @@ function txPromise(tx) {
 // the write; better than landing cleartext rows in an "encrypted at rest"
 // IDB without telling anyone.
 async function _encryptRowIfEnabled(row) {
-  let crypto;
-  try { crypto = await import('./crypto.js'); } catch { return row; }
-  if (!crypto.getEncryptionEnabled?.()) return row;
+  if (!wearablesStoreCryptoDeps.getEncryptionEnabled()) return row;
   // Already-encrypted rows (e.g. from a backup-restore RAW path) pass through
   // untouched. Note: when encryption is OFF we DON'T hit this branch because
   // we returned above; that scenario goes through the RAW upsert API
   // (upsertDailyBatchRaw) which doesn't call this helper.
   const { source, date, _payload, ...rest } = row;
   if (_payload?._enc === 'v1') return row;
-  const env = await crypto.encryptObject(rest);
+  const env = await wearablesStoreCryptoDeps.encryptObject(rest);
   if (!env) {
     // Encryption-on but session locked (or unavailable). Refuse rather than
     // silently writing cleartext. The error propagates up to the adapter
@@ -112,10 +139,8 @@ async function _encryptRowIfEnabled(row) {
 
 async function _decryptRowIfWrapped(row) {
   if (!row || !row._payload) return row;
-  let crypto;
-  try { crypto = await import('./crypto.js'); } catch { return null; }
-  if (!crypto.isEncryptedObject?.(row._payload)) return row;
-  const decrypted = await crypto.decryptObject(row._payload).catch(() => null);
+  if (!wearablesStoreCryptoDeps.isEncryptedObject(row._payload)) return row;
+  const decrypted = await wearablesStoreCryptoDeps.decryptObject(row._payload).catch(() => null);
   // Session locked / corrupt → return null. Earlier we returned the
   // wrapped row, but downstream consumers (`_mergeManualRow`,
   // `upsertDailyBatch`'s read-modify-write) would spread `_payload` into

--- a/scripts/architecture-cycle-baseline.json
+++ b/scripts/architecture-cycle-baseline.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "maxCyclicModules": 20,
-  "maxLargestCyclicComponent": 17,
+  "maxCyclicModules": 19,
+  "maxLargestCyclicComponent": 16,
   "allowedCyclicModules": [
     "js/backup.js",
     "js/crypto.js",
@@ -21,7 +21,6 @@
     "js/wearables-apple-health.js",
     "js/wearables-connect.js",
     "js/wearables-manual.js",
-    "js/wearables-store.js",
     "js/wearables-summary.js"
   ],
   "allowedComputedDynamicImports": [

--- a/tests/cycle-import-phase1.test.js
+++ b/tests/cycle-import-phase1.test.js
@@ -265,6 +265,29 @@ describe('cycle import phase 1 primitives', () => {
     }
   });
 
+  it('fails closed when wearable encryption is enabled without an unlocked provider', async () => {
+    const profileId = 'wearable-encryption-provider-locked';
+    const wearableStore = await import('../js/wearables-store.js');
+    const previous = wearableStore.configureWearablesStoreCrypto({
+      getEncryptionEnabled: () => true,
+      encryptObject: async () => null,
+      isEncryptedObject: value => value?._enc === 'v1',
+      decryptObject: async () => null,
+    });
+
+    try {
+      await expect(wearableStore.upsertDaily(profileId, {
+        source: 'manual',
+        date: '2026-01-01',
+        rhr: 61,
+      })).rejects.toMatchObject({ code: 'session-locked' });
+      expect(await wearableStore.getAllDailyRaw(profileId)).toEqual([]);
+    } finally {
+      wearableStore.configureWearablesStoreCrypto(previous);
+      await wearableStore.deleteWearablesDB(profileId).catch(() => {});
+    }
+  });
+
   it('migrates cycle, wearable, blob, and hyphenated-profile storage across key changes', async () => {
     const profileId = 'cycle-encryption-migration-profile';
     const importedKey = `labcharts-${profileId}-imported`;

--- a/tests/test-wearables.js
+++ b/tests/test-wearables.js
@@ -1331,11 +1331,10 @@ console.log('17r. Behavioral Coverage');
 // Asserts plaintext path passes through, encrypted path round-trips.
 try {
   window.__WEARABLES_TEST = true;
-  // CRITICAL: do NOT cache-bust the crypto/store modules. wearables-store
-  // imports crypto.js without cache-bust; if we bust here we'd get a
-  // separate module instance with its own private _sessionKey, and the
-  // store's encrypt path would still see the production module's null
-  // key. Use the production singleton.
+  // CRITICAL: do NOT cache-bust the crypto/store modules. crypto.js injects
+  // its providers into the production store singleton; a cache-busted crypto
+  // instance would own a separate private _sessionKey. Use the production
+  // singletons so encryption state and providers stay paired.
   const cryptoB = await import('../js/crypto.js');
   const storeB  = await import('../js/wearables-store.js');
   const TEST_PROFILE_E = '__test-encrypt-' + Date.now().toString(36);
@@ -1524,6 +1523,10 @@ const storeSrc31 = await fetch('/js/wearables-store.js').then(r => r.text());
 assert('Encrypt-or-throw: session-locked path throws session-locked error (no silent plaintext)',
   /code\s*=\s*'session-locked'/.test(storeSrc31) &&
   /encrypted;\s*unlock with your passphrase before syncing/.test(storeSrc31));
+assert('Wearable storage receives crypto providers without a reverse import',
+  /configureWearablesStoreCrypto\(\{/.test(cryptoSrc31)
+  && /export function configureWearablesStoreCrypto/.test(storeSrc31)
+  && !/import\(['"]\.\/crypto\.js['"]\)/.test(storeSrc31));
 
 // ═══════════════════════════════════════
 // 17t. Settings tab split — Wearables + Agent Access (v1.30.0)

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.339';
+self.APP_VERSION = '1.10.340';


### PR DESCRIPTION
## Summary

- inject wearable IndexedDB crypto providers from the crypto owner
- remove both reverse lazy imports while preserving encrypted row behavior and storage format
- fail closed with `session-locked` when encryption is enabled without an unlocked provider
- ratchet cyclic modules from 20 to 19 and the largest component from 17 to 16
- bump the cache version to 1.10.340

## Validation

- `./run-tests.sh` (131 static checks, 474 Vitest tests, 378 Chromium tests, 472 responsive-theme checks)
- `npm run test:firefox` (3 tests)
- focused Chromium crypto/wearable coverage (7 tests)
- `npm run quality`
- `npm run architecture:check`
- `git diff --check`