### PR TITLE
Lazy-load EMF stylesheet

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -219,3 +219,12 @@ requests share one load, failed links are removed and cache-busted for retry,
 and an HTML anchor preserves the original cascade position before
 Recommendations. The service-worker app shell retains the stylesheet for
 offline first use.
+
+The EMF assessment module and `css/emf.css` load together through
+`emf-runtime.js` when an EMF editor entry point is first used. Cross-feature
+launchers keep their presentation in their eager owning bundles, so the
+deferred stylesheet contains only EMF editor and interpretation UI. Opening
+waits for both resources, concurrent stylesheet requests share one load, and a
+failed link is removed and cache-busted for retry. An HTML anchor preserves
+the original cascade position, and the service-worker app shell retains the
+stylesheet for offline first use.

--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -10,7 +10,7 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | Metric | Current |
 | --- | ---: |
 | Modules | 465 |
-| Internal import edges | 2075 |
+| Internal import edges | 2076 |
 | Dynamic internal edges | 61 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -38,7 +38,7 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 
 | High fan-in | Dependants | High fan-out | Imports |
 | --- | ---: | --- | ---: |
-| [`js/utils.js`](js/utils.js) | 208 | [`js/app-shell-hooks.js`](js/app-shell-hooks.js) | 88 |
+| [`js/utils.js`](js/utils.js) | 209 | [`js/app-shell-hooks.js`](js/app-shell-hooks.js) | 88 |
 | [`js/state.js`](js/state.js) | 146 | [`js/app-light-sun-modules.js`](js/app-light-sun-modules.js) | 27 |
 | [`js/data.js`](js/data.js) | 73 | [`js/sync-configure.js`](js/sync-configure.js) | 27 |
 | [`js/api.js`](js/api.js) | 63 | [`js/dashboard-view-composition.js`](js/dashboard-view-composition.js) | 25 |
