### PR TITLE
Lazy-load Genetics stylesheet

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -195,6 +195,17 @@ a shared-profile link. The loader owns only lazy loading and route detection;
 responsibilities. `export.js` remains shell-owned without a Data I/O
 composition wrapper.
 
+Genome and DNA behavior stays module-eager because dashboard summaries,
+recommendations, startup catalog hydration, and import routing share it.
+`dna-runtime.js` owns the narrower presentation boundary: `css/genetics.css`
+loads when the Genome route or a DNA preview/manual-entry surface first opens.
+Every styled entry waits for the stylesheet, concurrent calls share one
+request, failed links are removed and cache-busted for retry, and route/action
+failures remain contained with an explanatory status. An HTML anchor preserves
+the original cascade position, while dashboard genome tiles remain in the
+eager `dashboard-data.css` bundle. The service-worker app shell retains the
+deferred stylesheet for offline first use.
+
 Client List remains module-eager because shell, profile, and location actions
 use it, but `css/client-list.css` loads only when `openClientList()` is first
 called. Opening waits for the stylesheet, concurrent opens share one request,

--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -10,7 +10,7 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | Metric | Current |
 | --- | ---: |
 | Modules | 465 |
-| Internal import edges | 2076 |
+| Internal import edges | 2077 |
 | Dynamic internal edges | 61 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -44,8 +44,8 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 | [`js/api.js`](js/api.js) | 63 | [`js/dashboard-view-composition.js`](js/dashboard-view-composition.js) | 25 |
 | [`js/modal-lifecycle.js`](js/modal-lifecycle.js) | 51 | [`js/settings.js`](js/settings.js) | 24 |
 | [`js/profile.js`](js/profile.js) | 45 | [`js/pdf-import.js`](js/pdf-import.js) | 23 |
-| [`js/schema.js`](js/schema.js) | 30 | [`js/chat-send.js`](js/chat-send.js) | 22 |
-| [`js/data-merge.js`](js/data-merge.js) | 29 | [`js/views.js`](js/views.js) | 22 |
+| [`js/schema.js`](js/schema.js) | 30 | [`js/views.js`](js/views.js) | 23 |
+| [`js/data-merge.js`](js/data-merge.js) | 29 | [`js/chat-send.js`](js/chat-send.js) | 22 |
 | [`js/crypto.js`](js/crypto.js) | 27 | [`js/wearables-connect.js`](js/wearables-connect.js) | 20 |
 | [`js/utils-runtime.js`](js/utils-runtime.js) | 19 | [`js/biology-scores.js`](js/biology-scores.js) | 19 |
 | [`js/marker-analysis.js`](js/marker-analysis.js) | 18 | [`js/sun.js`](js/sun.js) | 18 |
@@ -872,7 +872,7 @@ Native browser modules shipped with the static application.
 
 - [`js/views-router-runtime.js`](js/views-router-runtime.js) → [`js/pdf-import-progress.js`](js/pdf-import-progress.js)
 - [`js/views-router.js`](js/views-router.js) → [`js/data.js`](js/data.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js), [`js/views-router-runtime.js`](js/views-router-runtime.js)
