### PR TITLE
Add cold-load performance budgets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@
 #   - Node-side tests (native-dialog guard, lens-local-utils, dev-server
 #     origin guard)
 #   - Playwright-driven web-app suite
+#   - Cold mobile-load resource budgets
 #   - Focused Firefox smoke coverage for critical browser flows
 
 name: Tests

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -90,11 +90,10 @@ foundation, storage adapters, and pure utilities
   inversion seams. Keep them narrow; do not turn them into alternate global
   service locators.
 
-This fine-grained direction is a migration target, not a claim about the
-current graph. The baseline still contains legacy strongly connected
-components. The checker prevents new modules from entering cycles and prevents
-the cycle budgets from increasing while existing edges are removed
-incrementally.
+This fine-grained direction remains a migration target for coupling cleanup,
+but the runtime graph no longer contains strongly connected components. Both
+cycle ceilings are fixed at zero, so the checker rejects any new cyclic
+dependency.
 
 ## Module ownership map
 
@@ -151,13 +150,18 @@ the higher-layer behavior through a narrow runtime seam.
 - `npm run architecture:check` verifies the generated file, resolves every
   relative ESM import, enforces source boundaries, and rejects cycle growth.
 - [`scripts/architecture-cycle-baseline.json`](scripts/architecture-cycle-baseline.json)
-  records existing cyclic modules and numeric ceilings. It is debt, not an
-  allowlist for new design.
-- After a refactor removes cyclic modules, lower the baseline with
-  `node scripts/architecture-map.mjs --write --update-cycle-baseline`, inspect
-  both diffs, and never raise the baseline merely to pass CI.
+  fixes both cycle ceilings at zero. Never raise either ceiling merely to pass
+  CI; a new cycle is a design failure.
 
-The first refactoring objective is to isolate foundation modules (`state`,
-`crypto`, profile/data persistence, and storage) from feature UI. Work in
-small behavior-preserving slices, beginning with a single reverse edge and
-running the complete regression suite after each coherent batch.
+## Cold-load performance budget
+
+`npm run performance:check` measures a fresh mobile returning-user load of
+`/app` with the browser cache and service workers disabled. The committed
+ceilings in [`scripts/cold-load-budget.json`](scripts/cold-load-budget.json)
+cover same-origin application request count, compressed transfer bytes, and
+decoded bytes. Runtime `/api/*` calls and cross-origin services are excluded so
+the measurement tracks the shipped app graph rather than network availability.
+
+The browser check runs in the normal Chromium suite and therefore in CI. Lower
+the ceilings as route and feature lazy loading removes startup resources; do
+not raise them to absorb an unexplained regression.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,10 +25,12 @@ Prerequisites: a modern browser (Chrome or Firefox), Node.js for the dev server,
 COVERAGE=1 ./run-tests.sh
 npx playwright install firefox
 npm run test:firefox
+npm run performance:check
 ```
 
 `./run-tests.sh` auto-starts a server, runs Vitest, the origin guard, and the full Chromium Playwright suite. The Firefox command runs a focused cross-browser check of startup, demo data, navigation, settings, JSON round trips, and offline app-shell readiness. Exit code 0 = all pass. If you add a feature or fix a bug, add assertions to the relevant test file. See the [Testing developer doc](https://docs.getbased.health/developers/testing) for how the harness works.
 `COVERAGE=1 ./run-tests.sh` additionally enforces the combined function-coverage minimum in `scripts/coverage-baseline.json`. Raise that committed minimum when coverage improves; `COVERAGE_MIN` may temporarily demand a stricter local threshold but cannot weaken the repository baseline.
+`npm run performance:check` measures the cold mobile app path and enforces the committed request-count, compressed-transfer, and decoded-byte ceilings in `scripts/cold-load-budget.json`.
 
 If you add, remove, rename, or rewire a runtime module, regenerate and inspect the file map:
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ npm run vendor:check
 npm run quality
 npm test
 npm run test:firefox
+npm run performance:check
 ./run-tests.sh
 COVERAGE=1 ./run-tests.sh
 ```
@@ -133,6 +134,7 @@ COVERAGE=1 ./run-tests.sh
 `./run-tests.sh` runs both type checkers, verifies the architecture map, vendored browser assets, and static module graph, starts an isolated local server, runs the Node/Vitest tests, checks the dev-server origin guard, and runs Playwright browser assertions.
 `COVERAGE=1 ./run-tests.sh` also combines Vitest and Playwright V8 function coverage and enforces the committed ratchet in `scripts/coverage-baseline.json`; CI runs this mode on every change.
 `npm run test:firefox` runs the focused Firefox critical-flow suite; install its browser binary once with `npx playwright install firefox`.
