### PR TITLE
Inject sync action profiles

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -10,11 +10,11 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | Metric | Current |
 | --- | ---: |
 | Modules | 463 |
-| Internal import edges | 2059 |
+| Internal import edges | 2058 |
 | Dynamic internal edges | 57 |
-| Modules participating in cycles | 10 |
+| Modules participating in cycles | 9 |
 | Cyclic components | 2 |
-| Largest cyclic component | 7 |
+| Largest cyclic component | 6 |
 | Computed dynamic imports | 2 |
 
 ## Enforced source boundaries
@@ -43,7 +43,7 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 | [`js/data.js`](js/data.js) | 73 | [`js/sync-configure.js`](js/sync-configure.js) | 27 |
 | [`js/api.js`](js/api.js) | 63 | [`js/dashboard-view-composition.js`](js/dashboard-view-composition.js) | 24 |
 | [`js/modal-lifecycle.js`](js/modal-lifecycle.js) | 51 | [`js/settings.js`](js/settings.js) | 24 |
-| [`js/profile.js`](js/profile.js) | 47 | [`js/pdf-import.js`](js/pdf-import.js) | 23 |
+| [`js/profile.js`](js/profile.js) | 46 | [`js/pdf-import.js`](js/pdf-import.js) | 23 |
 | [`js/schema.js`](js/schema.js) | 30 | [`js/chat-send.js`](js/chat-send.js) | 22 |
 | [`js/data-merge.js`](js/data-merge.js) | 29 | [`js/views.js`](js/views.js) | 20 |
 | [`js/crypto.js`](js/crypto.js) | 27 | [`js/wearables-connect.js`](js/wearables-connect.js) | 20 |
@@ -58,9 +58,9 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 
 These are existing debt, not approved architecture. CI prevents new modules from joining a cycle and prevents the cycle budgets from increasing.
 
-<details><summary>Component 1 — 7 modules</summary>
+<details><summary>Component 1 — 6 modules</summary>
 
-[`js/data.js`](js/data.js), [`js/profile.js`](js/profile.js), [`js/sync-actions.js`](js/sync-actions.js), [`js/sync-tombstones.js`](js/sync-tombstones.js), [`js/sync.js`](js/sync.js), [`js/wearables-connect.js`](js/wearables-connect.js), [`js/wearables-manual.js`](js/wearables-manual.js)
+[`js/data.js`](js/data.js), [`js/profile.js`](js/profile.js), [`js/sync-tombstones.js`](js/sync-tombstones.js), [`js/sync.js`](js/sync.js), [`js/wearables-connect.js`](js/wearables-connect.js), [`js/wearables-manual.js`](js/wearables-manual.js)
 
 </details>
 
@@ -764,7 +764,7 @@ Native browser modules shipped with the static application.
 
 <details><summary><code>sync</code> family — 69 modules</summary>
 
