### PR TITLE
Lazy-load Settings stylesheet

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -176,7 +176,11 @@ Settings and Tweaks are loaded through `settings-loader.js` on their first
 shell, startup deep-link, or feature action. Theme-owned accent initialization
 stays in `theme.js`, while the Light page imports its Sun data-source renderer
 from `settings-privacy.js`; neither path requires the full Settings modal
-during normal startup.
+during normal startup. The loader also fetches `css/settings.css` on first use
+and waits for both resources before opening the UI. An HTML anchor preserves
+the stylesheet's cascade position, while the shell-owned Settings button rule
+stays in `app-shell.css`. The deferred stylesheet remains in the service-worker
+app shell for offline first use.
 
 Profile Sharing is loaded through `profile-share-loader.js` when a shell,
 Settings, or client-list action opens it, or when startup/hash routing detects

--- a/css/app-shell.css
+++ b/css/app-shell.css
@@ -18,6 +18,7 @@
 .header-group { display: flex; align-items: center; gap: 8px; }
 .header-divider { width: 1px; height: 20px; background: var(--border); flex-shrink: 0; }
 [data-theme="light"] .header { box-shadow: 0 1px 4px rgba(0,0,0,0.06); border-bottom-color: transparent; }
+.settings-btn:hover { background: var(--bg-hover); }
 
 /* Header/settings toggles */
 .sex-toggle { display: flex; align-items: center; gap: 4px; }

--- a/css/settings.css
+++ b/css/settings.css
@@ -1,7 +1,5 @@
 /* Settings modal and settings-owned controls */
 