+`npm run performance:check` runs the focused cold mobile-load check and enforces the committed request-count, compressed-transfer, and decoded-byte ceilings.
 
 ## Tech stack
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "architecture:build": "node scripts/architecture-map.mjs --write",
     "architecture:check": "node scripts/architecture-map.mjs --check",
     "dev-server": "node dev-server.js",
+    "performance:check": "playwright test tests/playwright/cold-load-budget.spec.js --workers=1",
     "quality": "node scripts/quality-guardrails.mjs",
     "test": "vitest run",
     "test:firefox": "playwright test --config=playwright.firefox.config.js",

--- a/plans/code-quality-audit-2026-07-21.md
+++ b/plans/code-quality-audit-2026-07-21.md
@@ -87,7 +87,9 @@ and target dependency direction, while generated `MODULE_MAP.md` records the
 file-level import graph. CI rejects stale maps, cross-runtime boundary
 violations, new computed dynamic imports, new modules entering dependency
 cycles, and increases to the cyclic-module or largest-component budgets. The
-existing cycle remains refactoring debt and is not marked complete.
+initial cycle was then removed in behavior-preserving dependency-inversion
+slices. Remediation status: **completed on 2026-07-23**. The current graph has
+zero cyclic modules and both cycle ceilings are fixed at zero.
 
 ### 3. Cold-load performance
 
@@ -95,6 +97,13 @@ The browser requests nearly the entire application as native modules, and the
 service worker precaches essentially all of them. Local performance is fine,
 but the request and decoded-byte totals are expensive on constrained mobile
 networks. There is no CI request-count or transfer-size budget.
+
+Remediation status: **in progress**. CI now measures a fresh mobile
+returning-user load with cache and service workers disabled and enforces
+ceilings for same-origin application requests, compressed transfer bytes, and
+decoded bytes. The initial reference is 474 requests, 2,017,210 compressed
+bytes, and 6,252,286 decoded bytes. Route and feature lazy loading remains the
+next implementation phase, with the ceilings intended to ratchet downward.
 
 ### 4. Guardrails and test gaps
 
@@ -121,9 +130,10 @@ current dependency-vulnerability state was not verified.
 
 1. Harden the production proxy boundary. **Completed in the immediate follow-up.**
 2. Break the large dependency cycle around state, crypto, profiles, storage,
-   and feature UI; enforce import boundaries.
+   and feature UI; enforce import boundaries. **Completed.**
 3. Add route/feature lazy loading and CI budgets for request count, transferred
-   bytes, and decoded bytes.
+   bytes, and decoded bytes. **In progress: CI budgets added; lazy loading
+   remains.**
 4. Vendor axe locally, fail when it cannot run, add a Firefox smoke suite, and
    ratchet function coverage upward. **Completed in follow-up changes.**
 5. Add linting and stricter type checking incrementally; lower large-file

--- a/scripts/cold-load-budget.json
+++ b/scripts/cold-load-budget.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": 1,
+  "route": "/app",
+  "scenario": "Fresh mobile returning-user load with browser cache and service workers disabled",
+  "maximums": {
+    "requests": 480,
+    "transferBytes": 2050000,
+    "decodedBytes": 6350000
+  },
+  "reference": {
+    "requests": 474,
+    "transferBytes": 2017210,
+    "decodedBytes": 6252286
+  },
+  "referenceCommit": "bb2b1e38",
+  "measuredAt": "2026-07-23"
+}

