### PR TITLE
Lazy-load Client List stylesheet

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -194,3 +194,10 @@ a shared-profile link. The loader owns only lazy loading and route detection;
 `profile-share.js` retains link validation, encryption, import, and UI
 responsibilities. `export.js` remains shell-owned without a Data I/O
 composition wrapper.
+
+Client List remains module-eager because shell, profile, and location actions
+use it, but `css/client-list.css` loads only when `openClientList()` is first
+called. Opening waits for the stylesheet, concurrent opens share one request,
+and a failed request is removed so the next open can retry. An HTML anchor
+preserves the stylesheet's cascade position, and the service-worker app shell
+retains it for offline first use.

--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
   <link rel="stylesheet" href="css/cycle.css">
   <link rel="stylesheet" href="css/marker-detail-modal.css">
   <link rel="stylesheet" href="css/recommendations.css">
-  <link rel="stylesheet" href="css/client-list.css">
+  <meta data-client-list-stylesheet-anchor>
   <link rel="stylesheet" href="css/wearables.css">
   <meta data-light-sun-stylesheet-anchor>
   <link rel="stylesheet" href="css/chat-panel.css">

--- a/js/client-list.js
+++ b/js/client-list.js
@@ -16,6 +16,8 @@ import {
   showClientListNotification,
 } from './client-list-runtime.js';
 
