### PR TITLE
Inject sync payload profiles

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -10,11 +10,11 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | Metric | Current |
 | --- | ---: |
 | Modules | 463 |
-| Internal import edges | 2058 |
+| Internal import edges | 2059 |
 | Dynamic internal edges | 58 |
-| Modules participating in cycles | 15 |
+| Modules participating in cycles | 13 |
 | Cyclic components | 2 |
-| Largest cyclic component | 12 |
+| Largest cyclic component | 10 |
 | Computed dynamic imports | 2 |
 
 ## Enforced source boundaries
@@ -40,9 +40,9 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 | --- | ---: | --- | ---: |
 | [`js/utils.js`](js/utils.js) | 205 | [`js/app-shell-hooks.js`](js/app-shell-hooks.js) | 83 |
 | [`js/state.js`](js/state.js) | 145 | [`js/app-light-sun-modules.js`](js/app-light-sun-modules.js) | 27 |
-| [`js/data.js`](js/data.js) | 74 | [`js/dashboard-view-composition.js`](js/dashboard-view-composition.js) | 24 |
-| [`js/api.js`](js/api.js) | 63 | [`js/settings.js`](js/settings.js) | 24 |
-| [`js/modal-lifecycle.js`](js/modal-lifecycle.js) | 51 | [`js/sync-configure.js`](js/sync-configure.js) | 24 |
+| [`js/data.js`](js/data.js) | 74 | [`js/sync-configure.js`](js/sync-configure.js) | 26 |
+| [`js/api.js`](js/api.js) | 63 | [`js/dashboard-view-composition.js`](js/dashboard-view-composition.js) | 24 |
+| [`js/modal-lifecycle.js`](js/modal-lifecycle.js) | 51 | [`js/settings.js`](js/settings.js) | 24 |
 | [`js/profile.js`](js/profile.js) | 48 | [`js/pdf-import.js`](js/pdf-import.js) | 23 |
 | [`js/schema.js`](js/schema.js) | 30 | [`js/chat-send.js`](js/chat-send.js) | 22 |
 | [`js/data-merge.js`](js/data-merge.js) | 29 | [`js/views.js`](js/views.js) | 20 |
@@ -58,9 +58,9 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 
 These are existing debt, not approved architecture. CI prevents new modules from joining a cycle and prevents the cycle budgets from increasing.
 
-<details><summary>Component 1 — 12 modules</summary>
+<details><summary>Component 1 — 10 modules</summary>
 
-[`js/data.js`](js/data.js), [`js/profile.js`](js/profile.js), [`js/sync-actions.js`](js/sync-actions.js), [`js/sync-cutover.js`](js/sync-cutover.js), [`js/sync-payload.js`](js/sync-payload.js), [`js/sync-save-hooks.js`](js/sync-save-hooks.js), [`js/sync-storage-cleanup.js`](js/sync-storage-cleanup.js), [`js/sync-tombstones.js`](js/sync-tombstones.js), [`js/sync.js`](js/sync.js), [`js/wearables-connect.js`](js/wearables-connect.js), [`js/wearables-manual.js`](js/wearables-manual.js), [`js/wearables-summary.js`](js/wearables-summary.js)
+[`js/data.js`](js/data.js), [`js/profile.js`](js/profile.js), [`js/sync-actions.js`](js/sync-actions.js), [`js/sync-save-hooks.js`](js/sync-save-hooks.js), [`js/sync-storage-cleanup.js`](js/sync-storage-cleanup.js), [`js/sync-tombstones.js`](js/sync-tombstones.js), [`js/sync.js`](js/sync.js), [`js/wearables-connect.js`](js/wearables-connect.js), [`js/wearables-manual.js`](js/wearables-manual.js), [`js/wearables-summary.js`](js/wearables-summary.js)
 
 </details>
 
@@ -767,7 +767,7 @@ Native browser modules shipped with the static application.
 - [`js/sync-actions.js`](js/sync-actions.js) → [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/sync-messenger.js`](js/sync-messenger.js), [`js/sync-save-hooks.js`](js/sync-save-hooks.js), [`js/sync-state.js`](js/sync-state.js), [`js/sync-storage-cleanup.js`](js/sync-storage-cleanup.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-apply.js`](js/sync-apply.js) → [`js/crypto.js`](js/crypto.js), [`js/sync-chat-apply.js`](js/sync-chat-apply.js), [`js/sync-payload-collectors.js`](js/sync-payload-collectors.js), [`js/sync-runtime.js`](js/sync-runtime.js)
 - [`js/sync-chat-apply.js`](js/sync-chat-apply.js) → [`js/crypto.js`](js/crypto.js), [`js/state.js`](js/state.js), [`js/sync-payload-collectors.js`](js/sync-payload-collectors.js), [`js/sync-state.js`](js/sync-state.js), [`js/utils.js`](js/utils.js)