-- [`js/views.js`](js/views.js) → [`js/category-customization.js`](js/category-customization.js), [`js/category-glyphs.js`](js/category-glyphs.js), [`js/category-page-view.js`](js/category-page-view.js), [`js/category-view-renderers.js`](js/category-view-renderers.js), [`js/compare-correlations.js`](js/compare-correlations.js), [`js/data.js`](js/data.js), [`js/focus-card.js`](js/focus-card.js), [`js/import-drop-zone.js`](js/import-drop-zone.js), [`js/lens-page-shell.js`](js/lens-page-shell.js), [`js/lens-pages.js`](js/lens-pages.js), [`js/light-channel-view.js`](js/light-channel-view.js), [`js/light-conditions-now.js`](js/light-conditions-now.js), [`js/light-page-view.js`](js/light-page-view.js), [`js/light-sessions-view.js`](js/light-sessions-view.js), [`js/light-sun-loader.js`](js/light-sun-loader.js), [`js/marker-detail-modal.js`](js/marker-detail-modal.js), [`js/mobile-dashboard.js`](js/mobile-dashboard.js), [`js/nav.js`](js/nav.js), [`js/onboarding-view.js`](js/onboarding-view.js), [`js/recommendation-actions.js`](js/recommendation-actions.js), [`js/state.js`](js/state.js), [`js/views-router.js`](js/views-router.js)
+- [`js/views.js`](js/views.js) → [`js/category-customization.js`](js/category-customization.js), [`js/category-glyphs.js`](js/category-glyphs.js), [`js/category-page-view.js`](js/category-page-view.js), [`js/category-view-renderers.js`](js/category-view-renderers.js), [`js/compare-correlations.js`](js/compare-correlations.js), [`js/data.js`](js/data.js), [`js/dna-runtime.js`](js/dna-runtime.js), [`js/focus-card.js`](js/focus-card.js), [`js/import-drop-zone.js`](js/import-drop-zone.js), [`js/lens-page-shell.js`](js/lens-page-shell.js), [`js/lens-pages.js`](js/lens-pages.js), [`js/light-channel-view.js`](js/light-channel-view.js), [`js/light-conditions-now.js`](js/light-conditions-now.js), [`js/light-page-view.js`](js/light-page-view.js), [`js/light-sessions-view.js`](js/light-sessions-view.js), [`js/light-sun-loader.js`](js/light-sun-loader.js), [`js/marker-detail-modal.js`](js/marker-detail-modal.js), [`js/mobile-dashboard.js`](js/mobile-dashboard.js), [`js/nav.js`](js/nav.js), [`js/onboarding-view.js`](js/onboarding-view.js), [`js/recommendation-actions.js`](js/recommendation-actions.js), [`js/state.js`](js/state.js), [`js/views-router.js`](js/views-router.js)
 
 </details>
 

--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
   <link rel="stylesheet" href="css/dashboard-data.css">
   <link rel="stylesheet" href="css/category-views.css">
   <link rel="stylesheet" href="css/context-profile.css">
-  <link rel="stylesheet" href="css/genetics.css">
+  <meta data-genetics-stylesheet-anchor>
   <link rel="stylesheet" href="css/data-protection.css">
   <meta data-settings-stylesheet-anchor>
   <link rel="stylesheet" href="css/mobile-dashboard.css">

