### PR TITLE
Lazy-load Category views stylesheet

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -206,6 +206,16 @@ the original cascade position, while dashboard genome tiles remain in the
 eager `dashboard-data.css` bundle. The service-worker app shell retains the
 deferred stylesheet for offline first use.
 
+Category, Compare, and Correlations behavior stays module-eager for route
+compatibility, but `category-page-runtime.js` loads `css/category-views.css`
+when one of those routes first opens. Each route waits for the stylesheet
+before rendering, concurrent route entries share one request, failed links are
+removed and cache-busted for retry, and an HTML anchor preserves the original
+cascade position. Dashboard greeting spacing, alert cards, and date-range
+controls remain in eager dashboard bundles because the returning-user dashboard
+renders them without entering a category-backed route. The service-worker app
+shell retains the deferred stylesheet for offline first use.
+
 Client List remains module-eager because shell, profile, and location actions
 use it, but `css/client-list.css` loads only when `openClientList()` is first
 called. Opening waits for the stylesheet, concurrent opens share one request,

--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -10,7 +10,7 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | Metric | Current |
 | --- | ---: |
 | Modules | 465 |
-| Internal import edges | 2077 |
+| Internal import edges | 2078 |
 | Dynamic internal edges | 61 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -43,8 +43,8 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 | [`js/data.js`](js/data.js) | 73 | [`js/sync-configure.js`](js/sync-configure.js) | 27 |
 | [`js/api.js`](js/api.js) | 63 | [`js/dashboard-view-composition.js`](js/dashboard-view-composition.js) | 25 |
 | [`js/modal-lifecycle.js`](js/modal-lifecycle.js) | 51 | [`js/settings.js`](js/settings.js) | 24 |
-| [`js/profile.js`](js/profile.js) | 45 | [`js/pdf-import.js`](js/pdf-import.js) | 23 |
-| [`js/schema.js`](js/schema.js) | 30 | [`js/views.js`](js/views.js) | 23 |
+| [`js/profile.js`](js/profile.js) | 45 | [`js/views.js`](js/views.js) | 24 |
+| [`js/schema.js`](js/schema.js) | 30 | [`js/pdf-import.js`](js/pdf-import.js) | 23 |
 | [`js/data-merge.js`](js/data-merge.js) | 29 | [`js/chat-send.js`](js/chat-send.js) | 22 |
 | [`js/crypto.js`](js/crypto.js) | 27 | [`js/wearables-connect.js`](js/wearables-connect.js) | 20 |
 | [`js/utils-runtime.js`](js/utils-runtime.js) | 19 | [`js/biology-scores.js`](js/biology-scores.js) | 19 |
@@ -872,7 +872,7 @@ Native browser modules shipped with the static application.
 
 - [`js/views-router-runtime.js`](js/views-router-runtime.js) → [`js/pdf-import-progress.js`](js/pdf-import-progress.js)
 - [`js/views-router.js`](js/views-router.js) → [`js/data.js`](js/data.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js), [`js/views-router-runtime.js`](js/views-router-runtime.js)