-.settings-btn:hover { background: var(--bg-hover); }
-
 .settings-modal {
   padding: 0;
   width: min(94vw, 860px);

--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
   <link rel="stylesheet" href="css/context-profile.css">
   <link rel="stylesheet" href="css/genetics.css">
   <link rel="stylesheet" href="css/data-protection.css">
-  <link rel="stylesheet" href="css/settings.css">
+  <meta data-settings-stylesheet-anchor>
   <link rel="stylesheet" href="css/mobile-dashboard.css">
   <link rel="stylesheet" href="css/cycle.css">
   <link rel="stylesheet" href="css/marker-detail-modal.css">

--- a/js/settings-loader.js
+++ b/js/settings-loader.js
@@ -7,10 +7,17 @@ import { configureSettingsModuleBridge } from './settings-runtime-bridge.js';
 
 /** @typedef {typeof import('./settings.js')} SettingsModule */
 
+const SETTINGS_STYLESHEET_URL = new URL('../css/settings.css', import.meta.url).href;
+
+/** @type {Promise<SettingsModule> | null} */
+let _settingsJavaScriptLoad = null;
 /** @type {Promise<SettingsModule> | null} */
 let _settingsModuleLoad = null;
+/** @type {Promise<HTMLLinkElement> | null} */
+let _settingsStylesheetLoad = null;
 let _settingsModuleLoaded = false;
 let _useSettingsRetryUrl = false;
+let _useSettingsStylesheetRetryUrl = false;
 /** @type {(module: SettingsModule) => void} */
 let _configureSettingsModule = () => {};
 
@@ -37,15 +44,65 @@ function loadSettingsRetryModule() {
 }
 
 /** @returns {Promise<SettingsModule>} */
-export function loadSettingsModule() {
-  if (!_settingsModuleLoad) {
+function loadSettingsJavaScript() {
+  if (!_settingsJavaScriptLoad) {
     // Browsers cache failed module-map fetches by URL. A fixed second literal
     // gives the user one genuine retry without introducing a computed import.
     const moduleLoad = _useSettingsRetryUrl
       ? loadSettingsRetryModule()
       : import('./settings.js');
-    _settingsModuleLoad = moduleLoad
-      .then(module => {
+    _settingsJavaScriptLoad = moduleLoad.catch(err => {
+      _settingsJavaScriptLoad = null;
+      _useSettingsRetryUrl = true;
+      throw err;
+    });
+  }
+  return _settingsJavaScriptLoad;
+}
+
+function settingsStylesheetUrl() {
+  if (!_useSettingsStylesheetRetryUrl) return SETTINGS_STYLESHEET_URL;
+  const retryUrl = new URL(SETTINGS_STYLESHEET_URL);
+  retryUrl.searchParams.set('lazy-retry', '1');
+  return retryUrl.href;
+}
+
+/** @returns {Promise<HTMLLinkElement>} */
+function loadSettingsStylesheet() {
+  if (!_settingsStylesheetLoad) {
+    _settingsStylesheetLoad = new Promise((resolve, reject) => {
+      if (typeof document === 'undefined') {
+        reject(new Error('Settings stylesheet requires a document'));
+        return;
+      }
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = settingsStylesheetUrl();
+      link.dataset.settingsStylesheet = '';
+      link.addEventListener('load', () => resolve(link), { once: true });
+      link.addEventListener('error', () => {
+        link.remove();
+        reject(new Error('Settings stylesheet could not be loaded'));
+      }, { once: true });
+      const anchor = document.querySelector('[data-settings-stylesheet-anchor]');
+      (anchor?.parentNode || document.head).insertBefore(link, anchor || null);
+    }).catch(err => {
+      _settingsStylesheetLoad = null;
+      _useSettingsStylesheetRetryUrl = true;
+      throw err;
+    });
+  }
+  return _settingsStylesheetLoad;
+}
+
+/** @returns {Promise<SettingsModule>} */
+export function loadSettingsModule() {
+  if (!_settingsModuleLoad) {
+    _settingsModuleLoad = Promise.all([
+      loadSettingsJavaScript(),
+      loadSettingsStylesheet(),
+    ])
+      .then(([module]) => {
         _configureSettingsModule(module);
         _settingsModuleLoaded = true;
         return module;
@@ -53,7 +110,6 @@ export function loadSettingsModule() {
       .catch(err => {
         _settingsModuleLoad = null;
         _settingsModuleLoaded = false;
-        _useSettingsRetryUrl = true;
         installSettingsLoaderBridge();
         throw err;
       });

--- a/plans/code-quality-audit-2026-07-21.md
+++ b/plans/code-quality-audit-2026-07-21.md
@@ -103,10 +103,12 @@ returning-user load with cache and service workers disabled and enforces
 ceilings for same-origin application requests, compressed transfer bytes, and
 decoded bytes. The initial reference was 474 requests, 2,017,210 compressed
 bytes, and 6,252,286 decoded bytes. Lazy-loading the PDF import review,
-Light/Sun analysis hooks, Settings/Tweaks, and Profile Sharing reduced that
-reference to 449 requests, 1,908,488 compressed bytes, and 5,890,321 decoded
-bytes. Route and feature lazy loading remains active, with the ceilings
-ratcheting downward after each reproducible slice.
+Light/Sun analysis hooks, Settings/Tweaks, Profile Sharing, and the Settings
+stylesheet reduced that reference to 448 requests, 1,900,879 compressed bytes,
+and 5,843,728 decoded bytes. The Settings stylesheet slice saved one request,
+7,645 compressed bytes, and 46,818 decoded bytes in identical before/after
+runs on the same machine. Route and feature lazy loading remains active, with
+the ceilings ratcheting downward after each reproducible slice.
 
 ### 4. Guardrails and test gaps
 

--- a/scripts/cold-load-budget.json
+++ b/scripts/cold-load-budget.json
@@ -3,15 +3,15 @@
   "route": "/app",
   "scenario": "Fresh mobile returning-user load with browser cache and service workers disabled",
   "maximums": {
-    "requests": 455,
-    "transferBytes": 1942000,
-    "decodedBytes": 5989000
+    "requests": 454,
+    "transferBytes": 1935000,
+    "decodedBytes": 5943000
   },
   "reference": {
-    "requests": 449,
-    "transferBytes": 1908488,
-    "decodedBytes": 5890321
+    "requests": 448,
+    "transferBytes": 1900879,
+    "decodedBytes": 5843728
   },
-  "referenceCommit": "9c31fcfd",
-  "measuredAt": "2026-07-23"
+  "referenceCommit": "73780afa",
+  "measuredAt": "2026-07-24"
 }

--- a/tests/firefox/smoke.spec.js
+++ b/tests/firefox/smoke.spec.js
@@ -150,8 +150,10 @@ test('installs a readable app shell for offline use', async ({ browserName, cont
     const requiredPaths = [
       '/index.html',
       '/styles.css',
+      '/css/settings.css',
       '/js/main.js',
       '/js/legal-consent.js',
+      '/js/settings.js',
       '/vendor/fonts/inter-400-7.woff2',
     ];
     const entries = await Promise.all(requiredPaths.map(async path => {
@@ -169,10 +171,18 @@ test('installs a readable app shell for offline use', async ({ browserName, cont
   expect(cached.entries).toEqual([
     { path: '/index.html', available: true },
     { path: '/styles.css', available: true },
+    { path: '/css/settings.css', available: true },
     { path: '/js/main.js', available: true },
     { path: '/js/legal-consent.js', available: true },
+    { path: '/js/settings.js', available: true },
     { path: '/vendor/fonts/inter-400-7.woff2', available: true },
   ]);
   expect(cached.offline).toBe(true);
+  // The delayed chat-onboarding panel can cover the header while the full app
+  // shell finishes installing. Dispatch the same delegated shell action
+  // directly so this check remains about offline first use, not panel timing.
+  await page.locator('.settings-btn').evaluate(button => button.click());
+  await expect(page.locator('#settings-modal-overlay')).toHaveClass(/\bshow\b/);
+  await expect(page.locator('#settings-modal .settings-layout')).toHaveCSS('display', 'grid');
   expect(pageErrors).toEqual([]);
 });

--- a/tests/firefox/smoke.spec.js
+++ b/tests/firefox/smoke.spec.js
@@ -58,10 +58,11 @@ test('loads demo data and supports core navigation and settings', async ({ brows
   await expect.poll(() => page.evaluate(async () => (await import('/js/state.js')).state.currentView)).toBe('labs');
   await expect(page.locator('.lens-page-widgets[data-lens-route="labs"]')).toBeVisible();
 
-  // A returning user with no chat history gets the onboarding panel after a
-  // short startup delay. Wait for that task before closing so it cannot race
-  // the Settings assertions below.
+  // Exercise chat after demo loading and navigation have settled. Depending on
+  // the delayed startup auto-open makes this assertion race with demo loading,
+  // which can close the panel again before the check runs.
   const chatPanel = page.locator('#chat-panel');
+  await page.evaluate(async () => (await import('/js/chat-panel.js')).openChatPanel());
   await expect(chatPanel).toHaveClass(/\bopen\b/);
   await page.evaluate(async () => (await import('/js/chat-panel.js')).closeChatPanel());
   await expect(chatPanel).not.toHaveClass(/\bopen\b/);

--- a/tests/playwright/cold-load-budget.spec.js
+++ b/tests/playwright/cold-load-budget.spec.js
@@ -70,6 +70,9 @@ test('cold mobile app load stays within committed resource budgets', async ({ pa
     transferSize: entry.transferSize,
     decodedBodySize: entry.decodedBodySize,
   })));
+  expect(entries.some(entry => (
+    new URL(entry.name).pathname === '/css/settings.css'
+  ))).toBe(false);
   const metrics = summarizeColdLoad(entries, appOrigin);
 
   console.log(`Cold-load budget: ${formatColdLoadSummary(metrics)}`);

--- a/tests/playwright/import-benchmarks.spec.js
+++ b/tests/playwright/import-benchmarks.spec.js
@@ -19,6 +19,8 @@ async function preparePage(page) {
     document.getElementById('tour-overlay')?.remove();
     const { state } = await import('/js/state.js');
     state.currentProfile = 'benchmark-ui-profile';
+    localStorage.setItem(`labcharts-${state.currentProfile}-emptyTour`, 'completed');
+    localStorage.setItem(`labcharts-${state.currentProfile}-tour`, 'completed');
     state.profiles = [{ id: 'benchmark-ui-profile', name: 'Benchmark UI' }];
     state.importedData = {
       entries: [{ date: '2026-07-19', markers: { glucose: 91 } }],
@@ -91,7 +93,7 @@ async function preparePage(page) {
         markerCount: 12,
       }],
     };
-    (await import('/js/settings.js')).openSettingsModal('ai');
+    await (await import('/js/settings-loader.js')).openSettingsModal('ai');
   });
 }
 
@@ -234,6 +236,8 @@ test('comparison headers distinguish the same model across cloud providers', asy
   await page.evaluate(async () => {
     const { state } = await import('/js/state.js');
     state.currentProfile = 'provider-identity-profile';
+    localStorage.setItem(`labcharts-${state.currentProfile}-emptyTour`, 'completed');
+    localStorage.setItem(`labcharts-${state.currentProfile}-tour`, 'completed');
     state.profiles = [{ id: state.currentProfile, name: 'Provider identity' }];
     const base = {
       benchmarkAt: Date.now(),
@@ -519,6 +523,8 @@ test('eGFR unit typography does not create false benchmark differences and repai
 
     const { state } = await import('/js/state.js');
     state.currentProfile = 'reference-equivalence-repair-profile';
+    localStorage.setItem(`labcharts-${state.currentProfile}-emptyTour`, 'completed');
+    localStorage.setItem(`labcharts-${state.currentProfile}-tour`, 'completed');
     state.importedData = {
       entries: [],
       importSnapshots: [],
@@ -591,6 +597,8 @@ test('two successful imports persist as two distinct comparable model runs', asy
     const { setPendingImportRuntime } = await import('/js/pdf-import-review-runtime.js');
     const { confirmImport } = await import('/js/pdf-import-commit.js');
     state.currentProfile = 'two-model-benchmark-profile';
+    localStorage.setItem(`labcharts-${state.currentProfile}-emptyTour`, 'completed');
+    localStorage.setItem(`labcharts-${state.currentProfile}-tour`, 'completed');
     state.profiles = [{ id: state.currentProfile, name: 'Two model benchmark' }];
     state.importedData = {
       entries: [],
@@ -653,7 +661,7 @@ test('two successful imports persist as two distinct comparable model runs', asy
       modelId: run.modelId,
       status: run.status,
     }));
-    (await import('/js/settings.js')).openSettingsModal('ai');
+    await (await import('/js/settings-loader.js')).openSettingsModal('ai');
     return { records, snapshotCount: state.importedData.importSnapshots.length };
   });
 
@@ -698,6 +706,8 @@ test('benchmark history remains device-local across saves and inbound sync merge
       isSyncing: () => false,
     });
     state.currentProfile = profileId;
+    localStorage.setItem(`labcharts-${state.currentProfile}-emptyTour`, 'completed');
+    localStorage.setItem(`labcharts-${state.currentProfile}-tour`, 'completed');
     state.importedData = {
       entries: [],
       notes: [{ id: 'local-note', text: 'kept locally' }],
@@ -751,6 +761,8 @@ test('LM Studio is shown as the local backend instead of the internal Ollama pro
     const { state } = await import('/js/state.js');
     const { getImportBenchmarkProviderLabel } = await import('/js/import-benchmarks.js');
     state.currentProfile = 'lm-studio-benchmark-profile';
+    localStorage.setItem(`labcharts-${state.currentProfile}-emptyTour`, 'completed');
+    localStorage.setItem(`labcharts-${state.currentProfile}-tour`, 'completed');
     state.profiles = [{ id: state.currentProfile, name: 'LM Studio test' }];
     state.importedData = {
       entries: [],
@@ -793,6 +805,8 @@ test('comparison model header opens exact expected-versus-returned differences',
   await page.evaluate(async () => {
     const { state } = await import('/js/state.js');
     state.currentProfile = 'difference-review-profile';
+    localStorage.setItem(`labcharts-${state.currentProfile}-emptyTour`, 'completed');
+    localStorage.setItem(`labcharts-${state.currentProfile}-tour`, 'completed');
     state.profiles = [{ id: state.currentProfile, name: 'Difference review' }];
     state.importedData = {
       entries: [],
@@ -970,6 +984,8 @@ test('reference model tests use deterministic prompts and explicit protocol iden
     const { parseLabPDFWithAI } = await import('/js/pdf-import.js');
     const { importBenchmarksUseSameInput } = await import('/js/settings-data.js');
     state.currentProfile = 'deterministic-benchmark-profile';
+    localStorage.setItem(`labcharts-${state.currentProfile}-emptyTour`, 'completed');
+    localStorage.setItem(`labcharts-${state.currentProfile}-tour`, 'completed');
     localStorage.setItem('labcharts-active-profile', state.currentProfile);
     state.profileSex = 'female';
     state.profiles = [{

--- a/tests/playwright/openrouter-settings.spec.js
+++ b/tests/playwright/openrouter-settings.spec.js
@@ -13,7 +13,7 @@ test('OpenRouter provider controls render from Settings AI', async ({ page }) =>
     document.getElementById('tour-overlay')?.remove();
     document.getElementById('tour-spotlight')?.remove();
     document.getElementById('tour-tooltip')?.remove();
-    (await import('/js/settings.js')).openSettingsModal('ai');
+    await (await import('/js/settings-loader.js')).openSettingsModal('ai');
   });
 
   const providerButtons = page.locator('.ai-provider-btn');

--- a/tests/playwright/settings-loader-browser-coverage.spec.js
+++ b/tests/playwright/settings-loader-browser-coverage.spec.js
@@ -39,12 +39,21 @@ function syntheticSettingsModule() {
 
 test('Settings loader caches initialization and preserves lazy bridge actions', async ({ page }) => {
   let settingsRequests = 0;
+  let settingsStylesheetRequests = 0;
   await page.route('**/js/settings.js*', route => {
     settingsRequests += 1;
     return route.fulfill({
       status: 200,
       contentType: 'application/javascript',
       body: syntheticSettingsModule(),
+    });
+  });
+  await page.route('**/css/settings.css*', route => {
+    settingsStylesheetRequests += 1;
+    return route.fulfill({
+      status: 200,
+      contentType: 'text/css',
+      body: '.settings-modal { display: block; }',
     });
   });
   await openBlankPage(page, '/settings-loader-cache-coverage');
@@ -96,6 +105,7 @@ test('Settings loader caches initialization and preserves lazy bridge actions', 
     };
   });
   results.lazyModuleRequestedOnce = settingsRequests === 1;
+  results.lazyStylesheetRequestedOnce = settingsStylesheetRequests === 1;
 
   for (const [name, passed] of Object.entries(results)) {
     expect(passed, name).toBe(true);
@@ -137,6 +147,54 @@ test('Settings loader retries direct loads after a failed import', async ({ page
   }
 });
 
+test('Settings loader retries a failed stylesheet without re-evaluating its module', async ({ page }) => {
+  let settingsRequests = 0;
+  let settingsStylesheetRequests = 0;
+  await page.route('**/js/settings.js*', route => {
+    settingsRequests += 1;
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/javascript',
+      body: syntheticSettingsModule(),
+    });
+  });
+  await page.route('**/css/settings.css*', route => {
+    settingsStylesheetRequests += 1;
+    if (settingsStylesheetRequests === 1) return route.abort('failed');
+    return route.fulfill({
+      status: 200,
+      contentType: 'text/css',
+      body: '.settings-modal { display: block; }',
+    });
+  });
+  await openBlankPage(page, '/settings-stylesheet-retry-coverage');
+
+  const results = await page.evaluate(async () => {
+    const loader = await import('/js/settings-loader.js');
+    let firstRejected = false;
+    try {
+      await loader.loadSettingsModule();
+    } catch {
+      firstRejected = true;
+    }
+    const retried = await loader.loadSettingsModule();
+    const stylesheet = document.querySelector('link[data-settings-stylesheet]');
+    return {
+      firstRejected,
+      retrySucceeds: retried.openSettingsModal('display') === 'display',
+      loadedAfterRetry: loader.isSettingsModuleLoaded() === true,
+      moduleEvaluatedOnce: globalThis.__settingsModuleEvalCount === 1,
+      retryUsesFixedStylesheetUrl: stylesheet?.href.includes('lazy-retry=1') === true,
+    };
+  });
+  results.moduleRequestedOnce = settingsRequests === 1;
+  results.stylesheetRequestedTwice = settingsStylesheetRequests === 2;
+
+  for (const [name, passed] of Object.entries(results)) {
+    expect(passed, name).toBe(true);
+  }
+});
+
 test('Settings lazy entry points contain load failures', async ({ page }) => {
   let settingsRequests = 0;
   await page.route('**/js/settings.js*', route => {
@@ -154,8 +212,11 @@ test('Settings lazy entry points contain load failures', async ({ page }) => {
 
 test('returning-user startup defers Settings until a shell action opens it', async ({ page }) => {
   let settingsRequests = 0;
+  let settingsStylesheetRequests = 0;
   page.on('request', request => {
-    if (new URL(request.url()).pathname === '/js/settings.js') settingsRequests += 1;
+    const pathname = new URL(request.url()).pathname;
+    if (pathname === '/js/settings.js') settingsRequests += 1;
+    if (pathname === '/css/settings.css') settingsStylesheetRequests += 1;
   });
   await page.addInitScript(() => {
     localStorage.setItem('labcharts-accent-override', 'blue');
@@ -170,6 +231,8 @@ test('returning-user startup defers Settings until a shell action opens it', asy
 
   await page.goto('/app', { waitUntil: 'networkidle' });
   expect(settingsRequests).toBe(0);
+  expect(settingsStylesheetRequests).toBe(0);
+  await expect(page.locator('link[data-settings-stylesheet]')).toHaveCount(0);
   await expect.poll(() => page.evaluate(() => (
     document.documentElement.style.getPropertyValue('--accent')
   ))).toBe('#4f8cff');
@@ -177,6 +240,9 @@ test('returning-user startup defers Settings until a shell action opens it', asy
   await expect(page.locator('#settings-modal-overlay')).toHaveClass(/show/);
   await expect(page.locator('[data-settings-tab="display"]')).toHaveAttribute('aria-selected', 'true');
   expect(settingsRequests).toBe(1);
+  expect(settingsStylesheetRequests).toBe(1);
+  await expect(page.locator('link[data-settings-stylesheet]')).toHaveCount(1);
+  await expect(page.locator('#settings-modal .settings-layout')).toHaveCSS('display', 'grid');
   await expect.poll(() => page.evaluate(async () => (
     (await import('/js/settings-loader.js')).isSettingsModuleLoaded()
   ))).toBe(true);

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -177,7 +177,14 @@ assert('index loads genetics CSS bundle', indexSrc.includes('href="css/genetics.
 assert('SW APP_SHELL includes genetics CSS bundle', swAuditSrc.includes("'/css/genetics.css'"));
 assert('index loads data protection CSS bundle', indexSrc.includes('href="css/data-protection.css"'));
 assert('SW APP_SHELL includes data protection CSS bundle', swAuditSrc.includes("'/css/data-protection.css'"));
-assert('index loads settings CSS bundle', indexSrc.includes('href="css/settings.css"'));
+assert('index defers settings CSS behind its ordered lazy-load anchor',
+  !indexSrc.includes('href="css/settings.css"') &&
+  indexSrc.includes('data-settings-stylesheet-anchor'));
+assert('settings CSS lazy-load anchor preserves the original cascade position',
+  indexSrc.indexOf('href="css/data-protection.css"') <
+    indexSrc.indexOf('data-settings-stylesheet-anchor') &&
+  indexSrc.indexOf('data-settings-stylesheet-anchor') <
+    indexSrc.indexOf('href="css/mobile-dashboard.css"'));
 assert('SW APP_SHELL includes settings CSS bundle', swAuditSrc.includes("'/css/settings.css'"));
 assert('index loads client list CSS bundle', indexSrc.includes('href="css/client-list.css"'));
 assert('SW APP_SHELL includes client list CSS bundle', swAuditSrc.includes("'/css/client-list.css'"));

--- a/tests/test-mobile.js
+++ b/tests/test-mobile.js
@@ -25,7 +25,9 @@ return (async function() {
     return css;
   }
 
-  const css = getCSS();
+  // Settings styles are lazy-loaded in production. Include their source in
+  // this static responsive-rule audit without making them startup resources.
+  const css = `${getCSS()}\n${await fetchWithRetry('css/settings.css')}`;
 
   // ═══ Section 1: Header mobile layout ═══
   console.log('%c[1] Header Mobile Layout', 'font-weight:bold');

--- a/tests/test-settings-delegated-actions.js
+++ b/tests/test-settings-delegated-actions.js
@@ -15,6 +15,8 @@ const loaderSrc = fs.readFileSync(path.join(root, 'js/settings-loader.js'), 'utf
 const src = fs.readFileSync(path.join(root, 'js/settings.js'), 'utf8');
 const privacySrc = fs.readFileSync(path.join(root, 'js/settings-privacy.js'), 'utf8');
 const settingsDataSrc = fs.readFileSync(path.join(root, 'js/settings-data.js'), 'utf8');
+const appShellCss = fs.readFileSync(path.join(root, 'css/app-shell.css'), 'utf8');
+const settingsCss = fs.readFileSync(path.join(root, 'css/settings.css'), 'utf8');
 const settingsSurfaceSrc = `${src}\n${privacySrc}\n${settingsDataSrc}`;
 
 let passed = 0;
@@ -48,6 +50,13 @@ assert('Settings entry points use the cached lazy loader',
     && chatOnboardingHostSrc.includes("from './settings-loader.js'")
     && loaderSrc.includes("import('./settings.js')")
     && loaderSrc.includes("import('./settings.js?lazy-retry=1')"));
+assert('Settings loader owns the deferred stylesheet boundary',
+  loaderSrc.includes("new URL('../css/settings.css', import.meta.url)")
+    && loaderSrc.includes('data-settings-stylesheet-anchor')
+    && loaderSrc.includes('lazy-retry'));
+assert('Settings shell control styling remains in the eager shell bundle',
+  appShellCss.includes('.settings-btn:hover')
+    && !settingsCss.includes('.settings-btn:hover'));
 assert('Light page owns only the Sun data-source Settings leaf',
   lightPageUIHooksSrc.includes("from './settings-privacy.js'"));
 

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.354';
+self.APP_VERSION = '1.10.355';


### PR DESCRIPTION
## Summary

- defer `css/settings.css` until the first Settings or Tweaks action and load it concurrently with the existing lazy Settings module
- preserve the stylesheet's cascade position, keep shell-owned button styling eager, and retain the stylesheet in the offline app shell
- retry stylesheet failures independently without re-evaluating a successfully loaded module
- add startup, retry, offline, and responsive regression coverage and ratchet the cold-load budgets

## Why

The Settings JavaScript was already lazy-loaded, but its 48 KB stylesheet still loaded for every returning-user startup even when Settings was never opened.

## Impact

Identical same-machine cold-load runs improved from:

- 449 to 448 requests
- 1,908,524 to 1,900,879 transferred bytes
- 5,890,546 to 5,843,728 decoded bytes

That saves one startup request, 7,645 transferred bytes, and 46,818 decoded bytes.

## Validation

- `npm run test:playwright` — 392 passed; responsive/theme suite 472 passed
- `npm run test:firefox` — 3 passed, including offline first-use Settings
- Settings-focused Playwright coverage — 15 passed
- import benchmark parallel stress rerun — 34 passed
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run architecture:check`
- `npm run quality`
- repeated cold-load measurement produced the same 448 / 1,900,879 / 5,843,728 result
- `git diff --check`