### PR TITLE
Inject sync save profile data

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -12,9 +12,9 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | Modules | 463 |
 | Internal import edges | 2059 |
 | Dynamic internal edges | 57 |
-| Modules participating in cycles | 11 |
+| Modules participating in cycles | 10 |
 | Cyclic components | 2 |
-| Largest cyclic component | 8 |
+| Largest cyclic component | 7 |
 | Computed dynamic imports | 2 |
 
 ## Enforced source boundaries
@@ -43,7 +43,7 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 | [`js/data.js`](js/data.js) | 73 | [`js/sync-configure.js`](js/sync-configure.js) | 27 |
 | [`js/api.js`](js/api.js) | 63 | [`js/dashboard-view-composition.js`](js/dashboard-view-composition.js) | 24 |
 | [`js/modal-lifecycle.js`](js/modal-lifecycle.js) | 51 | [`js/settings.js`](js/settings.js) | 24 |
-| [`js/profile.js`](js/profile.js) | 48 | [`js/pdf-import.js`](js/pdf-import.js) | 23 |
+| [`js/profile.js`](js/profile.js) | 47 | [`js/pdf-import.js`](js/pdf-import.js) | 23 |
 | [`js/schema.js`](js/schema.js) | 30 | [`js/chat-send.js`](js/chat-send.js) | 22 |
 | [`js/data-merge.js`](js/data-merge.js) | 29 | [`js/views.js`](js/views.js) | 20 |
 | [`js/crypto.js`](js/crypto.js) | 27 | [`js/wearables-connect.js`](js/wearables-connect.js) | 20 |
@@ -58,9 +58,9 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 
 These are existing debt, not approved architecture. CI prevents new modules from joining a cycle and prevents the cycle budgets from increasing.
 
-<details><summary>Component 1 — 8 modules</summary>
+<details><summary>Component 1 — 7 modules</summary>
 
-[`js/data.js`](js/data.js), [`js/profile.js`](js/profile.js), [`js/sync-actions.js`](js/sync-actions.js), [`js/sync-save-hooks.js`](js/sync-save-hooks.js), [`js/sync-tombstones.js`](js/sync-tombstones.js), [`js/sync.js`](js/sync.js), [`js/wearables-connect.js`](js/wearables-connect.js), [`js/wearables-manual.js`](js/wearables-manual.js)
+[`js/data.js`](js/data.js), [`js/profile.js`](js/profile.js), [`js/sync-actions.js`](js/sync-actions.js), [`js/sync-tombstones.js`](js/sync-tombstones.js), [`js/sync.js`](js/sync.js), [`js/wearables-connect.js`](js/wearables-connect.js), [`js/wearables-manual.js`](js/wearables-manual.js)
 
 </details>
 
@@ -824,7 +824,7 @@ Native browser modules shipped with the static application.
 - [`js/sync-recovery.js`](js/sync-recovery.js) → no in-scope imports
 - [`js/sync-relay-health.js`](js/sync-relay-health.js) → no in-scope imports
 - [`js/sync-runtime.js`](js/sync-runtime.js) → [`js/chat-runtime.js`](js/chat-runtime.js), [`js/provider-wallet-panels.js`](js/provider-wallet-panels.js) *(dynamic)*