-- [`js/sync-configure.js`](js/sync-configure.js) → [`js/lab-context.js`](js/lab-context.js), [`js/sync-actions.js`](js/sync-actions.js), [`js/sync-cutover.js`](js/sync-cutover.js), [`js/sync-delta.js`](js/sync-delta.js), [`js/sync-diagnose-ui.js`](js/sync-diagnose-ui.js), [`js/sync-diagnostics.js`](js/sync-diagnostics.js), [`js/sync-environment.js`](js/sync-environment.js), [`js/sync-identity.js`](js/sync-identity.js), [`js/sync-init.js`](js/sync-init.js), [`js/sync-messenger.js`](js/sync-messenger.js), [`js/sync-pull.js`](js/sync-pull.js), [`js/sync-push.js`](js/sync-push.js), [`js/sync-reconcile.js`](js/sync-reconcile.js), [`js/sync-recovery.js`](js/sync-recovery.js), [`js/sync-relay-health.js`](js/sync-relay-health.js), [`js/sync-runtime.js`](js/sync-runtime.js), [`js/sync-save-hooks.js`](js/sync-save-hooks.js), [`js/sync-settings-state.js`](js/sync-settings-state.js), [`js/sync-state.js`](js/sync-state.js), [`js/sync-storage-cleanup.js`](js/sync-storage-cleanup.js), [`js/sync-subscriptions.js`](js/sync-subscriptions.js), [`js/sync-tombstones.js`](js/sync-tombstones.js), [`js/sync-ui.js`](js/sync-ui.js), [`js/utils.js`](js/utils.js)
+- [`js/sync-configure.js`](js/sync-configure.js) → [`js/lab-context.js`](js/lab-context.js), [`js/profile.js`](js/profile.js), [`js/sync-actions.js`](js/sync-actions.js), [`js/sync-cutover.js`](js/sync-cutover.js), [`js/sync-delta.js`](js/sync-delta.js), [`js/sync-diagnose-ui.js`](js/sync-diagnose-ui.js), [`js/sync-diagnostics.js`](js/sync-diagnostics.js), [`js/sync-environment.js`](js/sync-environment.js), [`js/sync-identity.js`](js/sync-identity.js), [`js/sync-init.js`](js/sync-init.js), [`js/sync-messenger.js`](js/sync-messenger.js), [`js/sync-payload.js`](js/sync-payload.js), [`js/sync-pull.js`](js/sync-pull.js), [`js/sync-push.js`](js/sync-push.js), [`js/sync-reconcile.js`](js/sync-reconcile.js), [`js/sync-recovery.js`](js/sync-recovery.js), [`js/sync-relay-health.js`](js/sync-relay-health.js), [`js/sync-runtime.js`](js/sync-runtime.js), [`js/sync-save-hooks.js`](js/sync-save-hooks.js), [`js/sync-settings-state.js`](js/sync-settings-state.js), [`js/sync-state.js`](js/sync-state.js), [`js/sync-storage-cleanup.js`](js/sync-storage-cleanup.js), [`js/sync-subscriptions.js`](js/sync-subscriptions.js), [`js/sync-tombstones.js`](js/sync-tombstones.js), [`js/sync-ui.js`](js/sync-ui.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-cutover.js`](js/sync-cutover.js) → [`js/sync-delta.js`](js/sync-delta.js), [`js/sync-payload.js`](js/sync-payload.js)
 - [`js/sync-delta-array-merge.js`](js/sync-delta-array-merge.js) → [`js/data-merge.js`](js/data-merge.js), [`js/sync-delta-observability.js`](js/sync-delta-observability.js), [`js/sync-delta-registry.js`](js/sync-delta-registry.js), [`js/sync-delta-row-codec.js`](js/sync-delta-row-codec.js)
 - [`js/sync-delta-array-planner.js`](js/sync-delta-array-planner.js) → [`js/sync-delta-planner-context.js`](js/sync-delta-planner-context.js), [`js/sync-delta-registry.js`](js/sync-delta-registry.js), [`js/sync-delta-snapshot.js`](js/sync-delta-snapshot.js), [`js/sync-payload-codec.js`](js/sync-payload-codec.js)
@@ -811,7 +811,7 @@ Native browser modules shipped with the static application.
 - [`js/sync-messenger.js`](js/sync-messenger.js) → [`js/state.js`](js/state.js), [`js/utils-runtime.js`](js/utils-runtime.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-payload-codec.js`](js/sync-payload-codec.js) → no in-scope imports
 - [`js/sync-payload-collectors.js`](js/sync-payload-collectors.js) → [`js/crypto.js`](js/crypto.js)