-- [`js/sync-actions.js`](js/sync-actions.js) → [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/sync-messenger.js`](js/sync-messenger.js), [`js/sync-save-hooks.js`](js/sync-save-hooks.js), [`js/sync-state.js`](js/sync-state.js), [`js/sync-storage-cleanup.js`](js/sync-storage-cleanup.js), [`js/utils.js`](js/utils.js)
+- [`js/sync-actions.js`](js/sync-actions.js) → [`js/state.js`](js/state.js), [`js/sync-messenger.js`](js/sync-messenger.js), [`js/sync-save-hooks.js`](js/sync-save-hooks.js), [`js/sync-state.js`](js/sync-state.js), [`js/sync-storage-cleanup.js`](js/sync-storage-cleanup.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-apply.js`](js/sync-apply.js) → [`js/crypto.js`](js/crypto.js), [`js/sync-chat-apply.js`](js/sync-chat-apply.js), [`js/sync-payload-collectors.js`](js/sync-payload-collectors.js), [`js/sync-runtime.js`](js/sync-runtime.js)
 - [`js/sync-chat-apply.js`](js/sync-chat-apply.js) → [`js/crypto.js`](js/crypto.js), [`js/state.js`](js/state.js), [`js/sync-payload-collectors.js`](js/sync-payload-collectors.js), [`js/sync-state.js`](js/sync-state.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-configure.js`](js/sync-configure.js) → [`js/data.js`](js/data.js), [`js/lab-context.js`](js/lab-context.js), [`js/profile.js`](js/profile.js), [`js/sync-actions.js`](js/sync-actions.js), [`js/sync-cutover.js`](js/sync-cutover.js), [`js/sync-delta.js`](js/sync-delta.js), [`js/sync-diagnose-ui.js`](js/sync-diagnose-ui.js), [`js/sync-diagnostics.js`](js/sync-diagnostics.js), [`js/sync-environment.js`](js/sync-environment.js), [`js/sync-identity.js`](js/sync-identity.js), [`js/sync-init.js`](js/sync-init.js), [`js/sync-messenger.js`](js/sync-messenger.js), [`js/sync-payload.js`](js/sync-payload.js), [`js/sync-pull.js`](js/sync-pull.js), [`js/sync-push.js`](js/sync-push.js), [`js/sync-reconcile.js`](js/sync-reconcile.js), [`js/sync-recovery.js`](js/sync-recovery.js), [`js/sync-relay-health.js`](js/sync-relay-health.js), [`js/sync-runtime.js`](js/sync-runtime.js), [`js/sync-save-hooks.js`](js/sync-save-hooks.js), [`js/sync-settings-state.js`](js/sync-settings-state.js), [`js/sync-state.js`](js/sync-state.js), [`js/sync-storage-cleanup.js`](js/sync-storage-cleanup.js), [`js/sync-subscriptions.js`](js/sync-subscriptions.js), [`js/sync-tombstones.js`](js/sync-tombstones.js), [`js/sync-ui.js`](js/sync-ui.js), [`js/utils.js`](js/utils.js)

--- a/js/sync-actions.js
+++ b/js/sync-actions.js
@@ -3,7 +3,6 @@
 
 import { state } from './state.js';
 import { showNotification } from './utils.js';
-import { getProfiles, createDefaultProfileData } from './profile.js';
 import { pushContextToGateway } from './sync-messenger.js';
 import { logSyncEvent } from './sync-state.js';
 import {
@@ -20,6 +19,8 @@ let _pushProfile = async () => {};
 let _forcePull = () => {};
 let _isSyncEnabled = () => false;
 let _isEvoluReady = () => false;
+let _getProfiles = () => [];
+let _createDefaultProfileData = () => ({ entries: [] });
 
 /** @param {{
  *   pushProfile?: (...args: any[]) => Promise<any>,
@@ -27,6 +28,8 @@ let _isEvoluReady = () => false;
  *   isSyncEnabled?: () => boolean,
  *   isEvoluReady?: () => boolean,
  *   isSyncing?: () => boolean,
+ *   getProfiles?: () => any[],
+ *   createDefaultProfileData?: () => any,
  * }} [deps]
  */
 export function configureSyncActions({
@@ -35,11 +38,15 @@ export function configureSyncActions({
   isSyncEnabled,
   isEvoluReady,
   isSyncing,
+  getProfiles,
+  createDefaultProfileData,
 } = {}) {
   if (typeof pushProfile === 'function') _pushProfile = pushProfile;
   if (typeof forcePull === 'function') _forcePull = forcePull;
   if (typeof isSyncEnabled === 'function') _isSyncEnabled = isSyncEnabled;
   if (typeof isEvoluReady === 'function') _isEvoluReady = isEvoluReady;
+  if (typeof getProfiles === 'function') _getProfiles = getProfiles;
+  if (typeof createDefaultProfileData === 'function') _createDefaultProfileData = createDefaultProfileData;
   configureSyncSaveHooks({ pushProfile, isSyncEnabled, isEvoluReady, isSyncing });
 }
 
@@ -76,12 +83,12 @@ export async function syncNow() {
 // Push all profiles on first enable.
 /** @param {any} [options] */
 export async function pushAllProfiles(options = {}) {
-  const profiles = getProfiles();
+  const profiles = _getProfiles();
   for (const p of profiles) {
     try {
       let dataJson;
       if (p.id === state.currentProfile) {
-        dataJson = state.importedData || createDefaultProfileData();
+        dataJson = state.importedData || _createDefaultProfileData();
       } else {
         dataJson = await readProfileImportedData(p.id);
       }

--- a/js/sync-configure.js
+++ b/js/sync-configure.js
@@ -157,6 +157,8 @@ export function configureSyncModules({ enableSync, disableSync } = {}) {
     isSyncEnabled,
     isEvoluReady: isSyncEvoluReady,
     isSyncing: isSyncPushInFlight,
+    getProfiles,
+    createDefaultProfileData,
   });
 
   configureSyncSaveHooks({

--- a/scripts/architecture-cycle-baseline.json
+++ b/scripts/architecture-cycle-baseline.json
@@ -1,13 +1,12 @@
 {
   "schemaVersion": 1,
-  "maxCyclicModules": 10,
-  "maxLargestCyclicComponent": 7,
+  "maxCyclicModules": 9,
+  "maxLargestCyclicComponent": 6,
   "allowedCyclicModules": [
     "js/cycle-import.js",
     "js/cycle.js",
     "js/data.js",
     "js/profile.js",
-    "js/sync-actions.js",
     "js/sync-tombstones.js",
     "js/sync.js",
     "js/wearables-apple-health.js",

--- a/tests/playwright/sync-actions-browser-coverage.spec.js
+++ b/tests/playwright/sync-actions-browser-coverage.spec.js
@@ -309,6 +309,8 @@ test('sync action delegates push force pull and all-profile paths', async ({ pag
         isSyncEnabled: () => enabled,
         isEvoluReady: () => ready,
         isSyncing: () => false,
+        getProfiles: () => state.profiles || [],
+        createDefaultProfileData: profile.createDefaultProfileData,
       });
 
       await actions.forceResendCurrentProfile();
@@ -349,6 +351,8 @@ test('sync action delegates push force pull and all-profile paths', async ({ pag
         isSyncEnabled: () => false,
         isEvoluReady: () => false,
         isSyncing: () => false,
+        getProfiles: () => [],
+        createDefaultProfileData: () => ({ entries: [] }),
       });
       actions.clearSyncActionTimers();
       state.profiles = saved.profiles;

--- a/tests/sync-actions.test.js
+++ b/tests/sync-actions.test.js
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { configureSyncActions, pushAllProfiles } from '../js/sync-actions.js';
+import { state } from '../js/state.js';
+
+describe('sync action profile dependencies', () => {
+  it('uses configured profile metadata and default data when seeding sync', async () => {
+    const previousProfile = state.currentProfile;
+    const previousImportedData = state.importedData;
+    const pushProfile = vi.fn().mockResolvedValue({ ok: true });
+    const getProfiles = vi.fn(() => [{ id: 'seed-profile' }]);
+    const defaultData = { entries: [], seeded: true };
+    const createDefaultProfileData = vi.fn(() => defaultData);
+    state.currentProfile = 'seed-profile';
+    state.importedData = null;
+    configureSyncActions({ pushProfile, getProfiles, createDefaultProfileData });
+
+    try {
+      await pushAllProfiles({ force: true });
+
+      expect(getProfiles).toHaveBeenCalledOnce();
+      expect(createDefaultProfileData).toHaveBeenCalledOnce();
+      expect(pushProfile).toHaveBeenCalledWith('seed-profile', defaultData, { force: true });
+    } finally {
+      state.currentProfile = previousProfile;
+      state.importedData = previousImportedData;
+      configureSyncActions({
+        pushProfile: async () => {},
+        getProfiles: () => [],
+        createDefaultProfileData: () => ({ entries: [] }),
+      });
+    }
+  });
+});

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -560,6 +560,8 @@ await import('../js/settings.js');
   assert('sync-actions.js owns user sync actions and compatibility exports',
     syncSrc.includes("from './sync-actions.js'")
       && syncActionsSrc.includes('export function configureSyncActions')
+      && !syncActionsSrc.includes("from './profile.js'")
+      && /configureSyncActions\(\{[\s\S]{0,260}getProfiles,[\s\S]{0,80}createDefaultProfileData/.test(syncConfigureSrc)
       && syncActionsSrc.includes('export function bindSyncActionEvents')
       && syncActionsSrc.includes('export function clearSyncActionTimers')
       && syncActionsSrc.includes('export async function pushCurrentProfile')

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.345';
+self.APP_VERSION = '1.10.346';


### PR DESCRIPTION
## Summary

- inject profile enumeration and default profile data into sync actions from the sync composition root
- retain safe standalone defaults for isolated action helpers
- remove the sync action module's direct profile-domain dependency
- update focused browser coverage to exercise the explicit profile seam
- ratchet cyclic modules from 10 to 9 and the largest component from 7 to 6
- bump the cache version to 1.10.346

## Validation

- `./run-tests.sh` (131 static checks, 479 Vitest tests, 378 Chromium tests, 472 responsive-theme checks)
- `npm run test:firefox` (3 tests)
- sync action Vitest (1 test)
- legacy sync suite (833 assertions)
- focused sync Chromium suite (8 tests)
- `npm run quality`
- `npm run architecture:check`
- `git diff --check`