### PR TITLE
Inject profile wearable refresh

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -12,9 +12,9 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | Modules | 463 |
 | Internal import edges | 2058 |
 | Dynamic internal edges | 57 |
-| Modules participating in cycles | 7 |
-| Cyclic components | 2 |
-| Largest cyclic component | 4 |
+| Modules participating in cycles | 3 |
+| Cyclic components | 1 |
+| Largest cyclic component | 3 |
 | Computed dynamic imports | 2 |
 
 ## Enforced source boundaries
@@ -48,9 +48,9 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 | [`js/data-merge.js`](js/data-merge.js) | 29 | [`js/views.js`](js/views.js) | 20 |
 | [`js/crypto.js`](js/crypto.js) | 27 | [`js/wearables-connect.js`](js/wearables-connect.js) | 20 |
 | [`js/marker-analysis.js`](js/marker-analysis.js) | 18 | [`js/biology-scores.js`](js/biology-scores.js) | 19 |
-| [`js/utils-runtime.js`](js/utils-runtime.js) | 18 | [`js/profile.js`](js/profile.js) | 19 |
-| [`js/constants.js`](js/constants.js) | 17 | [`js/sun.js`](js/sun.js) | 18 |
-| [`js/chat-runtime.js`](js/chat-runtime.js) | 16 | [`js/export.js`](js/export.js) | 17 |
+| [`js/utils-runtime.js`](js/utils-runtime.js) | 18 | [`js/sun.js`](js/sun.js) | 18 |
+| [`js/constants.js`](js/constants.js) | 17 | [`js/export.js`](js/export.js) | 17 |
+| [`js/chat-runtime.js`](js/chat-runtime.js) | 16 | [`js/profile.js`](js/profile.js) | 16 |
 | [`js/recommendations-runtime.js`](js/recommendations-runtime.js) | 15 | [`js/context-card-dashboard-ai.js`](js/context-card-dashboard-ai.js) | 15 |
 | [`js/settings-runtime-bridge.js`](js/settings-runtime-bridge.js) | 15 | [`js/context-cards.js`](js/context-cards.js) | 15 |
 
@@ -58,13 +58,7 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 
 These are existing debt, not approved architecture. CI prevents new modules from joining a cycle and prevents the cycle budgets from increasing.
 
-<details><summary>Component 1 — 4 modules</summary>
-
-[`js/data.js`](js/data.js), [`js/profile.js`](js/profile.js), [`js/wearables-connect.js`](js/wearables-connect.js), [`js/wearables-manual.js`](js/wearables-manual.js)
-
-</details>
-
-<details><summary>Component 2 — 3 modules</summary>
+<details><summary>Component 1 — 3 modules</summary>
 
 [`js/cycle-import.js`](js/cycle-import.js), [`js/cycle.js`](js/cycle.js), [`js/wearables-apple-health.js`](js/wearables-apple-health.js)
 