+const CLIENT_LIST_STYLESHEET_URL = new URL('../css/client-list.css', import.meta.url).href;
+
 /**
  * @typedef {{
  *   exportAllDataJSON: () => Promise<void> | void,
@@ -49,6 +51,11 @@ let _tagFilter = '';
 let _editingId = null;
 let _pendingAvatar = undefined; // undefined = no change, null = remove, string = new dataURL
 let clientListDelegatesInstalled = false;
+/** @type {Promise<HTMLLinkElement> | null} */
+let _clientListStylesheetLoad = null;
+/** @type {Promise<boolean> | null} */
+let _clientListOpen = null;
+let _useClientListStylesheetRetryUrl = false;
 
 const CL_ICONS = Object.freeze({
   archive: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M21 8v13H3V8"/><path d="M1 3h22v5H1z"/><path d="M10 12h4"/></svg>',
@@ -155,16 +162,66 @@ function _renderAvatarEl(profile) {
 // ═══════════════════════════════════════════════
 // OPEN / CLOSE
 // ═══════════════════════════════════════════════
+function clientListStylesheetUrl() {
+  if (!_useClientListStylesheetRetryUrl) return CLIENT_LIST_STYLESHEET_URL;
+  const retryUrl = new URL(CLIENT_LIST_STYLESHEET_URL);
+  retryUrl.searchParams.set('lazy-retry', '1');
+  return retryUrl.href;
+}
+
+/** @returns {Promise<HTMLLinkElement>} */
+function loadClientListStylesheet() {
+  if (!_clientListStylesheetLoad) {
+    if (typeof document === 'undefined') {
+      return Promise.reject(new Error('Client List stylesheet requires a document'));
+    }
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = clientListStylesheetUrl();
+    link.dataset.clientListStylesheet = '';
+    _clientListStylesheetLoad = new Promise((resolve, reject) => {
+      link.addEventListener('load', () => resolve(link), { once: true });
+      link.addEventListener('error', () => {
+        reject(new Error('Client List stylesheet could not be loaded'));
+      }, { once: true });
+      const anchor = document.querySelector('[data-client-list-stylesheet-anchor]');
+      const parent = anchor?.parentNode || document.head;
+      parent.insertBefore(link, anchor || null);
+    }).catch(err => {
+      link.remove();
+      _clientListStylesheetLoad = null;
+      _useClientListStylesheetRetryUrl = true;
+      throw err;
+    });
+  }
+  return _clientListStylesheetLoad;
+}
+
+/** @returns {Promise<boolean>} */
 export function openClientList() {
-  _search = '';
-  _statusFilter = 'active';
-  _tagFilter = '';
-  _editingId = null;
-  _pendingAvatar = undefined;
-  const overlay = document.getElementById('client-list-overlay');
-  if (!overlay) return;
-  renderClientList();
-  openModalOverlay(overlay, { initialFocus: '#cl-search', scrollLock: true });
+  if (!_clientListOpen) {
+    _clientListOpen = loadClientListStylesheet()
+      .then(() => {
+        _search = '';
+        _statusFilter = 'active';
+        _tagFilter = '';
+        _editingId = null;
+        _pendingAvatar = undefined;
+        const overlay = document.getElementById('client-list-overlay');
+        if (!overlay) return false;
+        renderClientList();
+        openModalOverlay(overlay, { initialFocus: '#cl-search', scrollLock: true });
+        return true;
+      })
+      .catch(err => {
+        console.error('Failed to load Client List stylesheet', err);
+        return false;
+      })
+      .finally(() => {
+        _clientListOpen = null;
+      });
+  }
+  return _clientListOpen;
 }
 
 export function closeClientList() {
@@ -1054,12 +1111,13 @@ function _clHeightUnitChanged() {
 // .show class); openClientForm(id) replaces the list view with the form.
 // Calling openClientForm alone leaves the overlay hidden — the form
 // renders in the DOM but isn't visible to the user.
-export function openProfileLocationEditor() {
+export async function openProfileLocationEditor() {
   // Close any other modal that might be on top first (marker modal, etc.)
   // so the client-list overlay isn't sitting behind it.
   const otherOverlay = document.getElementById('modal-overlay');
   if (otherOverlay) otherOverlay.classList.remove('show');
-  openClientList();
+  const opened = await openClientList();
+  if (!opened) return false;
   const id = state?.currentProfile;
   if (id) openClientForm(id);
   // Focus the country input after the form mounts.
@@ -1067,6 +1125,7 @@ export function openProfileLocationEditor() {
     const el = document.getElementById('cl-country');
     if (el) { el.focus(); el.scrollIntoView({ behavior: 'smooth', block: 'center' }); }
   }, 80);
+  return true;
 }
 
 installClientListDelegates();

--- a/plans/code-quality-audit-2026-07-21.md
+++ b/plans/code-quality-audit-2026-07-21.md
@@ -104,12 +104,12 @@ ceilings for same-origin application requests, compressed transfer bytes, and
 decoded bytes. The initial reference was 474 requests, 2,017,210 compressed
 bytes, and 6,252,286 decoded bytes. Lazy-loading the PDF import review,
 Light/Sun analysis hooks, Settings/Tweaks, Profile Sharing, and the Settings
-and Light/Sun stylesheets reduced that reference to 441 requests, 1,857,409
-compressed bytes, and 5,650,563 decoded bytes. The Light/Sun stylesheet slice
-saved seven requests, 43,470 compressed bytes, and 193,165 decoded bytes in
-identical before/after runs on the same machine. Route and feature lazy loading
-remains active, with the ceilings ratcheting downward after each reproducible
-slice.
+Light/Sun, and Client List stylesheets reduced that reference to 440 requests,
+1,854,314 compressed bytes, and 5,635,229 decoded bytes. The Client List
+stylesheet slice saved one request, 3,095 compressed bytes, and 15,334 decoded
+bytes in identical before/after runs on the same machine. Route and feature
+lazy loading remains active, with the ceilings ratcheting downward after each
+reproducible slice.
 
 ### 4. Guardrails and test gaps
 

--- a/scripts/cold-load-budget.json
+++ b/scripts/cold-load-budget.json
@@ -3,15 +3,15 @@
   "route": "/app",
   "scenario": "Fresh mobile returning-user load with browser cache and service workers disabled",
   "maximums": {
-    "requests": 447,
-    "transferBytes": 1891000,
-    "decodedBytes": 5747000
+    "requests": 446,
+    "transferBytes": 1888000,
+    "decodedBytes": 5732000
   },
   "reference": {
-    "requests": 441,
-    "transferBytes": 1857409,
-    "decodedBytes": 5650563
+    "requests": 440,
+    "transferBytes": 1854314,
+    "decodedBytes": 5635229
   },
-  "referenceCommit": "087c5674",
+  "referenceCommit": "0fa94ac3",
   "measuredAt": "2026-07-24"
 }

--- a/tests/client-list-runtime.test.js
+++ b/tests/client-list-runtime.test.js
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { state } from '../js/state.js';
 import { configureClientListRuntimeDeps } from '../js/client-list-runtime.js';
@@ -35,6 +35,20 @@ async function loadClientList() {
 beforeEach(() => {
   localStorage.clear();
   sessionStorage.clear();
+  document.querySelectorAll(
+    '[data-client-list-stylesheet-anchor], link[data-client-list-stylesheet]',
+  ).forEach(element => element.remove());
+  const stylesheetAnchor = document.createElement('meta');
+  stylesheetAnchor.dataset.clientListStylesheetAnchor = '';
+  document.head.appendChild(stylesheetAnchor);
+  const insertBefore = document.head.insertBefore.bind(document.head);
+  vi.spyOn(document.head, 'insertBefore').mockImplementation((node, referenceNode) => {
+    const inserted = insertBefore(node, referenceNode);
+    if (node instanceof HTMLLinkElement && node.dataset.clientListStylesheet !== undefined) {
+      queueMicrotask(() => node.dispatchEvent(new Event('load')));
+    }
+    return inserted;
+  });
   document.body.innerHTML = `
     <div id="modal-overlay" class="show"></div>
     <div id="client-list-overlay"><div id="client-list-modal"></div></div>
@@ -57,6 +71,13 @@ beforeEach(() => {
   ];
 });
 
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.querySelectorAll(
+    '[data-client-list-stylesheet-anchor], link[data-client-list-stylesheet]',
+  ).forEach(element => element.remove());
+});
+
 describe('client list runtime behavior', () => {
   it('drives list filters, row menus, and edit form through delegated handlers', async () => {
     const clientList = await loadClientList();
@@ -68,7 +89,7 @@ describe('client list runtime behavior', () => {
     });
     const topLevelNames = () => [...document.querySelectorAll('.cl-list > .cl-row .cl-row-name')].map(el => el.textContent);
 
-    clientList.openClientList();
+    await clientList.openClientList();
     expect(document.getElementById('client-list-overlay').classList.contains('show')).toBe(true);
     expect(document.body.style.overflow).toBe('hidden');
     expect(topLevelNames()).toEqual(['Alice', 'Bob']);

--- a/tests/firefox/smoke.spec.js
+++ b/tests/firefox/smoke.spec.js
@@ -152,6 +152,7 @@ test('installs a readable app shell for offline use', async ({ browserName, cont
       '/index.html',
       '/styles.css',
       '/css/settings.css',
+      '/css/client-list.css',
       '/css/light-sun.css',
       '/css/light-channels.css',
       '/css/light-devices.css',
@@ -181,6 +182,7 @@ test('installs a readable app shell for offline use', async ({ browserName, cont
     { path: '/index.html', available: true },
     { path: '/styles.css', available: true },
     { path: '/css/settings.css', available: true },
+    { path: '/css/client-list.css', available: true },
     { path: '/css/light-sun.css', available: true },
     { path: '/css/light-channels.css', available: true },
     { path: '/css/light-devices.css', available: true },
@@ -208,5 +210,9 @@ test('installs a readable app shell for offline use', async ({ browserName, cont
   await expect(page.locator('.light-page')).toBeVisible();
   await expect(page.locator('.light-page')).toHaveCSS('display', 'grid');
   await expect(page.locator('link[data-light-sun-stylesheet]')).toHaveCount(7);
+  await page.locator('#profile-selector .profile-compact-btn').click();
+  await expect(page.locator('#client-list-overlay')).toHaveClass(/\bshow\b/);
+  await expect(page.locator('#client-list-modal')).toHaveCSS('display', 'flex');
+  await expect(page.locator('link[data-client-list-stylesheet]')).toHaveCount(1);
   expect(pageErrors).toEqual([]);
 });

--- a/tests/playwright/client-list-browser-coverage.spec.js
+++ b/tests/playwright/client-list-browser-coverage.spec.js
@@ -79,7 +79,7 @@ test('client list live menu actions dispatch exports share demos and profile sta
       renderProfileButton: () => calls.push(['render-profile-button']),
     });
     const openList = async () => {
-      clientList.openClientList();
+      await clientList.openClientList();
       await waitFor(() => document.getElementById('client-list-overlay')?.classList.contains('show'), 'client list overlay');
       await waitFor(() => document.activeElement?.id === 'cl-search', 'client list search focus');
     };
@@ -358,7 +358,7 @@ test('client list form live actions cover health link avatar haplogroup and loca
         document.body.appendChild(strip);
       }
 
-      clientList.openClientList();
+      await clientList.openClientList();
       clientList.openClientForm('client-active');
       await waitFor(() => !!document.querySelector('.cl-form'), 'client edit form');
       document.querySelector('[data-cl-action="health-metrics"]')?.click();
@@ -372,7 +372,7 @@ test('client list form live actions cover health link avatar haplogroup and loca
         && clientListRuntimeSrc.includes('clientListRuntimeDeps.renderProfileButton?.()')
         && !clientListRuntimeSrc.includes('getViewRuntimeFunction');
 
-      clientList.openClientList();
+      await clientList.openClientList();
       clientList.openClientForm('client-active');
       await waitFor(() => !!document.querySelector('.cl-form'), 'reopened client edit form');
       document.querySelector('.cl-avatar-picker')?.dispatchEvent(new KeyboardEvent('keydown', {
@@ -400,7 +400,7 @@ test('client list form live actions cover health link avatar haplogroup and loca
         && calls.some(call => call[0] === 'notification' && call[1] === '"Active Browser" updated' && call[2] === 'info');
 
       document.getElementById('modal-overlay')?.classList.add('show');
-      clientList.openProfileLocationEditor();
+      await clientList.openProfileLocationEditor();
       await waitFor(() => document.activeElement?.id === 'cl-country', 'location editor focus');
       outcomes.locationEditorOpensVisibleFormAndHidesOtherModal = document.getElementById('client-list-overlay')?.classList.contains('show') === true
         && !document.getElementById('modal-overlay')?.classList.contains('show')
@@ -527,7 +527,7 @@ test('client list remaining browser helpers cover filters avatar upload tags and
         },
       ];
       localStorage.setItem('labcharts-profiles', JSON.stringify(state.profiles));
-      clientList.openClientList();
+      await clientList.openClientList();
       await waitFor(() => document.getElementById('client-list-overlay')?.classList.contains('show'), 'client list open');
       const search = document.getElementById('cl-search');
       search.value = 'alpha';

--- a/tests/playwright/client-list-stylesheet-browser-coverage.spec.js
+++ b/tests/playwright/client-list-stylesheet-browser-coverage.spec.js
@@ -1,0 +1,102 @@
+import { expect, test } from './coverage-fixture.js';
+
+async function prepareReturningApp(page) {
+  await page.addInitScript(() => {
+    const profileId = localStorage.getItem('labcharts-active-profile') || 'default';
+    localStorage.setItem(`labcharts-${profileId}-emptyTour`, 'completed');
+    localStorage.setItem(`labcharts-${profileId}-tour`, 'completed');
+  });
+  await page.goto('/app', { waitUntil: 'networkidle' });
+  await page.waitForFunction(async () => {
+    const { state } = await import('/js/state.js');
+    return typeof state.currentView === 'string' && !!document.getElementById('profile-selector');
+  });
+}
+
+test('returning-user startup defers Client List CSS until the real shell action opens it', async ({ page }) => {
+  const stylesheetRequests = [];
+  page.on('request', request => {
+    const url = new URL(request.url());
+    if (url.pathname === '/css/client-list.css') stylesheetRequests.push(url.href);
+  });
+
+  await prepareReturningApp(page);
+
+  expect(stylesheetRequests).toEqual([]);
+  await expect(page.locator('link[data-client-list-stylesheet]')).toHaveCount(0);
+  await page.locator('#profile-selector .profile-compact-btn').click();
+
+  const overlay = page.locator('#client-list-overlay');
+  await expect(overlay).toHaveClass(/\bshow\b/);
+  await expect(overlay.locator('.client-list-modal')).toHaveCSS('display', 'flex');
+  await expect(page.locator('link[data-client-list-stylesheet]')).toHaveCount(1);
+  expect(stylesheetRequests).toHaveLength(1);
+});
+
+test('Client List stylesheet and modal opening are single-flight', async ({ page }) => {
+  let stylesheetRequests = 0;
+  page.on('request', request => {
+    if (new URL(request.url()).pathname === '/css/client-list.css') stylesheetRequests += 1;
+  });
+  await prepareReturningApp(page);
+
+  const results = await page.evaluate(async () => {
+    const clientList = await import('/js/client-list.js');
+    const [first, second] = await Promise.all([
+      clientList.openClientList(),
+      clientList.openClientList(),
+    ]);
+    return {
+      bothCallsOpenTheModal: first === true && second === true,
+      overlayVisible: document.getElementById('client-list-overlay')?.classList.contains('show') === true,
+      oneStylesheetLink: document.querySelectorAll('link[data-client-list-stylesheet]').length === 1,
+    };
+  });
+
+  expect(results).toEqual({
+    bothCallsOpenTheModal: true,
+    overlayVisible: true,
+    oneStylesheetLink: true,
+  });
+  expect(stylesheetRequests).toBe(1);
+});
+
+test('Client List stylesheet failure is contained and retries with a cache-busting URL', async ({ page }) => {
+  const stylesheetRequests = [];
+  let failFirstRequest = true;
+  await page.route('**/css/client-list.css*', route => {
+    stylesheetRequests.push(route.request().url());
+    if (failFirstRequest) {
+      failFirstRequest = false;
+      return route.abort('failed');
+    }
+    return route.continue();
+  });
+  await prepareReturningApp(page);
+
+  const results = await page.evaluate(async () => {
+    const clientList = await import('/js/client-list.js');
+    const first = await clientList.openClientList();
+    const firstFailureWasContained =
+      first === false
+      && document.querySelectorAll('link[data-client-list-stylesheet]').length === 0
+      && document.getElementById('client-list-overlay')?.classList.contains('show') !== true;
+    const second = await clientList.openClientList();
+    const retryLink = document.querySelector('link[data-client-list-stylesheet]');
+    return {
+      firstFailureWasContained,
+      retryOpensModal: second === true
+        && document.getElementById('client-list-overlay')?.classList.contains('show') === true,
+      retryUsesCacheBuster:
+        retryLink && new URL(retryLink.href).searchParams.get('lazy-retry') === '1',
+    };
+  });
+
+  expect(results).toEqual({
+    firstFailureWasContained: true,
+    retryOpensModal: true,
+    retryUsesCacheBuster: true,
+  });
+  expect(stylesheetRequests).toHaveLength(2);
+  expect(new URL(stylesheetRequests[1]).searchParams.get('lazy-retry')).toBe('1');
+});

--- a/tests/playwright/cold-load-budget.spec.js
+++ b/tests/playwright/cold-load-budget.spec.js
@@ -73,6 +73,9 @@ test('cold mobile app load stays within committed resource budgets', async ({ pa
   expect(entries.some(entry => (
     new URL(entry.name).pathname === '/css/settings.css'
   ))).toBe(false);
+  expect(entries.some(entry => (
+    new URL(entry.name).pathname === '/css/client-list.css'
+  ))).toBe(false);
   const deferredLightStylesheets = new Set([
     '/css/light-sun.css',
     '/css/light-channels.css',

--- a/tests/playwright/profile-share-browser-coverage.spec.js
+++ b/tests/playwright/profile-share-browser-coverage.spec.js
@@ -65,7 +65,7 @@ test('Share Profile entry points open the sharing modal', async ({ page }) => {
       import('/js/client-list.js'),
     ]);
     await closeSettingsModal();
-    openClientList();
+    await openClientList();
     return {
       id: state.currentProfile,
       name: state.profiles.find(item => item.id === state.currentProfile)?.name || 'Active profile',

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -186,7 +186,17 @@ assert('settings CSS lazy-load anchor preserves the original cascade position',
   indexSrc.indexOf('data-settings-stylesheet-anchor') <
     indexSrc.indexOf('href="css/mobile-dashboard.css"'));
 assert('SW APP_SHELL includes settings CSS bundle', swAuditSrc.includes("'/css/settings.css'"));
-assert('index loads client list CSS bundle', indexSrc.includes('href="css/client-list.css"'));
+const clientListSrc = read('js/client-list.js');
+assert('index defers client list CSS behind its ordered lazy-load anchor',
+  !indexSrc.includes('href="css/client-list.css"') &&
+  indexSrc.includes('data-client-list-stylesheet-anchor') &&
+  clientListSrc.includes("new URL('../css/client-list.css', import.meta.url)") &&
+  clientListSrc.includes('data-client-list-stylesheet-anchor'));
+assert('client list CSS lazy-load anchor preserves the original cascade position',
+  indexSrc.indexOf('href="css/recommendations.css"') <
+    indexSrc.indexOf('data-client-list-stylesheet-anchor') &&
+  indexSrc.indexOf('data-client-list-stylesheet-anchor') <
+    indexSrc.indexOf('href="css/wearables.css"'));
 assert('SW APP_SHELL includes client list CSS bundle', swAuditSrc.includes("'/css/client-list.css'"));
 assert('index loads mobile dashboard CSS bundle', indexSrc.includes('href="css/mobile-dashboard.css"'));
 assert('SW APP_SHELL includes mobile dashboard CSS bundle', swAuditSrc.includes("'/css/mobile-dashboard.css'"));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.356';
+self.APP_VERSION = '1.10.357';


### PR DESCRIPTION
## What changed

- replace the eager Client List stylesheet link with an ordered lazy-load anchor
- load `css/client-list.css` on the first Client List open, single-flight concurrent opens, and retry safely after failures
- keep the stylesheet in the service-worker app shell for offline first use
- add real shell-entry, concurrency, retry, cold-load, and Firefox offline coverage
- ratchet the committed cold-load budget and bump the app version

## Why

Client List is not visible during a returning-user startup, but its 17.5 KB stylesheet was fetched on every cold load. Deferring it to the feature boundary removes startup work without making the module itself lazy or changing its shell/profile/location integrations.

## Impact

Identical before/after cold mobile runs reduced startup from 441 to 440 requests, 1,857,409 to 1,854,314 compressed bytes, and 5,650,563 to 5,635,229 decoded bytes. The modal now waits for its CSS before opening; a failed load is contained and the next open retries.

## Validation

- `COVERAGE=1 PORT=8271 ./run-tests.sh`
- 487 Vitest tests passed
- 399 Chromium tests passed
- 472 responsive checks passed
- Firefox offline smoke: 3 passed
- audit: 338 passed
- combined function coverage: 67.11% (ratchet: 67.10%)
- cold-load budget reproduced exactly: 440 requests / 1,854,314 compressed / 5,635,229 decoded