--- a/js/dna-mtdna.js
+++ b/js/dna-mtdna.js
@@ -10,6 +10,7 @@ import {
   clearPendingMtDnaImport,
   getDnaProfileLatitudeBand,
   getPendingMtDnaImport,
+  loadGeneticsStylesheetForAction,
   logDnaDebugError,
   refreshDnaShell,
   setPendingMtDnaImport,
@@ -139,6 +140,7 @@ let _mtdnaImportRunning = false;
 
 export async function handleMtDNAFile(file) {
   if (_mtdnaImportRunning) { showNotification('mtDNA import already in progress', 'info'); return; }
+  if (!await loadGeneticsStylesheetForAction()) return false;
   _mtdnaImportRunning = true;
   try {
     const text = await file.text();

--- a/js/dna-runtime.js
+++ b/js/dna-runtime.js
@@ -3,9 +3,16 @@
 
 import { isImportRunning } from './pdf-import-progress.js';
 import { getLatitudeFromLocation } from './profile.js';
-import { isDebugMode, showConfirmDialog } from './utils.js';
+import { isDebugMode, showConfirmDialog, showNotification } from './utils.js';
 import { triggerContextCardDNAFilePickerRuntime } from './context-cards-runtime.js';
 import { updateChatNudgeRuntime } from './chat-runtime.js';
+
+const GENETICS_STYLESHEET_URL = new URL('../css/genetics.css', import.meta.url).href;
+
+/** @type {Promise<HTMLLinkElement> | null} */
+let geneticsStylesheetPromise = null;
+let geneticsStylesheetLoaded = false;
+let useGeneticsStylesheetRetryUrl = false;
 
 const dnaRuntimeDeps = {
   buildSidebar: /** @type {null | (() => void)} */ (null),
@@ -15,6 +22,60 @@ const dnaRuntimeDeps = {
   navigate: /** @type {null | ((route: string) => void)} */ (null),
   showConfirmDialog,
 };
+
+function geneticsStylesheetUrl() {
+  if (!useGeneticsStylesheetRetryUrl) return GENETICS_STYLESHEET_URL;
+  const retryUrl = new URL(GENETICS_STYLESHEET_URL);
+  retryUrl.searchParams.set('lazy-retry', '1');
+  return retryUrl.href;
+}
+
+export function isGeneticsStylesheetLoaded() {
+  return geneticsStylesheetLoaded;
+}
+
+/** @returns {Promise<HTMLLinkElement>} */
+export function loadGeneticsStylesheet() {
+  if (!geneticsStylesheetPromise) {
+    if (typeof document === 'undefined') {
+      return Promise.reject(new Error('Genetics stylesheet requires a document'));
+    }
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = geneticsStylesheetUrl();
+    link.dataset.geneticsStylesheet = '';
+    geneticsStylesheetPromise = new Promise((resolve, reject) => {
+      link.addEventListener('load', () => {
+        geneticsStylesheetLoaded = true;
+        resolve(link);
+      }, { once: true });
+      link.addEventListener('error', () => {
+        reject(new Error('Genetics stylesheet could not be loaded'));
+      }, { once: true });
+      const anchor = document.querySelector('[data-genetics-stylesheet-anchor]');
+      const parent = anchor?.parentNode || document.head;
+      parent.insertBefore(link, anchor || null);
+    }).catch(err => {
+      link.remove();
+      geneticsStylesheetPromise = null;
+      geneticsStylesheetLoaded = false;
+      useGeneticsStylesheetRetryUrl = true;
+      throw err;
+    });
+  }
+  return geneticsStylesheetPromise;
+}
+
+/** @returns {Promise<HTMLLinkElement | false>} */
+export async function loadGeneticsStylesheetForAction() {
+  try {
+    return await loadGeneticsStylesheet();
+  } catch (err) {
+    console.error('[dna] Could not load stylesheet:', err);
+    showNotification('Could not open DNA tools. Reload the app to finish updating, then try again.', 'error');
+    return false;
+  }
+}
 
 export function configureDnaRuntimeDeps(deps = {}) {
   const previous = { ...dnaRuntimeDeps };

--- a/js/dna.js
+++ b/js/dna.js
@@ -18,6 +18,7 @@ import {
   cacheDnaSnpTable, clearPendingDnaImport,
   confirmDnaDeleteDialog, getPendingDnaImport,
   isDnaLabImportRunning, logDnaDebugError, logDnaDebugWarn,
+  loadGeneticsStylesheetForAction,
   navigateDnaRoute, refreshDnaShell,
   refreshDnaSidebar, setPendingDnaImport,
   triggerDnaFilePicker, updateDnaChatNudge,
@@ -708,6 +709,7 @@ function openDnaModalOverlay(overlay, initialFocus) {
 }
 
 export async function openManualSnpModal() {
+  if (!await loadGeneticsStylesheetForAction()) return false;
   await loadSNPTable();
   clearPendingDnaImport();
   const html = `<div class="dna-preview-header dna-manual-header">
@@ -802,6 +804,7 @@ export async function importSnpReport() {
 
 export async function handleSnpReportFile(file) {
   if (_dnaImportRunning) { showNotification('DNA import already in progress', 'info'); return; }
+  if (!await loadGeneticsStylesheetForAction()) return false;
   _dnaImportRunning = true;
   try {
     showNotification('Reading SNP report...', 'info');
@@ -837,6 +840,7 @@ let _dnaImportRunning = false;
 export async function handleDNAFile(file) {
   if (_dnaImportRunning) { showNotification('DNA import already in progress', 'info'); return; }
   if (isDnaLabImportRunning()) { showNotification('Lab import in progress — wait for it to finish', 'info'); return; }
+  if (!await loadGeneticsStylesheetForAction()) return false;
   _dnaImportRunning = true;
   try {
     showNotification('Parsing DNA file...', 'info');

--- a/js/views.js
+++ b/js/views.js
@@ -12,6 +12,7 @@ import {
 import { setupDropZone } from './import-drop-zone.js';
 import { createRecommendationActions } from './recommendation-actions.js';
 import { createNavigate, getInitialView as getRouterInitialView } from './views-router.js';
+import { isGeneticsStylesheetLoaded, loadGeneticsStylesheet } from './dna-runtime.js';
 import { isLightSunUILoaded, loadLightSunUI } from './light-sun-loader.js';
 import { state } from './state.js';
 import { createLensPageHandlers } from './lens-pages.js';
@@ -204,7 +205,7 @@ export async function _openAllSessionsModal() {
   return openAllSessionsModal();
 }
 
-function renderLightRouteStatus(content, message, { busy = false, error = false } = {}) {
+function renderDeferredRouteStatus(content, message, { busy = false, error = false } = {}) {
   const status = document.createElement('section');
   status.className = 'dashboard-widget-empty';
   status.textContent = message;
@@ -220,7 +221,7 @@ function showLightRoute(data) {
   if (isLightSunUILoaded()) return showLight(data);
 
   const content = typeof document !== 'undefined' ? document.getElementById('main-content') : null;
-  if (content) renderLightRouteStatus(content, 'Loading Light & Sun…', { busy: true });
+  if (content) renderDeferredRouteStatus(content, 'Loading Light & Sun…', { busy: true });
 
   return loadLightSunUI()
     .then(() => {
@@ -231,9 +232,34 @@ function showLightRoute(data) {
     .catch(err => {
       console.error('Failed to load Light & Sun modules', err);
       if (state.currentView === 'light' && content) {
-        renderLightRouteStatus(
+        renderDeferredRouteStatus(
           content,
           'Light & Sun could not be loaded. Try opening the page again.',
+          { error: true },
+        );
+      }
+      return false;
+    });
+}
+
+function showGenomeRoute() {
+  if (isGeneticsStylesheetLoaded()) return showGenomeLens();
+
+  const content = typeof document !== 'undefined' ? document.getElementById('main-content') : null;
+  if (content) renderDeferredRouteStatus(content, 'Loading Genome…', { busy: true });
+
+  return loadGeneticsStylesheet()
+    .then(() => {
+      if (state.currentView !== 'genome') return false;
+      showGenomeLens();
+      return true;
+    })
+    .catch(err => {
+      console.error('Failed to load Genome presentation', err);
+      if (state.currentView === 'genome' && content) {
+        renderDeferredRouteStatus(
+          content,
+          'Genome could not be loaded. Try opening the page again.',
           { error: true },
         );
       }
@@ -246,7 +272,7 @@ const _navigate = createNavigate({
     dashboard: showDashboard,
     labs: showLabs,
     biologyScores: showBiologyScoresLens,
-    genome: showGenomeLens,
+    genome: showGenomeRoute,
     body: showBodyLens,
     insight: showInsightLens,
     recommendations: showRecommendations,

--- a/plans/code-quality-audit-2026-07-21.md
+++ b/plans/code-quality-audit-2026-07-21.md
@@ -104,12 +104,12 @@ ceilings for same-origin application requests, compressed transfer bytes, and
 decoded bytes. The initial reference was 474 requests, 2,017,210 compressed
 bytes, and 6,252,286 decoded bytes. Lazy-loading the PDF import review,
 Light/Sun analysis hooks, Settings/Tweaks, Profile Sharing, and the Settings,
-Light/Sun, Client List, Import review, Marker Detail, and EMF stylesheets
-reduced that reference to 437 requests, 1,844,244 compressed bytes, and
-5,577,570 decoded bytes. The EMF stylesheet slice saved one request, 1,835
-compressed bytes, and 8,390 decoded bytes in identical before/after runs on the
-same machine. Route and feature lazy loading remains active, with the ceilings
-ratcheting downward after each reproducible slice.
+Light/Sun, Client List, Import review, Marker Detail, EMF, and Genetics
+stylesheets reduced that reference to 436 requests, 1,841,186 compressed
+bytes, and 5,562,340 decoded bytes. The Genetics stylesheet slice saved one
+request, 3,058 compressed bytes, and 15,230 decoded bytes in identical
+before/after runs on the same machine. Route and feature lazy loading remains
+active, with the ceilings ratcheting downward after each reproducible slice.
 
 ### 4. Guardrails and test gaps
 

--- a/scripts/cold-load-budget.json
+++ b/scripts/cold-load-budget.json
@@ -3,15 +3,15 @@
   "route": "/app",
   "scenario": "Fresh mobile returning-user load with browser cache and service workers disabled",
   "maximums": {
-    "requests": 443,
-    "transferBytes": 1878000,
-    "decodedBytes": 5674000
+    "requests": 442,
+    "transferBytes": 1875000,
+    "decodedBytes": 5659000
   },
   "reference": {
-    "requests": 437,
-    "transferBytes": 1844244,
-    "decodedBytes": 5577570
+    "requests": 436,
+    "transferBytes": 1841186,
+    "decodedBytes": 5562340
   },
-  "referenceCommit": "e60c6502",
+  "referenceCommit": "62b6d06e",
   "measuredAt": "2026-07-24"
 }

--- a/tests/playwright/cold-load-budget.spec.js
+++ b/tests/playwright/cold-load-budget.spec.js
@@ -85,6 +85,9 @@ test('cold mobile app load stays within committed resource budgets', async ({ pa
   expect(entries.some(entry => (
     new URL(entry.name).pathname === '/css/emf.css'
   ))).toBe(false);
+  expect(entries.some(entry => (
+    new URL(entry.name).pathname === '/css/genetics.css'
+  ))).toBe(false);
   const deferredLightStylesheets = new Set([
     '/css/light-sun.css',
     '/css/light-channels.css',

--- a/tests/playwright/genetics-stylesheet-browser-coverage.spec.js
+++ b/tests/playwright/genetics-stylesheet-browser-coverage.spec.js
@@ -1,0 +1,124 @@
+import { expect, test } from './coverage-fixture.js';
+
+function moduleUrl(path) {
+  return `${path}?geneticsStylesheetCoverage=${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+async function openGeneticsLoaderPage(page, path) {
+  await page.route(`**${path}`, route => route.fulfill({
+    status: 200,
+    contentType: 'text/html',
+    body: `<!doctype html><html><head><meta data-genetics-stylesheet-anchor></head><body>
+      <div id="notification-container"></div>
+    </body></html>`,
+  }));
+  await page.goto(path, { waitUntil: 'load' });
+}
+
+test('Genetics stylesheet loader single-flights and preserves cascade order', async ({ page }) => {
+  let stylesheetRequests = 0;
+  await page.route('**/css/genetics.css*', route => {
+    stylesheetRequests += 1;
+    return route.fulfill({
+      status: 200,
+      contentType: 'text/css',
+      body: '.genetics-overview-grid { display: grid; }',
+    });
+  });
+  await openGeneticsLoaderPage(page, '/genetics-stylesheet-cache-coverage');
+
+  const outcomes = await page.evaluate(async ({ runtimeUrl }) => {
+    const runtime = await import(runtimeUrl);
+    const loadedBeforeRequest = runtime.isGeneticsStylesheetLoaded();
+    const [first, second] = await Promise.all([
+      runtime.loadGeneticsStylesheet(),
+      runtime.loadGeneticsStylesheet(),
+    ]);
+    const third = await runtime.loadGeneticsStylesheet();
+    const anchor = document.querySelector('[data-genetics-stylesheet-anchor]');
+    return {
+      loadedBeforeRequest,
+      loadedAfterRequest: runtime.isGeneticsStylesheetLoaded(),
+      concurrentCallsShareTheSameLink: first === second,
+      laterCallsReuseTheResolvedLink: first === third,
+      oneStylesheetLink: document.querySelectorAll('link[data-genetics-stylesheet]').length === 1,
+      linkPrecedesAnchor: first.nextElementSibling === anchor,
+    };
+  }, { runtimeUrl: moduleUrl('/js/dna-runtime.js') });
+
+  expect(outcomes).toEqual({
+    loadedBeforeRequest: false,
+    loadedAfterRequest: true,
+    concurrentCallsShareTheSameLink: true,
+    laterCallsReuseTheResolvedLink: true,
+    oneStylesheetLink: true,
+    linkPrecedesAnchor: true,
+  });
+  expect(stylesheetRequests).toBe(1);
+});
+
+test('Genome route contains a stylesheet failure and retries with a fresh URL', async ({ page }) => {
+  const stylesheetRequests = [];
+  await page.route('**/css/genetics.css*', route => {
+    stylesheetRequests.push(route.request().url());
+    return route.abort('failed');
+  });
+  await page.goto('/app', { waitUntil: 'load' });
+
+  const firstOpen = await page.evaluate(async () => {
+    const views = await import('/js/views.js');
+    const opened = await views.navigate('genome');
+    return {
+      opened,
+      status: document.getElementById('main-content')?.textContent || '',
+      links: document.querySelectorAll('link[data-genetics-stylesheet]').length,
+    };
+  });
+
+  expect(firstOpen.opened).toBe(false);
+  expect(firstOpen.status).toContain('Genome could not be loaded');
+  expect(firstOpen.links).toBe(0);
+  expect(stylesheetRequests).toHaveLength(1);
+
+  await page.unroute('**/css/genetics.css*');
+  const retryOpen = await page.evaluate(async () => {
+    const views = await import('/js/views.js');
+    const opened = await views.navigate('genome');
+    const link = document.querySelector('link[data-genetics-stylesheet]');
+    return {
+      opened,
+      workspace: document.getElementById('main-content')?.textContent || '',
+      href: link?.href || '',
+      sheetLoaded: link?.sheet !== null,
+    };
+  });
+
+  expect(retryOpen.opened).toBe(true);
+  expect(retryOpen.workspace).toContain('Dedicated DNA workspace');
+  expect(retryOpen.sheetLoaded).toBe(true);
+  expect(new URL(retryOpen.href).searchParams.get('lazy-retry')).toBe('1');
+});
+
+test('DNA modal entry contains a stylesheet failure', async ({ page }) => {
+  await page.route('**/css/genetics.css*', route => route.abort('failed'));
+  await openGeneticsLoaderPage(page, '/genetics-stylesheet-action-failure-coverage');
+
+  const outcomes = await page.evaluate(async ({ runtimeUrl }) => {
+    const runtime = await import(runtimeUrl);
+    const loaded = await runtime.loadGeneticsStylesheetForAction();
+    return {
+      returnsFalse: loaded === false,
+      failedLinkWasRemoved:
+        document.querySelectorAll('link[data-genetics-stylesheet]').length === 0,
+      errorWasExplained:
+        document.getElementById('notification-container')?.textContent
+          ?.includes('Could not open DNA tools') === true,
+    };
+  }, { runtimeUrl: moduleUrl('/js/dna-runtime.js') });
+
+  expect(outcomes).toEqual({
+    returnsFalse: true,
+    failedLinkWasRemoved: true,
+    errorWasExplained: true,
+  });
+});

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -188,7 +188,17 @@ assert('shared modal CSS loads before feature modal overrides',
   swAuditSrc.indexOf("'/css/modal-shared.css'") < swAuditSrc.indexOf("'/css/context-profile.css'"));
 assert('index loads context/profile CSS bundle', indexSrc.includes('href="css/context-profile.css"'));
 assert('SW APP_SHELL includes context/profile CSS bundle', swAuditSrc.includes("'/css/context-profile.css'"));
-assert('index loads genetics CSS bundle', indexSrc.includes('href="css/genetics.css"'));
+const dnaRuntimeAuditSrc = read('js/dna-runtime.js');
+assert('index defers genetics CSS behind its ordered lazy-load anchor',
+  !indexSrc.includes('href="css/genetics.css"') &&
+  indexSrc.includes('data-genetics-stylesheet-anchor') &&
+  dnaRuntimeAuditSrc.includes("new URL('../css/genetics.css', import.meta.url)") &&
+  dnaRuntimeAuditSrc.includes('data-genetics-stylesheet-anchor'));
+assert('genetics CSS lazy-load anchor preserves the original cascade position',
+  indexSrc.indexOf('href="css/context-profile.css"') <
+    indexSrc.indexOf('data-genetics-stylesheet-anchor') &&
+  indexSrc.indexOf('data-genetics-stylesheet-anchor') <
+    indexSrc.indexOf('href="css/data-protection.css"'));
 assert('SW APP_SHELL includes genetics CSS bundle', swAuditSrc.includes("'/css/genetics.css'"));
 assert('index loads data protection CSS bundle', indexSrc.includes('href="css/data-protection.css"'));
 assert('SW APP_SHELL includes data protection CSS bundle', swAuditSrc.includes("'/css/data-protection.css'"));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.360';
+self.APP_VERSION = '1.10.361';


### PR DESCRIPTION
## What

- defer `css/genetics.css` until the Genome route or a styled DNA import/manual-entry surface is opened
- keep shared DNA behavior eager while the existing DNA runtime owns stylesheet single-flight, cascade position, failure containment, and retry
- cover cold-start exclusion, route/action failures, retries, and cache behavior in browser and audit tests
- ratchet the cold-load reference and document the new presentation boundary

## Why

DNA logic is shared by returning-user dashboard summaries, recommendations, catalog setup, and import routing, so splitting that behavior would add risk and requests. The Genetics presentation layer is not needed on a normal returning-user dashboard startup and can be deferred safely.

## Cold-load impact

Identical fresh mobile returning-user runs with browser cache and service workers disabled:

- requests: 437 → 436 (-1)
- compressed transfer: 1,844,244 → 1,841,186 bytes (-3,058)
- decoded resources: 5,577,570 → 5,562,340 bytes (-15,230)

## Validation

- `COVERAGE=1 ./run-tests.sh`
  - 487 Node/Vitest tests
  - 410 Chromium tests
  - 472 responsive assertions
  - offline PWA and two-device sync coverage
  - 67.13% global function coverage (67.10% floor)
- `npm run quality` (11/11)
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run architecture:check` (465 modules, 0 cycles)
- targeted Genetics/DNA/views browser coverage (8/8)
- `npm run performance:check` (436 requests, 1,841,186 transfer bytes, 5,562,340 decoded bytes)