--- a/scripts/cold-load-budget.mjs
+++ b/scripts/cold-load-budget.mjs
@@ -1,0 +1,83 @@
+const METRICS = [
+  ['requests', 'requests'],
+  ['transferBytes', 'compressed transfer bytes'],
+  ['decodedBytes', 'decoded bytes'],
+];
+
+function requireNonNegativeNumber(value, label) {
+  const number = Number(value);
+  if (!Number.isFinite(number) || number < 0) {
+    throw new Error(`${label} must be a non-negative number.`);
+  }
+  return number;
+}
+
+function requirePositiveNumber(value, label) {
+  const number = Number(value);
+  if (!Number.isFinite(number) || number <= 0) {
+    throw new Error(`${label} must be a number greater than zero.`);
+  }
+  return number;
+}
+
+function isMeasuredAppResource(entry, appOrigin) {
+  try {
+    const url = new URL(entry?.name || '');
+    if (url.origin !== appOrigin) return false;
+    return url.pathname !== '/proxy' && !url.pathname.startsWith('/api/');
+  } catch {
+    return false;
+  }
+}
+
+export function summarizeColdLoad(entries, appOrigin) {
+  if (!Array.isArray(entries)) {
+    throw new Error('Cold-load resource entries must be an array.');
+  }
+  const origin = new URL(appOrigin).origin;
+  const measured = entries.filter(entry => isMeasuredAppResource(entry, origin));
+  return {
+    requests: measured.length,
+    transferBytes: measured.reduce(
+      (total, entry) => total + requireNonNegativeNumber(entry.transferSize, 'resource transferSize'),
+      0,
+    ),
+    decodedBytes: measured.reduce(
+      (total, entry) => total + requireNonNegativeNumber(entry.decodedBodySize, 'resource decodedBodySize'),
+      0,
+    ),
+  };
+}
+
+export function enforceColdLoadBudget(metrics, budget) {
+  const maximums = budget?.maximums;
+  const failures = [];
+  const result = {};
+
+  for (const [key, label] of METRICS) {
+    const actual = requireNonNegativeNumber(metrics?.[key], `cold-load ${key}`);
+    const maximum = requirePositiveNumber(maximums?.[key], `cold-load maximums.${key}`);
+    result[key] = {
+      actual,
+      maximum,
+      remaining: maximum - actual,
+    };
+    if (actual > maximum) {
+      failures.push(`${label} ${actual} exceeds ${maximum}`);
+    }
+  }
+
+  if (failures.length) {
+    throw new Error(`Cold-load budget exceeded: ${failures.join('; ')}.`);
+  }
+  return result;
+}
+
+export function formatColdLoadSummary(metrics) {
+  const kib = bytes => `${(bytes / 1024).toFixed(1)} KiB`;
+  return [
+    `${metrics.requests} requests`,
+    `${kib(metrics.transferBytes)} compressed`,
+    `${kib(metrics.decodedBytes)} decoded`,
+  ].join(', ');
+}

--- a/tests/cold-load-budget.test.js
+++ b/tests/cold-load-budget.test.js
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  enforceColdLoadBudget,
+  formatColdLoadSummary,
+  summarizeColdLoad,
+} from '../scripts/cold-load-budget.mjs';
+
+const BUDGET = {
+  maximums: {
+    requests: 3,
+    transferBytes: 1000,
+    decodedBytes: 2000,
+  },
+};
+
+describe('cold-load performance budget', () => {
+  it('summarizes same-origin application resources and excludes APIs', () => {
+    const metrics = summarizeColdLoad([
+      {
+        name: 'http://127.0.0.1:8000/app',
+        transferSize: 300,
+        decodedBodySize: 500,
+      },
+      {
+        name: 'http://127.0.0.1:8000/js/main.js',
+        transferSize: 200,
+        decodedBodySize: 400,
+      },
+      {
+        name: 'http://127.0.0.1:8000/api/commit',
+        transferSize: 100,
+        decodedBodySize: 100,
+      },
+      {
+        name: 'https://example.com/font.woff2',
+        transferSize: 100,
+        decodedBodySize: 100,
+      },
+    ], 'http://127.0.0.1:8000');
+
+    expect(metrics).toEqual({
+      requests: 2,
+      transferBytes: 500,
+      decodedBytes: 900,
+    });
+  });
+
+  it('passes at the ceilings and reports remaining margin', () => {
+    expect(enforceColdLoadBudget({
+      requests: 3,
+      transferBytes: 900,
+      decodedBytes: 1800,
+    }, BUDGET)).toEqual({
+      requests: { actual: 3, maximum: 3, remaining: 0 },
+      transferBytes: { actual: 900, maximum: 1000, remaining: 100 },
+      decodedBytes: { actual: 1800, maximum: 2000, remaining: 200 },
+    });
+  });
+
+  it('reports every exceeded ceiling in one actionable failure', () => {
+    expect(() => enforceColdLoadBudget({
+      requests: 4,
+      transferBytes: 1100,
+      decodedBytes: 2200,
+    }, BUDGET)).toThrow(
+      'requests 4 exceeds 3; compressed transfer bytes 1100 exceeds 1000; decoded bytes 2200 exceeds 2000',
+    );
+  });
+
+  it('rejects malformed measurements and budgets', () => {
+    expect(() => summarizeColdLoad([], 'not a URL')).toThrow();
+    expect(() => enforceColdLoadBudget({
+      requests: -1,
+      transferBytes: 0,
+      decodedBytes: 0,
+    }, BUDGET)).toThrow('cold-load requests must be a non-negative number');
+    expect(() => enforceColdLoadBudget({
+      requests: 0,
+      transferBytes: 0,
+      decodedBytes: 0,
+    }, { maximums: {} })).toThrow('maximums.requests');
+  });
+
+  it('formats a compact CI summary', () => {
+    expect(formatColdLoadSummary({
+      requests: 420,
+      transferBytes: 2048,
+      decodedBytes: 4096,
+    })).toBe('420 requests, 2.0 KiB compressed, 4.0 KiB decoded');
+  });
+});