@@ -607,10 +601,10 @@ Native browser modules shipped with the static application.
 - [`js/profile-context.js`](js/profile-context.js) → [`js/context-source-registry.js`](js/context-source-registry.js), [`js/state.js`](js/state.js)
 - [`js/profile-fatty-acid-migrations.js`](js/profile-fatty-acid-migrations.js) → [`js/adapters.js`](js/adapters.js)
 - [`js/profile-marker-migrations.js`](js/profile-marker-migrations.js) → [`js/adapters.js`](js/adapters.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/pdf-import-marker-mapping.js`](js/pdf-import-marker-mapping.js), [`js/profile-fatty-acid-migrations.js`](js/profile-fatty-acid-migrations.js), [`js/schema.js`](js/schema.js)
-- [`js/profile-runtime.js`](js/profile-runtime.js) → [`js/chat-discussion.js`](js/chat-discussion.js) *(dynamic)*, [`js/chat-history.js`](js/chat-history.js) *(dynamic)*, [`js/chat-personalities.js`](js/chat-personalities.js) *(dynamic)*, [`js/chat-threads.js`](js/chat-threads.js) *(dynamic)*, [`js/data.js`](js/data.js) *(dynamic)*, [`js/lab-context.js`](js/lab-context.js) *(dynamic)*, [`js/nav.js`](js/nav.js) *(dynamic)*, [`js/state.js`](js/state.js), [`js/views.js`](js/views.js) *(dynamic)*
+- [`js/profile-runtime.js`](js/profile-runtime.js) → [`js/chat-discussion.js`](js/chat-discussion.js) *(dynamic)*, [`js/chat-history.js`](js/chat-history.js) *(dynamic)*, [`js/chat-personalities.js`](js/chat-personalities.js) *(dynamic)*, [`js/chat-threads.js`](js/chat-threads.js) *(dynamic)*, [`js/data.js`](js/data.js) *(dynamic)*, [`js/lab-context.js`](js/lab-context.js) *(dynamic)*, [`js/nav.js`](js/nav.js) *(dynamic)*, [`js/state.js`](js/state.js), [`js/views.js`](js/views.js) *(dynamic)*, [`js/wearables-connect.js`](js/wearables-connect.js) *(dynamic)*, [`js/wearables-manual.js`](js/wearables-manual.js) *(dynamic)*, [`js/wearables-summary.js`](js/wearables-summary.js) *(dynamic)*
 - [`js/profile-share.js`](js/profile-share.js) → [`js/export.js`](js/export.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils-runtime.js`](js/utils-runtime.js), [`js/utils.js`](js/utils.js)
 - [`js/profile-storage-key.js`](js/profile-storage-key.js) → no in-scope imports
-- [`js/profile.js`](js/profile.js) → [`js/adapters.js`](js/adapters.js), [`js/api.js`](js/api.js), [`js/blob-storage.js`](js/blob-storage.js) *(dynamic)*, [`js/constants.js`](js/constants.js), [`js/context-source-registry.js`](js/context-source-registry.js), [`js/crypto.js`](js/crypto.js), [`js/cycle-store.js`](js/cycle-store.js) *(dynamic)*, [`js/lab-entry.js`](js/lab-entry.js), [`js/light-env-evening.js`](js/light-env-evening.js), [`js/profile-marker-migrations.js`](js/profile-marker-migrations.js), [`js/profile-storage-key.js`](js/profile-storage-key.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/sync.js`](js/sync.js) *(dynamic)*, [`js/utils.js`](js/utils.js), [`js/wearables-connect.js`](js/wearables-connect.js) *(dynamic)*, [`js/wearables-manual.js`](js/wearables-manual.js) *(dynamic)*, [`js/wearables-store.js`](js/wearables-store.js) *(dynamic)*, [`js/wearables-summary.js`](js/wearables-summary.js) *(dynamic)*
+- [`js/profile.js`](js/profile.js) → [`js/adapters.js`](js/adapters.js), [`js/api.js`](js/api.js), [`js/blob-storage.js`](js/blob-storage.js) *(dynamic)*, [`js/constants.js`](js/constants.js), [`js/context-source-registry.js`](js/context-source-registry.js), [`js/crypto.js`](js/crypto.js), [`js/cycle-store.js`](js/cycle-store.js) *(dynamic)*, [`js/lab-entry.js`](js/lab-entry.js), [`js/light-env-evening.js`](js/light-env-evening.js), [`js/profile-marker-migrations.js`](js/profile-marker-migrations.js), [`js/profile-storage-key.js`](js/profile-storage-key.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/sync.js`](js/sync.js) *(dynamic)*, [`js/utils.js`](js/utils.js), [`js/wearables-store.js`](js/wearables-store.js) *(dynamic)*
 
 </details>
 

--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -140,6 +140,7 @@ import {
   dispatchProfileSwitched,
   invalidateProfileContextCache,
   refreshProfileButton,
+  refreshProfileWearables,
   reloadProfileRuntimeShell,
 } from './profile-runtime.js';
 import { detectWearableTrendSlots } from './recommendations.js';
