### PR TITLE
Lazy-load Marker Detail stylesheet

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -213,8 +213,9 @@ shell retains `css/import.css` for offline first use.
 Marker detail, manual-entry, and custom-marker presentation remains
 module-eager because dashboard, category, Biology Score, and sync refresh paths
 share its behavior, but `css/marker-detail-modal.css` loads only when one of
-those modal surfaces first opens. The entry waits for the stylesheet so an
-unstyled modal is never shown, concurrent requests share one load, failed links
-are removed and cache-busted for retry, and an HTML anchor preserves the
-original cascade position before Recommendations. The service-worker app shell
-retains the stylesheet for offline first use.
+those modal surfaces first opens through its already-eager runtime adapter. The
+entry waits for the stylesheet so an unstyled modal is never shown, concurrent
+requests share one load, failed links are removed and cache-busted for retry,
+and an HTML anchor preserves the original cascade position before
+Recommendations. The service-worker app shell retains the stylesheet for
+offline first use.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -209,3 +209,12 @@ zone remain in `app-shell.css` because non-import features and startup routes
 use them. Concurrent stylesheet requests share one load, failures are removed
 for retry, an HTML anchor preserves cascade order, and the service-worker app
 shell retains `css/import.css` for offline first use.
+
+Marker detail, manual-entry, and custom-marker presentation remains
+module-eager because dashboard, category, Biology Score, and sync refresh paths
+share its behavior, but `css/marker-detail-modal.css` loads only when one of
+those modal surfaces first opens. The entry waits for the stylesheet so an
+unstyled modal is never shown, concurrent requests share one load, failed links
+are removed and cache-busted for retry, and an HTML anchor preserves the
+original cascade position before Recommendations. The service-worker app shell
+retains the stylesheet for offline first use.

--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -10,7 +10,7 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | Metric | Current |
 | --- | ---: |
 | Modules | 465 |
-| Internal import edges | 2074 |
+| Internal import edges | 2075 |
 | Dynamic internal edges | 61 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -38,7 +38,7 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 
 | High fan-in | Dependants | High fan-out | Imports |
 | --- | ---: | --- | ---: |
-| [`js/utils.js`](js/utils.js) | 207 | [`js/app-shell-hooks.js`](js/app-shell-hooks.js) | 88 |
+| [`js/utils.js`](js/utils.js) | 208 | [`js/app-shell-hooks.js`](js/app-shell-hooks.js) | 88 |
 | [`js/state.js`](js/state.js) | 146 | [`js/app-light-sun-modules.js`](js/app-light-sun-modules.js) | 27 |
 | [`js/data.js`](js/data.js) | 73 | [`js/sync-configure.js`](js/sync-configure.js) | 27 |
 | [`js/api.js`](js/api.js) | 63 | [`js/dashboard-view-composition.js`](js/dashboard-view-composition.js) | 25 |