-- [`js/sync-payload.js`](js/sync-payload.js) → [`js/profile.js`](js/profile.js), [`js/sync-payload-codec.js`](js/sync-payload-codec.js), [`js/sync-payload-collectors.js`](js/sync-payload-collectors.js)
+- [`js/sync-payload.js`](js/sync-payload.js) → [`js/sync-payload-codec.js`](js/sync-payload-codec.js), [`js/sync-payload-collectors.js`](js/sync-payload-collectors.js)
 - [`js/sync-pull-active-refresh-runtime.js`](js/sync-pull-active-refresh-runtime.js) → no in-scope imports
 - [`js/sync-pull-active-refresh.js`](js/sync-pull-active-refresh.js) → [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/sync-pull-active-refresh-runtime.js`](js/sync-pull-active-refresh-runtime.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-pull-maintenance.js`](js/sync-pull-maintenance.js) → no in-scope imports

--- a/js/sync-configure.js
+++ b/js/sync-configure.js
@@ -2,6 +2,7 @@
 // sync-configure.js - Dependency wiring for the sync subsystem.
 
 import { showNotification, isDebugMode } from './utils.js';
+import { getProfiles } from './profile.js';
 import { configureRelayHealth } from './sync-relay-health.js';
 import { logSyncEvent, updateSyncStatus } from './sync-state.js';
 import { isSyncEnabled } from './sync-settings-state.js';
@@ -20,6 +21,7 @@ import {
 } from './sync-actions.js';
 import { bindSyncSaveHookEvents, configureSyncSaveHooks } from './sync-save-hooks.js';
 import { configureSyncPush, isSyncPushInFlight, pushProfile } from './sync-push.js';
+import { configureSyncPayload } from './sync-payload.js';
 import { configureSyncRecovery } from './sync-recovery.js';
 import { configureSyncInit } from './sync-init.js';
 import { configureSyncReconcile, reconcileLocalStorageWithEvolu } from './sync-reconcile.js';