-- [`js/views.js`](js/views.js) → [`js/category-customization.js`](js/category-customization.js), [`js/category-glyphs.js`](js/category-glyphs.js), [`js/category-page-view.js`](js/category-page-view.js), [`js/category-view-renderers.js`](js/category-view-renderers.js), [`js/compare-correlations.js`](js/compare-correlations.js), [`js/data.js`](js/data.js), [`js/dna-runtime.js`](js/dna-runtime.js), [`js/focus-card.js`](js/focus-card.js), [`js/import-drop-zone.js`](js/import-drop-zone.js), [`js/lens-page-shell.js`](js/lens-page-shell.js), [`js/lens-pages.js`](js/lens-pages.js), [`js/light-channel-view.js`](js/light-channel-view.js), [`js/light-conditions-now.js`](js/light-conditions-now.js), [`js/light-page-view.js`](js/light-page-view.js), [`js/light-sessions-view.js`](js/light-sessions-view.js), [`js/light-sun-loader.js`](js/light-sun-loader.js), [`js/marker-detail-modal.js`](js/marker-detail-modal.js), [`js/mobile-dashboard.js`](js/mobile-dashboard.js), [`js/nav.js`](js/nav.js), [`js/onboarding-view.js`](js/onboarding-view.js), [`js/recommendation-actions.js`](js/recommendation-actions.js), [`js/state.js`](js/state.js), [`js/views-router.js`](js/views-router.js)
+- [`js/views.js`](js/views.js) → [`js/category-customization.js`](js/category-customization.js), [`js/category-glyphs.js`](js/category-glyphs.js), [`js/category-page-runtime.js`](js/category-page-runtime.js), [`js/category-page-view.js`](js/category-page-view.js), [`js/category-view-renderers.js`](js/category-view-renderers.js), [`js/compare-correlations.js`](js/compare-correlations.js), [`js/data.js`](js/data.js), [`js/dna-runtime.js`](js/dna-runtime.js), [`js/focus-card.js`](js/focus-card.js), [`js/import-drop-zone.js`](js/import-drop-zone.js), [`js/lens-page-shell.js`](js/lens-page-shell.js), [`js/lens-pages.js`](js/lens-pages.js), [`js/light-channel-view.js`](js/light-channel-view.js), [`js/light-conditions-now.js`](js/light-conditions-now.js), [`js/light-page-view.js`](js/light-page-view.js), [`js/light-sessions-view.js`](js/light-sessions-view.js), [`js/light-sun-loader.js`](js/light-sun-loader.js), [`js/marker-detail-modal.js`](js/marker-detail-modal.js), [`js/mobile-dashboard.js`](js/mobile-dashboard.js), [`js/nav.js`](js/nav.js), [`js/onboarding-view.js`](js/onboarding-view.js), [`js/recommendation-actions.js`](js/recommendation-actions.js), [`js/state.js`](js/state.js), [`js/views-router.js`](js/views-router.js)
 
 </details>
 

--- a/css/category-views.css
+++ b/css/category-views.css
@@ -1,5 +1,4 @@
 /* Category routes: headers, marker cards, tables, heatmaps, and compare views */
-.category-header { margin-bottom: 24px; }
 .category-header h2 {
   font-family: var(--font-display); font-size: 24px; font-weight: 700; letter-spacing: -0.3px;
   display: flex; align-items: center; gap: 10px;
@@ -61,28 +60,6 @@
 }
 .view-btn.active { background: var(--accent-gradient); color: white; }
 .view-btn:hover:not(.active) { background: var(--bg-hover); }
-
-.alerts-section { margin-bottom: 32px; }
-.alerts-title {
-  font-family: var(--font-display); font-size: 16px; font-weight: 600; margin-bottom: 12px;
-  display: flex; align-items: center; gap: 8px;
-}
-.alert-card {
-  background: var(--bg-card); border-radius: var(--radius-sm);
-  border: 1px solid var(--border); padding: 14px 18px; margin-bottom: 8px;
-  display: flex; align-items: center; gap: 12px; cursor: pointer; transition: all 0.15s;
-}
-.alert-card:hover { border-color: var(--accent); }
-.alert-card.alert-high { border-left: 3px solid var(--red); }
-.alert-card.alert-low { border-left: 3px solid var(--yellow); }
-.alert-indicator {
-  font-family: var(--font-mono); font-size: 11px; font-weight: 700; padding: 2px 8px; border-radius: 4px; white-space: nowrap; flex-shrink: 0;
-}
-.alert-high .alert-indicator { background: var(--red-bg); color: var(--red); }
-.alert-low .alert-indicator { background: var(--yellow-bg); color: var(--yellow); }
-.alert-name { font-size: 14px; font-weight: 500; flex: 1; }
-.alert-value { font-family: var(--font-mono); font-size: 14px; font-weight: 600; font-variant-numeric: tabular-nums; }
-.alert-ref { font-size: 12px; color: var(--text-muted); width: 120px; text-align: right; }
 
 #view-content {
   width: 100%;
@@ -496,20 +473,6 @@
 .fa-card-value { font-family: var(--font-mono); font-size: 24px; font-weight: 700; font-variant-numeric: tabular-nums; }
 .fa-card-ref { font-size: 12px; color: var(--text-muted); margin-top: 4px; }
 
-/* Date range filter */
-.date-range-filter {
-  display: flex; gap: 4px; background: var(--bg-secondary); padding: 3px;
-  border-radius: var(--radius-sm); border: 1px solid var(--border);
-  width: fit-content;
-}
-.range-btn {
-  padding: 6px 12px; border-radius: 6px; border: none; background: transparent;
-  color: var(--text-secondary); font-size: 12px; cursor: pointer;
-  font-weight: 600; transition: all 0.15s; font-family: inherit;
-}
-.range-btn.active { background: var(--accent-gradient); color: white; }
-.range-btn:hover:not(.active) { background: var(--bg-hover); }
-
 /* Chart Layers Dropdown */
 .chart-layers-wrapper { position: relative; }
 .chart-layers-trigger { white-space: nowrap; }
