### PR TITLE
Lazy-load Light and Sun stylesheets

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -170,7 +170,13 @@ Light & Sun keeps `sun-context-hooks.js` in the startup graph so dashboard,
 chat, and Agent Access context remains complete. Its analysis and feature hook
 group is loaded through `light-sun-loader.js` when the Light route or an
 optional Light dashboard widget is opened, or when a background Light/Sun
-session finishes and needs analysis.
+session finishes and needs analysis. Background completion uses the module-only
+loader so it does not fetch presentation assets. Visual entry points use the
+UI loader, which waits for the module graph and all seven ordered Light
+stylesheets before rendering. An HTML anchor preserves the original cascade
+position. Marker-history controls and the context-card Ott badge keep their
+cross-feature styles in their eager owning bundles, while the deferred Light
+stylesheets remain in the service-worker app shell for offline first use.
 
 Settings and Tweaks are loaded through `settings-loader.js` on their first
 shell, startup deep-link, or feature action. Theme-owned accent initialization

--- a/css/context-profile.css
+++ b/css/context-profile.css
@@ -563,6 +563,21 @@
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
   min-width: 0;
 }
+.ctx-lightsetup-ott-badge {
+  display: inline-block;
+  padding: 2px 9px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 600;
+}
+.ctx-lightsetup-ott-tier-0 { background: var(--green-bg); color: var(--green); border-color: var(--green); }
+.ctx-lightsetup-ott-tier-1 { background: var(--bg-secondary); color: var(--text-primary); border-color: var(--text-muted); }
+.ctx-lightsetup-ott-tier-2 { background: var(--yellow-bg); color: var(--yellow); border-color: var(--yellow); }
+.ctx-lightsetup-ott-tier-3 { background: var(--orange-bg); color: var(--orange); border-color: var(--orange); }
+.ctx-lightsetup-ott-tier-4 { background: var(--red-bg); color: var(--red); border-color: var(--red); }
 .ctx-lightsetup-edit {
   background: transparent; border: none;
   color: var(--accent); font-size: 12px; font-weight: 500;

--- a/css/marker-detail-modal.css
+++ b/css/marker-detail-modal.css
@@ -221,6 +221,21 @@
 }
 .marker-detail-modal .marker-history-show-more {
   width: calc(100% - 56px);
+  display: block;
+  margin-top: 8px;
+  padding: 8px 12px;
+  background: transparent;
+  border: 1px dashed var(--border);
+  border-radius: 6px;
+  color: var(--text-muted);
+  font-size: 12.5px;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+.marker-detail-modal .marker-history-show-more:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+  border-style: solid;
 }
 .marker-detail-modal .marker-description {
   margin-top: 18px;

--- a/index.html
+++ b/index.html
@@ -70,13 +70,7 @@
   <link rel="stylesheet" href="css/recommendations.css">
   <link rel="stylesheet" href="css/client-list.css">
   <link rel="stylesheet" href="css/wearables.css">
-  <link rel="stylesheet" href="css/light-sun.css">
-  <link rel="stylesheet" href="css/light-channels.css">
-  <link rel="stylesheet" href="css/light-devices.css">
-  <link rel="stylesheet" href="css/light-conditions-now.css">
-  <link rel="stylesheet" href="css/light-setup.css">
-  <link rel="stylesheet" href="css/light-tools.css">
-  <link rel="stylesheet" href="css/light-env.css">
+  <meta data-light-sun-stylesheet-anchor>
   <link rel="stylesheet" href="css/chat-panel.css">
   <link rel="stylesheet" href="css/chat-personality.css">
   <link rel="stylesheet" href="css/chat-messages.css">

--- a/js/context-card-lifestyle-editors.js
+++ b/js/context-card-lifestyle-editors.js
@@ -390,9 +390,9 @@ function renderLightSetupMirror(current) {
   let ottBadge = '';
   if (sd && typeof sd.ottScore === 'number') {
     const { label, tier } = ottScoreToLabel(sd.ottScore);
-    ottBadge = `<span class="light-ott-badge light-ott-tier-${tier}">${escapeHTML(label)}</span>`;
+    ottBadge = `<span class="ctx-lightsetup-ott-badge ctx-lightsetup-ott-tier-${tier}">${escapeHTML(label)}</span>`;
   } else if (sd?.skipped) {
-    ottBadge = `<span class="light-ott-badge">skipped</span>`;
+    ottBadge = `<span class="ctx-lightsetup-ott-badge">skipped</span>`;
   }
 
   const hasAny = !!(skin || sd?.homeLight || sd?.eyewear || ottBadge);

--- a/js/dashboard-view-composition.js
+++ b/js/dashboard-view-composition.js
@@ -24,7 +24,7 @@ import { ensureActiveDeviceTicker } from './light-devices.js';
 import { renderDashboardLightChannelPills, renderLightSessionLogActions } from './light-page-view.js';
 import { renderLightTodayHero } from './light-today-ai.js';
 import { navigateViewportRuntime } from './views-router-runtime.js';
-import { isLightSunModulesLoaded, loadLightSunModules } from './light-sun-loader.js';
+import { isLightSunUILoaded, loadLightSunUI } from './light-sun-loader.js';
 import {
   configureMobileDashboardView,
   getMobileDashboardMarkers,
@@ -65,8 +65,8 @@ export function createDashboardViewComposition({
     formatMobileWearableValue,
     formatMobileWearableDelta,
     getMobileWearablePriority,
-    isLightSunModulesLoaded,
-    loadLightSunModules,
+    isLightSunUILoaded,
+    loadLightSunUI,
     rerenderDashboardFromWidgetChange,
     renderLightTodayHero,
     showRecommendations,

--- a/js/dashboard-widget-renderers.js
+++ b/js/dashboard-widget-renderers.js
@@ -41,8 +41,8 @@ export function createDashboardWidgetRenderers(deps) {
     formatMobileWearableValue,
     formatMobileWearableDelta,
     getMobileWearablePriority = () => [],
-    isLightSunModulesLoaded = () => true,
-    loadLightSunModules = async () => {},
+    isLightSunUILoaded = () => true,
+    loadLightSunUI = async () => {},
     rerenderDashboardFromWidgetChange,
     renderLightTodayHero = () => '',
     showRecommendations,
@@ -50,7 +50,7 @@ export function createDashboardWidgetRenderers(deps) {
 
   function renderLightSunLoadingState() {
     if (!_lightSunModulesLoadPromise) {
-      _lightSunModulesLoadPromise = loadLightSunModules()
+      _lightSunModulesLoadPromise = loadLightSunUI()
         .then(() => rerenderDashboardFromWidgetChange())
         .catch(err => console.error('Failed to load Light & Sun dashboard modules', err))
         .finally(() => { _lightSunModulesLoadPromise = null; });
@@ -61,7 +61,7 @@ export function createDashboardWidgetRenderers(deps) {
   }
 
   function lightSunModulesReady() {
-    return isLightSunModulesLoaded() || false;
+    return isLightSunUILoaded() || false;
   }
 
   const labRenderers = createDashboardLabWidgetRenderers({
@@ -100,6 +100,7 @@ export function createDashboardWidgetRenderers(deps) {
   } = recommendationWidget;
 
   function renderDashboardLightTodayWidget() {
+    if (!lightSunModulesReady()) return renderLightSunLoadingState();
     const hero = renderLightTodayHero();
     const heroHtml = hero || `<div class="light-today-hero light-today-hero-dashboard-fallback">
       <div class="light-today-hero-head"><span class="light-today-hero-label">Today's light</span></div>

--- a/js/light-env-shell-hooks.js
+++ b/js/light-env-shell-hooks.js
@@ -3,7 +3,7 @@
 
 import { configureAppEventListeners } from './app-event-listeners.js';
 import { closeLightEnvironmentAssessment, configureLightEnv, openLightEnvironmentAssessment } from './light-env.js';
-import { loadLightSunModules } from './light-sun-loader.js';
+import { loadLightSunUI } from './light-sun-loader.js';
 import { getMeasurementsForRoom } from './light-tools.js';
 import { configureNavActions } from './nav.js';
 import { navigate } from './views.js';
@@ -12,7 +12,7 @@ configureLightEnv({ getMeasurementsForRoom, navigate });
 
 configureNavActions({
   openLightEnvironmentAssessment() {
-    void loadLightSunModules()
+    void loadLightSunUI()
       .then(() => openLightEnvironmentAssessment())
       .catch(err => console.error('Failed to load Light & Sun modules', err));
   },

--- a/js/light-sun-loader.js
+++ b/js/light-sun-loader.js
@@ -4,12 +4,32 @@
 import { configureLightDevicesStore } from './light-devices-store.js';
 import { configureSunSessionsStore } from './sun-sessions-store.js';
 
+const LIGHT_SUN_STYLESHEET_URLS = [
+  '../css/light-sun.css',
+  '../css/light-channels.css',
+  '../css/light-devices.css',
+  '../css/light-conditions-now.css',
+  '../css/light-setup.css',
+  '../css/light-tools.css',
+  '../css/light-env.css',
+].map(path => new URL(path, import.meta.url).href);
+
 /** @type {Promise<typeof import('./app-light-sun-modules.js')> | null} */
 let _lightSunModulesLoad = null;
+/** @type {Promise<HTMLLinkElement[]> | null} */
+let _lightSunStylesheetsLoad = null;
+/** @type {Promise<typeof import('./app-light-sun-modules.js')> | null} */
+let _lightSunUILoad = null;
 let _lightSunModulesLoaded = false;
+let _lightSunUILoaded = false;
+let _useLightSunStylesheetRetryUrls = false;
 
 export function isLightSunModulesLoaded() {
   return _lightSunModulesLoaded;
+}
+
+export function isLightSunUILoaded() {
+  return _lightSunUILoaded;
 }
 
 /** @returns {Promise<typeof import('./app-light-sun-modules.js')>} */
@@ -26,6 +46,67 @@ export function loadLightSunModules() {
       });
   }
   return _lightSunModulesLoad;
+}
+
+/** @param {string} stylesheetUrl */
+function lightSunStylesheetUrl(stylesheetUrl) {
+  if (!_useLightSunStylesheetRetryUrls) return stylesheetUrl;
+  const retryUrl = new URL(stylesheetUrl);
+  retryUrl.searchParams.set('lazy-retry', '1');
+  return retryUrl.href;
+}
+
+/** @returns {Promise<HTMLLinkElement[]>} */
+function loadLightSunStylesheets() {
+  if (!_lightSunStylesheetsLoad) {
+    if (typeof document === 'undefined') {
+      return Promise.reject(new Error('Light & Sun stylesheets require a document'));
+    }
+    const anchor = document.querySelector('[data-light-sun-stylesheet-anchor]');
+    const parent = anchor?.parentNode || document.head;
+    const links = LIGHT_SUN_STYLESHEET_URLS.map((stylesheetUrl, index) => {
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = lightSunStylesheetUrl(stylesheetUrl);
+      link.dataset.lightSunStylesheet = String(index);
+      return link;
+    });
+    const loads = links.map(link => new Promise((resolve, reject) => {
+      link.addEventListener('load', () => resolve(link), { once: true });
+      link.addEventListener('error', () => {
+        reject(new Error(`Light & Sun stylesheet could not be loaded: ${link.href}`));
+      }, { once: true });
+      parent.insertBefore(link, anchor || null);
+    }));
+    _lightSunStylesheetsLoad = Promise.all(loads)
+      .catch(err => {
+        links.forEach(link => link.remove());
+        _lightSunStylesheetsLoad = null;
+        _useLightSunStylesheetRetryUrls = true;
+        throw err;
+      });
+  }
+  return _lightSunStylesheetsLoad;
+}
+
+/** @returns {Promise<typeof import('./app-light-sun-modules.js')>} */
+export function loadLightSunUI() {
+  if (!_lightSunUILoad) {
+    _lightSunUILoad = Promise.all([
+      loadLightSunModules(),
+      loadLightSunStylesheets(),
+    ])
+      .then(([module]) => {
+        _lightSunUILoaded = true;
+        return module;
+      })
+      .catch(err => {
+        _lightSunUILoad = null;
+        _lightSunUILoaded = false;
+        throw err;
+      });
+  }
+  return _lightSunUILoad;
 }
 
 // A session can finish from a dashboard ticker before the user opens the

--- a/js/marker-detail-modal.js
+++ b/js/marker-detail-modal.js
@@ -578,9 +578,9 @@ export function showDetailModal(id, opts = {}) {
     const historyButtonLabel = showAllHistory
       ? `Show ${showCount} older ${showCount === 1 ? 'value' : 'values'}`
       : `View more history (${modalPoints.length} values)`;
-    html += `<button class="light-sessions-show-more marker-history-show-more" ${markerDetailActionAttrs('show-detail-modal', { id, showAllHistory: true, historyLimit: nextHistoryLimit, scrollToHistory: true })}>${historyButtonLabel}</button>`;
+    html += `<button class="marker-history-show-more" ${markerDetailActionAttrs('show-detail-modal', { id, showAllHistory: true, historyLimit: nextHistoryLimit, scrollToHistory: true })}>${historyButtonLabel}</button>`;
   } else if (showAllHistory && modalPoints.length > MARKER_HISTORY_DEFAULT_CAP) {
-    html += `<button class="light-sessions-show-more marker-history-show-more" ${markerDetailActionAttrs('show-detail-modal', { id, scrollToHistory: true })}>Show last ${MARKER_HISTORY_DEFAULT_CAP} values</button>`;
+    html += `<button class="marker-history-show-more" ${markerDetailActionAttrs('show-detail-modal', { id, scrollToHistory: true })}>Show last ${MARKER_HISTORY_DEFAULT_CAP} values</button>`;
   }
   const nonNull = modalPoints;
   if (nonNull.length >= 2) {

--- a/js/views.js
+++ b/js/views.js
@@ -12,7 +12,7 @@ import {
 import { setupDropZone } from './import-drop-zone.js';
 import { createRecommendationActions } from './recommendation-actions.js';
 import { createNavigate, getInitialView as getRouterInitialView } from './views-router.js';
-import { isLightSunModulesLoaded, loadLightSunModules } from './light-sun-loader.js';
+import { isLightSunUILoaded, loadLightSunUI } from './light-sun-loader.js';
 import { state } from './state.js';
 import { createLensPageHandlers } from './lens-pages.js';
 import { lensPageActionAttrs, renderLensHeader, renderLensPageWidgets, renderLensWidget, moveLensPageWidget } from './lens-page-shell.js';
@@ -200,7 +200,7 @@ function getRecommendationActions() {
 export function showDashboard(data) { return getDashboardView().showDashboard(data); }
 
 export async function _openAllSessionsModal() {
-  await loadLightSunModules();
+  await loadLightSunUI();
   return openAllSessionsModal();
 }
 
@@ -217,12 +217,12 @@ function renderLightRouteStatus(content, message, { busy = false, error = false 
 }
 
 function showLightRoute(data) {
-  if (isLightSunModulesLoaded()) return showLight(data);
+  if (isLightSunUILoaded()) return showLight(data);
 
   const content = typeof document !== 'undefined' ? document.getElementById('main-content') : null;
   if (content) renderLightRouteStatus(content, 'Loading Light & Sun…', { busy: true });
 
-  return loadLightSunModules()
+  return loadLightSunUI()
     .then(() => {
       if (state.currentView !== 'light') return false;
       showLight(data);

--- a/plans/code-quality-audit-2026-07-21.md
+++ b/plans/code-quality-audit-2026-07-21.md
@@ -104,11 +104,12 @@ ceilings for same-origin application requests, compressed transfer bytes, and
 decoded bytes. The initial reference was 474 requests, 2,017,210 compressed
 bytes, and 6,252,286 decoded bytes. Lazy-loading the PDF import review,
 Light/Sun analysis hooks, Settings/Tweaks, Profile Sharing, and the Settings
-stylesheet reduced that reference to 448 requests, 1,900,879 compressed bytes,
-and 5,843,728 decoded bytes. The Settings stylesheet slice saved one request,
-7,645 compressed bytes, and 46,818 decoded bytes in identical before/after
-runs on the same machine. Route and feature lazy loading remains active, with
-the ceilings ratcheting downward after each reproducible slice.
+and Light/Sun stylesheets reduced that reference to 441 requests, 1,857,409
+compressed bytes, and 5,650,563 decoded bytes. The Light/Sun stylesheet slice
+saved seven requests, 43,470 compressed bytes, and 193,165 decoded bytes in
+identical before/after runs on the same machine. Route and feature lazy loading
+remains active, with the ceilings ratcheting downward after each reproducible
+slice.
 
 ### 4. Guardrails and test gaps
 

--- a/scripts/cold-load-budget.json
+++ b/scripts/cold-load-budget.json
@@ -3,15 +3,15 @@
   "route": "/app",
   "scenario": "Fresh mobile returning-user load with browser cache and service workers disabled",
   "maximums": {
-    "requests": 454,
-    "transferBytes": 1935000,
-    "decodedBytes": 5943000
+    "requests": 447,
+    "transferBytes": 1891000,
+    "decodedBytes": 5747000
   },
   "reference": {
-    "requests": 448,
-    "transferBytes": 1900879,
-    "decodedBytes": 5843728
+    "requests": 441,
+    "transferBytes": 1857409,
+    "decodedBytes": 5650563
   },
-  "referenceCommit": "73780afa",
+  "referenceCommit": "087c5674",
   "measuredAt": "2026-07-24"
 }

--- a/tests/firefox/smoke.spec.js
+++ b/tests/firefox/smoke.spec.js
@@ -152,7 +152,15 @@ test('installs a readable app shell for offline use', async ({ browserName, cont
       '/index.html',
       '/styles.css',
       '/css/settings.css',
+      '/css/light-sun.css',
+      '/css/light-channels.css',
+      '/css/light-devices.css',
+      '/css/light-conditions-now.css',
+      '/css/light-setup.css',
+      '/css/light-tools.css',
+      '/css/light-env.css',
       '/js/main.js',
+      '/js/app-light-sun-modules.js',
       '/js/legal-consent.js',
       '/js/settings.js',
       '/vendor/fonts/inter-400-7.woff2',
@@ -173,7 +181,15 @@ test('installs a readable app shell for offline use', async ({ browserName, cont
     { path: '/index.html', available: true },
     { path: '/styles.css', available: true },
     { path: '/css/settings.css', available: true },
+    { path: '/css/light-sun.css', available: true },
+    { path: '/css/light-channels.css', available: true },
+    { path: '/css/light-devices.css', available: true },
+    { path: '/css/light-conditions-now.css', available: true },
+    { path: '/css/light-setup.css', available: true },
+    { path: '/css/light-tools.css', available: true },
+    { path: '/css/light-env.css', available: true },
     { path: '/js/main.js', available: true },
+    { path: '/js/app-light-sun-modules.js', available: true },
     { path: '/js/legal-consent.js', available: true },
     { path: '/js/settings.js', available: true },
     { path: '/vendor/fonts/inter-400-7.woff2', available: true },
@@ -185,5 +201,12 @@ test('installs a readable app shell for offline use', async ({ browserName, cont
   await page.locator('.settings-btn').evaluate(button => button.click());
   await expect(page.locator('#settings-modal-overlay')).toHaveClass(/\bshow\b/);
   await expect(page.locator('#settings-modal .settings-layout')).toHaveCSS('display', 'grid');
+  await page.evaluate(async () => {
+    (await import('/js/settings-loader.js')).closeSettingsModal();
+    return (await import('/js/views.js')).navigate('light');
+  });
+  await expect(page.locator('.light-page')).toBeVisible();
+  await expect(page.locator('.light-page')).toHaveCSS('display', 'grid');
+  await expect(page.locator('link[data-light-sun-stylesheet]')).toHaveCount(7);
   expect(pageErrors).toEqual([]);
 });

--- a/tests/light-env-shell-hooks-runtime.test.js
+++ b/tests/light-env-shell-hooks-runtime.test.js
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const MOCKED_MODULES = [
+  '../js/app-event-listeners.js',
+  '../js/light-env.js',
+  '../js/light-sun-loader.js',
+  '../js/light-tools.js',
+  '../js/nav.js',
+  '../js/views.js',
+];
+
+afterEach(() => {
+  for (const modulePath of MOCKED_MODULES) vi.doUnmock(modulePath);
+  vi.resetModules();
+  vi.restoreAllMocks();
+});
+
+describe('Light environment shell hooks', () => {
+  it('opens after lazy UI readiness and contains lazy-load failures', async () => {
+    let appEventActions;
+    let navActions;
+    const closeLightEnvironmentAssessment = vi.fn();
+    const configureLightEnv = vi.fn();
+    const getMeasurementsForRoom = vi.fn();
+    const navigate = vi.fn();
+    const openLightEnvironmentAssessment = vi.fn();
+    const loadError = new Error('Light UI unavailable');
+    const loadLightSunUI = vi.fn()
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(loadError);
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    vi.doMock('../js/app-event-listeners.js', () => ({
+      configureAppEventListeners(actions) {
+        appEventActions = actions;
+      },
+    }));
+    vi.doMock('../js/light-env.js', () => ({
+      closeLightEnvironmentAssessment,
+      configureLightEnv,
+      openLightEnvironmentAssessment,
+    }));
+    vi.doMock('../js/light-sun-loader.js', () => ({ loadLightSunUI }));
+    vi.doMock('../js/light-tools.js', () => ({ getMeasurementsForRoom }));
+    vi.doMock('../js/nav.js', () => ({
+      configureNavActions(actions) {
+        navActions = actions;
+      },
+    }));
+    vi.doMock('../js/views.js', () => ({ navigate }));
+
+    await import('../js/light-env-shell-hooks.js');
+
+    expect(configureLightEnv).toHaveBeenCalledWith({ getMeasurementsForRoom, navigate });
+    expect(appEventActions).toEqual({ closeLightEnvironmentAssessment });
+
+    navActions.openLightEnvironmentAssessment();
+    await vi.waitFor(() => {
+      expect(openLightEnvironmentAssessment).toHaveBeenCalledOnce();
+    });
+
+    navActions.openLightEnvironmentAssessment();
+    await vi.waitFor(() => {
+      expect(consoleError).toHaveBeenCalledWith('Failed to load Light & Sun modules', loadError);
+    });
+
+    expect(loadLightSunUI).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/playwright/cold-load-budget.spec.js
+++ b/tests/playwright/cold-load-budget.spec.js
@@ -73,6 +73,18 @@ test('cold mobile app load stays within committed resource budgets', async ({ pa
   expect(entries.some(entry => (
     new URL(entry.name).pathname === '/css/settings.css'
   ))).toBe(false);
+  const deferredLightStylesheets = new Set([
+    '/css/light-sun.css',
+    '/css/light-channels.css',
+    '/css/light-devices.css',
+    '/css/light-conditions-now.css',
+    '/css/light-setup.css',
+    '/css/light-tools.css',
+    '/css/light-env.css',
+  ]);
+  expect(entries.some(entry => (
+    deferredLightStylesheets.has(new URL(entry.name).pathname)
+  ))).toBe(false);
   const metrics = summarizeColdLoad(entries, appOrigin);
 
   console.log(`Cold-load budget: ${formatColdLoadSummary(metrics)}`);

--- a/tests/playwright/dashboard-widgets-browser-coverage.spec.js
+++ b/tests/playwright/dashboard-widgets-browser-coverage.spec.js
@@ -265,8 +265,8 @@ test('dashboard Light widgets share lazy initialization before rendering', async
       getMobileWearableTiles: () => [],
       formatMobileWearableValue: () => '',
       formatMobileWearableDelta: () => '',
-      isLightSunModulesLoaded: () => loaded,
-      loadLightSunModules: () => {
+      isLightSunUILoaded: () => loaded,
+      loadLightSunUI: () => {
         loadCalls += 1;
         return pendingLoad.then(() => { loaded = true; });
       },
@@ -285,8 +285,8 @@ test('dashboard Light widgets share lazy initialization before rendering', async
     const loadingStateIsShared =
       loadCalls === 1
       && [first, second, third].every(html => html.includes('Loading Light &amp; Sun'))
-      && todayBeforeLoad.includes('today')
-      && heroCalls === 1;
+      && todayBeforeLoad.includes('Loading Light &amp; Sun')
+      && heroCalls === 0;
 
     resolveLoad();
     await pendingLoad;
@@ -301,7 +301,7 @@ test('dashboard Light widgets share lazy initialization before rendering', async
       initializedLightWidgetsRenderTheirRealBodies:
         readyToday.includes('today')
         && readyConditions.includes('conditions')
-        && heroCalls === 2,
+        && heroCalls === 1,
     };
   }, {
     renderersUrl: moduleUrl('/js/dashboard-widget-renderers.js'),

--- a/tests/playwright/light-sun-loader-browser-coverage.spec.js
+++ b/tests/playwright/light-sun-loader-browser-coverage.spec.js
@@ -4,13 +4,14 @@ async function openBlankPage(page, path) {
   await page.route(`**${path}`, route => route.fulfill({
     status: 200,
     contentType: 'text/html',
-    body: '<!doctype html><html><body><main id="main-content"></main></body></html>',
+    body: '<!doctype html><html><head><meta data-light-sun-stylesheet-anchor></head><body><main id="main-content"></main></body></html>',
   }));
   await page.goto(path, { waitUntil: 'load' });
 }
 
-test('Light & Sun loader caches successful concurrent initialization', async ({ page }) => {
+test('Light & Sun module loader caches background initialization without loading UI styles', async ({ page }) => {
   let moduleRequests = 0;
+  let stylesheetRequests = 0;
   await page.route('**/js/app-light-sun-modules.js', route => {
     moduleRequests += 1;
     return route.fulfill({
@@ -40,11 +41,20 @@ test('Light & Sun loader caches successful concurrent initialization', async ({ 
       }
     `,
   }));
+  await page.route('**/css/light-*.css*', route => {
+    stylesheetRequests += 1;
+    return route.fulfill({
+      status: 200,
+      contentType: 'text/css',
+      body: '.light-page { display: grid; }',
+    });
+  });
   await openBlankPage(page, '/light-sun-loader-cache-coverage');
 
   const results = await page.evaluate(async ({ loaderUrl }) => {
     const loader = await import(loaderUrl);
     const startsUnloaded = loader.isLightSunModulesLoaded() === false;
+    const startsUIUnloaded = loader.isLightSunUILoaded() === false;
     const [first, second] = await Promise.all([
       loader.loadLightSunModules(),
       loader.loadLightSunModules(),
@@ -81,9 +91,13 @@ test('Light & Sun loader caches successful concurrent initialization', async ({ 
     await new Promise(resolve => setTimeout(resolve, 50));
     return {
       startsUnloaded,
+      startsUIUnloaded,
       concurrentCallsShareModuleNamespace: first === second,
       laterCallsReuseModuleNamespace: first === third,
       loadedStateFlipsAfterInitialization: loader.isLightSunModulesLoaded() === true,
+      backgroundLoadLeavesUIUninitialized: loader.isLightSunUILoaded() === false,
+      backgroundLoadAddsNoStylesheets:
+        document.querySelectorAll('link[data-light-sun-stylesheet]').length === 0,
       lazyModuleEvaluatesOnce:
         globalThis.__lightSunModuleEvalCount === 1
         && first.marker === 'light-sun-ready',
@@ -98,6 +112,136 @@ test('Light & Sun loader caches successful concurrent initialization', async ({ 
     loaderUrl: '/js/light-sun-loader.js',
   });
   results.lazyModuleRequestedOnce = moduleRequests === 1;
+  results.backgroundLoadMakesNoStylesheetRequests = stylesheetRequests === 0;
+
+  for (const [name, passed] of Object.entries(results)) {
+    expect(passed, name).toBe(true);
+  }
+});
+
+test('Light & Sun UI loader caches concurrent ordered stylesheet initialization', async ({ page }) => {
+  let moduleRequests = 0;
+  const stylesheetRequests = [];
+  await page.route('**/js/app-light-sun-modules.js', route => {
+    moduleRequests += 1;
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/javascript',
+      body: `
+        globalThis.__lightSunUIEvalCount = (globalThis.__lightSunUIEvalCount || 0) + 1;
+        export const marker = 'light-sun-ui-ready';
+      `,
+    });
+  });
+  await page.route('**/css/light-*.css*', route => {
+    stylesheetRequests.push(new URL(route.request().url()).pathname);
+    return route.fulfill({
+      status: 200,
+      contentType: 'text/css',
+      body: '.light-page { display: grid; }',
+    });
+  });
+  await openBlankPage(page, '/light-sun-ui-loader-cache-coverage');
+
+  const results = await page.evaluate(async ({ loaderUrl }) => {
+    const loader = await import(loaderUrl);
+    const [first, second] = await Promise.all([
+      loader.loadLightSunUI(),
+      loader.loadLightSunUI(),
+    ]);
+    const third = await loader.loadLightSunUI();
+    const stylesheetPaths = [...document.querySelectorAll('link[data-light-sun-stylesheet]')]
+      .map(link => new URL(link.href).pathname);
+    return {
+      concurrentCallsShareModuleNamespace: first === second,
+      laterCallsReuseModuleNamespace: first === third,
+      UIStateFlipsAfterInitialization: loader.isLightSunUILoaded() === true,
+      moduleStateAlsoLoaded: loader.isLightSunModulesLoaded() === true,
+      moduleEvaluatedOnce:
+        globalThis.__lightSunUIEvalCount === 1
+        && first.marker === 'light-sun-ui-ready',
+      stylesheetsPreserveCascadeOrder: stylesheetPaths.join(',') === [
+        '/css/light-sun.css',
+        '/css/light-channels.css',
+        '/css/light-devices.css',
+        '/css/light-conditions-now.css',
+        '/css/light-setup.css',
+        '/css/light-tools.css',
+        '/css/light-env.css',
+      ].join(','),
+    };
+  }, {
+    loaderUrl: '/js/light-sun-loader.js',
+  });
+  results.lazyModuleRequestedOnce = moduleRequests === 1;
+  results.eachStylesheetRequestedOnce =
+    stylesheetRequests.length === 7
+    && new Set(stylesheetRequests).size === 7;
+
+  for (const [name, passed] of Object.entries(results)) {
+    expect(passed, name).toBe(true);
+  }
+});
+
+test('Light & Sun UI loader retries failed styles without re-evaluating its module', async ({ page }) => {
+  let moduleRequests = 0;
+  const stylesheetRequests = [];
+  let failedEnvironmentStylesheet = false;
+  await page.route('**/js/app-light-sun-modules.js', route => {
+    moduleRequests += 1;
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/javascript',
+      body: `
+        globalThis.__lightSunUIRetryEvalCount = (globalThis.__lightSunUIRetryEvalCount || 0) + 1;
+        export const marker = 'light-sun-ui-retried';
+      `,
+    });
+  });
+  await page.route('**/css/light-*.css*', route => {
+    const url = new URL(route.request().url());
+    stylesheetRequests.push(`${url.pathname}${url.search}`);
+    if (url.pathname === '/css/light-env.css' && !failedEnvironmentStylesheet) {
+      failedEnvironmentStylesheet = true;
+      return route.abort('failed');
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: 'text/css',
+      body: '.light-page { display: grid; }',
+    });
+  });
+  await openBlankPage(page, '/light-sun-ui-loader-retry-coverage');
+
+  const results = await page.evaluate(async ({ loaderUrl }) => {
+    const loader = await import(loaderUrl);
+    let firstRejected = false;
+    try {
+      await loader.loadLightSunUI();
+    } catch {
+      firstRejected = true;
+    }
+    const linksRemovedAfterFailure =
+      document.querySelectorAll('link[data-light-sun-stylesheet]').length === 0;
+    const retried = await loader.loadLightSunUI();
+    const links = [...document.querySelectorAll('link[data-light-sun-stylesheet]')];
+    return {
+      firstRejected,
+      linksRemovedAfterFailure,
+      retrySucceeds: retried.marker === 'light-sun-ui-retried',
+      UIStateFlipsAfterRetry: loader.isLightSunUILoaded() === true,
+      moduleEvaluatedOnce: globalThis.__lightSunUIRetryEvalCount === 1,
+      retryUsesFixedStylesheetUrls:
+        links.length === 7
+        && links.every(link => new URL(link.href).searchParams.get('lazy-retry') === '1'),
+    };
+  }, {
+    loaderUrl: '/js/light-sun-loader.js',
+  });
+  results.moduleRequestedOnce = moduleRequests === 1;
+  results.twoCompleteStylesheetBatchesRequested =
+    stylesheetRequests.length === 14
+    && stylesheetRequests.slice(7).every(url => url.endsWith('?lazy-retry=1'));
 
   for (const [name, passed] of Object.entries(results)) {
     expect(passed, name).toBe(true);
@@ -174,4 +318,52 @@ test('Light & Sun loader clears its cached promise after failure', async ({ page
   for (const [name, passed] of Object.entries(results)) {
     expect(passed, name).toBe(true);
   }
+});
+
+test('returning-user startup defers Light UI resources until the Light route opens', async ({ page }) => {
+  const lightStylesheetPaths = new Set([
+    '/css/light-sun.css',
+    '/css/light-channels.css',
+    '/css/light-devices.css',
+    '/css/light-conditions-now.css',
+    '/css/light-setup.css',
+    '/css/light-tools.css',
+    '/css/light-env.css',
+  ]);
+  const stylesheetRequests = [];
+  let moduleRequests = 0;
+  page.on('request', request => {
+    const pathname = new URL(request.url()).pathname;
+    if (lightStylesheetPaths.has(pathname)) stylesheetRequests.push(pathname);
+    if (pathname === '/js/app-light-sun-modules.js') moduleRequests += 1;
+  });
+  await page.addInitScript(() => {
+    localStorage.setItem('labcharts-legal-acceptance', JSON.stringify({
+      accepted: true,
+      termsVersion: '2026-06-22',
+      privacyVersion: '2026-06-22',
+      acceptedAt: '2026-07-24T00:00:00.000Z',
+      appVersion: 'light-ui-loader-coverage',
+      location: 'light-ui-loader-coverage',
+    }));
+    localStorage.setItem('labcharts-default-onboarded', 'profile-set');
+    localStorage.setItem('labcharts-default-emptyTour', 'completed');
+    localStorage.setItem('labcharts-default-tour', 'completed');
+    localStorage.setItem('labcharts-default-ai-reminder-dismissed', '1');
+    localStorage.setItem('labcharts-onboard-extras-done-default', '1');
+    localStorage.setItem('labcharts-onboard-provider-skipped-default', '1');
+  });
+
+  await page.goto('/app', { waitUntil: 'networkidle' });
+  expect(stylesheetRequests).toEqual([]);
+  expect(moduleRequests).toBe(0);
+  await expect(page.locator('link[data-light-sun-stylesheet]')).toHaveCount(0);
+
+  await page.evaluate(async () => (await import('/js/views.js')).navigate('light'));
+  await expect(page.locator('.light-page')).toBeVisible();
+  await expect(page.locator('.light-page')).toHaveCSS('display', 'grid');
+  await expect(page.locator('link[data-light-sun-stylesheet]')).toHaveCount(7);
+  expect(moduleRequests).toBe(1);
+  expect(stylesheetRequests.length).toBe(7);
+  expect(new Set(stylesheetRequests)).toEqual(lightStylesheetPaths);
 });

--- a/tests/playwright/nav-delegated-actions.spec.js
+++ b/tests/playwright/nav-delegated-actions.spec.js
@@ -20,6 +20,24 @@ async function prepareApp(page) {
   });
 }
 
+test('sidebar Light assessment waits for its lazy UI before opening', async ({ page }) => {
+  await prepareApp(page);
+
+  const assessmentItem = page.locator(
+    '#sidebar-nav .nav-item[data-nav-action="open-light-assessment"]',
+  );
+  await expect(assessmentItem).toHaveCount(1);
+  await assessmentItem.click();
+
+  const overlay = page.locator('#light-env-assessment-overlay');
+  await expect(overlay).toHaveClass(/\bshow\b/);
+  await expect(overlay.locator('.light-env-assessment-modal')).toBeVisible();
+  await expect(page.locator('link[data-light-sun-stylesheet]')).toHaveCount(7);
+
+  await overlay.locator('.modal-close').click();
+  await expect(overlay).toHaveCount(0);
+});
+
 test('sidebar nav delegated actions route, filter, and open utilities', async ({ page }) => {
   await prepareApp(page);
 

--- a/tests/playwright/theme-responsive-e2e.spec.js
+++ b/tests/playwright/theme-responsive-e2e.spec.js
@@ -53,7 +53,7 @@ async function waitForApp(page) {
 
 async function seedDemoData(page) {
   await page.evaluate(async () => {
-    const [{ state }, dataModule, profileModule, { loadLightSunModules }] = await Promise.all([
+    const [{ state }, dataModule, profileModule, { loadLightSunUI }] = await Promise.all([
       import('/js/state.js'),
       import('/js/data.js'),
       import('/js/profile.js'),
@@ -103,7 +103,7 @@ async function seedDemoData(page) {
       };
     };
     window.fetchAtmosphere = fetchAtmosphereStub;
-    await loadLightSunModules();
+    await loadLightSunUI();
     const conditionsNow = await import('/js/light-conditions-now.js');
     conditionsNow.configureLightConditionsNow?.({ fetchAtmosphere: fetchAtmosphereStub });
     state.importedData = demo;

--- a/tests/test-audit-fixes.js
+++ b/tests/test-audit-fixes.js
@@ -440,7 +440,9 @@ return (async function () {
       /import\s+['"]\.\/sun-context-hooks\.js['"]/.test(appFeatures)
         && /import\s+['"]\.\/light-sun-loader\.js['"]/.test(appFeatures)
         && !/import\s+['"]\.\/app-light-sun-modules\.js['"]/.test(appFeatures)
-        && /import\(['"]\.\/app-light-sun-modules\.js['"]\)/.test(lightSunLoader));
+        && /import\(['"]\.\/app-light-sun-modules\.js['"]\)/.test(lightSunLoader)
+        && /export function loadLightSunUI\(\)/.test(lightSunLoader)
+        && /data-light-sun-stylesheet-anchor/.test(lightSunLoader));
     assert('app-feature-modules.js delegates Health & Data imports',
       /import\s+['"]\.\/app-health-data-modules\.js['"]/.test(appFeatures));
     assert('app-feature-modules.js drops the obsolete Data I/O composition wrapper',

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -206,17 +206,25 @@ const LIGHT_CSS_BUNDLES = [
   'css/light-tools.css',
   'css/light-env.css',
 ];
+const lightSunLoaderSrc = read('js/light-sun-loader.js');
 for (const lightCss of LIGHT_CSS_BUNDLES) {
-  assert(`index loads ${lightCss}`, indexSrc.includes(`href="${lightCss}"`));
+  assert(`index defers ${lightCss}`, !indexSrc.includes(`href="${lightCss}"`));
+  assert(`Light UI loader owns ${lightCss}`, lightSunLoaderSrc.includes(`'../${lightCss}'`));
   assert(`SW APP_SHELL includes ${lightCss}`, swAuditSrc.includes(`'/${lightCss}'`));
 }
+assert('index keeps an ordered Light stylesheet anchor at the original cascade position',
+  indexSrc.includes('data-light-sun-stylesheet-anchor') &&
+  indexSrc.indexOf('href="css/wearables.css"') <
+    indexSrc.indexOf('data-light-sun-stylesheet-anchor') &&
+  indexSrc.indexOf('data-light-sun-stylesheet-anchor') <
+    indexSrc.indexOf('href="css/chat-panel.css"'));
 assert('light CSS split preserves override order',
-  indexSrc.indexOf('href="css/light-sun.css"') < indexSrc.indexOf('href="css/light-channels.css"') &&
-  indexSrc.indexOf('href="css/light-channels.css"') < indexSrc.indexOf('href="css/light-devices.css"') &&
-  indexSrc.indexOf('href="css/light-devices.css"') < indexSrc.indexOf('href="css/light-conditions-now.css"') &&
-  indexSrc.indexOf('href="css/light-conditions-now.css"') < indexSrc.indexOf('href="css/light-setup.css"') &&
-  indexSrc.indexOf('href="css/light-setup.css"') < indexSrc.indexOf('href="css/light-tools.css"') &&
-  indexSrc.indexOf('href="css/light-tools.css"') < indexSrc.indexOf('href="css/light-env.css"') &&
+  lightSunLoaderSrc.indexOf("'../css/light-sun.css'") < lightSunLoaderSrc.indexOf("'../css/light-channels.css'") &&
+  lightSunLoaderSrc.indexOf("'../css/light-channels.css'") < lightSunLoaderSrc.indexOf("'../css/light-devices.css'") &&
+  lightSunLoaderSrc.indexOf("'../css/light-devices.css'") < lightSunLoaderSrc.indexOf("'../css/light-conditions-now.css'") &&
+  lightSunLoaderSrc.indexOf("'../css/light-conditions-now.css'") < lightSunLoaderSrc.indexOf("'../css/light-setup.css'") &&
+  lightSunLoaderSrc.indexOf("'../css/light-setup.css'") < lightSunLoaderSrc.indexOf("'../css/light-tools.css'") &&
+  lightSunLoaderSrc.indexOf("'../css/light-tools.css'") < lightSunLoaderSrc.indexOf("'../css/light-env.css'") &&
   swAuditSrc.indexOf("'/css/light-sun.css'") < swAuditSrc.indexOf("'/css/light-channels.css'") &&
   swAuditSrc.indexOf("'/css/light-channels.css'") < swAuditSrc.indexOf("'/css/light-devices.css'") &&
   swAuditSrc.indexOf("'/css/light-devices.css'") < swAuditSrc.indexOf("'/css/light-conditions-now.css'") &&
@@ -275,12 +283,17 @@ const dashboardLabRenderersSrc = read('js/dashboard-lab-widget-renderers.js');
 const dashboardViewCompositionSrc = read('js/dashboard-view-composition.js');
 const geneticsCssAuditSrc = read('css/genetics.css');
 const markerDetailCssAuditSrc = read('css/marker-detail-modal.css');
+const contextProfileCssAuditSrc = read('css/context-profile.css');
 const dnaSrc = read('js/dna.js');
 assert('Trend alert name escaped', dashboardLabRenderersSrc.includes('escapeHTML(alert.name)'));
 assert('Trend alert category escaped', dashboardLabRenderersSrc.includes('escapeHTML(alert.category)'));
 assert('Flagged marker name escaped', /escapeHTML\(f\.name\)/.test(dashboardLabRenderersSrc));
 assert('Category label escaped in header', categoryPageViewSrc.includes('escapeHTML(cat.label)'));
 assert('marker.unit escaped in detail modal', /escapeHTML\(marker\.unit\)/.test(markerDetailSrc));
+assert('marker history controls keep their styling in the eager marker-detail bundle',
+  markerDetailSrc.includes('class="marker-history-show-more"') &&
+  !markerDetailSrc.includes('light-sessions-show-more marker-history-show-more') &&
+  markerDetailCssAuditSrc.includes('.marker-detail-modal .marker-history-show-more:hover'));
 assert('Correlation option names escaped', /escapeHTML\(marker\.name\)/.test(compareCorrelationsSrc));
 assert('Light channel device names escaped before next-move HTML',
   /const dev = matchingDevice \? escapeHTML\(`\$\{matchingDevice\.brand\} \$\{matchingDevice\.model\}`\) : ''/.test(lightChannelViewSrc));
@@ -357,6 +370,11 @@ console.log('3c. innerHTML sanitizer sweep');
 
 const contextCardEditorSrc = read('js/context-card-editor-ui.js');
 const contextCardLifestyleSrc = read('js/context-card-lifestyle-editors.js');
+assert('context Light setup mirror owns its eager Ott badge styling',
+  contextCardLifestyleSrc.includes('ctx-lightsetup-ott-badge') &&
+  !contextCardLifestyleSrc.includes('class="light-ott-badge') &&
+  contextProfileCssAuditSrc.includes('.ctx-lightsetup-ott-badge') &&
+  contextProfileCssAuditSrc.includes('.ctx-lightsetup-ott-tier-4'));
 assert('Context select field escapes label text',
   /function renderSelectField[\s\S]{0,220}<label class="ctx-field-label">\$\{escapeHTML\(label\)\}<\/label>/.test(contextCardEditorSrc));
 assert('Context tags field escapes label text',

--- a/tests/test-light-env-delegated-actions.js
+++ b/tests/test-light-env-delegated-actions.js
@@ -106,11 +106,11 @@ assert('Light environment modal shell actions are wired through startup hooks',
     envShellHooksSrc.includes("import { configureNavActions } from './nav.js';") &&
     envShellHooksSrc.includes("import { configureAppEventListeners } from './app-event-listeners.js';") &&
     envShellHooksSrc.includes("import { closeLightEnvironmentAssessment, configureLightEnv, openLightEnvironmentAssessment } from './light-env.js';") &&
-    envShellHooksSrc.includes("import { loadLightSunModules } from './light-sun-loader.js';") &&
+    envShellHooksSrc.includes("import { loadLightSunUI } from './light-sun-loader.js';") &&
     envShellHooksSrc.includes("import { getMeasurementsForRoom } from './light-tools.js';") &&
     envShellHooksSrc.includes("import { navigate } from './views.js';") &&
     envShellHooksSrc.includes('configureLightEnv({ getMeasurementsForRoom, navigate });') &&
-    envShellHooksSrc.includes('loadLightSunModules()') &&
+    envShellHooksSrc.includes('loadLightSunUI()') &&
     !envSrc.includes('globalThis.navigate') &&
     appUiShellSrc.includes("import './light-env-shell-hooks.js';"));
 assert('light-env screen renderer takes AI renderer from options instead of global lookup',

--- a/tests/test-light-env.js
+++ b/tests/test-light-env.js
@@ -727,11 +727,11 @@ const {
     appUiShellSrc.includes("import './light-env-shell-hooks.js';") &&
     lightEnvShellHooksSrc.includes("import { configureAppEventListeners } from './app-event-listeners.js';") &&
     lightEnvShellHooksSrc.includes("import { closeLightEnvironmentAssessment, configureLightEnv, openLightEnvironmentAssessment } from './light-env.js';") &&
-    lightEnvShellHooksSrc.includes("import { loadLightSunModules } from './light-sun-loader.js';") &&
+    lightEnvShellHooksSrc.includes("import { loadLightSunUI } from './light-sun-loader.js';") &&
     lightEnvShellHooksSrc.includes("import { getMeasurementsForRoom } from './light-tools.js';") &&
     lightEnvShellHooksSrc.includes("import { navigate } from './views.js';") &&
     lightEnvShellHooksSrc.includes('configureLightEnv({ getMeasurementsForRoom, navigate });') &&
-    lightEnvShellHooksSrc.includes('loadLightSunModules()') &&
+    lightEnvShellHooksSrc.includes('loadLightSunUI()') &&
     lightEnvShellHooksSrc.includes("import { configureNavActions } from './nav.js';") &&
     navSrc.includes("typeof value === 'function'") &&
     appEventSrc.includes("typeof value === 'function'") &&

--- a/tests/test-sun-ui-flow.js
+++ b/tests/test-sun-ui-flow.js
@@ -11,6 +11,14 @@ return (async function() {
     else { fail++; console.error(`FAIL  ${name}` + (detail ? ` — ${detail}` : '')); }
   }
   const wait = ms => new Promise(r => setTimeout(r, ms));
+  async function waitFor(condition, timeout = 3000, interval = 20) {
+    const deadline = Date.now() + timeout;
+    while (Date.now() < deadline) {
+      if (condition()) return true;
+      await wait(interval);
+    }
+    return condition();
+  }
   const main = document.getElementById('main-content');
   const { state: S } = await import('/js/state.js');
   const dataModule = await import('/js/data.js');
@@ -53,11 +61,12 @@ return (async function() {
   console.log('%c 1. Light Today hero on dashboard ', 'font-weight:bold;color:#6366f1');
 
   viewsModule.navigate('dashboard');
-  await wait(80);
+  await waitFor(() => !!main.querySelector('.dashboard-widgets'));
   if (!main.querySelector('.dashboard-widget[data-widget-id="light-today"]')) {
     viewsModule.showDashboardWidget?.('light-today');
-    await wait(120);
   }
+  await waitFor(() =>
+    !!main.querySelector('.dashboard-widget[data-widget-id="light-today"] .light-today-hero'));
   const todayWidget = main.querySelector('.dashboard-widget[data-widget-id="light-today"]');
   const hero = todayWidget?.querySelector('.light-today-hero');
   assert('Dashboard renders the Light Today widget',
@@ -91,7 +100,8 @@ return (async function() {
   assert('logCompletedSession returns id', typeof id === 'string');
 
   viewsModule.navigate('dashboard');
-  await wait(80);
+  await waitFor(() =>
+    !!main.querySelector('.dashboard-widget[data-widget-id="light-today"] .light-today-hero'));
   const todayWidgetAfter = main.querySelector('.dashboard-widget[data-widget-id="light-today"]');
   assert('Dashboard Light Today still renders as hero after logging',
     !!todayWidgetAfter?.querySelector('.light-today-hero'));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.355';
+self.APP_VERSION = '1.10.356';


### PR DESCRIPTION
## What changed

- defer the seven Light & Sun stylesheets until a visible Light UI entry point is opened
- keep background Light/Sun session analysis on the existing module-only loader so it does not fetch presentation assets
- preserve the original cascade position with an ordered stylesheet anchor and make concurrent loading single-flight and retry-safe
- move the two cross-feature style consumers (marker history controls and context-card Ott badges) into their eager owning bundles
- retain all deferred resources in the service-worker app shell for offline first use
- add browser coverage for cold startup, ordering, concurrency, failure/retry, dashboard widgets, sidebar assessment, route rendering, and Firefox offline navigation
- make the Light Today browser flow wait for the observable lazy-loaded UI state instead of a fixed runner-dependent delay

## Why

Returning users paid for seven Light-only stylesheets on every startup even when they never opened Light & Sun. This moves that cost to first visual use without delaying background analysis or weakening offline behavior.

## Impact

Measured on the same fresh mobile returning-user scenario with browser cache and service workers disabled:

- requests: 448 → 441 (-7)
- compressed transfer: 1,900,879 → 1,857,409 bytes (-43,470)
- decoded bytes: 5,843,728 → 5,650,563 (-193,165)

The ratcheted cold-load budget and architecture notes are updated, and the app version advances to 1.10.356.

## Validation

- `COVERAGE=1 PORT=8265 ./run-tests.sh`
  - 487 Vitest tests passed
  - 396 Chromium tests passed
  - 472 responsive/theme checks passed
  - combined function coverage passed at 67.11% against the 67.10% ratchet
  - Firefox smoke and offline first-use coverage passed in the preceding full run
- Light Today browser fixture passed 10/10 consecutive stress runs
- real sidebar-to-lazy-Light assessment integration passed 5/5 consecutive stress runs
- `npm run quality` — 11/11 guardrails passed
- TypeScript typecheck, JS check, architecture, vendor integrity, and `git diff --check` passed
- cold-load measurement reproduced 441 requests / 1,857,409 transfer bytes / 5,650,563 decoded bytes