@@ -43,6 +45,8 @@ function dbg(...args) { if (isDebugMode()) console.log('[sync]', ...args); }
 
 /** @param {{ enableSync?: (...args: any[]) => any, disableSync?: (...args: any[]) => any }} [deps] */
 export function configureSyncModules({ enableSync, disableSync } = {}) {
+  configureSyncPayload({ getProfiles });
+
   configureRelayHealth({
     getAppOwner: getSyncAppOwner,
     getSyncRelay,

--- a/js/sync-payload.js
+++ b/js/sync-payload.js
@@ -1,7 +1,6 @@
 // @ts-check
 // sync-payload.js - outbound/inbound wire payload helpers for Evolu sync
 
-import { getProfiles } from './profile.js';
 import {
   collectAISettings, collectChatData, collectDisplayPrefs,
 } from './sync-payload-collectors.js';
@@ -17,6 +16,25 @@ export {
   _base64ToBytes, _bytesToBase64, _gzipString, _gunzipToStringCapped,
   _PER_ROW_DECOMPRESSED_CAP_BYTES, MAX_SYNC_PAYLOAD_BYTES, parseSyncPayload,
 } from './sync-payload-codec.js';
+
+/** @type {{ getProfiles: () => any[] }} */
+const syncPayloadDeps = {
+  getProfiles: () => {
+    try {
+      const profiles = JSON.parse(localStorage.getItem('labcharts-profiles') || '[]');
+      return Array.isArray(profiles) ? profiles : [];
+    } catch {
+      return [];
+    }
+  },
+};
+
+/** @param {{ getProfiles?: () => any[] }} [deps] */
+export function configureSyncPayload(deps = {}) {
+  const previous = { ...syncPayloadDeps };
+  if (typeof deps.getProfiles === 'function') syncPayloadDeps.getProfiles = deps.getProfiles;
+  return previous;
+}
 
 // Phase 2 cutover flag — when set, buildSyncPayload omits importedData
 // from the blob entirely. Per-row CRDT deltas carry every field instead.
@@ -47,7 +65,7 @@ export function disablePhase2CutoverFlag(profileId) {
  * @param {any} importedData
  */
 export async function buildSyncPayload(profileId, importedData) {
-  const profiles = getProfiles();
+  const profiles = syncPayloadDeps.getProfiles();
   const profile = profiles.find(p => p.id === profileId);
   const aiSettings = await collectAISettings();
   const chatData = await collectChatData(profileId);

--- a/scripts/architecture-cycle-baseline.json
+++ b/scripts/architecture-cycle-baseline.json
@@ -1,15 +1,13 @@
 {
   "schemaVersion": 1,
-  "maxCyclicModules": 15,
-  "maxLargestCyclicComponent": 12,
+  "maxCyclicModules": 13,
+  "maxLargestCyclicComponent": 10,
   "allowedCyclicModules": [
     "js/cycle-import.js",
     "js/cycle.js",
     "js/data.js",
     "js/profile.js",
     "js/sync-actions.js",
-    "js/sync-cutover.js",
-    "js/sync-payload.js",
     "js/sync-save-hooks.js",
     "js/sync-storage-cleanup.js",
     "js/sync-tombstones.js",

--- a/tests/sync-runtime.test.js
+++ b/tests/sync-runtime.test.js
@@ -37,7 +37,7 @@ import {
   isSyncDisableCleanupKey,
 } from '../js/sync-disable-cleanup.js';
 import { clearStaleSyncHashKeysOnce } from '../js/sync-pull-maintenance.js';
-import { parseSyncPayload } from '../js/sync-payload.js';
+import { buildSyncPayload, configureSyncPayload, parseSyncPayload } from '../js/sync-payload.js';
 import { collectAISettings } from '../js/sync-payload-collectors.js';
 import { maybeScheduleRebroadcast } from '../js/sync-pull-rebroadcast.js';
 import { applyCommittedDeltas, planProfileDeltas } from '../js/sync-push-deltas.js';
@@ -186,6 +186,20 @@ afterEach(() => {
   vi.useRealTimers();
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
+});
+
+describe('sync payload composition', () => {
+  it('uses the configured profile provider for outbound metadata', async () => {
+    const profile = { id: PROFILE_ID, name: 'Configured profile' };
+    const previous = configureSyncPayload({ getProfiles: () => [profile] });
+
+    try {
+      const payload = JSON.parse(await buildSyncPayload(PROFILE_ID, { entries: [] }));
+      expect(payload.profile).toEqual(profile);
+    } finally {
+      configureSyncPayload(previous);
+    }
+  });
 });
 
 describe('sync apply runtime behavior', () => {

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -1012,6 +1012,10 @@ await import('../js/settings.js');
   assert('sync-payload.js owns buildSyncPayload',
     syncPushSrc.includes("from './sync-payload.js'")
       && syncPayloadSrc.includes('export async function buildSyncPayload'));
+  assert('sync composition injects profile metadata into the payload builder',
+    syncPayloadSrc.includes('export function configureSyncPayload')
+      && !syncPayloadSrc.includes("from './profile.js'")
+      && syncConfigureSrc.includes('configureSyncPayload({ getProfiles });'));
   assert('buildSyncPayload still emits _v: 3 (default dual-write)', syncPayloadSrc.includes('cutover ? 4 : 3'));
   assert('buildSyncPayload includes importedData', syncPayloadSrc.includes('importedData,') || syncPayloadSrc.includes('importedData:'));
   assert('buildSyncPayload includes profile metadata', syncPayloadSrc.includes('profile: profile'));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.341';
+self.APP_VERSION = '1.10.342';


### PR DESCRIPTION
## Summary

- inject the cached profile provider into sync payload construction from the sync composition root
- retain the fail-soft localStorage fallback for standalone payload use
- remove the sync payload reverse dependency on the profile domain module
- ratchet cyclic modules from 15 to 13 and the largest component from 12 to 10
- bump the cache version to 1.10.342

## Validation

- `./run-tests.sh` (131 static checks, 475 Vitest tests, 378 Chromium tests, 472 responsive-theme checks)
- `npm run test:firefox` (3 tests)
- sync payload/runtime suite (42 tests)
- legacy sync suite (833 assertions)
- focused sync Chromium suite (16 tests)
- `npm run quality`
- `npm run architecture:check`
- `git diff --check`