@@ -788,5 +751,4 @@
 @media (pointer: coarse) {
   .compare-swap-btn { min-height: 44px; }
   .chart-layers-row { min-height: 44px; }
-  .range-btn { min-height: 44px; }
 }

--- a/css/dashboard-core.css
+++ b/css/dashboard-core.css
@@ -4,6 +4,7 @@
   display: flex; align-items: flex-start; justify-content: space-between;
   gap: 16px; margin-bottom: 16px;
 }
+.category-header { margin-bottom: 24px; }
 .dashboard-greeting h1 {
   margin: 0;
   font-family: var(--font-display);

--- a/css/dashboard-data.css
+++ b/css/dashboard-data.css
@@ -197,6 +197,27 @@
   margin-bottom: 6px;
 }
 .trend-alert-card:hover { background: var(--bg-hover); }
+.alerts-section { margin-bottom: 32px; }
+.alerts-title {
+  font-family: var(--font-display); font-size: 16px; font-weight: 600; margin-bottom: 12px;
+  display: flex; align-items: center; gap: 8px;
+}
+.alert-card {
+  background: var(--bg-card); border-radius: var(--radius-sm);
+  border: 1px solid var(--border); padding: 14px 18px; margin-bottom: 8px;
+  display: flex; align-items: center; gap: 12px; cursor: pointer; transition: all 0.15s;
+}
+.alert-card:hover { border-color: var(--accent); }
+.alert-card.alert-high { border-left: 3px solid var(--red); }
+.alert-card.alert-low { border-left: 3px solid var(--yellow); }
+.alert-indicator {
+  font-family: var(--font-mono); font-size: 11px; font-weight: 700; padding: 2px 8px; border-radius: 4px; white-space: nowrap; flex-shrink: 0;
+}
+.alert-high .alert-indicator { background: var(--red-bg); color: var(--red); }
+.alert-low .alert-indicator { background: var(--yellow-bg); color: var(--yellow); }
+.alert-name { font-size: 14px; font-weight: 500; flex: 1; }
+.alert-value { font-family: var(--font-mono); font-size: 14px; font-weight: 600; font-variant-numeric: tabular-nums; }
+.alert-ref { font-size: 12px; color: var(--text-muted); width: 120px; text-align: right; }
 .trend-alert-danger { border-left: 3px solid var(--red); }
 .trend-alert-warning { border-left: 3px solid var(--yellow); }
 .trend-alert-sudden { border-left: 3px solid var(--orange); }
@@ -431,6 +452,18 @@
   color: var(--text-muted);
   font-size: 10px;
 }
