### PR TITLE
Inject sync storage persistence

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -11,10 +11,10 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | --- | ---: |
 | Modules | 463 |
 | Internal import edges | 2059 |
-| Dynamic internal edges | 58 |
-| Modules participating in cycles | 13 |
+| Dynamic internal edges | 57 |
+| Modules participating in cycles | 12 |
 | Cyclic components | 2 |
-| Largest cyclic component | 10 |
+| Largest cyclic component | 9 |
 | Computed dynamic imports | 2 |
 
 ## Enforced source boundaries
@@ -40,7 +40,7 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 | --- | ---: | --- | ---: |
 | [`js/utils.js`](js/utils.js) | 205 | [`js/app-shell-hooks.js`](js/app-shell-hooks.js) | 83 |
 | [`js/state.js`](js/state.js) | 145 | [`js/app-light-sun-modules.js`](js/app-light-sun-modules.js) | 27 |
-| [`js/data.js`](js/data.js) | 74 | [`js/sync-configure.js`](js/sync-configure.js) | 26 |
+| [`js/data.js`](js/data.js) | 74 | [`js/sync-configure.js`](js/sync-configure.js) | 27 |
 | [`js/api.js`](js/api.js) | 63 | [`js/dashboard-view-composition.js`](js/dashboard-view-composition.js) | 24 |
 | [`js/modal-lifecycle.js`](js/modal-lifecycle.js) | 51 | [`js/settings.js`](js/settings.js) | 24 |
 | [`js/profile.js`](js/profile.js) | 48 | [`js/pdf-import.js`](js/pdf-import.js) | 23 |
@@ -58,9 +58,9 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 
 These are existing debt, not approved architecture. CI prevents new modules from joining a cycle and prevents the cycle budgets from increasing.
 
-<details><summary>Component 1 — 10 modules</summary>
+<details><summary>Component 1 — 9 modules</summary>
 
-[`js/data.js`](js/data.js), [`js/profile.js`](js/profile.js), [`js/sync-actions.js`](js/sync-actions.js), [`js/sync-save-hooks.js`](js/sync-save-hooks.js), [`js/sync-storage-cleanup.js`](js/sync-storage-cleanup.js), [`js/sync-tombstones.js`](js/sync-tombstones.js), [`js/sync.js`](js/sync.js), [`js/wearables-connect.js`](js/wearables-connect.js), [`js/wearables-manual.js`](js/wearables-manual.js), [`js/wearables-summary.js`](js/wearables-summary.js)
+[`js/data.js`](js/data.js), [`js/profile.js`](js/profile.js), [`js/sync-actions.js`](js/sync-actions.js), [`js/sync-save-hooks.js`](js/sync-save-hooks.js), [`js/sync-tombstones.js`](js/sync-tombstones.js), [`js/sync.js`](js/sync.js), [`js/wearables-connect.js`](js/wearables-connect.js), [`js/wearables-manual.js`](js/wearables-manual.js), [`js/wearables-summary.js`](js/wearables-summary.js)
 
 </details>
 
@@ -767,7 +767,7 @@ Native browser modules shipped with the static application.
 - [`js/sync-actions.js`](js/sync-actions.js) → [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/sync-messenger.js`](js/sync-messenger.js), [`js/sync-save-hooks.js`](js/sync-save-hooks.js), [`js/sync-state.js`](js/sync-state.js), [`js/sync-storage-cleanup.js`](js/sync-storage-cleanup.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-apply.js`](js/sync-apply.js) → [`js/crypto.js`](js/crypto.js), [`js/sync-chat-apply.js`](js/sync-chat-apply.js), [`js/sync-payload-collectors.js`](js/sync-payload-collectors.js), [`js/sync-runtime.js`](js/sync-runtime.js)
 - [`js/sync-chat-apply.js`](js/sync-chat-apply.js) → [`js/crypto.js`](js/crypto.js), [`js/state.js`](js/state.js), [`js/sync-payload-collectors.js`](js/sync-payload-collectors.js), [`js/sync-state.js`](js/sync-state.js), [`js/utils.js`](js/utils.js)