@@ -190,6 +191,7 @@ configureProfileRuntimeDeps({
   dispatchProfileSwitched,
   invalidateProfileContextCache,
   refreshProfileButton,
+  refreshProfileWearables,
   reloadProfileRuntimeShell,
 });
 

--- a/js/profile-runtime.js
+++ b/js/profile-runtime.js
@@ -47,6 +47,25 @@ export async function reloadProfileRuntimeShell(profileId) {
   nav.renderProfileButton();
 }
 
+// Refresh wearable summary for the freshly-loaded profile so the strip
+// reflects this profile's L1 IDB rather than carrying over stale state from
+// the boot profile. Migration runs first (idempotent per profile), then the
+// summary recomputes from this profile's connected sources.
+export async function refreshProfileWearables(profileId, biometrics) {
+  const [manual, summary, connect] = await Promise.all([
+    import('./wearables-manual.js'),
+    import('./wearables-summary.js'),
+    import('./wearables-connect.js'),
+  ]);
+  try { await manual.migrateBiometricsToManual(profileId, biometrics); } catch {}
+  // The user can swap profile A→B during an IDB read. Abort before and after
+  // summary persistence so A's metrics can never be saved into B's profile.
+  if (state.currentProfile !== profileId) return;
+  try { await summary.syncWearableSummary(profileId, connect.listConnectedSources()); } catch {}
+  if (state.currentProfile !== profileId) return;
+  connect.syncStaleWearablesNow?.().catch(() => {});
+}
+
 export async function refreshProfileButton() {
   try {
     const mod = await import('./nav.js');

--- a/js/profile.js
+++ b/js/profile.js
@@ -43,6 +43,7 @@ export function configureProfileDeps(deps = {}) {
  *   invalidateProfileContextCache: null | (() => Promise<void> | void),
  *   refreshProfileButton: null | (() => Promise<void> | void),
  *   reloadProfileRuntimeShell: null | ((profileId: string) => Promise<void> | void),
+ *   refreshProfileWearables: null | ((profileId: string, biometrics: any) => Promise<void> | void),
  * }} ProfileRuntimeDeps
  */
 
@@ -52,6 +53,7 @@ const profileRuntimeDeps = {
   invalidateProfileContextCache: null,
   refreshProfileButton: null,
   reloadProfileRuntimeShell: null,
+  refreshProfileWearables: null,
 };
 
 /** @param {Partial<ProfileRuntimeDeps>} [deps] */
@@ -77,6 +79,11 @@ export function configureProfileRuntimeDeps(deps = {}) {
       ? deps.reloadProfileRuntimeShell
       : null;
   }
+  if (Object.hasOwn(deps, 'refreshProfileWearables')) {
+    profileRuntimeDeps.refreshProfileWearables = typeof deps.refreshProfileWearables === 'function'
+      ? deps.refreshProfileWearables
+      : null;
+  }
   return previous;
 }
 