+.date-range-filter {
+  display: flex; gap: 4px; background: var(--bg-secondary); padding: 3px;
+  border-radius: var(--radius-sm); border: 1px solid var(--border);
+  width: fit-content;
+}
+.range-btn {
+  padding: 6px 12px; border-radius: 6px; border: none; background: transparent;
+  color: var(--text-secondary); font-size: 12px; cursor: pointer;
+  font-weight: 600; transition: all 0.15s; font-family: inherit;
+}
+.range-btn.active { background: var(--accent-gradient); color: white; }
+.range-btn:hover:not(.active) { background: var(--bg-hover); }
 .db-insights-list { display: grid; gap: 10px; }
 .db-insight {
   width: 100%; padding: 14px 16px; border-radius: var(--radius-sm);
@@ -529,6 +562,7 @@
 .db-wearable-foot { display: flex; justify-content: space-between; gap: 6px; color: var(--text-muted); font-family: var(--font-mono); font-size: 10px; }
 .db-wearable-foot em { font-style: normal; color: var(--text-secondary); }
 @media (pointer: coarse) {
+  .range-btn { min-height: 44px; }
   .db-biometric-remove {
     width: 44px;
     height: 44px;

--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
   <link rel="stylesheet" href="css/dashboard-widgets.css">
   <link rel="stylesheet" href="css/dashboard-welcome.css">
   <link rel="stylesheet" href="css/dashboard-data.css">
-  <link rel="stylesheet" href="css/category-views.css">
+  <meta data-category-views-stylesheet-anchor>
   <link rel="stylesheet" href="css/context-profile.css">
   <meta data-genetics-stylesheet-anchor>
   <link rel="stylesheet" href="css/data-protection.css">

--- a/js/category-page-runtime.js
+++ b/js/category-page-runtime.js
@@ -7,6 +7,56 @@ import {
   setRecommendationsCatalogCache,
 } from './recommendations-runtime.js';
 
+const CATEGORY_VIEWS_STYLESHEET_URL = new URL('../css/category-views.css', import.meta.url).href;
+
+/** @type {Promise<HTMLLinkElement> | null} */
+let categoryViewsStylesheetPromise = null;
+let categoryViewsStylesheetLoaded = false;
+let useCategoryViewsStylesheetRetryUrl = false;
+
+function categoryViewsStylesheetUrl() {
+  if (!useCategoryViewsStylesheetRetryUrl) return CATEGORY_VIEWS_STYLESHEET_URL;
+  const retryUrl = new URL(CATEGORY_VIEWS_STYLESHEET_URL);
+  retryUrl.searchParams.set('lazy-retry', '1');
+  return retryUrl.href;
+}
+
+export function isCategoryViewsStylesheetLoaded() {
+  return categoryViewsStylesheetLoaded;
+}
+
+/** @returns {Promise<HTMLLinkElement>} */
+export function loadCategoryViewsStylesheet() {
+  if (!categoryViewsStylesheetPromise) {
+    if (typeof document === 'undefined') {
+      return Promise.reject(new Error('Category views stylesheet requires a document'));
+    }
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = categoryViewsStylesheetUrl();
+    link.dataset.categoryViewsStylesheet = '';
+    categoryViewsStylesheetPromise = new Promise((resolve, reject) => {
+      link.addEventListener('load', () => {
+        categoryViewsStylesheetLoaded = true;
+        resolve(link);
+      }, { once: true });
+      link.addEventListener('error', () => {
+        reject(new Error('Category views stylesheet could not be loaded'));
+      }, { once: true });
+      const anchor = document.querySelector('[data-category-views-stylesheet-anchor]');
+      const parent = anchor?.parentNode || document.head;
+      parent.insertBefore(link, anchor || null);
+    }).catch(err => {
+      link.remove();
+      categoryViewsStylesheetPromise = null;
+      categoryViewsStylesheetLoaded = false;
+      useCategoryViewsStylesheetRetryUrl = true;
+      throw err;
+    });
+  }
+  return categoryViewsStylesheetPromise;
+}
+
 export function getCategoryPageCatalogSlots() {
   return getRecommendationsCatalogCache()?.slots || null;
 }

--- a/js/views.js
+++ b/js/views.js
@@ -22,6 +22,7 @@ import { configureOnboardingView, renderOnboardingBanner, renderAIConnectionRemi
 import { renderCategoryGlyph } from './category-glyphs.js';
 import { renderChartCard, renderTableColgroup, renderScrollableTableShell, renderTableView, renderHeatmapView, renderFattyAcidsView, renderFattyAcidsCharts } from './category-view-renderers.js';
 import { showCategory, switchView } from './category-page-view.js';
+import { isCategoryViewsStylesheetLoaded, loadCategoryViewsStylesheet } from './category-page-runtime.js';
 import { configureCategoryCustomization, renameCategory, renameMarker, revertMarkerName, showEmojiPicker, changeCategoryIcon } from './category-customization.js';
 import { renderConditionsNow, _refreshConditionsNow, _inspectConditionsNow, _setManualUvi, _clearManualUvi } from './light-conditions-now.js';
 import { _openAllSessionsModal as openAllSessionsModal } from './light-sessions-view.js';
@@ -267,6 +268,36 @@ function showGenomeRoute() {
     });
 }
 
+/**
+ * @param {string} route
+ * @param {string} label
+ * @param {() => any} render
+ */
+function showCategoryPresentationRoute(route, label, render) {
+  if (isCategoryViewsStylesheetLoaded()) return render();
+
+  const content = typeof document !== 'undefined' ? document.getElementById('main-content') : null;
+  if (content) renderDeferredRouteStatus(content, `Loading ${label}…`, { busy: true });
+
+  return loadCategoryViewsStylesheet()
+    .then(() => {
+      if (state.currentView !== route) return false;
+      render();
+      return true;
+    })
+    .catch(err => {
+      console.error(`Failed to load ${label} presentation`, err);
+      if (state.currentView === route && content) {
+        renderDeferredRouteStatus(
+          content,
+          `${label} could not be loaded. Try opening the page again.`,
+          { error: true },
+        );
+      }
+      return false;
+    });
+}
+
 const _navigate = createNavigate({
   routeHandlers: {
     dashboard: showDashboard,
@@ -276,10 +307,18 @@ const _navigate = createNavigate({
     body: showBodyLens,
     insight: showInsightLens,
     recommendations: showRecommendations,
-    correlations: showCorrelations,
-    compare: showCompare,
+    correlations: data => showCategoryPresentationRoute(
+      'correlations',
+      'Correlations',
+      () => showCorrelations(data),
+    ),
+    compare: data => showCategoryPresentationRoute('compare', 'Compare', () => showCompare(data)),
     light: showLightRoute,
-    category: showCategory,
+    category: (category, data) => showCategoryPresentationRoute(
+      category,
+      'Category',
+      () => showCategory(category, data),
+    ),
   },
   syncMobileBottomNav,
   destroyAllCharts,

--- a/plans/code-quality-audit-2026-07-21.md
+++ b/plans/code-quality-audit-2026-07-21.md
@@ -104,12 +104,13 @@ ceilings for same-origin application requests, compressed transfer bytes, and
 decoded bytes. The initial reference was 474 requests, 2,017,210 compressed
 bytes, and 6,252,286 decoded bytes. Lazy-loading the PDF import review,
 Light/Sun analysis hooks, Settings/Tweaks, Profile Sharing, and the Settings,
-Light/Sun, Client List, Import review, Marker Detail, EMF, and Genetics
-stylesheets reduced that reference to 436 requests, 1,841,186 compressed
-bytes, and 5,562,340 decoded bytes. The Genetics stylesheet slice saved one
-request, 3,058 compressed bytes, and 15,230 decoded bytes in identical
-before/after runs on the same machine. Route and feature lazy loading remains
-active, with the ceilings ratcheting downward after each reproducible slice.
+Light/Sun, Client List, Import review, Marker Detail, EMF, Genetics, and
+Category/Compare stylesheets reduced that reference to 435 requests, 1,836,218
+compressed bytes, and 5,539,354 decoded bytes. The Category/Compare stylesheet
+slice saved one request, 4,968 compressed bytes, and 22,986 decoded bytes in
+identical before/after runs on the same machine. Route and feature lazy loading
+remains active, with the ceilings ratcheting downward after each reproducible
+slice.
 
 ### 4. Guardrails and test gaps
 

--- a/scripts/cold-load-budget.json
+++ b/scripts/cold-load-budget.json
@@ -3,15 +3,15 @@
   "route": "/app",
   "scenario": "Fresh mobile returning-user load with browser cache and service workers disabled",
   "maximums": {
-    "requests": 442,
-    "transferBytes": 1875000,
-    "decodedBytes": 5659000
+    "requests": 441,
+    "transferBytes": 1870000,
+    "decodedBytes": 5636000
   },
   "reference": {
-    "requests": 436,
-    "transferBytes": 1841186,
-    "decodedBytes": 5562340
+    "requests": 435,
+    "transferBytes": 1836218,
+    "decodedBytes": 5539354
   },
-  "referenceCommit": "62b6d06e",
+  "referenceCommit": "6419855a",
   "measuredAt": "2026-07-24"
 }

--- a/tests/playwright/category-stylesheet-browser-coverage.spec.js
+++ b/tests/playwright/category-stylesheet-browser-coverage.spec.js
@@ -1,0 +1,140 @@
+import { expect, test } from './coverage-fixture.js';
+
+function moduleUrl(path) {
+  return `${path}?categoryStylesheetCoverage=${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+async function openCategoryLoaderPage(page, path) {
+  await page.route(`**${path}`, route => route.fulfill({
+    status: 200,
+    contentType: 'text/html',
+    body: `<!doctype html><html><head>
+      <link rel="stylesheet" href="/css/dashboard-data.css">
+      <meta data-category-views-stylesheet-anchor>
+      <link rel="stylesheet" href="/css/context-profile.css">
+    </head><body></body></html>`,
+  }));
+  await page.goto(path, { waitUntil: 'load' });
+}
+
+test('Category stylesheet loader single-flights and preserves cascade order', async ({ page }) => {
+  let stylesheetRequests = 0;
+  await page.route('**/css/category-views.css*', route => {
+    stylesheetRequests += 1;
+    return route.fulfill({
+      status: 200,
+      contentType: 'text/css',
+      body: '.category-header { margin-bottom: 24px; }',
+    });
+  });
+  await openCategoryLoaderPage(page, '/category-stylesheet-cache-coverage');
+
+  const outcomes = await page.evaluate(async ({ runtimeUrl }) => {
+    const runtime = await import(runtimeUrl);
+    const loadedBeforeRequest = runtime.isCategoryViewsStylesheetLoaded();
+    const [first, second] = await Promise.all([
+      runtime.loadCategoryViewsStylesheet(),
+      runtime.loadCategoryViewsStylesheet(),
+    ]);
+    const third = await runtime.loadCategoryViewsStylesheet();
+    const anchor = document.querySelector('[data-category-views-stylesheet-anchor]');
+    return {
+      loadedBeforeRequest,
+      loadedAfterRequest: runtime.isCategoryViewsStylesheetLoaded(),
+      concurrentCallsShareTheSameLink: first === second,
+      laterCallsReuseTheResolvedLink: first === third,
+      oneStylesheetLink:
+        document.querySelectorAll('link[data-category-views-stylesheet]').length === 1,
+      linkPrecedesAnchor: first.nextElementSibling === anchor,
+      contextStylesheetFollowsAnchor:
+        anchor?.nextElementSibling?.getAttribute('href') === '/css/context-profile.css',
+    };
+  }, { runtimeUrl: moduleUrl('/js/category-page-runtime.js') });
+
+  expect(outcomes).toEqual({
+    loadedBeforeRequest: false,
+    loadedAfterRequest: true,
+    concurrentCallsShareTheSameLink: true,
+    laterCallsReuseTheResolvedLink: true,
+    oneStylesheetLink: true,
+    linkPrecedesAnchor: true,
+    contextStylesheetFollowsAnchor: true,
+  });
+  expect(stylesheetRequests).toBe(1);
+});
+
+test('Compare route contains a stylesheet failure and retries with a fresh URL', async ({ page }) => {
+  const stylesheetRequests = [];
+  await page.route('**/css/category-views.css*', route => {
+    stylesheetRequests.push(route.request().url());
+    return route.abort('failed');
+  });
+  await page.goto('/app', { waitUntil: 'load' });
+
+  const firstOpen = await page.evaluate(async () => {
+    const views = await import('/js/views.js');
+    const opened = await views.navigate('compare');
+    return {
+      opened,
+      status: document.getElementById('main-content')?.textContent || '',
+      links: document.querySelectorAll('link[data-category-views-stylesheet]').length,
+    };
+  });
+
+  expect(firstOpen.opened).toBe(false);
+  expect(firstOpen.status).toContain('Compare could not be loaded');
+  expect(firstOpen.links).toBe(0);
+  expect(stylesheetRequests).toHaveLength(1);
+
+  await page.unroute('**/css/category-views.css*');
+  const retryOpen = await page.evaluate(async () => {
+    const views = await import('/js/views.js');
+    const opened = await views.navigate('compare');
+    const link = document.querySelector('link[data-category-views-stylesheet]');
+    return {
+      opened,
+      workspace: document.getElementById('main-content')?.textContent || '',
+      href: link?.href || '',
+      sheetLoaded: link?.sheet !== null,
+    };
+  });
+
+  expect(retryOpen.opened).toBe(true);
+  expect(retryOpen.workspace).toContain('Compare Dates');
+  expect(retryOpen.sheetLoaded).toBe(true);
+  expect(new URL(retryOpen.href).searchParams.get('lazy-retry')).toBe('1');
+});
+
+test('Dashboard-owned shared styles remain eager without Category presentation', async ({ page }) => {
+  await page.goto('/app', { waitUntil: 'load' });
+
+  const outcomes = await page.evaluate(() => {
+    const host = document.createElement('div');
+    host.innerHTML = `
+      <div class="dashboard-greeting category-header"></div>
+      <div class="alerts-section"><div class="alert-card alert-high">
+        <span class="alert-indicator">High</span>
+      </div></div>
+      <div class="date-range-filter"><button class="range-btn active">All</button></div>`;
+    document.body.append(host);
+    const greeting = host.querySelector('.dashboard-greeting');
+    const alert = host.querySelector('.alert-card');
+    const range = host.querySelector('.range-btn');
+    return {
+      categoryStylesheetAbsent:
+        document.querySelector('link[data-category-views-stylesheet]') === null,
+      greetingMargin: greeting ? getComputedStyle(greeting).marginBottom : '',
+      alertDisplay: alert ? getComputedStyle(alert).display : '',
+      alertLeftWidth: alert ? getComputedStyle(alert).borderLeftWidth : '',
+      rangeWeight: range ? getComputedStyle(range).fontWeight : '',
+    };
+  });
+
+  expect(outcomes).toEqual({
+    categoryStylesheetAbsent: true,
+    greetingMargin: '24px',
+    alertDisplay: 'flex',
+    alertLeftWidth: '3px',
+    rangeWeight: '600',
+  });
+});

--- a/tests/playwright/cold-load-budget.spec.js
+++ b/tests/playwright/cold-load-budget.spec.js
@@ -88,6 +88,9 @@ test('cold mobile app load stays within committed resource budgets', async ({ pa
   expect(entries.some(entry => (
     new URL(entry.name).pathname === '/css/genetics.css'
   ))).toBe(false);
+  expect(entries.some(entry => (
+    new URL(entry.name).pathname === '/css/category-views.css'
+  ))).toBe(false);
   const deferredLightStylesheets = new Set([
     '/css/light-sun.css',
     '/css/light-channels.css',

--- a/tests/playwright/theme-responsive-e2e.spec.js
+++ b/tests/playwright/theme-responsive-e2e.spec.js
@@ -1067,7 +1067,7 @@ async function checkMobileInteractions(page, theme, viewportName, assert) {
   await page.evaluate(async () => {
     const viewsModule = await import('/js/views.js');
     window.scrollTo(0, 0);
-    viewsModule.showCategory?.('biochemistry');
+    await viewsModule.navigate('biochemistry');
   });
   await page.waitForSelector('.category-header', { timeout: 5000 });
   for (const view of ['table', 'heatmap']) {

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -174,12 +174,35 @@ assert('dashboard CSS split loads before category views',
   indexSrc.indexOf('href="css/dashboard-core.css"') < indexSrc.indexOf('href="css/dashboard-widgets.css"') &&
   indexSrc.indexOf('href="css/dashboard-widgets.css"') < indexSrc.indexOf('href="css/dashboard-welcome.css"') &&
   indexSrc.indexOf('href="css/dashboard-welcome.css"') < indexSrc.indexOf('href="css/dashboard-data.css"') &&
-  indexSrc.indexOf('href="css/dashboard-data.css"') < indexSrc.indexOf('href="css/category-views.css"') &&
+  indexSrc.indexOf('href="css/dashboard-data.css"') < indexSrc.indexOf('data-category-views-stylesheet-anchor') &&
   swAuditSrc.indexOf("'/css/dashboard-core.css'") < swAuditSrc.indexOf("'/css/dashboard-widgets.css'") &&
   swAuditSrc.indexOf("'/css/dashboard-widgets.css'") < swAuditSrc.indexOf("'/css/dashboard-welcome.css'") &&
   swAuditSrc.indexOf("'/css/dashboard-welcome.css'") < swAuditSrc.indexOf("'/css/dashboard-data.css'") &&
   swAuditSrc.indexOf("'/css/dashboard-data.css'") < swAuditSrc.indexOf("'/css/category-views.css'"));
-assert('index loads category views CSS bundle', indexSrc.includes('href="css/category-views.css"'));
+const categoryPageRuntimeAuditSrc = read('js/category-page-runtime.js');
+const categoryViewsRouteAuditSrc = read('js/views.js');
+const dashboardCoreAuditSrc = read('css/dashboard-core.css');
+const dashboardDataAuditSrc = read('css/dashboard-data.css');
+assert('index defers category views CSS behind its ordered lazy-load anchor',
+  !indexSrc.includes('href="css/category-views.css"') &&
+  indexSrc.includes('data-category-views-stylesheet-anchor') &&
+  categoryPageRuntimeAuditSrc.includes("new URL('../css/category-views.css', import.meta.url)") &&
+  categoryPageRuntimeAuditSrc.includes('data-category-views-stylesheet-anchor'));
+assert('category views CSS lazy-load anchor preserves the original cascade position',
+  indexSrc.indexOf('href="css/dashboard-data.css"') <
+    indexSrc.indexOf('data-category-views-stylesheet-anchor') &&
+  indexSrc.indexOf('data-category-views-stylesheet-anchor') <
+    indexSrc.indexOf('href="css/context-profile.css"'));
+assert('category, compare, and correlations routes wait for category presentation',
+  categoryViewsRouteAuditSrc.includes("category: (category, data) => showCategoryPresentationRoute(") &&
+  categoryViewsRouteAuditSrc.includes("showCategoryPresentationRoute('compare'") &&
+  categoryViewsRouteAuditSrc.includes("'correlations',\n      'Correlations',"));
+assert('dashboard-owned category primitives remain eager',
+  dashboardCoreAuditSrc.includes('.category-header { margin-bottom: 24px; }') &&
+  dashboardDataAuditSrc.includes('.alerts-section') &&
+  dashboardDataAuditSrc.includes('.alert-card') &&
+  dashboardDataAuditSrc.includes('.date-range-filter') &&
+  dashboardDataAuditSrc.includes('.range-btn'));
 assert('SW APP_SHELL includes category views CSS bundle', swAuditSrc.includes("'/css/category-views.css'"));
 assert('index loads shared modal CSS bundle', indexSrc.includes('href="css/modal-shared.css"'));
 assert('SW APP_SHELL includes shared modal CSS bundle', swAuditSrc.includes("'/css/modal-shared.css'"));

--- a/tests/test-mobile.js
+++ b/tests/test-mobile.js
@@ -30,9 +30,12 @@ return (async function() {
   const { loadMarkerDetailStylesheet } = await import('/js/marker-detail-modal.js');
   await loadMarkerDetailStylesheet();
 
-  // Settings styles are also lazy-loaded in production. Include their source
-  // in this static responsive-rule audit without making them startup resources.
-  const css = `${getCSS()}\n${await fetchWithRetry('css/settings.css')}`;
+  // Settings and category-route styles are lazy-loaded in production. Include
+  // their source in this static responsive-rule audit without making them
+  // startup resources.
+  const css = `${getCSS()}
+${await fetchWithRetry('css/settings.css')}
+${await fetchWithRetry('css/category-views.css')}`;
 
   // ═══ Section 1: Header mobile layout ═══
   console.log('%c[1] Header Mobile Layout', 'font-weight:bold');

--- a/tests/test-ui-flows.js
+++ b/tests/test-ui-flows.js
@@ -203,7 +203,7 @@ return (async function() {
   console.log('%c 2. Navigation', 'font-weight:bold;color:#6366f1');
 
   // Navigate to biochemistry
-  viewsModule.navigate('biochemistry');
+  await viewsModule.navigate('biochemistry');
   await wait(50);
   const bioNav = sidebar.querySelector('.nav-item[data-category="biochemistry"]');
   assert('Biochemistry nav item active', bioNav?.classList.contains('active'));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.361';
+self.APP_VERSION = '1.10.362';


### PR DESCRIPTION
## What

- defer `css/category-views.css` until Category, Compare, or Correlations is opened
- use the already-eager category runtime for single-flight loading, cascade preservation, failure containment, and cache-busted retry
- keep dashboard greeting spacing, alert cards, and date-range controls in eager dashboard ownership
- update route/static CSS fixtures for the new async presentation contract
- add browser coverage for cache/order, failure/retry, and eager shared-style ownership
- ratchet the cold-load budget and document the boundary

## Why

Category and comparison presentation is not needed on a normal returning-user dashboard startup. A few rules in the former bundle were shared by dashboard widgets, so those rules were relocated unchanged before deferring the remaining route-only stylesheet.

## Cold-load impact

Identical fresh mobile returning-user runs with browser cache and service workers disabled:

- requests: 436 → 435 (-1)
- compressed transfer: 1,841,186 → 1,836,218 bytes (-4,968)
- decoded resources: 5,562,340 → 5,539,354 bytes (-22,986)

## Validation

- `COVERAGE=1 ./run-tests.sh`
  - 487 Node/Vitest tests
  - 413 Chromium tests
  - 472 responsive assertions
  - offline PWA and two-device sync coverage
  - 67.24% global function coverage (67.10% floor)
- `npm run quality` (11/11)
- type checks, architecture (465 modules, 0 cycles), vendor integrity, and 131 verification checks
- targeted route/dashboard/cold-load browser coverage (11/11)
- `npm run performance:check` (435 requests, 1,836,218 transfer bytes, 5,539,354 decoded bytes)