--- a/tests/playwright/cold-load-budget.spec.js
+++ b/tests/playwright/cold-load-budget.spec.js
@@ -1,0 +1,78 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { devices, expect, test } from '@playwright/test';
+
+import {
+  enforceColdLoadBudget,
+  formatColdLoadSummary,
+  summarizeColdLoad,
+} from '../../scripts/cold-load-budget.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const budget = JSON.parse(
+  fs.readFileSync(path.join(repoRoot, 'scripts', 'cold-load-budget.json'), 'utf8'),
+);
+const port = process.env.PORT || '8000';
+const appOrigin = `http://127.0.0.1:${port}`;
+const mobile = devices['Pixel 5'];
+
+test.use({
+  viewport: mobile.viewport,
+  userAgent: mobile.userAgent,
+  deviceScaleFactor: mobile.deviceScaleFactor,
+  isMobile: mobile.isMobile,
+  hasTouch: mobile.hasTouch,
+  serviceWorkers: 'block',
+});
+
+test('cold mobile app load stays within committed resource budgets', async ({ page }) => {
+  const client = await page.context().newCDPSession(page);
+  await client.send('Network.enable');
+  await client.send('Network.setCacheDisabled', { cacheDisabled: true });
+
+  await page.route('**/*', async route => {
+    const url = new URL(route.request().url());
+    if (url.origin === appOrigin) {
+      await route.continue();
+      return;
+    }
+    await route.abort();
+  });
+
+  await page.addInitScript(() => {
+    performance.setResourceTimingBufferSize(2000);
+    localStorage.setItem('labcharts-legal-acceptance', JSON.stringify({
+      accepted: true,
+      termsVersion: '2026-06-22',
+      privacyVersion: '2026-06-22',
+      acceptedAt: '2026-07-23T00:00:00.000Z',
+      appVersion: 'cold-load-budget',
+      location: 'cold-load-budget',
+    }));
+    localStorage.setItem('labcharts-default-onboarded', 'profile-set');
+    localStorage.setItem('labcharts-default-emptyTour', 'completed');
+    localStorage.setItem('labcharts-default-tour', 'completed');
+    localStorage.setItem('labcharts-default-ai-reminder-dismissed', '1');
+    localStorage.setItem('labcharts-onboard-extras-done-default', '1');
+    localStorage.setItem('labcharts-onboard-provider-skipped-default', '1');
+    localStorage.setItem('labcharts-analytics-consent-seen', '1');
+  });
+
+  await page.goto(budget.route, { waitUntil: 'networkidle', timeout: 30_000 });
+  await expect(page.locator('#main-content')).toBeVisible();
+
+  const entries = await page.evaluate(() => [
+    ...performance.getEntriesByType('navigation'),
+    ...performance.getEntriesByType('resource'),
+  ].map(entry => ({
+    name: entry.name,
+    transferSize: entry.transferSize,
+    decodedBodySize: entry.decodedBodySize,
+  })));
+  const metrics = summarizeColdLoad(entries, appOrigin);
+
+  console.log(`Cold-load budget: ${formatColdLoadSummary(metrics)}`);
+  console.log(`Cold-load metrics: ${JSON.stringify(metrics)}`);
+  expect(() => enforceColdLoadBudget(metrics, budget)).not.toThrow();
+});


### PR DESCRIPTION
## Summary

- add a focused mobile cold-load Playwright check with browser cache and service workers disabled
- measure same-origin application request count, compressed transfer bytes, and decoded bytes while excluding runtime APIs and external availability
- commit an initial 474-request / 2,017,210-byte compressed / 6,252,286-byte decoded reference with small regression ceilings
- exercise the budget logic with focused Vitest coverage and run the browser check in the normal Chromium/CI suite
- record the zero-cycle architecture milestone and mark cold-load performance work in progress in the audit plan
- document the new `npm run performance:check` contributor command

## Why

The architecture audit identified cold startup cost as the next major codebase concern after dependency-cycle removal. The repository had no deterministic guard against adding more startup requests or bytes, so lazy-loading work had no committed baseline to improve or protect.

## Validation

- `./run-tests.sh` (131 static checks, 486 Vitest tests, 379 Chromium tests, 472 responsive-theme checks)
- `PORT=8240 npm run performance:check` (474 requests, 2,017,210 compressed bytes, 6,252,286 decoded bytes)
- focused cold-load budget Vitest suite (5 tests)
- `npm run typecheck`
- `npm run architecture:check` (463 modules, 0 cyclic, largest cycle 0)
- `npm run quality`
- `git diff --check`