@@ -94,6 +101,13 @@ async function refreshProfileButton() {
 
 async function reloadProfileRuntimeShell(profileId) {
   await profileRuntimeDeps.reloadProfileRuntimeShell?.(profileId);
+}
+
+function refreshProfileWearables(profileId, biometrics) {
+  try {
+    const pending = profileRuntimeDeps.refreshProfileWearables?.(profileId, biometrics);
+    Promise.resolve(pending).catch(() => {});
+  } catch {}
 }
 
 /**
@@ -619,28 +633,7 @@ export async function loadProfile(profileId) {
   state.currentThreadId = null;
   state.markerRegistry = {};
   await reloadProfileRuntimeShell(profileId);
-  // Refresh wearable summary for the freshly-loaded profile so the strip
-  // reflects THIS profile's L1 IDB rather than carrying over stale state
-  // from the boot profile. Both modules dynamic-imported to avoid circular
-  // deps (profile.js → wearables-* → profile.js for getActiveProfileId).
-  // Migration runs first (idempotent — it self-flag-gates after one run per
-  // profile), then summary recomputes from this profile's IDB.
-  Promise.all([
-    import('./wearables-manual.js'),
-    import('./wearables-summary.js'),
-    import('./wearables-connect.js'),
-  ]).then(async ([manualMod, summaryMod, connectMod]) => {
-    try { await manualMod.migrateBiometricsToManual(profileId, state.importedData?.biometrics); } catch {}
-    // Profile-switch race guard: the user can swap profile A→B during the
-    // ~100ms cold-cache IDB read interval. If that happens, abort BEFORE
-    // syncWearableSummary persists A's metrics into B's wearableSummary
-    // and saves them under B's localStorage key. Same shape as the
-    // v1.24.1 OAuth-callback profile-swap guard.
-    if (state.currentProfile !== profileId) return;
-    try { await summaryMod.syncWearableSummary(profileId, connectMod.listConnectedSources()); } catch {}
-    if (state.currentProfile !== profileId) return; // re-check post-await — sync also takes IDB time
-    connectMod.syncStaleWearablesNow?.().catch(() => {});
-  }).catch(() => {});
+  refreshProfileWearables(profileId, state.importedData?.biometrics);
 }
 
 /**

--- a/scripts/architecture-cycle-baseline.json
+++ b/scripts/architecture-cycle-baseline.json
@@ -1,15 +1,11 @@
 {
   "schemaVersion": 1,
-  "maxCyclicModules": 7,
-  "maxLargestCyclicComponent": 4,
+  "maxCyclicModules": 3,
+  "maxLargestCyclicComponent": 3,
   "allowedCyclicModules": [
     "js/cycle-import.js",
     "js/cycle.js",
-    "js/data.js",
-    "js/profile.js",
-    "js/wearables-apple-health.js",
-    "js/wearables-connect.js",
-    "js/wearables-manual.js"
+    "js/wearables-apple-health.js"
   ],
   "allowedComputedDynamicImports": [
     {

--- a/tests/profile-wearable-refresh.test.js
+++ b/tests/profile-wearable-refresh.test.js
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { configureProfileRuntimeDeps, loadProfile } from '../js/profile.js';
+import { state } from '../js/state.js';
+
+const PROFILE_ID = 'injected-wearable-refresh';
+const IMPORTED_KEY = `labcharts-${PROFILE_ID}-imported`;
+
+describe('profile wearable refresh dependency', () => {
+  afterEach(() => {
+    localStorage.removeItem(IMPORTED_KEY);
+  });
+
+  it('passes the loaded profile and its biometrics to the runtime seam', async () => {
+    const previousProfile = state.currentProfile;
+    const previousImportedData = state.importedData;
+    const previousActiveProfile = localStorage.getItem('labcharts-active-profile');
+    const refreshProfileWearables = vi.fn();
+    const previousDeps = configureProfileRuntimeDeps({
+      reloadProfileRuntimeShell: async () => {},
+      refreshProfileWearables,
+    });
+    localStorage.setItem(IMPORTED_KEY, JSON.stringify({
+      entries: [],
+      biometrics: { weight: 72 },
+    }));
+
+    try {
+      await loadProfile(PROFILE_ID);
+
+      expect(refreshProfileWearables).toHaveBeenCalledWith(
+        PROFILE_ID,
+        expect.objectContaining({ weight: 72 })
+      );
+    } finally {
+      configureProfileRuntimeDeps(previousDeps);
+      state.currentProfile = previousProfile;
+      state.importedData = previousImportedData;
+      if (previousActiveProfile == null) localStorage.removeItem('labcharts-active-profile');
+      else localStorage.setItem('labcharts-active-profile', previousActiveProfile);
+    }
+  });
+});

--- a/tests/test-crypto.js
+++ b/tests/test-crypto.js
@@ -472,7 +472,9 @@ try {
     src.includes('await invalidateProfileContextCache()') &&
     src.includes('await reloadProfileRuntimeShell(profileId)') &&
     runtimeSrc.includes('export async function invalidateProfileContextCache') &&
-    runtimeSrc.includes('export async function reloadProfileRuntimeShell'));
+    runtimeSrc.includes('export async function reloadProfileRuntimeShell') &&
+    runtimeSrc.includes('export async function refreshProfileWearables') &&
+    appShellHooksSrc.includes('refreshProfileWearables,'));
   assert('profile delete awaits profile list save before completion',
     src.includes('await saveProfiles(updated)') &&
     (src.includes('await loadProfile(updated[0].id)') || src.includes('await refreshProfileButton()')));

--- a/tests/test-wearables.js
+++ b/tests/test-wearables.js
@@ -1489,8 +1489,10 @@ console.log('17s. Encryption Hardening');
 
 // P0-1: profile-switch race in loadProfile refresh
 const profileSrc31 = await fetch('/js/profile.js').then(r => r.text());
+const profileRuntimeSrc31 = await fetch('/js/profile-runtime.js').then(r => r.text());
 assert('loadProfile refresh aborts when state.currentProfile changes mid-await',
-  /state\.currentProfile\s*!==\s*profileId\)\s*return/.test(profileSrc31));
+  profileSrc31.includes('refreshProfileWearables(profileId, state.importedData?.biometrics)') &&
+  /state\.currentProfile\s*!==\s*profileId\)\s*return/.test(profileRuntimeSrc31));
 
 // P0-1 (the orchestrator side): syncWearableSummary bails on profile swap.
 const summarySrc31 = await fetch('/js/wearables-summary.js').then(r => r.text());
@@ -1698,10 +1700,13 @@ console.log('17w. P2 Cleanup');
 // P2: loadProfile triggers wearable-summary refresh on profile switch
 // (was only running once at boot in main.js).
 const profileSrcP2 = await fetch('/js/profile.js').then(r => r.text());
+const profileRuntimeSrcP2 = await fetch('/js/profile-runtime.js').then(r => r.text());
 assert('loadProfile dispatches migrateBiometricsToManual + syncWearableSummary on every load',
-  /export\s+async\s+function\s+loadProfile[\s\S]*?migrateBiometricsToManual\(profileId/.test(profileSrcP2) &&
-  /loadProfile[\s\S]*?syncWearableSummary\(profileId,\s*connectMod\.listConnectedSources\(\)\)/.test(profileSrcP2) &&
-  /loadProfile[\s\S]*?connectMod\.syncStaleWearablesNow\?\.\(\)\.catch/.test(profileSrcP2));
+  profileSrcP2.includes('refreshProfileWearables(profileId, state.importedData?.biometrics)') &&
+  !profileSrcP2.includes("import('./wearables-manual.js')") &&
+  profileRuntimeSrcP2.includes('manual.migrateBiometricsToManual(profileId, biometrics)') &&
+  profileRuntimeSrcP2.includes('summary.syncWearableSummary(profileId, connect.listConnectedSources())') &&
+  profileRuntimeSrcP2.includes('connect.syncStaleWearablesNow?.().catch'));
 
 // P2: deleteWearablesDB closes the cached connection before deleting
 // (otherwise indexedDB.deleteDatabase hits onblocked).

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.347';
+self.APP_VERSION = '1.10.348';


### PR DESCRIPTION
## Summary

- inject post-load wearable refreshes into the profile lifecycle through the existing profile runtime seam
- move wearable migration, summary refresh, stale-sync kick, and profile-switch race guards into `profile-runtime.js`
- snapshot the loaded profile's biometrics before the asynchronous wearable refresh begins
- add focused dependency-injection coverage and update profile/wearable source contracts
- ratchet cyclic modules from 7 to 3 and the largest component from 4 to 3
- bump the cache version to 1.10.348

## Validation

- `./run-tests.sh` (131 static checks, 481 Vitest tests, 378 Chromium tests, 472 responsive-theme checks)
- `npm run test:firefox` (3 tests)
- profile wearable-refresh Vitest (1 test)
- legacy crypto/profile suite (298 assertions)
- legacy wearables suite (587 assertions)
- focused profile/wearables Chromium suite (4 tests)
- `npm run quality`
- `npm run architecture:check`
- `git diff --check`