@@ -337,7 +337,7 @@ Native browser modules shipped with the static application.
 <details><summary><code>emf</code> family — 3 modules</summary>
 
 - [`js/emf-interpretation.js`](js/emf-interpretation.js) → [`js/api.js`](js/api.js), [`js/data.js`](js/data.js), [`js/markdown.js`](js/markdown.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/recommendations.js`](js/recommendations.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
-- [`js/emf-runtime.js`](js/emf-runtime.js) → no in-scope imports
+- [`js/emf-runtime.js`](js/emf-runtime.js) → [`js/utils.js`](js/utils.js)
 - [`js/emf.js`](js/emf.js) → [`js/api.js`](js/api.js), [`js/constants.js`](js/constants.js), [`js/context-card-editor-ui.js`](js/context-card-editor-ui.js), [`js/data.js`](js/data.js), [`js/emf-interpretation.js`](js/emf-interpretation.js), [`js/image-utils.js`](js/image-utils.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/pdf-import.js`](js/pdf-import.js), [`js/pii.js`](js/pii.js), [`js/recommendations.js`](js/recommendations.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 
 </details>

--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
   <link rel="stylesheet" href="styles.css">
   <link rel="stylesheet" href="css/app-shell.css">
   <meta data-import-stylesheet-anchor>
-  <link rel="stylesheet" href="css/emf.css">
+  <meta data-emf-stylesheet-anchor>
   <link rel="stylesheet" href="css/modal-shared.css">
   <link rel="stylesheet" href="css/dashboard-core.css">
   <link rel="stylesheet" href="css/dashboard-widgets.css">

--- a/js/emf-runtime.js
+++ b/js/emf-runtime.js
@@ -1,6 +1,10 @@
 // @ts-check
 // emf-runtime.js - module-only lazy access to the EMF assessment feature.
 
+import { showNotification } from './utils.js';
+
+const EMF_STYLESHEET_URL = new URL('../css/emf.css', import.meta.url).href;
+
 /** @typedef {{
  * configureEMFRuntimeDeps: (deps?: object) => unknown,
  * openEMFAssessmentEditor: () => unknown,
@@ -11,14 +15,53 @@
 let emfModulePromise = null;
 /** @type {EMFModule | null} */
 let emfModule = null;
+/** @type {Promise<HTMLLinkElement> | null} */
+let emfStylesheetPromise = null;
+let useEMFStylesheetRetryUrl = false;
 
 function rejectUnconfiguredEMFModuleLoad() {
   throw new Error('EMF module loader is not configured.');
 }
 
+function emfStylesheetUrl() {
+  if (!useEMFStylesheetRetryUrl) return EMF_STYLESHEET_URL;
+  const retryUrl = new URL(EMF_STYLESHEET_URL);
+  retryUrl.searchParams.set('lazy-retry', '1');
+  return retryUrl.href;
+}
+
+/** @returns {Promise<HTMLLinkElement>} */
+export function loadEMFStylesheet() {
+  if (!emfStylesheetPromise) {
+    if (typeof document === 'undefined') {
+      return Promise.reject(new Error('EMF stylesheet requires a document'));
+    }
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = emfStylesheetUrl();
+    link.dataset.emfStylesheet = '';
+    emfStylesheetPromise = new Promise((resolve, reject) => {
+      link.addEventListener('load', () => resolve(link), { once: true });
+      link.addEventListener('error', () => {
+        reject(new Error('EMF stylesheet could not be loaded'));
+      }, { once: true });
+      const anchor = document.querySelector('[data-emf-stylesheet-anchor]');
+      const parent = anchor?.parentNode || document.head;
+      parent.insertBefore(link, anchor || null);
+    }).catch(err => {
+      link.remove();
+      emfStylesheetPromise = null;
+      useEMFStylesheetRetryUrl = true;
+      throw err;
+    });
+  }
+  return emfStylesheetPromise;
+}
+
 const emfRuntimeDeps = {
   closeModal: /** @type {null | (() => void)} */ (null),
   loadModule: /** @type {() => Promise<EMFModule>} */ (rejectUnconfiguredEMFModuleLoad),
+  loadStylesheet: loadEMFStylesheet,
 };
 
 export function configureEMFRuntimeDeps(deps = {}) {
@@ -30,6 +73,11 @@ export function configureEMFRuntimeDeps(deps = {}) {
     emfRuntimeDeps.loadModule = typeof deps.loadModule === 'function'
       ? deps.loadModule
       : rejectUnconfiguredEMFModuleLoad;
+  }
+  if (Object.hasOwn(deps, 'loadStylesheet')) {
+    emfRuntimeDeps.loadStylesheet = typeof deps.loadStylesheet === 'function'
+      ? deps.loadStylesheet
+      : loadEMFStylesheet;
   }
   emfModule?.configureEMFRuntimeDeps(emfRuntimeDeps);
   return previous;
@@ -54,8 +102,17 @@ export async function loadEMFModule() {
 }
 
 export async function openEMFAssessmentEditor() {
-  const mod = await loadEMFModule();
-  return mod.openEMFAssessmentEditor();
+  try {
+    const [mod] = await Promise.all([
+      loadEMFModule(),
+      emfRuntimeDeps.loadStylesheet(),
+    ]);
+    return mod.openEMFAssessmentEditor();
+  } catch (err) {
+    console.error('[emf] Could not load assessment UI:', err);
+    showNotification('Could not open the EMF assessment. Reload the app to finish updating, then try again.', 'error');
+    return false;
+  }
 }
 
 export async function closeEMFInterpretation() {

--- a/plans/code-quality-audit-2026-07-21.md
+++ b/plans/code-quality-audit-2026-07-21.md
@@ -103,13 +103,13 @@ returning-user load with cache and service workers disabled and enforces
 ceilings for same-origin application requests, compressed transfer bytes, and
 decoded bytes. The initial reference was 474 requests, 2,017,210 compressed
 bytes, and 6,252,286 decoded bytes. Lazy-loading the PDF import review,
-Light/Sun analysis hooks, Settings/Tweaks, Profile Sharing, and the Settings
-Light/Sun, Client List, and Import review stylesheets reduced that reference to
-438 requests, 1,846,079 compressed bytes, and 5,585,960 decoded bytes. The
-Marker Detail stylesheet slice saved one request, 3,989 compressed bytes, and
-26,229 decoded bytes in identical before/after runs on the same machine. Route
-and feature lazy loading remains active, with the ceilings ratcheting downward
-after each reproducible slice.
+Light/Sun analysis hooks, Settings/Tweaks, Profile Sharing, and the Settings,
+Light/Sun, Client List, Import review, Marker Detail, and EMF stylesheets
+reduced that reference to 437 requests, 1,844,244 compressed bytes, and
+5,577,570 decoded bytes. The EMF stylesheet slice saved one request, 1,835
+compressed bytes, and 8,390 decoded bytes in identical before/after runs on the
+same machine. Route and feature lazy loading remains active, with the ceilings
+ratcheting downward after each reproducible slice.
 
 ### 4. Guardrails and test gaps
 

--- a/scripts/cold-load-budget.json
+++ b/scripts/cold-load-budget.json
@@ -3,15 +3,15 @@
   "route": "/app",
   "scenario": "Fresh mobile returning-user load with browser cache and service workers disabled",
   "maximums": {
-    "requests": 444,
-    "transferBytes": 1880000,
-    "decodedBytes": 5682000
+    "requests": 443,
+    "transferBytes": 1878000,
+    "decodedBytes": 5674000
   },
   "reference": {
-    "requests": 438,
-    "transferBytes": 1846079,
-    "decodedBytes": 5585960
+    "requests": 437,
+    "transferBytes": 1844244,
+    "decodedBytes": 5577570
   },
-  "referenceCommit": "7e399951",
+  "referenceCommit": "e60c6502",
   "measuredAt": "2026-07-24"
 }

--- a/tests/emf-runtime.test.js
+++ b/tests/emf-runtime.test.js
@@ -22,12 +22,18 @@ describe('EMF lazy runtime', () => {
       closeEMFInterpretation,
     }));
     const closeModal = vi.fn();
+    const loadStylesheet = vi.fn(async () => {});
 
-    runtime.configureEMFRuntimeDeps({ closeModal, loadModule });
+    runtime.configureEMFRuntimeDeps({ closeModal, loadModule, loadStylesheet });
 
     await expect(runtime.openEMFAssessmentEditor()).resolves.toBe('opened');
     await expect(runtime.closeEMFInterpretation()).resolves.toBe('closed');
     expect(loadModule).toHaveBeenCalledTimes(1);
-    expect(configureEMFRuntimeDeps).toHaveBeenCalledWith(expect.objectContaining({ closeModal, loadModule }));
+    expect(loadStylesheet).toHaveBeenCalledTimes(1);
+    expect(configureEMFRuntimeDeps).toHaveBeenCalledWith(expect.objectContaining({
+      closeModal,
+      loadModule,
+      loadStylesheet,
+    }));
   });
 });