-- [`js/sync-configure.js`](js/sync-configure.js) → [`js/lab-context.js`](js/lab-context.js), [`js/profile.js`](js/profile.js), [`js/sync-actions.js`](js/sync-actions.js), [`js/sync-cutover.js`](js/sync-cutover.js), [`js/sync-delta.js`](js/sync-delta.js), [`js/sync-diagnose-ui.js`](js/sync-diagnose-ui.js), [`js/sync-diagnostics.js`](js/sync-diagnostics.js), [`js/sync-environment.js`](js/sync-environment.js), [`js/sync-identity.js`](js/sync-identity.js), [`js/sync-init.js`](js/sync-init.js), [`js/sync-messenger.js`](js/sync-messenger.js), [`js/sync-payload.js`](js/sync-payload.js), [`js/sync-pull.js`](js/sync-pull.js), [`js/sync-push.js`](js/sync-push.js), [`js/sync-reconcile.js`](js/sync-reconcile.js), [`js/sync-recovery.js`](js/sync-recovery.js), [`js/sync-relay-health.js`](js/sync-relay-health.js), [`js/sync-runtime.js`](js/sync-runtime.js), [`js/sync-save-hooks.js`](js/sync-save-hooks.js), [`js/sync-settings-state.js`](js/sync-settings-state.js), [`js/sync-state.js`](js/sync-state.js), [`js/sync-storage-cleanup.js`](js/sync-storage-cleanup.js), [`js/sync-subscriptions.js`](js/sync-subscriptions.js), [`js/sync-tombstones.js`](js/sync-tombstones.js), [`js/sync-ui.js`](js/sync-ui.js), [`js/utils.js`](js/utils.js)
+- [`js/sync-configure.js`](js/sync-configure.js) → [`js/data.js`](js/data.js), [`js/lab-context.js`](js/lab-context.js), [`js/profile.js`](js/profile.js), [`js/sync-actions.js`](js/sync-actions.js), [`js/sync-cutover.js`](js/sync-cutover.js), [`js/sync-delta.js`](js/sync-delta.js), [`js/sync-diagnose-ui.js`](js/sync-diagnose-ui.js), [`js/sync-diagnostics.js`](js/sync-diagnostics.js), [`js/sync-environment.js`](js/sync-environment.js), [`js/sync-identity.js`](js/sync-identity.js), [`js/sync-init.js`](js/sync-init.js), [`js/sync-messenger.js`](js/sync-messenger.js), [`js/sync-payload.js`](js/sync-payload.js), [`js/sync-pull.js`](js/sync-pull.js), [`js/sync-push.js`](js/sync-push.js), [`js/sync-reconcile.js`](js/sync-reconcile.js), [`js/sync-recovery.js`](js/sync-recovery.js), [`js/sync-relay-health.js`](js/sync-relay-health.js), [`js/sync-runtime.js`](js/sync-runtime.js), [`js/sync-save-hooks.js`](js/sync-save-hooks.js), [`js/sync-settings-state.js`](js/sync-settings-state.js), [`js/sync-state.js`](js/sync-state.js), [`js/sync-storage-cleanup.js`](js/sync-storage-cleanup.js), [`js/sync-subscriptions.js`](js/sync-subscriptions.js), [`js/sync-tombstones.js`](js/sync-tombstones.js), [`js/sync-ui.js`](js/sync-ui.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-cutover.js`](js/sync-cutover.js) → [`js/sync-delta.js`](js/sync-delta.js), [`js/sync-payload.js`](js/sync-payload.js)
 - [`js/sync-delta-array-merge.js`](js/sync-delta-array-merge.js) → [`js/data-merge.js`](js/data-merge.js), [`js/sync-delta-observability.js`](js/sync-delta-observability.js), [`js/sync-delta-registry.js`](js/sync-delta-registry.js), [`js/sync-delta-row-codec.js`](js/sync-delta-row-codec.js)
 - [`js/sync-delta-array-planner.js`](js/sync-delta-array-planner.js) → [`js/sync-delta-planner-context.js`](js/sync-delta-planner-context.js), [`js/sync-delta-registry.js`](js/sync-delta-registry.js), [`js/sync-delta-snapshot.js`](js/sync-delta-snapshot.js), [`js/sync-payload-codec.js`](js/sync-payload-codec.js)
@@ -828,7 +828,7 @@ Native browser modules shipped with the static application.
 - [`js/sync-schema.js`](js/sync-schema.js) → no in-scope imports
 - [`js/sync-settings-state.js`](js/sync-settings-state.js) → no in-scope imports
 - [`js/sync-state.js`](js/sync-state.js) → no in-scope imports
-- [`js/sync-storage-cleanup.js`](js/sync-storage-cleanup.js) → [`js/data-merge.js`](js/data-merge.js), [`js/data.js`](js/data.js) *(dynamic)*, [`js/state.js`](js/state.js), [`js/sync-state.js`](js/sync-state.js), [`js/utils.js`](js/utils.js)
+- [`js/sync-storage-cleanup.js`](js/sync-storage-cleanup.js) → [`js/data-merge.js`](js/data-merge.js), [`js/state.js`](js/state.js), [`js/sync-state.js`](js/sync-state.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-subscriptions.js`](js/sync-subscriptions.js) → no in-scope imports
 - [`js/sync-tombstones.js`](js/sync-tombstones.js) → [`js/crypto.js`](js/crypto.js), [`js/cycle-store.js`](js/cycle-store.js) *(dynamic)*, [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/sync-payload.js`](js/sync-payload.js), [`js/utils.js`](js/utils.js), [`js/wearables-store.js`](js/wearables-store.js) *(dynamic)*
 - [`js/sync-ui.js`](js/sync-ui.js) → [`js/settings-runtime-bridge.js`](js/settings-runtime-bridge.js), [`js/sync-environment.js`](js/sync-environment.js), [`js/sync-relay-health.js`](js/sync-relay-health.js), [`js/sync-state.js`](js/sync-state.js), [`js/utils.js`](js/utils.js)

--- a/js/sync-configure.js
+++ b/js/sync-configure.js
@@ -2,6 +2,7 @@
 // sync-configure.js - Dependency wiring for the sync subsystem.
 
 import { showNotification, isDebugMode } from './utils.js';
+import { saveImportedData } from './data.js';
 import { getProfiles } from './profile.js';
 import { configureRelayHealth } from './sync-relay-health.js';
 import { logSyncEvent, updateSyncStatus } from './sync-state.js';
@@ -34,7 +35,7 @@ import {
 import {
   configureSyncSubscriptions, getSyncSubscriptionFireCount,
 } from './sync-subscriptions.js';
-import { cleanStorage } from './sync-storage-cleanup.js';
+import { cleanStorage, configureSyncStorageCleanup } from './sync-storage-cleanup.js';
 import {
   getSyncAppOwner, getSyncAppOwnerError, getSyncEvolu, getSyncItemRowQuery,
   getSyncProfileQuery, getSyncTombstoneQuery, isSyncEvoluReady,
@@ -46,6 +47,7 @@ function dbg(...args) { if (isDebugMode()) console.log('[sync]', ...args); }
 /** @param {{ enableSync?: (...args: any[]) => any, disableSync?: (...args: any[]) => any }} [deps] */
 export function configureSyncModules({ enableSync, disableSync } = {}) {
   configureSyncPayload({ getProfiles });
+  configureSyncStorageCleanup({ saveImportedData });
 
   configureRelayHealth({
     getAppOwner: getSyncAppOwner,

--- a/js/sync-storage-cleanup.js
+++ b/js/sync-storage-cleanup.js
@@ -6,6 +6,22 @@ import { showNotification } from './utils.js';
 import { logSyncEvent } from './sync-state.js';
 import { trimImportedArray } from './data-merge.js';
 
+/** @type {{ saveImportedData: () => Promise<any> }} */
+const syncStorageCleanupDeps = {
+  saveImportedData: async () => {
+    throw new Error('Sync storage cleanup is not configured');
+  },
+};
+
+/** @param {{ saveImportedData?: () => Promise<any> }} [deps] */
+export function configureSyncStorageCleanup(deps = {}) {
+  const previous = { ...syncStorageCleanupDeps };
+  if (typeof deps.saveImportedData === 'function') {
+    syncStorageCleanupDeps.saveImportedData = deps.saveImportedData;
+  }
+  return previous;
+}
+
 // "Clean storage" - emergency localStorage compaction. The 'imported'
 // blob can grow past the browser's 5 MB localStorage cap (caps were
 // bypassed by the cross-device merge before the data-merge.js fix).
@@ -37,8 +53,7 @@ export async function cleanStorage() {
     historyTrimmed = state.importedData.changeHistory.length - 200;
     trimImportedArray(state.importedData, 'changeHistory', 200);
     try {
-      const { saveImportedData } = await import('./data.js');
-      await saveImportedData();
+      await syncStorageCleanupDeps.saveImportedData();
     } catch (e) {
       console.warn('[sync] cleanStorage: saveImportedData failed:', e?.message || e);
     }

--- a/scripts/architecture-cycle-baseline.json
+++ b/scripts/architecture-cycle-baseline.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "maxCyclicModules": 13,
-  "maxLargestCyclicComponent": 10,
+  "maxCyclicModules": 12,
+  "maxLargestCyclicComponent": 9,
   "allowedCyclicModules": [
     "js/cycle-import.js",
     "js/cycle.js",
@@ -9,7 +9,6 @@
     "js/profile.js",
     "js/sync-actions.js",
     "js/sync-save-hooks.js",
-    "js/sync-storage-cleanup.js",
     "js/sync-tombstones.js",
     "js/sync.js",
     "js/wearables-apple-health.js",

--- a/tests/sync-runtime.test.js
+++ b/tests/sync-runtime.test.js
@@ -51,6 +51,7 @@ import {
   setSyncAppOwner,
 } from '../js/sync-runtime.js';
 import { getRecentSyncEvents, resetSyncStatus, updateSyncStatus } from '../js/sync-state.js';
+import { cleanStorage, configureSyncStorageCleanup } from '../js/sync-storage-cleanup.js';
 import { state } from '../js/state.js';
 import {
   _resetAgentAccessMigrationStateForTesting,
@@ -705,6 +706,26 @@ describe('sync push runtime behavior', () => {
 });
 
 describe('sync cleanup and rebroadcast runtime behavior', () => {
+  it('persists trimmed change history through the configured data saver', async () => {
+    const previousImportedData = state.importedData;
+    const saveImportedData = vi.fn().mockResolvedValue(true);
+    const previousDeps = configureSyncStorageCleanup({ saveImportedData });
+    state.importedData = {
+      changeHistory: Array.from({ length: 205 }, (_, index) => ({ index })),
+    };
+
+    try {
+      const result = await cleanStorage();
+
+      expect(result.historyTrimmed).toBe(5);
+      expect(state.importedData.changeHistory).toHaveLength(200);
+      expect(saveImportedData).toHaveBeenCalledOnce();
+    } finally {
+      state.importedData = previousImportedData;
+      configureSyncStorageCleanup(previousDeps);
+    }
+  });
+
   it('recognizes and clears disable-time sync storage plus stale pull hash keys', () => {
     expect(isSyncDisableCleanupKey(`labcharts-${PROFILE_ID}-delta-sunSessions`)).toBe(true);
     expect(isSyncDisableCleanupKey(`labcharts-${PROFILE_ID}-sync-cutover-v2`)).toBe(true);

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -594,6 +594,9 @@ await import('../js/settings.js');
   assert('sync-storage-cleanup.js owns emergency sync storage compaction',
     syncSrc.includes("from './sync-storage-cleanup.js'")
       && syncConfigureSrc.includes("from './sync-storage-cleanup.js'")
+      && syncConfigureSrc.includes('configureSyncStorageCleanup({ saveImportedData })')
+      && syncStorageCleanupSrc.includes('export function configureSyncStorageCleanup')
+      && !syncStorageCleanupSrc.includes("import('./data.js')")
       && syncStorageCleanupSrc.includes('export async function cleanStorage')
       && syncStorageCleanupSrc.includes('changeHistory')
       && syncStorageCleanupSrc.includes('labcharts-openrouter-models')

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.342';
+self.APP_VERSION = '1.10.343';


### PR DESCRIPTION
## Summary

- inject imported-data persistence into emergency sync storage cleanup from the sync composition root
- keep cleanup fail-soft if persistence is unavailable or fails
- remove the storage cleanup module's dynamic reverse dependency on the data domain module
- ratchet cyclic modules from 13 to 12 and the largest component from 10 to 9
- bump the cache version to 1.10.343

## Validation

- `./run-tests.sh` (131 static checks, 476 Vitest tests, 378 Chromium tests, 472 responsive-theme checks)
- `npm run test:firefox` (3 tests)
- sync runtime suite (43 tests)
- legacy sync suite (833 assertions)
- focused sync Chromium suite (16 tests)
- `npm run quality`
- `npm run architecture:check`
- `git diff --check`