@@ -518,7 +518,7 @@ Native browser modules shipped with the static application.
 - [`js/marker-detail-actions.js`](js/marker-detail-actions.js) → [`js/utils.js`](js/utils.js)
 - [`js/marker-detail-editing.js`](js/marker-detail-editing.js) → [`js/data.js`](js/data.js), [`js/marker-detail-actions.js`](js/marker-detail-actions.js), [`js/marker-detail-runtime.js`](js/marker-detail-runtime.js), [`js/marker-detail-store.js`](js/marker-detail-store.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/marker-detail-modal.js`](js/marker-detail-modal.js) → [`js/api.js`](js/api.js), [`js/charts.js`](js/charts.js), [`js/context-cards.js`](js/context-cards.js), [`js/data.js`](js/data.js), [`js/lab-entry-mutations.js`](js/lab-entry-mutations.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/marker-analysis.js`](js/marker-analysis.js), [`js/marker-detail-actions.js`](js/marker-detail-actions.js), [`js/marker-detail-editing.js`](js/marker-detail-editing.js), [`js/marker-detail-runtime.js`](js/marker-detail-runtime.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
-- [`js/marker-detail-runtime.js`](js/marker-detail-runtime.js) → [`js/dna-runtime-bridge.js`](js/dna-runtime-bridge.js), [`js/emf-runtime.js`](js/emf-runtime.js), [`js/recommendations-runtime.js`](js/recommendations-runtime.js), [`js/wearables-runtime.js`](js/wearables-runtime.js)
+- [`js/marker-detail-runtime.js`](js/marker-detail-runtime.js) → [`js/dna-runtime-bridge.js`](js/dna-runtime-bridge.js), [`js/emf-runtime.js`](js/emf-runtime.js), [`js/recommendations-runtime.js`](js/recommendations-runtime.js), [`js/utils.js`](js/utils.js), [`js/wearables-runtime.js`](js/wearables-runtime.js)
 - [`js/marker-detail-store.js`](js/marker-detail-store.js) → [`js/data.js`](js/data.js), [`js/lab-entry-mutations.js`](js/lab-entry-mutations.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/state.js`](js/state.js)
 
 </details>

--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@
   <meta data-settings-stylesheet-anchor>
   <link rel="stylesheet" href="css/mobile-dashboard.css">
   <link rel="stylesheet" href="css/cycle.css">
-  <link rel="stylesheet" href="css/marker-detail-modal.css">
+  <meta data-marker-detail-stylesheet-anchor>
   <link rel="stylesheet" href="css/recommendations.css">
   <meta data-client-list-stylesheet-anchor>
   <link rel="stylesheet" href="css/wearables.css">

--- a/js/marker-detail-modal.js
+++ b/js/marker-detail-modal.js
@@ -28,6 +28,7 @@ import {
   showEmojiPickerRuntime,
   toggleDashboardQuickMarkerPinRuntime,
   uninstallWearableModalFocusTrapRuntime,
+  loadMarkerDetailStylesheet, openWithMarkerDetailStylesheet,
 } from './marker-detail-runtime.js';
 import {
   configureMarkerDetailEditing,
@@ -46,12 +47,6 @@ import {
   deleteMarkerNote,
 } from './marker-detail-editing.js';
 
-const MARKER_DETAIL_STYLESHEET_URL = new URL('../css/marker-detail-modal.css', import.meta.url).href;
-
-/** @type {Promise<HTMLLinkElement> | null} */
-let _markerDetailStylesheetLoad = null;
-let _useMarkerDetailStylesheetRetryUrl = false;
-
 export {
   editRefRange,
   saveRefRange,
@@ -67,56 +62,7 @@ export {
   saveMarkerNote,
   deleteMarkerNote,
 };
-
-function markerDetailStylesheetUrl() {
-  if (!_useMarkerDetailStylesheetRetryUrl) return MARKER_DETAIL_STYLESHEET_URL;
-  const retryUrl = new URL(MARKER_DETAIL_STYLESHEET_URL);
-  retryUrl.searchParams.set('lazy-retry', '1');
-  return retryUrl.href;
-}
-
-/** @returns {Promise<HTMLLinkElement>} */
-export function loadMarkerDetailStylesheet() {
-  if (!_markerDetailStylesheetLoad) {
-    if (typeof document === 'undefined') {
-      return Promise.reject(new Error('Marker Detail stylesheet requires a document'));
-    }
-    const link = document.createElement('link');
-    link.rel = 'stylesheet';
-    link.href = markerDetailStylesheetUrl();
-    link.dataset.markerDetailStylesheet = '';
-    _markerDetailStylesheetLoad = new Promise((resolve, reject) => {
-      link.addEventListener('load', () => resolve(link), { once: true });
-      link.addEventListener('error', () => {
-        reject(new Error('Marker Detail stylesheet could not be loaded'));
-      }, { once: true });
-      const anchor = document.querySelector('[data-marker-detail-stylesheet-anchor]');
-      const parent = anchor?.parentNode || document.head;
-      parent.insertBefore(link, anchor || null);
-    }).catch(err => {
-      link.remove();
-      _markerDetailStylesheetLoad = null;
-      _useMarkerDetailStylesheetRetryUrl = true;
-      throw err;
-    });
-  }
-  return _markerDetailStylesheetLoad;
-}
-
-/**
- * @template T
- * @param {() => T} open
- * @returns {Promise<T | false>}
- */
-function openWithMarkerDetailStylesheet(open) {
-  return loadMarkerDetailStylesheet()
-    .catch(err => {
-      console.error('[marker-detail] Could not load stylesheet:', err);
-      showNotification('Could not open marker details. Reload the app to finish updating, then try again.', 'error');
-      return null;
-    })
-    .then(link => link ? open() : false);
-}
+export { loadMarkerDetailStylesheet };
 
 const markerDetailDeps = /** @type {{
   navigate: (category?: string, data?: any) => any,

--- a/js/marker-detail-modal.js
+++ b/js/marker-detail-modal.js
@@ -46,6 +46,12 @@ import {
   deleteMarkerNote,
 } from './marker-detail-editing.js';
 
+const MARKER_DETAIL_STYLESHEET_URL = new URL('../css/marker-detail-modal.css', import.meta.url).href;
+
+/** @type {Promise<HTMLLinkElement> | null} */
+let _markerDetailStylesheetLoad = null;
+let _useMarkerDetailStylesheetRetryUrl = false;
+
 export {
   editRefRange,
   saveRefRange,
@@ -61,6 +67,56 @@ export {
   saveMarkerNote,
   deleteMarkerNote,
 };
+
+function markerDetailStylesheetUrl() {
+  if (!_useMarkerDetailStylesheetRetryUrl) return MARKER_DETAIL_STYLESHEET_URL;
+  const retryUrl = new URL(MARKER_DETAIL_STYLESHEET_URL);
+  retryUrl.searchParams.set('lazy-retry', '1');
+  return retryUrl.href;
+}
+
+/** @returns {Promise<HTMLLinkElement>} */
+export function loadMarkerDetailStylesheet() {
+  if (!_markerDetailStylesheetLoad) {
+    if (typeof document === 'undefined') {
+      return Promise.reject(new Error('Marker Detail stylesheet requires a document'));
+    }
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = markerDetailStylesheetUrl();
+    link.dataset.markerDetailStylesheet = '';
+    _markerDetailStylesheetLoad = new Promise((resolve, reject) => {
+      link.addEventListener('load', () => resolve(link), { once: true });
+      link.addEventListener('error', () => {
+        reject(new Error('Marker Detail stylesheet could not be loaded'));
+      }, { once: true });
+      const anchor = document.querySelector('[data-marker-detail-stylesheet-anchor]');
+      const parent = anchor?.parentNode || document.head;
+      parent.insertBefore(link, anchor || null);
+    }).catch(err => {
+      link.remove();
+      _markerDetailStylesheetLoad = null;
+      _useMarkerDetailStylesheetRetryUrl = true;
+      throw err;
+    });
+  }
+  return _markerDetailStylesheetLoad;
+}
+
+/**
+ * @template T
+ * @param {() => T} open
+ * @returns {Promise<T | false>}
+ */
+function openWithMarkerDetailStylesheet(open) {
+  return loadMarkerDetailStylesheet()
+    .catch(err => {
+      console.error('[marker-detail] Could not load stylesheet:', err);
+      showNotification('Could not open marker details. Reload the app to finish updating, then try again.', 'error');
+      return null;
+    })
+    .then(link => link ? open() : false);
+}
 
 const markerDetailDeps = /** @type {{
   navigate: (category?: string, data?: any) => any,
@@ -269,6 +325,11 @@ export async function fetchCustomMarkerDescription(markerId, markerName, unit) {
 }
 
 export function showDetailModal(id, opts = {}) {
+  if (!safeMarkerId(id)) return Promise.resolve(false);
+  return openWithMarkerDetailStylesheet(() => renderDetailModal(id, opts));
+}
+
+function renderDetailModal(id, opts = {}) {
   // id is interpolated into delegated data-action attributes throughout the
   // modal body. Reject anything outside the strict allowlist so a poisoned
   // customMarker key cannot break attribute context or state lookups.
@@ -827,9 +888,14 @@ export function showDetailModal(id, opts = {}) {
       descEl.remove();
     }
   }
+  return true;
 }
 
 export function openManualEntryForm(id, prefillDate) {
+  return openWithMarkerDetailStylesheet(() => renderManualEntryForm(id, prefillDate));
+}
+
+function renderManualEntryForm(id, prefillDate) {
   // Always re-resolve from getActiveData — `state.markerRegistry` carries a
   // marker frozen at the moment it was rendered, and `marker.unit` reflects
   // the unit-system mode in effect *then*. After a US↔EU toggle the registry
@@ -939,6 +1005,10 @@ export function openManualEntryForm(id, prefillDate) {
 }
 
 export function openCreateMarkerModal() {
+  return openWithMarkerDetailStylesheet(renderCreateMarkerModal);
+}
+
+function renderCreateMarkerModal() {
   const modal = setDetailModalShell('gb-form-modal', 'marker-form-modal');
   const overlay = document.getElementById("modal-overlay");
   if (!modal) return;

--- a/js/marker-detail-runtime.js
+++ b/js/marker-detail-runtime.js
@@ -5,6 +5,63 @@ import { closeEMFInterpretation } from './emf-runtime.js';
 import { getDnaModuleFunction } from './dna-runtime-bridge.js';
 import { getRecommendationModuleFunction } from './recommendations-runtime.js';
 import { getWearablesModuleFunction } from './wearables-runtime.js';
+import { showNotification } from './utils.js';
+
+const MARKER_DETAIL_STYLESHEET_URL = new URL('../css/marker-detail-modal.css', import.meta.url).href;
+
+/** @type {Promise<HTMLLinkElement> | null} */
+let _markerDetailStylesheetLoad = null;
+let _useMarkerDetailStylesheetRetryUrl = false;
+
+function markerDetailStylesheetUrl() {
+  if (!_useMarkerDetailStylesheetRetryUrl) return MARKER_DETAIL_STYLESHEET_URL;
+  const retryUrl = new URL(MARKER_DETAIL_STYLESHEET_URL);
+  retryUrl.searchParams.set('lazy-retry', '1');
+  return retryUrl.href;
+}
+
+/** @returns {Promise<HTMLLinkElement>} */
+export function loadMarkerDetailStylesheet() {
+  if (!_markerDetailStylesheetLoad) {
+    if (typeof document === 'undefined') {
+      return Promise.reject(new Error('Marker Detail stylesheet requires a document'));
+    }
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = markerDetailStylesheetUrl();
+    link.dataset.markerDetailStylesheet = '';
+    _markerDetailStylesheetLoad = new Promise((resolve, reject) => {
+      link.addEventListener('load', () => resolve(link), { once: true });
+      link.addEventListener('error', () => {
+        reject(new Error('Marker Detail stylesheet could not be loaded'));
+      }, { once: true });
+      const anchor = document.querySelector('[data-marker-detail-stylesheet-anchor]');
+      const parent = anchor?.parentNode || document.head;
+      parent.insertBefore(link, anchor || null);
+    }).catch(err => {
+      link.remove();
+      _markerDetailStylesheetLoad = null;
+      _useMarkerDetailStylesheetRetryUrl = true;
+      throw err;
+    });
+  }
+  return _markerDetailStylesheetLoad;
+}
+
+/**
+ * @template T
+ * @param {() => T} open
+ * @returns {Promise<T | false>}
+ */
+export function openWithMarkerDetailStylesheet(open) {
+  return loadMarkerDetailStylesheet()
+    .catch(err => {
+      console.error('[marker-detail] Could not load stylesheet:', err);
+      showNotification('Could not open marker details. Reload the app to finish updating, then try again.', 'error');
+      return null;
+    })
+    .then(link => link ? open() : false);
+}
 
 /**
  * @typedef {{

--- a/plans/code-quality-audit-2026-07-21.md
+++ b/plans/code-quality-audit-2026-07-21.md
@@ -105,9 +105,9 @@ decoded bytes. The initial reference was 474 requests, 2,017,210 compressed
 bytes, and 6,252,286 decoded bytes. Lazy-loading the PDF import review,
 Light/Sun analysis hooks, Settings/Tweaks, Profile Sharing, and the Settings
 Light/Sun, Client List, and Import review stylesheets reduced that reference to
-438 requests, 1,845,990 compressed bytes, and 5,585,805 decoded bytes. The
-Marker Detail stylesheet slice saved one request, 4,078 compressed bytes, and
-26,384 decoded bytes in identical before/after runs on the same machine. Route
+438 requests, 1,846,079 compressed bytes, and 5,585,960 decoded bytes. The
+Marker Detail stylesheet slice saved one request, 3,989 compressed bytes, and
+26,229 decoded bytes in identical before/after runs on the same machine. Route
 and feature lazy loading remains active, with the ceilings ratcheting downward
 after each reproducible slice.
 

--- a/plans/code-quality-audit-2026-07-21.md
+++ b/plans/code-quality-audit-2026-07-21.md
@@ -105,9 +105,9 @@ decoded bytes. The initial reference was 474 requests, 2,017,210 compressed
 bytes, and 6,252,286 decoded bytes. Lazy-loading the PDF import review,
 Light/Sun analysis hooks, Settings/Tweaks, Profile Sharing, and the Settings
 Light/Sun, Client List, and Import review stylesheets reduced that reference to
-439 requests, 1,850,068 compressed bytes, and 5,612,189 decoded bytes. The
-Import review stylesheet slice saved one request, 4,246 compressed bytes, and
-23,040 decoded bytes in identical before/after runs on the same machine. Route
+438 requests, 1,845,990 compressed bytes, and 5,585,805 decoded bytes. The
+Marker Detail stylesheet slice saved one request, 4,078 compressed bytes, and
+26,384 decoded bytes in identical before/after runs on the same machine. Route
 and feature lazy loading remains active, with the ceilings ratcheting downward
 after each reproducible slice.
 

--- a/scripts/cold-load-budget.json
+++ b/scripts/cold-load-budget.json
@@ -3,15 +3,15 @@
   "route": "/app",
   "scenario": "Fresh mobile returning-user load with browser cache and service workers disabled",
   "maximums": {
-    "requests": 445,
-    "transferBytes": 1884000,
-    "decodedBytes": 5708000
+    "requests": 444,
+    "transferBytes": 1880000,
+    "decodedBytes": 5682000
   },
   "reference": {
-    "requests": 439,
-    "transferBytes": 1850068,
-    "decodedBytes": 5612189
+    "requests": 438,
+    "transferBytes": 1845990,
+    "decodedBytes": 5585805
   },
-  "referenceCommit": "758ce3f2",
+  "referenceCommit": "7e399951",
   "measuredAt": "2026-07-24"
 }

--- a/scripts/cold-load-budget.json
+++ b/scripts/cold-load-budget.json
@@ -9,8 +9,8 @@
   },
   "reference": {
     "requests": 438,
-    "transferBytes": 1845990,
-    "decodedBytes": 5585805
+    "transferBytes": 1846079,
+    "decodedBytes": 5585960
   },
   "referenceCommit": "7e399951",
   "measuredAt": "2026-07-24"

--- a/tests/firefox/smoke.spec.js
+++ b/tests/firefox/smoke.spec.js
@@ -154,6 +154,7 @@ test('installs a readable app shell for offline use', async ({ browserName, cont
       '/css/import.css',
       '/css/settings.css',
       '/css/client-list.css',
+      '/css/marker-detail-modal.css',
       '/css/light-sun.css',
       '/css/light-channels.css',
       '/css/light-devices.css',
@@ -185,6 +186,7 @@ test('installs a readable app shell for offline use', async ({ browserName, cont
     { path: '/css/import.css', available: true },
     { path: '/css/settings.css', available: true },
     { path: '/css/client-list.css', available: true },
+    { path: '/css/marker-detail-modal.css', available: true },
     { path: '/css/light-sun.css', available: true },
     { path: '/css/light-channels.css', available: true },
     { path: '/css/light-devices.css', available: true },
@@ -240,5 +242,26 @@ test('installs a readable app shell for offline use', async ({ browserName, cont
   await expect(page.locator('#import-modal .import-review-summary')).toHaveCSS('display', 'grid');
   await expect(page.locator('link[data-import-stylesheet]')).toHaveCount(1);
   await page.locator('.import-review-actions [data-cycle-import-action="close"]').click();
+  await page.evaluate(async () => {
+    const [{ state }, data, views] = await Promise.all([
+      import('/js/state.js'),
+      import('/js/data.js'),
+      import('/js/views.js'),
+    ]);
+    state.importedData = {
+      ...state.importedData,
+      entries: [{
+        date: '2026-07-01',
+        markers: { 'proteins.albumin': 42 },
+      }],
+    };
+    data.invalidateActiveDataCache();
+    await views.showDetailModal('proteins_albumin');
+  });
+  await expect(page.locator('#modal-overlay')).toHaveClass(/\bshow\b/);
+  await expect(page.locator('#detail-modal')).toHaveClass(/\bmarker-detail-modal\b/);
+  await expect(page.locator('#detail-modal')).toHaveCSS('padding-top', '0px');
+  await expect(page.locator('link[data-marker-detail-stylesheet]')).toHaveCount(1);
+  await page.evaluate(async () => (await import('/js/views.js')).closeModal());
   expect(pageErrors).toEqual([]);
 });

--- a/tests/playwright/backup-browser-coverage.spec.js
+++ b/tests/playwright/backup-browser-coverage.spec.js
@@ -124,6 +124,23 @@ test('backup browser coverage exercises export import auto backup and folder sta
         && snapshot.profiles?.[0]?.keys?.units === 'EU'
         && snapshot.profiles?.[0]?.keys?.chatRailOpen === 'true';
 
+      const serializedBytes = backup.serializeBackupSnapshot({
+        bytes: new Uint8Array([0, 127, 255]),
+        encrypted: {
+          _enc: 'v1',
+          iv: { 0: 1, 1: 2 },
+          ct: { 0: 3, 1: 4 },
+        },
+      });
+      const parsedBytes = backup.parseBackupSnapshot(serializedBytes);
+      outcomes.backupSerializationRoundTripsCurrentAndLegacyByteArrays =
+        parsedBytes.bytes instanceof Uint8Array
+        && parsedBytes.bytes.join(',') === '0,127,255'
+        && parsedBytes.encrypted.iv instanceof Uint8Array
+        && parsedBytes.encrypted.iv.join(',') === '1,2'
+        && parsedBytes.encrypted.ct instanceof Uint8Array
+        && parsedBytes.encrypted.ct.join(',') === '3,4';
+
       localStorage.removeItem(importedKey);
       await blobStorage.setBlob(importedKey, JSON.stringify({ entries: [{ date: '2026-06-11', markers: { cobalt: 3 } }] }));
       const fullSnapshot = await backup.buildFullBackupSnapshot();

--- a/tests/playwright/browser-coverage-batch.spec.js
+++ b/tests/playwright/browser-coverage-batch.spec.js
@@ -194,19 +194,54 @@ test('notes editor browser contract adds edits and deletes notes', async ({ page
   }
 });
 
-test('chat send controls cover button state typewriter and abort paths', async ({ page }) => {
+test('chat send controls cover button state typewriter runtime bridges and abort paths', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
   await page.waitForSelector('#chat-input');
 
-  const results = await page.evaluate(async ({ chatSendUrl }) => {
-    const chatSend = await import(chatSendUrl);
+  const results = await page.evaluate(async ({ chatSendUrl, chatSendRuntimeUrl }) => {
+    const [chatSend, chatSendRuntime, recommendationRuntime] = await Promise.all([
+      import(chatSendUrl),
+      import(chatSendRuntimeUrl),
+      import('/js/recommendations-runtime.js'),
+    ]);
     const outcomes = {};
     const originalProvider = localStorage.getItem('labcharts-ai-provider');
     const originalPaused = localStorage.getItem('labcharts-ai-paused');
+    const attestationKeys = ['_ppqAttestation', '_routstrAttestation', '_veniceAttestation'];
+    const originalAttestations = Object.fromEntries(attestationKeys.map(key => [
+      key,
+      {
+        owned: Object.prototype.hasOwnProperty.call(window, key),
+        value: window[key],
+      },
+    ]));
+    const restoreRecommendationBridge = recommendationRuntime.configureRecommendationModuleBridge({
+      isProductRecsEnabled: () => true,
+      detectSupplementSlots: text => text.includes('magnesium') ? ['magnesium'] : [],
+      detectEMFRelevance: text => text.includes('router'),
+      renderRecommendationSection: async () => '<div>async rec</div>',
+      renderRecommendationSectionSync: () => '<div>sync rec</div>',
+      loadCatalog: async () => ({ products: [] }),
+    });
 
     try {
       localStorage.setItem('labcharts-ai-provider', 'ollama');
       localStorage.setItem('labcharts-ai-paused', 'false');
+      window._ppqAttestation = 'ppq-attestation';
+      window._routstrAttestation = 'routstr-attestation';
+      window._veniceAttestation = 'venice-attestation';
+
+      const recommendationBridge = chatSendRuntime.getChatSendRecommendationRuntime();
+      outcomes.chatSendRuntimeReadsAttestationsAndRecommendationBridge =
+        chatSendRuntime.getChatSendProviderAttestation('ppq') === 'ppq-attestation'
+        && chatSendRuntime.getChatSendProviderAttestation('routstr') === 'routstr-attestation'
+        && chatSendRuntime.getChatSendProviderAttestation('venice') === 'venice-attestation'
+        && chatSendRuntime.isChatSendProductRecsEnabled() === true
+        && chatSendRuntime.detectChatSendSupplementSlots('try magnesium')[0] === 'magnesium'
+        && chatSendRuntime.isChatSendEMFRelevant('move the router') === true
+        && typeof recommendationBridge?.renderRecommendationSection === 'function'
+        && typeof recommendationBridge?.renderRecommendationSectionSync === 'function'
+        && typeof recommendationBridge?.loadCatalog === 'function';
 
       const input = document.getElementById('chat-input');
       const sendBtn = document.getElementById('chat-send-btn');
@@ -280,10 +315,27 @@ test('chat send controls cover button state typewriter and abort paths', async (
       else localStorage.setItem('labcharts-ai-provider', originalProvider);
       if (originalPaused == null) localStorage.removeItem('labcharts-ai-paused');
       else localStorage.setItem('labcharts-ai-paused', originalPaused);
+      recommendationRuntime.configureRecommendationModuleBridge({
+        isProductRecsEnabled: null,
+        detectSupplementSlots: null,
+        detectEMFRelevance: null,
+        renderRecommendationSection: null,
+        renderRecommendationSectionSync: null,
+        loadCatalog: null,
+        ...restoreRecommendationBridge,
+      });
+      for (const key of attestationKeys) {
+        const original = originalAttestations[key];
+        if (original.owned) window[key] = original.value;
+        else delete window[key];
+      }
     }
 
     return outcomes;
-  }, { chatSendUrl: moduleUrl('/js/chat-send.js') });
+  }, {
+    chatSendUrl: moduleUrl('/js/chat-send.js'),
+    chatSendRuntimeUrl: moduleUrl('/js/chat-send-runtime.js'),
+  });
 
   for (const [name, passed] of Object.entries(results)) {
     expect(passed, name).toBe(true);

--- a/tests/playwright/browser-helper-modules-coverage.spec.js
+++ b/tests/playwright/browser-helper-modules-coverage.spec.js
@@ -10,13 +10,23 @@ async function openBlankPage(page) {
   await page.goto('/browser-helper-coverage', { waitUntil: 'load' });
 }
 
-test('browser helper coverage exercises url safety marker keys markdown brand assets and health goals', async ({ page }) => {
+test('browser helper coverage exercises url safety marker keys markdown legal lens brand assets and health goals', async ({ page }) => {
   await openBlankPage(page);
 
-  const results = await page.evaluate(async ({ brandAssetsUrl, healthGoalsUrl, markdownUrl, urlSafetyUrl, utilsUrl }) => {
-    const [brandAssets, healthGoals, markdown, urlSafety, utils] = await Promise.all([
+  const results = await page.evaluate(async ({
+    brandAssetsUrl,
+    healthGoalsUrl,
+    legalConsentUrl,
+    lensLocalStoreUrl,
+    markdownUrl,
+    urlSafetyUrl,
+    utilsUrl,
+  }) => {
+    const [brandAssets, healthGoals, legalConsent, lensLocalStore, markdown, urlSafety, utils] = await Promise.all([
       import(brandAssetsUrl),
       import(healthGoalsUrl),
+      import(legalConsentUrl),
+      import(lensLocalStoreUrl),
       import(markdownUrl),
       import(urlSafetyUrl),
       import(utilsUrl),
@@ -184,6 +194,64 @@ test('browser helper coverage exercises url safety marker keys markdown brand as
       }
     }
 
+    const normalizedLibraries = lensLocalStore.normaliseLibraryRegistry({
+      activeId: 'missing',
+      revision: '4',
+      updatedAt: '10',
+      libraries: [
+        { id: 'lib-primary', name: '', createdAt: 5, model: 'small' },
+        { id: 'lib-primary', name: 'Duplicate' },
+        { id: 'bad id', name: 'Unsafe' },
+      ],
+    });
+    const sameLibraries = lensLocalStore.normaliseLibraryRegistry({
+      ...normalizedLibraries,
+      libraries: normalizedLibraries?.libraries.map(record => ({ ...record })),
+    });
+    outcomes.lensLocalStoreNormalizesValidatesComparesAndMatchesModels =
+      normalizedLibraries?.activeId === 'lib-primary'
+      && normalizedLibraries.libraries[0].name === 'primary'
+      && normalizedLibraries.revision === 4
+      && lensLocalStore.sameLibraryRegistry(normalizedLibraries, sameLibraries)
+      && lensLocalStore.normaliseLibraryRecord({ id: 'default', createdAt: 1 })?.name === 'My Library'
+      && lensLocalStore.isSafeLibraryId('safe_library-1')
+      && !lensLocalStore.isSafeLibraryId('unsafe library')
+      && lensLocalStore.fallbackLibraryName('lib-recovered_name') === 'recovered name'
+      && lensLocalStore.modelKeyFromManifest(
+        { modelId: 'model-small', dim: 384 },
+        { small: { id: 'model-small', dim: 384 } },
+      ) === 'small';
+
+    const legalKey = 'labcharts-legal-acceptance';
+    const oldLegalAcceptance = localStorage.getItem(legalKey);
+    try {
+      localStorage.removeItem(legalKey);
+      document.getElementById('legal-consent-overlay')?.remove();
+      document.body.classList.remove('legal-consent-visible');
+      const firstShow = legalConsent.maybeShowLegalConsentGate();
+      const checkbox = document.getElementById('legal-consent-checkbox');
+      const acceptButton = document.querySelector('[data-legal-consent-action="accept"]');
+      checkbox.checked = true;
+      checkbox.dispatchEvent(new Event('change', { bubbles: true }));
+      const buttonEnabled = acceptButton.disabled === false;
+      acceptButton.click();
+      const accepted = legalConsent.getLegalAcceptance();
+      outcomes.legalConsentGatePersistsAndClosesThroughDelegatedEvents =
+        firstShow === true
+        && buttonEnabled
+        && accepted?.accepted === true
+        && typeof accepted.acceptedAt === 'string'
+        && legalConsent.hasAcceptedCurrentLegal()
+        && !legalConsent.isLegalConsentGateVisible()
+        && !document.body.classList.contains('legal-consent-visible');
+    } finally {
+      document.getElementById('legal-consent-overlay')?.remove();
+      document.body.classList.remove('legal-consent-visible');
+      document.querySelectorAll('.notification-toast').forEach(el => el.remove());
+      if (oldLegalAcceptance == null) localStorage.removeItem(legalKey);
+      else localStorage.setItem(legalKey, oldLegalAcceptance);
+    }
+
     const inlineHtml = markdown.applyInlineMarkdown(
       '**bold** and *italic* with `code`, [safe](https://example.com/"quoted"), [bad](javascript:alert(1)), https://docs.example/path and <script>'
     );
@@ -275,6 +343,8 @@ test('browser helper coverage exercises url safety marker keys markdown brand as
   }, {
     brandAssetsUrl: moduleUrl('/js/brand-assets.js'),
     healthGoalsUrl: moduleUrl('/js/health-goals-utils.js'),
+    legalConsentUrl: moduleUrl('/js/legal-consent.js'),
+    lensLocalStoreUrl: moduleUrl('/js/lens-local-store.js'),
     markdownUrl: moduleUrl('/js/markdown.js'),
     urlSafetyUrl: moduleUrl('/js/url-safety.js'),
     utilsUrl: moduleUrl('/js/utils.js'),

--- a/tests/playwright/cold-load-budget.spec.js
+++ b/tests/playwright/cold-load-budget.spec.js
@@ -79,6 +79,9 @@ test('cold mobile app load stays within committed resource budgets', async ({ pa
   expect(entries.some(entry => (
     new URL(entry.name).pathname === '/css/client-list.css'
   ))).toBe(false);
+  expect(entries.some(entry => (
+    new URL(entry.name).pathname === '/css/marker-detail-modal.css'
+  ))).toBe(false);
   const deferredLightStylesheets = new Set([
     '/css/light-sun.css',
     '/css/light-channels.css',

--- a/tests/playwright/cycle-browser-coverage.spec.js
+++ b/tests/playwright/cycle-browser-coverage.spec.js
@@ -13,13 +13,14 @@ function expectAll(outcomes) {
 test('cycle browser coverage exercises editor save clear and period guards', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
 
-  const results = await page.evaluate(async ({ cycleUrl }) => {
-    const [{ state }, cycle, cycleRuntime, tour, cycleStore, contextCardsRuntime] = await Promise.all([
+  const results = await page.evaluate(async ({ cycleStoreCoverageUrl, cycleUrl }) => {
+    const [{ state }, cycle, cycleRuntime, tour, cycleStore, cycleStoreCoverage, contextCardsRuntime] = await Promise.all([
       import('/js/state.js'),
       import(cycleUrl),
       import('/js/cycle-runtime.js'),
       import('/js/tour.js'),
       import('/js/cycle-store.js'),
+      import(cycleStoreCoverageUrl),
       import('/js/context-cards-runtime.js'),
     ]);
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
@@ -30,7 +31,9 @@ test('cycle browser coverage exercises editor save clear and period guards', asy
     const saved = {
       importedData: clone(state.importedData),
       profileDob: state.profileDob,
+      encryptionEnabled: localStorage.getItem('labcharts-encryption-enabled'),
     };
+    const cycleStoreCoverageProfile = `cycle-store-coverage-${Date.now()}-${Math.random().toString(36).slice(2)}`;
     const previousContextCardsRuntime = contextCardsRuntime.configureContextCardsRuntimeCallbacks({
       recordChange: field => calls.push(['record', field]),
     });
@@ -65,6 +68,63 @@ test('cycle browser coverage exercises editor save clear and period guards', asy
     });
 
     try {
+      localStorage.setItem('labcharts-encryption-enabled', 'false');
+      await cycleStoreCoverage.upsertCycleObservation(cycleStoreCoverageProfile, {
+        source: 'coverage',
+        importId: 'coverage-import',
+        date: '2026-07-01',
+        bleeding: { flow: 'light' },
+      });
+      const storedObservation = await cycleStoreCoverage.getCycleObservation(
+        cycleStoreCoverageProfile,
+        'coverage',
+        '2026-07-01',
+      );
+      const rawRange = await cycleStoreCoverage.getCycleObservationRangeRaw(
+        cycleStoreCoverageProfile,
+        'coverage',
+        '2026-07-01',
+        '2026-07-31',
+      );
+      await cycleStoreCoverage.setCycleMeta(cycleStoreCoverageProfile, 'coverage-key', { ready: true });
+      const storedMeta = await cycleStoreCoverage.getCycleMeta(cycleStoreCoverageProfile, 'coverage-key');
+      await cycleStoreCoverage.deleteCycleMeta(cycleStoreCoverageProfile, 'coverage-key');
+      const deletedMeta = await cycleStoreCoverage.getCycleMeta(cycleStoreCoverageProfile, 'coverage-key');
+      await cycleStoreCoverage.clearCycleSource(cycleStoreCoverageProfile, 'coverage');
+      const clearedSourceCount = await cycleStoreCoverage.countCycleSource(cycleStoreCoverageProfile, 'coverage');
+
+      localStorage.setItem('labcharts-encryption-enabled', 'true');
+      let lockedWriteRejected = false;
+      try {
+        await cycleStoreCoverage.upsertCycleObservation(cycleStoreCoverageProfile, {
+          source: 'coverage',
+          importId: 'locked-import',
+          date: '2026-07-02',
+        });
+      } catch (error) {
+        lockedWriteRejected = error?.code === 'session-locked';
+      }
+      localStorage.setItem('labcharts-encryption-enabled', 'false');
+      await cycleStoreCoverage.upsertCycleObservationBatchRaw(cycleStoreCoverageProfile, [{
+        source: 'coverage',
+        importId: 'encrypted-import',
+        date: '2026-07-03',
+        _payload: { _enc: 'v1', iv: 'coverage', ct: 'coverage' },
+      }]);
+      const unavailableDecryption = await cycleStoreCoverage.getCycleObservation(
+        cycleStoreCoverageProfile,
+        'coverage',
+        '2026-07-03',
+      );
+      outcomes.cycleStoreCoversObservationSourceMetaAndDefaultCryptoPaths =
+        storedObservation?.bleeding?.flow === 'light'
+        && rawRange.length === 1
+        && storedMeta?.ready === true
+        && deletedMeta === null
+        && clearedSourceCount === 0
+        && lockedWriteRejected
+        && unavailableDecryption === null;
+
       if (!overlay()) {
         const createdOverlay = document.createElement('div');
         createdOverlay.id = 'modal-overlay';
@@ -241,6 +301,9 @@ test('cycle browser coverage exercises editor save clear and period guards', asy
     } finally {
       state.importedData = saved.importedData;
       state.profileDob = saved.profileDob;
+      if (saved.encryptionEnabled == null) localStorage.removeItem('labcharts-encryption-enabled');
+      else localStorage.setItem('labcharts-encryption-enabled', saved.encryptionEnabled);
+      await cycleStoreCoverage.deleteCycleDB(cycleStoreCoverageProfile).catch(() => {});
       cycleRuntime.configureCycleRuntimeDeps(previousCycleRuntime);
       contextCardsRuntime.configureContextCardsRuntimeCallbacks(previousContextCardsRuntime);
       tour.endTour();
@@ -253,7 +316,10 @@ test('cycle browser coverage exercises editor save clear and period guards', asy
     }
 
     return outcomes;
-  }, { cycleUrl: moduleUrl('/js/cycle.js') });
+  }, {
+    cycleStoreCoverageUrl: moduleUrl('/js/cycle-store.js'),
+    cycleUrl: moduleUrl('/js/cycle.js'),
+  });
 
   expectAll(results);
 });

--- a/tests/playwright/marker-detail-browser-coverage.spec.js
+++ b/tests/playwright/marker-detail-browser-coverage.spec.js
@@ -4,6 +4,129 @@ function moduleUrl(path) {
   return `${path}?markerDetailCoverage=${Date.now()}-${Math.random().toString(36).slice(2)}`;
 }
 
+async function openMarkerDetailLoaderPage(page, path) {
+  await page.route(`**${path}`, route => route.fulfill({
+    status: 200,
+    contentType: 'text/html',
+    body: `<!doctype html><html><head><meta data-marker-detail-stylesheet-anchor></head><body>
+      <div id="modal-overlay" class="modal-overlay"><div id="detail-modal" class="modal"></div></div>
+      <div id="notification-container"></div>
+    </body></html>`,
+  }));
+  await page.goto(path, { waitUntil: 'load' });
+}
+
+test('marker detail stylesheet loader single-flights and preserves cascade order', async ({ page }) => {
+  let stylesheetRequests = 0;
+  await page.route('**/css/marker-detail-modal.css*', route => {
+    stylesheetRequests += 1;
+    return route.fulfill({
+      status: 200,
+      contentType: 'text/css',
+      body: '.marker-detail-modal { padding: 0; }',
+    });
+  });
+  await openMarkerDetailLoaderPage(page, '/marker-detail-stylesheet-cache-coverage');
+
+  const outcomes = await page.evaluate(async ({ modalUrl }) => {
+    const modal = await import(modalUrl);
+    const [first, second] = await Promise.all([
+      modal.loadMarkerDetailStylesheet(),
+      modal.loadMarkerDetailStylesheet(),
+    ]);
+    const third = await modal.loadMarkerDetailStylesheet();
+    const anchor = document.querySelector('[data-marker-detail-stylesheet-anchor]');
+    return {
+      concurrentCallsShareTheSameLink: first === second,
+      laterCallsReuseTheResolvedLink: first === third,
+      oneStylesheetLink: document.querySelectorAll('link[data-marker-detail-stylesheet]').length === 1,
+      linkPrecedesAnchor: first.nextElementSibling === anchor,
+    };
+  }, { modalUrl: moduleUrl('/js/marker-detail-modal.js') });
+
+  expect(outcomes).toEqual({
+    concurrentCallsShareTheSameLink: true,
+    laterCallsReuseTheResolvedLink: true,
+    oneStylesheetLink: true,
+    linkPrecedesAnchor: true,
+  });
+  expect(stylesheetRequests).toBe(1);
+});
+
+test('marker detail stylesheet loader removes a failure and retries', async ({ page }) => {
+  const stylesheetRequests = [];
+  let failFirstRequest = true;
+  await page.route('**/css/marker-detail-modal.css*', route => {
+    stylesheetRequests.push(route.request().url());
+    if (failFirstRequest) {
+      failFirstRequest = false;
+      return route.abort('failed');
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: 'text/css',
+      body: '.marker-detail-modal { padding: 0; }',
+    });
+  });
+  await openMarkerDetailLoaderPage(page, '/marker-detail-stylesheet-retry-coverage');
+
+  const outcomes = await page.evaluate(async ({ modalUrl }) => {
+    const modal = await import(modalUrl);
+    let firstRejected = false;
+    try {
+      await modal.loadMarkerDetailStylesheet();
+    } catch {
+      firstRejected = true;
+    }
+    const failedLinkWasRemoved =
+      document.querySelectorAll('link[data-marker-detail-stylesheet]').length === 0;
+    const retryLink = await modal.loadMarkerDetailStylesheet();
+    return {
+      firstRejected,
+      failedLinkWasRemoved,
+      retryLoaded: retryLink.sheet !== null,
+      retryUsesCacheBuster:
+        new URL(retryLink.href).searchParams.get('lazy-retry') === '1',
+    };
+  }, { modalUrl: moduleUrl('/js/marker-detail-modal.js') });
+
+  expect(outcomes).toEqual({
+    firstRejected: true,
+    failedLinkWasRemoved: true,
+    retryLoaded: true,
+    retryUsesCacheBuster: true,
+  });
+  expect(stylesheetRequests).toHaveLength(2);
+  expect(new URL(stylesheetRequests[1]).searchParams.get('lazy-retry')).toBe('1');
+});
+
+test('marker detail entry contains a stylesheet load failure', async ({ page }) => {
+  await page.route('**/css/marker-detail-modal.css*', route => route.abort('failed'));
+  await openMarkerDetailLoaderPage(page, '/marker-detail-stylesheet-entry-failure-coverage');
+
+  const outcomes = await page.evaluate(async ({ modalUrl }) => {
+    const modal = await import(modalUrl);
+    const opened = await modal.openCreateMarkerModal();
+    return {
+      returnsFalse: opened === false,
+      failedLinkWasRemoved:
+        document.querySelectorAll('link[data-marker-detail-stylesheet]').length === 0,
+      modalStayedClosed:
+        !document.getElementById('modal-overlay')?.classList.contains('show'),
+      errorWasExplained:
+        document.getElementById('notification-container')?.textContent
+          ?.includes('Could not open marker details') === true,
+    };
+  }, { modalUrl: moduleUrl('/js/marker-detail-modal.js') });
+
+  expect(outcomes).toEqual({
+    returnsFalse: true,
+    failedLinkWasRemoved: true,
+    modalStayedClosed: true,
+    errorWasExplained: true,
+  });
+});
+
 test('marker detail editing covers default dependency callbacks', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
   await page.waitForSelector('#notification-container', { state: 'attached' });
@@ -656,7 +779,8 @@ test('marker detail modal covers default deps descriptions alt units and bio age
   await page.route('**/marker-detail-modal-isolated-coverage', route => route.fulfill({
     status: 200,
     contentType: 'text/html',
-    body: `<!doctype html><html><head><title>Marker detail isolated coverage</title></head>
+    body: `<!doctype html><html><head><title>Marker detail isolated coverage</title>
+        <meta data-marker-detail-stylesheet-anchor></head>
       <body>
         <div id="modal-overlay" class="modal-overlay"><div id="detail-modal" class="modal"></div></div>
         <div id="notification-container"></div>
@@ -762,10 +886,19 @@ test('marker detail modal covers default deps descriptions alt units and bio age
       outcomes.fetchCustomMarkerDescriptionUsesCache =
         await modal.fetchCustomMarkerDescription('coverage.cached', 'Coverage cached', 'u') === 'Cached marker description';
 
-      modal.showDetailModal(albuminId, { scrollToRec: true });
+      outcomes.markerDetailStylesheetIsAbsentBeforeFirstOpen =
+        document.querySelectorAll('link[data-marker-detail-stylesheet]').length === 0;
+      const firstOpenStartedAt = performance.now();
+      await modal.showDetailModal(albuminId, { scrollToRec: true });
+      outcomes.firstOpenCompletesWithinInteractionBudget =
+        performance.now() - firstOpenStartedAt < 1000;
       await wait(80);
       const detail = document.getElementById('detail-modal');
       const detailText = detail?.textContent || '';
+      outcomes.firstOpenLoadsAndAppliesMarkerDetailStylesheet =
+        document.querySelectorAll('link[data-marker-detail-stylesheet]').length === 1
+        && !!detail
+        && getComputedStyle(detail).paddingTop === '0px';
       outcomes.detailModalRendersAltUnitsQuickPinAndRecommendations =
         detailText.includes('Albumin renamed')
         && detailText.includes('g/dl')
@@ -779,7 +912,7 @@ test('marker detail modal covers default deps descriptions alt units and bio age
         && detailText.includes('History All time');
 
       state.rangeMode = 'reference';
-      modal.showDetailModal(albuminId);
+      await modal.showDetailModal(albuminId);
       await wait(20);
       const referenceDetail = document.getElementById('detail-modal');
       outcomes.detailModalReferenceModeUsesReferenceAsThePrimaryRange =
@@ -788,7 +921,7 @@ test('marker detail modal covers default deps descriptions alt units and bio age
       outcomes.detailModalReferenceModeOmitsOptimalSecondaryRange =
         !referenceDetail?.querySelector('.stat-card:nth-child(2) .stat-card-meta')?.textContent.includes('Optimal');
       state.rangeMode = 'both';
-      modal.showDetailModal(albuminId);
+      await modal.showDetailModal(albuminId);
       await wait(20);
 
       const restoredDetail = document.getElementById('detail-modal');
@@ -808,7 +941,7 @@ test('marker detail modal covers default deps descriptions alt units and bio age
       modal.pickNewCatIcon(icon);
       outcomes.defaultEmojiPickerNoops = icon.textContent === '*';
 
-      modal.showDetailModal('calculatedRatios_phenoAge');
+      await modal.showDetailModal('calculatedRatios_phenoAge');
       await wait(80);
       const bioText = document.getElementById('detail-modal')?.textContent || '';
       outcomes.bioAgeDetailUsesStandardCrpPresenceFallback =

--- a/tests/playwright/marker-detail-browser-coverage.spec.js
+++ b/tests/playwright/marker-detail-browser-coverage.spec.js
@@ -818,14 +818,21 @@ test('marker detail modal covers default deps descriptions alt units and bio age
       showAltUnits: state.showAltUnits,
       rangeMode: state.rangeMode,
       chartInstances: state.chartInstances,
+      scrollIntoView: Element.prototype.scrollIntoView,
+    };
+    let scrollCalls = 0;
+    Element.prototype.scrollIntoView = function scrollIntoView() {
+      scrollCalls += 1;
     };
     const date = '2026-06-01';
     const albuminId = 'proteins_albumin';
     const albuminKey = 'proteins.albumin';
     const restoreMarkerRuntime = markerRuntime.configureMarkerDetailRuntime({
       askAIAboutMarker: id => calls.push(['ask-ai', id]),
+      buildSidebar: () => calls.push(['sidebar']),
       closeEMFInterpretation: () => calls.push(['close-emf']),
       isDashboardQuickMarkerPinned: () => false,
+      navigate: (...args) => calls.push(['navigate', ...args]),
       renameMarker: id => calls.push(['rename', id]),
       revertMarkerName: id => calls.push(['revert-name', id]),
       showEmojiPicker: () => {},
@@ -889,7 +896,7 @@ test('marker detail modal covers default deps descriptions alt units and bio age
       outcomes.markerDetailStylesheetIsAbsentBeforeFirstOpen =
         document.querySelectorAll('link[data-marker-detail-stylesheet]').length === 0;
       const firstOpenStartedAt = performance.now();
-      await modal.showDetailModal(albuminId, { scrollToRec: true });
+      await modal.showDetailModal(albuminId, { scrollToHistory: true, scrollToRec: true });
       outcomes.firstOpenCompletesWithinInteractionBudget =
         performance.now() - firstOpenStartedAt < 1000;
       await wait(80);
@@ -905,6 +912,7 @@ test('marker detail modal covers default deps descriptions alt units and bio age
         && detailText.includes('coverage-lab.pdf')
         && !!detail?.querySelector('.gb-detail-pin-btn[aria-pressed="false"]')
         && detailText.includes('rec proteins.albumin');
+      outcomes.detailModalRunsRequestedScrollCallbacks = scrollCalls >= 2;
       outcomes.detailModalBothModeLabelsEachRangeAndUsesNativeEditButtons =
         detail?.querySelector('.stat-card-value-range')?.textContent.includes('reference')
         && detail.querySelector('.stat-card:nth-child(2) .stat-card-meta')?.textContent.includes('Optimal')
@@ -949,6 +957,113 @@ test('marker detail modal covers default deps descriptions alt units and bio age
         && !bioText.includes('Missing: hs-CRP')
         && !bioText.includes('Missing on latest date');
 
+      await modal.openManualEntryForm(albuminId, '2026-06-02');
+      await wait(70);
+      const escapeInput = document.getElementById('me-value');
+      escapeInput?.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        cancelable: true,
+      }));
+      await wait(20);
+      outcomes.manualEntryEscapeReturnsToDetail =
+        document.getElementById('detail-modal')?.textContent.includes('Albumin renamed') === true;
+
+      await modal.openManualEntryForm(albuminId, '2026-06-02');
+      await wait(70);
+      document.getElementById('me-value').value = '43';
+      await modal.saveManualEntry(albuminId, { keepOpen: true });
+      await wait(20);
+      outcomes.keepOpenManualSaveRunsDefaultSidebarAndFormCallbacks =
+        calls.some(call => call[0] === 'sidebar')
+        && calls.some(call => call[0] === 'navigate')
+        && document.getElementById('me-date')?.value === '2026-06-02';
+
+      document.getElementById('me-date').value = '2026-06-03';
+      document.getElementById('me-value').value = '44';
+      await modal.saveManualEntry(albuminId);
+      await wait(80);
+      outcomes.closingManualSaveRunsDefaultCloseCallback =
+        !document.getElementById('modal-overlay')?.classList.contains('show')
+        || document.getElementById('detail-modal')?.textContent.includes('Albumin renamed') === true;
+
+      state.importedData.entries = [{
+        date: '2026-06-10',
+        markers: { 'proteins.crp': 1.2 },
+      }];
+      data.invalidateActiveDataCache();
+      const sparseData = data.getActiveData();
+      if (sparseData.categories.proteins?.markers.hsCRP) {
+        sparseData.categories.proteins.markers.hsCRP.values = sparseData.dates.map(() => null);
+      }
+      await modal.showDetailModal('calculatedRatios_phenoAge');
+      await wait(20);
+      const sparseIssue = document.querySelector('.calc-missing-inputs')?.textContent || '';
+      outcomes.bioAgeFallbackRebuildsRemainingMissingInputs =
+        sparseIssue.includes('Missing:')
+        && sparseIssue.includes('Albumin')
+        && !sparseIssue.includes('hs-CRP');
+
+      state.importedData.entries = [{
+        date: '2026-06-11',
+        markers: {
+          [albuminKey]: 42,
+          'biochemistry.creatinine': 82,
+          'biochemistry.glucose': 5.1,
+          'proteins.crp': 1.2,
+          'differential.lymphocytesPct': 0.28,
+          'hematology.mcv': 90,
+          'hematology.rdwcv': 12.5,
+          'biochemistry.alp': 1.1,
+          'hematology.wbc': 5.4,
+        },
+      }, {
+        date: '2026-06-12',
+        markers: { 'proteins.crp': 1.1 },
+      }];
+      data.invalidateActiveDataCache();
+      const latestGapData = data.getActiveData();
+      if (latestGapData.categories.proteins?.markers.hsCRP) {
+        latestGapData.categories.proteins.markers.hsCRP.values = latestGapData.dates.map(() => null);
+      }
+      await modal.showDetailModal('calculatedRatios_phenoAge');
+      await wait(20);
+      const latestGapIssue = document.querySelector('.calc-missing-inputs')?.textContent || '';
+      outcomes.bioAgeFallbackNamesLatestPanelGaps =
+        latestGapIssue.includes('Missing on latest date')
+        && latestGapIssue.includes('Albumin');
+
+      const customKey = 'customCoverage.marker';
+      const customId = 'customCoverage_marker';
+      state.importedData.entries = [{
+        date,
+        markers: {
+          [albuminKey]: 42,
+          [customKey]: 7,
+        },
+      }];
+      state.importedData.customMarkers = {
+        [customKey]: {
+          name: 'Coverage marker',
+          unit: 'u',
+          categoryLabel: 'Coverage',
+        },
+      };
+      data.invalidateActiveDataCache();
+      localStorage.setItem('labcharts-ai-provider', 'ollama');
+      localStorage.setItem('labcharts-ai-paused', 'false');
+      localStorage.setItem('labcharts-marker-desc', JSON.stringify({
+        'coverage.cached': 'Cached marker description',
+        [customId]: 'Cached custom marker description',
+      }));
+      await modal.showDetailModal(customId);
+      await wait(20);
+      const customDescription = document.getElementById('marker-desc');
+      outcomes.customMarkerDescriptionPromiseUpdatesTheModal =
+        customDescription?.textContent === 'Cached custom marker description'
+        && customDescription.classList.contains('loaded')
+        && !customDescription.classList.contains('loading');
+
       modal.closeModal();
       outcomes.closeModalRunsCleanupHooks =
         calls.some(call => call[0] === 'close-emf')
@@ -965,6 +1080,7 @@ test('marker detail modal covers default deps descriptions alt units and bio age
       state.showAltUnits = saved.showAltUnits;
       state.rangeMode = saved.rangeMode;
       state.chartInstances = saved.chartInstances;
+      Element.prototype.scrollIntoView = saved.scrollIntoView;
       markerRuntime.configureMarkerDetailRuntime(restoreMarkerRuntime);
       dnaBridge.configureDnaModuleBridge({ getRelevantSNPs: null, ...restoreDnaBridge });
       recommendationRuntime.configureRecommendationModuleBridge({

--- a/tests/playwright/modal-session-coverage-batch.spec.js
+++ b/tests/playwright/modal-session-coverage-batch.spec.js
@@ -71,7 +71,7 @@ test('marker detail modal covers custom marker create delete and focus restore p
       markerModal.closeModal();
       outcomes.closeRestoresRememberedFocus = document.activeElement === trigger;
 
-      markerModal.openCreateMarkerModal();
+      await markerModal.openCreateMarkerModal();
       const catSelect = document.getElementById('cm-category');
       if (catSelect) {
         catSelect.value = '__new__';

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -213,15 +213,17 @@ assert('SW APP_SHELL includes mobile dashboard CSS bundle', swAuditSrc.includes(
 assert('index loads cycle CSS bundle', indexSrc.includes('href="css/cycle.css"'));
 assert('SW APP_SHELL includes cycle CSS bundle', swAuditSrc.includes("'/css/cycle.css'"));
 const markerDetailSrc = read('js/marker-detail-modal.js');
+const markerDetailRuntimeSrc = read('js/marker-detail-runtime.js');
 assert('index defers marker detail CSS behind its ordered lazy-load anchor',
   !indexSrc.includes('href="css/marker-detail-modal.css"') &&
   indexSrc.includes('data-marker-detail-stylesheet-anchor') &&
-  markerDetailSrc.includes("new URL('../css/marker-detail-modal.css', import.meta.url)") &&
-  markerDetailSrc.includes('data-marker-detail-stylesheet-anchor'));
+  markerDetailSrc.includes('loadMarkerDetailStylesheet') &&
+  markerDetailRuntimeSrc.includes("new URL('../css/marker-detail-modal.css', import.meta.url)") &&
+  markerDetailRuntimeSrc.includes('data-marker-detail-stylesheet-anchor'));
 assert('marker detail CSS lazy-load anchor preserves the original cascade position',
   indexSrc.indexOf('href="css/cycle.css"') <
     indexSrc.indexOf('data-marker-detail-stylesheet-anchor') &&
-  indexSrc.indexOf('data-marker-detail-stylesheet-anchor') <
+    indexSrc.indexOf('data-marker-detail-stylesheet-anchor') <
     indexSrc.indexOf('href="css/recommendations.css"'));
 assert('SW APP_SHELL includes marker detail modal CSS bundle', swAuditSrc.includes("'/css/marker-detail-modal.css'"));
 assert('index loads recommendations CSS bundle', indexSrc.includes('href="css/recommendations.css"'));

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -212,7 +212,17 @@ assert('index loads mobile dashboard CSS bundle', indexSrc.includes('href="css/m
 assert('SW APP_SHELL includes mobile dashboard CSS bundle', swAuditSrc.includes("'/css/mobile-dashboard.css'"));
 assert('index loads cycle CSS bundle', indexSrc.includes('href="css/cycle.css"'));
 assert('SW APP_SHELL includes cycle CSS bundle', swAuditSrc.includes("'/css/cycle.css'"));
-assert('index loads marker detail modal CSS bundle', indexSrc.includes('href="css/marker-detail-modal.css"'));
+const markerDetailSrc = read('js/marker-detail-modal.js');
+assert('index defers marker detail CSS behind its ordered lazy-load anchor',
+  !indexSrc.includes('href="css/marker-detail-modal.css"') &&
+  indexSrc.includes('data-marker-detail-stylesheet-anchor') &&
+  markerDetailSrc.includes("new URL('../css/marker-detail-modal.css', import.meta.url)") &&
+  markerDetailSrc.includes('data-marker-detail-stylesheet-anchor'));
+assert('marker detail CSS lazy-load anchor preserves the original cascade position',
+  indexSrc.indexOf('href="css/cycle.css"') <
+    indexSrc.indexOf('data-marker-detail-stylesheet-anchor') &&
+  indexSrc.indexOf('data-marker-detail-stylesheet-anchor') <
+    indexSrc.indexOf('href="css/recommendations.css"'));
 assert('SW APP_SHELL includes marker detail modal CSS bundle', swAuditSrc.includes("'/css/marker-detail-modal.css'"));
 assert('index loads recommendations CSS bundle', indexSrc.includes('href="css/recommendations.css"'));
 assert('SW APP_SHELL includes recommendations CSS bundle', swAuditSrc.includes("'/css/recommendations.css'"));
@@ -293,7 +303,6 @@ const categoryViewRenderersSrc = read('js/category-view-renderers.js');
 const categoryCustomizationSrc = read('js/category-customization.js');
 const focusCardSrc = read('js/focus-card.js');
 const compareCorrelationsSrc = read('js/compare-correlations.js');
-const markerDetailSrc = read('js/marker-detail-modal.js');
 const lightSessionsViewSrc = read('js/light-sessions-view.js');
 const lightPageViewSrc = read('js/light-page-view.js');
 const lightChannelViewSrc = read('js/light-channel-view.js');
@@ -310,7 +319,7 @@ assert('Trend alert category escaped', dashboardLabRenderersSrc.includes('escape
 assert('Flagged marker name escaped', /escapeHTML\(f\.name\)/.test(dashboardLabRenderersSrc));
 assert('Category label escaped in header', categoryPageViewSrc.includes('escapeHTML(cat.label)'));
 assert('marker.unit escaped in detail modal', /escapeHTML\(marker\.unit\)/.test(markerDetailSrc));
-assert('marker history controls keep their styling in the eager marker-detail bundle',
+assert('marker history controls keep their styling in the lazy marker-detail bundle',
   markerDetailSrc.includes('class="marker-history-show-more"') &&
   !markerDetailSrc.includes('light-sessions-show-more marker-history-show-more') &&
   markerDetailCssAuditSrc.includes('.marker-detail-modal .marker-history-show-more:hover'));

--- a/tests/test-mobile.js
+++ b/tests/test-mobile.js
@@ -25,8 +25,13 @@ return (async function() {
     return css;
   }
 
-  // Settings styles are lazy-loaded in production. Include their source in
-  // this static responsive-rule audit without making them startup resources.
+  // Exercise the production loader before auditing marker-detail responsive
+  // rules. The stylesheet remains absent from the real cold-start path.
+  const { loadMarkerDetailStylesheet } = await import('/js/marker-detail-modal.js');
+  await loadMarkerDetailStylesheet();
+
+  // Settings styles are also lazy-loaded in production. Include their source
+  // in this static responsive-rule audit without making them startup resources.
   const css = `${getCSS()}\n${await fetchWithRetry('css/settings.css')}`;
 
   // ═══ Section 1: Header mobile layout ═══

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.358';
+self.APP_VERSION = '1.10.359';


### PR DESCRIPTION
## What changed

- Replace the eager Marker Detail stylesheet link with an ordered lazy-load anchor.
- Load and apply the stylesheet before opening marker detail, manual-entry, or custom-marker modals.
- Single-flight concurrent loads, remove failed links, and use a cache-busting retry URL.
- Keep the loader in the already-eager Marker Detail runtime adapter, avoiding another startup or first-click module request.
- Keep the stylesheet in the service-worker app shell so the first offline open still works.
- Add cold-start, first-open, failure/retry, responsive, Firefox offline, and deterministic coverage-ratchet coverage.

## Why

Marker Detail presentation is not needed for the initial dashboard render. Deferring its CSS removes an unconditional startup request while preserving the first-interaction experience: the modal waits for styling and the isolated first-open contract completes within 1 second.

## Measured impact

Identical cold mobile returning-user runs with browser cache and service workers disabled:

- Before: 439 requests, 1,850,068 transferred bytes, 5,612,189 decoded bytes
- After: 438 requests, 1,846,079 transferred bytes, 5,585,960 decoded bytes
- Saved: 1 request, 3,989 transferred bytes, 26,229 decoded bytes

## Validation

- Quality guardrails: 11/11; largest module at the 1,168-line cap
- TypeScript typecheck and check-JS typecheck
- Architecture check: 465 modules, 0 cycles
- Static verification: 131/131
- Vitest: 487/487
- Chromium Playwright: 404/404
- Responsive matrix: 472/472
- Firefox/offline smoke: 3/3
- Combined function coverage: 67.33% (67.10% ratchet)
- Final cold-load budget: 438 requests / 1,846,079 transferred / 5,585,960 decoded