--- a/tests/playwright/cold-load-budget.spec.js
+++ b/tests/playwright/cold-load-budget.spec.js
@@ -82,6 +82,9 @@ test('cold mobile app load stays within committed resource budgets', async ({ pa
   expect(entries.some(entry => (
     new URL(entry.name).pathname === '/css/marker-detail-modal.css'
   ))).toBe(false);
+  expect(entries.some(entry => (
+    new URL(entry.name).pathname === '/css/emf.css'
+  ))).toBe(false);
   const deferredLightStylesheets = new Set([
     '/css/light-sun.css',
     '/css/light-channels.css',

--- a/tests/playwright/environment-coverage-batch.spec.js
+++ b/tests/playwright/environment-coverage-batch.spec.js
@@ -1,5 +1,140 @@
 import { expect, test } from './coverage-fixture.js';
 
+function moduleUrl(path) {
+  return `${path}?emfRuntimeCoverage=${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+async function openEMFLoaderPage(page, path) {
+  await page.route(`**${path}`, route => route.fulfill({
+    status: 200,
+    contentType: 'text/html',
+    body: `<!doctype html><html><head><meta data-emf-stylesheet-anchor></head><body>
+      <div id="notification-container"></div>
+    </body></html>`,
+  }));
+  await page.goto(path, { waitUntil: 'load' });
+}
+
+test('EMF stylesheet loader single-flights and preserves cascade order', async ({ page }) => {
+  let stylesheetRequests = 0;
+  await page.route('**/css/emf.css*', route => {
+    stylesheetRequests += 1;
+    return route.fulfill({
+      status: 200,
+      contentType: 'text/css',
+      body: '.emf-editor-actions { display: flex; }',
+    });
+  });
+  await openEMFLoaderPage(page, '/emf-stylesheet-cache-coverage');
+
+  const outcomes = await page.evaluate(async ({ runtimeUrl }) => {
+    const runtime = await import(runtimeUrl);
+    const [first, second] = await Promise.all([
+      runtime.loadEMFStylesheet(),
+      runtime.loadEMFStylesheet(),
+    ]);
+    const third = await runtime.loadEMFStylesheet();
+    const anchor = document.querySelector('[data-emf-stylesheet-anchor]');
+    return {
+      concurrentCallsShareTheSameLink: first === second,
+      laterCallsReuseTheResolvedLink: first === third,
+      oneStylesheetLink: document.querySelectorAll('link[data-emf-stylesheet]').length === 1,
+      linkPrecedesAnchor: first.nextElementSibling === anchor,
+    };
+  }, { runtimeUrl: moduleUrl('/js/emf-runtime.js') });
+
+  expect(outcomes).toEqual({
+    concurrentCallsShareTheSameLink: true,
+    laterCallsReuseTheResolvedLink: true,
+    oneStylesheetLink: true,
+    linkPrecedesAnchor: true,
+  });
+  expect(stylesheetRequests).toBe(1);
+});
+
+test('EMF stylesheet loader removes a failure and retries', async ({ page }) => {
+  const stylesheetRequests = [];
+  let failFirstRequest = true;
+  await page.route('**/css/emf.css*', route => {
+    stylesheetRequests.push(route.request().url());
+    if (failFirstRequest) {
+      failFirstRequest = false;
+      return route.abort('failed');
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: 'text/css',
+      body: '.emf-editor-actions { display: flex; }',
+    });
+  });
+  await openEMFLoaderPage(page, '/emf-stylesheet-retry-coverage');
+
+  const outcomes = await page.evaluate(async ({ runtimeUrl }) => {
+    const runtime = await import(runtimeUrl);
+    let firstRejected = false;
+    try {
+      await runtime.loadEMFStylesheet();
+    } catch {
+      firstRejected = true;
+    }
+    const failedLinkWasRemoved =
+      document.querySelectorAll('link[data-emf-stylesheet]').length === 0;
+    const retryLink = await runtime.loadEMFStylesheet();
+    return {
+      firstRejected,
+      failedLinkWasRemoved,
+      retryLoaded: retryLink.sheet !== null,
+      retryUsesCacheBuster:
+        new URL(retryLink.href).searchParams.get('lazy-retry') === '1',
+    };
+  }, { runtimeUrl: moduleUrl('/js/emf-runtime.js') });
+
+  expect(outcomes).toEqual({
+    firstRejected: true,
+    failedLinkWasRemoved: true,
+    retryLoaded: true,
+    retryUsesCacheBuster: true,
+  });
+  expect(stylesheetRequests).toHaveLength(2);
+  expect(new URL(stylesheetRequests[1]).searchParams.get('lazy-retry')).toBe('1');
+});
+
+test('EMF entry contains a stylesheet load failure', async ({ page }) => {
+  await page.route('**/css/emf.css*', route => route.abort('failed'));
+  await openEMFLoaderPage(page, '/emf-stylesheet-entry-failure-coverage');
+
+  const outcomes = await page.evaluate(async ({ runtimeUrl }) => {
+    const runtime = await import(runtimeUrl);
+    let opened = 0;
+    runtime.configureEMFRuntimeDeps({
+      loadModule: async () => ({
+        configureEMFRuntimeDeps() {},
+        openEMFAssessmentEditor() {
+          opened += 1;
+        },
+        closeEMFInterpretation() {},
+      }),
+    });
+    const result = await runtime.openEMFAssessmentEditor();
+    return {
+      returnsFalse: result === false,
+      editorStayedClosed: opened === 0,
+      failedLinkWasRemoved:
+        document.querySelectorAll('link[data-emf-stylesheet]').length === 0,
+      errorWasExplained:
+        document.getElementById('notification-container')?.textContent
+          ?.includes('Could not open the EMF assessment') === true,
+    };
+  }, { runtimeUrl: moduleUrl('/js/emf-runtime.js') });
+
+  expect(outcomes).toEqual({
+    returnsFalse: true,
+    editorStayedClosed: true,
+    failedLinkWasRemoved: true,
+    errorWasExplained: true,
+  });
+});
+
 function seedCompletedTour() {
   const profileId = localStorage.getItem('labcharts-active-profile') || 'default';
   localStorage.setItem(`labcharts-${profileId}-emptyTour`, 'completed');
@@ -88,7 +223,7 @@ test('EMF assessment editor covers room measurements tags compare delete and cha
       document.querySelectorAll('.emf-lightbox,.notification-container').forEach(el => el.remove());
       document.getElementById('confirm-dialog-overlay')?.remove();
 
-      await emf.openEMFAssessmentEditor();
+      await emfRuntime.openEMFAssessmentEditor();
       await waitFor('#detail-modal .emf-editor-actions', 'EMF editor actions');
       document.querySelector('.emf-editor-actions .import-btn-primary')?.click();
       await waitUntil(() => assessments().length === 1, 'new EMF assessment');

--- a/tests/playwright/light-tools-browser-coverage.spec.js
+++ b/tests/playwright/light-tools-browser-coverage.spec.js
@@ -145,7 +145,8 @@ test('light tools browser coverage exercises storage render and modal flows', as
         && call[1]?.scrollAnchor === '[data-id="room-2"]');
       modalBlocker.remove();
       await lightTools.saveMeasurement('darkness', 0.2, { roomId: 'room-2' });
-      await wait(80);
+      await waitUntil(() => navigateCalls.some(call => call[0] === 'light'
+        && call[1]?.scrollAnchor === '[data-id="room-2"]'), 2500);
       results.navigateUsesRoomScrollAnchor = navigateCalls.some(call => call[0] === 'light'
         && call[1]?.scrollAnchor === '[data-id="room-2"]');
 
@@ -196,7 +197,8 @@ test('light tools browser coverage exercises storage render and modal flows', as
       const durationInput = document.getElementById('sunrise-duration');
       if (durationInput) durationInput.value = '500';
       document.getElementById('sunrise-save')?.click();
-      await wait(20);
+      await waitUntil(() => navigateCalls.slice(sunriseNavigateStart)
+        .some(call => call[0] === 'light' && !call[1]), 2500);
       results.sunriseLoggerSavesClampedSession = !document.querySelector('[aria-label="Golden hour log"]')
         && loggedSessions[0]?.eyeExposure?.durationSec === 120 * 60
         && loggedSessions[0]?.bodyExposure?.preset === 'face_hands'

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -146,13 +146,18 @@ assert('shared import controls remain in the eager app shell',
   appShellCssAuditSrc.includes('.header-icon-btn.header-import-btn {') &&
   appShellCssAuditSrc.includes('.drop-zone {'));
 assert('SW APP_SHELL includes import CSS bundle', swAuditSrc.includes("'/css/import.css'"));
-assert('index loads EMF CSS bundle', indexSrc.includes('href="css/emf.css"'));
+const emfRuntimeSrc = read('js/emf-runtime.js');
+assert('index defers EMF CSS behind its ordered lazy-load anchor',
+  !indexSrc.includes('href="css/emf.css"') &&
+  indexSrc.includes('data-emf-stylesheet-anchor') &&
+  emfRuntimeSrc.includes("new URL('../css/emf.css', import.meta.url)") &&
+  emfRuntimeSrc.includes('data-emf-stylesheet-anchor'));
 assert('SW APP_SHELL includes EMF CSS bundle', swAuditSrc.includes("'/css/emf.css'"));
-assert('import CSS lazy-load anchor preserves its position before EMF CSS',
-  indexSrc.indexOf('data-import-stylesheet-anchor') < indexSrc.indexOf('href="css/emf.css"') &&
+assert('import and EMF CSS lazy-load anchors preserve their original order',
+  indexSrc.indexOf('data-import-stylesheet-anchor') < indexSrc.indexOf('data-emf-stylesheet-anchor') &&
   swAuditSrc.indexOf("'/css/import.css'") < swAuditSrc.indexOf("'/css/emf.css'"));
-assert('import CSS lazy-load anchor preserves its position before modal shell CSS',
-  indexSrc.indexOf('data-import-stylesheet-anchor') < indexSrc.indexOf('href="css/modal-shared.css"') &&
+assert('EMF CSS lazy-load anchor preserves its position before modal shell CSS',
+  indexSrc.indexOf('data-emf-stylesheet-anchor') < indexSrc.indexOf('href="css/modal-shared.css"') &&
   swAuditSrc.indexOf("'/css/import.css'") < swAuditSrc.indexOf("'/css/modal-shared.css'"));
 assert('index loads dashboard core CSS bundle', indexSrc.includes('href="css/dashboard-core.css"'));
 assert('SW APP_SHELL includes dashboard core CSS bundle', swAuditSrc.includes("'/css/dashboard-core.css'"));

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -472,7 +472,7 @@
     'interpretEMFComparison','addEMFPhotos','removeEMFPhoto','viewEMFPhoto','saveEMFExplicit'
   ];
   const emfLegacyGlobals = emfExports.filter(name => !name.startsWith('configureEMF'));
-  const emfRuntimeExports = ['configureEMFRuntimeDeps','loadEMFModule','openEMFAssessmentEditor','closeEMFInterpretation'];
+  const emfRuntimeExports = ['configureEMFRuntimeDeps','loadEMFModule','loadEMFStylesheet','openEMFAssessmentEditor','closeEMFInterpretation'];
 
   // data.js (30 former browser globals plus one test hook, now module-only)
   const dataExports = [

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.359';
+self.APP_VERSION = '1.10.360';


### PR DESCRIPTION
## What changed

- defer `css/emf.css` until the existing lazy EMF runtime opens the assessment UI
- preserve stylesheet cascade order, offline precaching, concurrent-load sharing, and cache-busted retry behavior
- contain stylesheet failures with a visible error instead of opening an unstyled editor
- add browser coverage for load caching, retry, failure containment, and the real EMF entry path
- ratchet the cold-load request and byte budgets and update architecture/audit documentation

## Why

The EMF JavaScript feature was already lazy, but its feature-only stylesheet was still fetched on every returning-user startup. Loading both together removes that unnecessary cold-load request without changing EMF entry points or offline availability.

## Impact

Measured on the same local cold mobile returning-user scenario:

- requests: 438 → 437
- compressed bytes: 1,846,079 → 1,844,244 (-1,835)
- decoded bytes: 5,585,960 → 5,577,570 (-8,390)

## Validation

- `COVERAGE=1 ./run-tests.sh`
- 487 Vitest/Node tests passed
- 407 Chromium tests passed
- 472 responsive-theme assertions passed
- 67.29% combined function coverage passed the 67.10% ratchet
- type checks, architecture checks, vendor integrity, module verification, and cold-load budget passed