-- [`js/sync-save-hooks.js`](js/sync-save-hooks.js) → [`js/crypto.js`](js/crypto.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/sync-chat-apply.js`](js/sync-chat-apply.js), [`js/sync-messenger.js`](js/sync-messenger.js), [`js/utils-runtime.js`](js/utils-runtime.js)
+- [`js/sync-save-hooks.js`](js/sync-save-hooks.js) → [`js/crypto.js`](js/crypto.js), [`js/profile-storage-key.js`](js/profile-storage-key.js), [`js/state.js`](js/state.js), [`js/sync-chat-apply.js`](js/sync-chat-apply.js), [`js/sync-messenger.js`](js/sync-messenger.js), [`js/utils-runtime.js`](js/utils-runtime.js)
 - [`js/sync-schema.js`](js/sync-schema.js) → no in-scope imports
 - [`js/sync-settings-state.js`](js/sync-settings-state.js) → no in-scope imports
 - [`js/sync-state.js`](js/sync-state.js) → no in-scope imports

--- a/js/sync-configure.js
+++ b/js/sync-configure.js
@@ -3,7 +3,7 @@
 
 import { showNotification, isDebugMode } from './utils.js';
 import { saveImportedData } from './data.js';
-import { getProfiles } from './profile.js';
+import { createDefaultProfileData, getProfiles, migrateProfileData } from './profile.js';
 import { configureRelayHealth } from './sync-relay-health.js';
 import { logSyncEvent, updateSyncStatus } from './sync-state.js';
 import { isSyncEnabled } from './sync-settings-state.js';
@@ -164,6 +164,8 @@ export function configureSyncModules({ enableSync, disableSync } = {}) {
     isSyncEnabled,
     isEvoluReady: isSyncEvoluReady,
     isSyncing: isSyncPushInFlight,
+    createDefaultProfileData,
+    migrateProfileData,
   });
   bindSyncSaveHookEvents();
 

--- a/js/sync-save-hooks.js
+++ b/js/sync-save-hooks.js
@@ -2,7 +2,7 @@
 // sync-save-hooks.js - Save/chat/profile sync debounce hooks.
 
 import { state } from './state.js';
-import { profileStorageKey, createDefaultProfileData, migrateProfileData } from './profile.js';
+import { profileStorageKey } from './profile-storage-key.js';
 import { getEncryptionEnabled, encryptedGetItem } from './crypto.js';
 import { markChatDataLocal } from './sync-chat-apply.js';
 import { pushContextToGateway } from './sync-messenger.js';
@@ -13,6 +13,9 @@ let _pushProfile = async () => {};
 let _isSyncEnabled = () => false;
 let _isEvoluReady = () => false;
 let _isSyncing = () => false;
+let _createDefaultProfileData = () => ({ entries: [] });
+/** @type {(data: any) => any} */
+let _migrateProfileData = (data) => data;
 
 // Per-profile debounce timers. Switching profiles mid-debounce previously
 // dropped the pending push for the prior profile because the single shared
@@ -29,6 +32,8 @@ let _eventsBound = false;
  *   isSyncEnabled?: () => boolean,
  *   isEvoluReady?: () => boolean,
  *   isSyncing?: () => boolean,
+ *   createDefaultProfileData?: () => any,
+ *   migrateProfileData?: (data: any) => any,
  * }} [deps]
  */
 export function configureSyncSaveHooks({
@@ -36,11 +41,24 @@ export function configureSyncSaveHooks({
   isSyncEnabled,
   isEvoluReady,
   isSyncing,
+  createDefaultProfileData,
+  migrateProfileData,
 } = {}) {
+  const previous = {
+    pushProfile: _pushProfile,
+    isSyncEnabled: _isSyncEnabled,
+    isEvoluReady: _isEvoluReady,
+    isSyncing: _isSyncing,
+    createDefaultProfileData: _createDefaultProfileData,
+    migrateProfileData: _migrateProfileData,
+  };
   if (typeof pushProfile === 'function') _pushProfile = pushProfile;
   if (typeof isSyncEnabled === 'function') _isSyncEnabled = isSyncEnabled;
   if (typeof isEvoluReady === 'function') _isEvoluReady = isEvoluReady;
   if (typeof isSyncing === 'function') _isSyncing = isSyncing;
+  if (typeof createDefaultProfileData === 'function') _createDefaultProfileData = createDefaultProfileData;
+  if (typeof migrateProfileData === 'function') _migrateProfileData = migrateProfileData;
+  return previous;
 }
 
 export function bindSyncSaveHookEvents() {
@@ -86,7 +104,7 @@ export function clearSyncSaveTimers() {
  */
 export async function readProfileImportedData(profileId, fallback = null) {
   const normalize = (data) => {
-    if (data && typeof data === 'object') migrateProfileData(data);
+    if (data && typeof data === 'object') _migrateProfileData(data);
     return data;
   };
   if (fallback && typeof fallback === 'object') return normalize(fallback);
@@ -100,7 +118,7 @@ export async function readProfileImportedData(profileId, fallback = null) {
   } catch (e) {
     console.warn('[sync] Could not read profile importedData for profile sync:', e?.message || e);
   }
-  return createDefaultProfileData();
+  return _createDefaultProfileData();
 }
 
 /** @param {string} profileId

--- a/scripts/architecture-cycle-baseline.json
+++ b/scripts/architecture-cycle-baseline.json
@@ -1,14 +1,13 @@
 {
   "schemaVersion": 1,
-  "maxCyclicModules": 11,
-  "maxLargestCyclicComponent": 8,
+  "maxCyclicModules": 10,
+  "maxLargestCyclicComponent": 7,
   "allowedCyclicModules": [
     "js/cycle-import.js",
     "js/cycle.js",
     "js/data.js",
     "js/profile.js",
     "js/sync-actions.js",
-    "js/sync-save-hooks.js",
     "js/sync-tombstones.js",
     "js/sync.js",
     "js/wearables-apple-health.js",

--- a/tests/sync-save-hooks.test.js
+++ b/tests/sync-save-hooks.test.js
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  configureSyncSaveHooks,
+  readProfileImportedData,
+} from '../js/sync-save-hooks.js';
+
+describe('sync save-hook profile data dependencies', () => {
+  it('normalizes fallback data and creates missing profile data through configured helpers', async () => {
+    const fallback = { entries: [] };
+    const createDefaultProfileData = vi.fn(() => ({ entries: [], created: true }));
+    const migrateProfileData = vi.fn(data => {
+      data.migrated = true;
+      return data;
+    });
+    const previous = configureSyncSaveHooks({ createDefaultProfileData, migrateProfileData });
+
+    try {
+      await expect(readProfileImportedData('fallback-profile', fallback)).resolves.toBe(fallback);
+      expect(fallback.migrated).toBe(true);
+      expect(migrateProfileData).toHaveBeenCalledWith(fallback);
+
+      localStorage.removeItem('labcharts-missing-profile-imported');
+      await expect(readProfileImportedData('missing-profile')).resolves.toEqual({
+        entries: [],
+        created: true,
+      });
+      expect(createDefaultProfileData).toHaveBeenCalledOnce();
+    } finally {
+      configureSyncSaveHooks(previous);
+    }
+  });
+});

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -577,6 +577,9 @@ await import('../js/settings.js');
   assert('sync-save-hooks.js owns save/chat/profile debounce hooks',
     syncSrc.includes("from './sync-save-hooks.js'")
       && syncSaveHooksSrc.includes('export function configureSyncSaveHooks')
+      && syncSaveHooksSrc.includes("from './profile-storage-key.js'")
+      && !syncSaveHooksSrc.includes("from './profile.js'")
+      && /configureSyncSaveHooks\(\{[\s\S]{0,260}createDefaultProfileData,[\s\S]{0,80}migrateProfileData/.test(syncConfigureSrc)
       && syncSaveHooksSrc.includes('export function bindSyncSaveHookEvents')
       && syncSaveHooksSrc.includes('export function clearSyncSaveTimers')
       && syncSaveHooksSrc.includes('export function onDataSaved')

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.344';
+self.APP_VERSION = '1.10.345';


### PR DESCRIPTION
## Summary

- read profile storage keys from the extracted leaf helper in sync save hooks
- inject profile data migration and default construction from the sync composition root
- keep safe standalone defaults and make dependency restoration explicit for tests
- remove sync save hooks from the main dependency cycle
- ratchet cyclic modules from 11 to 10 and the largest component from 8 to 7
- bump the cache version to 1.10.345

## Validation

- `./run-tests.sh` (clean rerun: 131 static checks, 478 Vitest tests, 378 Chromium tests, 472 responsive-theme checks)
- `npm run test:firefox` (3 tests)
- sync save-hook Vitest (1 test)
- legacy sync suite (833 assertions)
- focused sync Chromium suite (8 tests)
- `npm run quality`
- `npm run architecture:check`
- `git diff --check`