### PR TITLE
Lazy-load Wearables stylesheet

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -188,6 +188,15 @@ the stylesheet's cascade position, while the shell-owned Settings button rule
 stays in `app-shell.css`. The deferred stylesheet remains in the service-worker
 app shell for offline first use.
 
+Wearables presentation is loaded through the single-flight stylesheet boundary
+in `wearables-runtime.js` when a biometric detail, inline manual log, or the
+Wearables settings tab is opened. The dashboard's compact biometric tiles and
+empty manual-card shell retain their small shared rules in
+`css/dashboard-data.css`, so the default dashboard paints without
+`css/wearables.css`. The deferred sheet stays in the service-worker app shell
+for offline first use, and its HTML anchor preserves its original cascade
+position between Client List and Light & Sun.
+
 Profile Sharing is loaded through `profile-share-loader.js` when a shell,
 Settings, or client-list action opens it, or when startup/hash routing detects
 a shared-profile link. The loader owns only lazy loading and route detection;

--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -10,7 +10,7 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | Metric | Current |
 | --- | ---: |
 | Modules | 465 |
-| Internal import edges | 2078 |
+| Internal import edges | 2080 |
 | Dynamic internal edges | 61 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -38,11 +38,11 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 
 | High fan-in | Dependants | High fan-out | Imports |
 | --- | ---: | --- | ---: |
-| [`js/utils.js`](js/utils.js) | 209 | [`js/app-shell-hooks.js`](js/app-shell-hooks.js) | 88 |
+| [`js/utils.js`](js/utils.js) | 210 | [`js/app-shell-hooks.js`](js/app-shell-hooks.js) | 88 |
 | [`js/state.js`](js/state.js) | 146 | [`js/app-light-sun-modules.js`](js/app-light-sun-modules.js) | 27 |
 | [`js/data.js`](js/data.js) | 73 | [`js/sync-configure.js`](js/sync-configure.js) | 27 |
 | [`js/api.js`](js/api.js) | 63 | [`js/dashboard-view-composition.js`](js/dashboard-view-composition.js) | 25 |
-| [`js/modal-lifecycle.js`](js/modal-lifecycle.js) | 51 | [`js/settings.js`](js/settings.js) | 24 |
+| [`js/modal-lifecycle.js`](js/modal-lifecycle.js) | 51 | [`js/settings.js`](js/settings.js) | 25 |
 | [`js/profile.js`](js/profile.js) | 45 | [`js/views.js`](js/views.js) | 24 |
 | [`js/schema.js`](js/schema.js) | 30 | [`js/pdf-import.js`](js/pdf-import.js) | 23 |
 | [`js/data-merge.js`](js/data-merge.js) | 29 | [`js/chat-send.js`](js/chat-send.js) | 22 |
@@ -678,7 +678,7 @@ Native browser modules shipped with the static application.
 - [`js/settings-runtime-bridge.js`](js/settings-runtime-bridge.js) → no in-scope imports
 - [`js/settings-runtime.js`](js/settings-runtime.js) → [`js/settings-runtime-bridge.js`](js/settings-runtime-bridge.js), [`js/sun-uvdata-config.js`](js/sun-uvdata-config.js)
 - [`js/settings-sync-panel.js`](js/settings-sync-panel.js) → [`js/data.js`](js/data.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/settings-agent-access-panel.js`](js/settings-agent-access-panel.js), [`js/settings-runtime-bridge.js`](js/settings-runtime-bridge.js), [`js/state.js`](js/state.js), [`js/sync.js`](js/sync.js), [`js/utils.js`](js/utils.js)
-- [`js/settings.js`](js/settings.js) → [`js/api.js`](js/api.js), [`js/changelog.js`](js/changelog.js), [`js/charts.js`](js/charts.js), [`js/chat-runtime.js`](js/chat-runtime.js), [`js/crypto.js`](js/crypto.js), [`js/data.js`](js/data.js), [`js/import-loader.js`](js/import-loader.js), [`js/local-ai-discovery.js`](js/local-ai-discovery.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/profile.js`](js/profile.js), [`js/recommendations.js`](js/recommendations.js), [`js/settings-data.js`](js/settings-data.js), [`js/settings-import-benchmark-controller.js`](js/settings-import-benchmark-controller.js), [`js/settings-privacy.js`](js/settings-privacy.js), [`js/settings-provider-bridge.js`](js/settings-provider-bridge.js), [`js/settings-runtime-bridge.js`](js/settings-runtime-bridge.js), [`js/settings-runtime.js`](js/settings-runtime.js), [`js/settings-sync-panel.js`](js/settings-sync-panel.js), [`js/state.js`](js/state.js), [`js/theme.js`](js/theme.js), [`js/tour.js`](js/tour.js), [`js/utils-runtime.js`](js/utils-runtime.js), [`js/utils.js`](js/utils.js), [`js/wearables-settings-panel.js`](js/wearables-settings-panel.js)
+- [`js/settings.js`](js/settings.js) → [`js/api.js`](js/api.js), [`js/changelog.js`](js/changelog.js), [`js/charts.js`](js/charts.js), [`js/chat-runtime.js`](js/chat-runtime.js), [`js/crypto.js`](js/crypto.js), [`js/data.js`](js/data.js), [`js/import-loader.js`](js/import-loader.js), [`js/local-ai-discovery.js`](js/local-ai-discovery.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/profile.js`](js/profile.js), [`js/recommendations.js`](js/recommendations.js), [`js/settings-data.js`](js/settings-data.js), [`js/settings-import-benchmark-controller.js`](js/settings-import-benchmark-controller.js), [`js/settings-privacy.js`](js/settings-privacy.js), [`js/settings-provider-bridge.js`](js/settings-provider-bridge.js), [`js/settings-runtime-bridge.js`](js/settings-runtime-bridge.js), [`js/settings-runtime.js`](js/settings-runtime.js), [`js/settings-sync-panel.js`](js/settings-sync-panel.js), [`js/state.js`](js/state.js), [`js/theme.js`](js/theme.js), [`js/tour.js`](js/tour.js), [`js/utils-runtime.js`](js/utils-runtime.js), [`js/utils.js`](js/utils.js), [`js/wearables-runtime.js`](js/wearables-runtime.js), [`js/wearables-settings-panel.js`](js/wearables-settings-panel.js)
 
 </details>
 
@@ -901,7 +901,7 @@ Native browser modules shipped with the static application.
 - [`js/wearables-oura.js`](js/wearables-oura.js) → [`js/utils.js`](js/utils.js), [`js/wearable-adapters.js`](js/wearable-adapters.js)
 - [`js/wearables-polar-auth.js`](js/wearables-polar-auth.js) → [`js/utils.js`](js/utils.js), [`js/wearables-auth-runtime.js`](js/wearables-auth-runtime.js)
 - [`js/wearables-polar.js`](js/wearables-polar.js) → [`js/utils.js`](js/utils.js)
-- [`js/wearables-runtime.js`](js/wearables-runtime.js) → [`js/emf-runtime.js`](js/emf-runtime.js), [`js/settings-runtime-bridge.js`](js/settings-runtime-bridge.js)
+- [`js/wearables-runtime.js`](js/wearables-runtime.js) → [`js/emf-runtime.js`](js/emf-runtime.js), [`js/settings-runtime-bridge.js`](js/settings-runtime-bridge.js), [`js/utils.js`](js/utils.js)
 - [`js/wearables-settings-panel.js`](js/wearables-settings-panel.js) → [`js/brand-assets.js`](js/brand-assets.js), [`js/data.js`](js/data.js) *(dynamic)*, [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js), [`js/wearable-adapters.js`](js/wearable-adapters.js), [`js/wearables-apple-health.js`](js/wearables-apple-health.js) *(dynamic)*, [`js/wearables-connect.js`](js/wearables-connect.js), [`js/wearables-manual.js`](js/wearables-manual.js) *(dynamic)*, [`js/wearables-settings-runtime.js`](js/wearables-settings-runtime.js), [`js/wearables-store.js`](js/wearables-store.js) *(dynamic)*, [`js/wearables-summary.js`](js/wearables-summary.js)
 - [`js/wearables-settings-runtime.js`](js/wearables-settings-runtime.js) → [`js/settings-runtime-bridge.js`](js/settings-runtime-bridge.js), [`js/utils.js`](js/utils.js)
 - [`js/wearables-store.js`](js/wearables-store.js) → no in-scope imports

--- a/css/dashboard-data.css
+++ b/css/dashboard-data.css
@@ -516,13 +516,68 @@
 }
 .wearable-card.db-biometric-manual-empty {
   background: var(--bg-hover);
-  border-color: var(--border);
-  border-style: solid;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 12px 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
   margin: 0;
   opacity: 1;
   box-shadow: none;
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: border-color 0.15s ease, transform 0.15s ease;
 }
-.wearable-card.db-biometric-manual-empty:hover { opacity: 1; }
+.wearable-card.db-biometric-manual-empty:hover {
+  border-color: var(--accent);
+  opacity: 1;
+  transform: translateY(-1px);
+}
+.wearable-card.db-biometric-manual-empty:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.db-biometric-manual-empty .wearable-card-top,
+.db-biometric-manual-empty .wearable-card-bottom {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.db-biometric-manual-empty .wearable-card-bottom { min-height: 18px; }
+.db-biometric-manual-empty .wearable-metric-name {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+.db-biometric-manual-empty .wearable-value-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: flex-start;
+  gap: 4px;
+  min-height: 24px;
+}
+.db-biometric-manual-empty .wearable-value {
+  color: var(--text-muted);
+  font-size: 22px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 400;
+  line-height: 1;
+}
+.db-biometric-manual-empty .wearable-empty-cta {
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
 .db-biometric-remove {
   position: absolute;
   top: 8px;

--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
   <meta data-marker-detail-stylesheet-anchor>
   <link rel="stylesheet" href="css/recommendations.css">
   <meta data-client-list-stylesheet-anchor>
-  <link rel="stylesheet" href="css/wearables.css">
+  <meta data-wearables-stylesheet-anchor>
   <meta data-light-sun-stylesheet-anchor>
   <link rel="stylesheet" href="css/chat-panel.css">
   <link rel="stylesheet" href="css/chat-personality.css">

--- a/js/dashboard-widget-runtime.js
+++ b/js/dashboard-widget-runtime.js
@@ -5,7 +5,11 @@ import { triggerContextCardDNAFilePickerRuntime } from './context-cards-runtime.
 import { getDeviceSessions } from './light-devices-store.js';
 import { getSettingsModuleFunction } from './settings-runtime-bridge.js';
 import { getSessions } from './sun-sessions-store.js';
-import { getWearablesModuleFunction } from './wearables-runtime.js';
+import {
+  getWearablesModuleFunction,
+  isWearablesStylesheetLoaded,
+  loadWearablesStylesheetForAction,
+} from './wearables-runtime.js';
 
 const dashboardWidgetRuntimeDeps = {
   navigate: /** @type {null | ((route: string) => unknown)} */ (null),
@@ -102,7 +106,15 @@ export function syncDashboardWearableNow(actionEl) {
 export function openDashboardWearableDetail(id) {
   const openDetail = getWearablesModuleFunction('openWearableDetail');
   if (!openDetail) return false;
-  openDetail(id);
+  const ownsLazyStylesheet = typeof document !== 'undefined'
+    && !!document.querySelector('[data-wearables-stylesheet-anchor]');
+  if (!ownsLazyStylesheet || isWearablesStylesheetLoaded()) {
+    openDetail(id);
+  } else {
+    void loadWearablesStylesheetForAction().then(loaded => {
+      if (loaded) openDetail(id);
+    });
+  }
   return true;
 }
 
@@ -111,7 +123,17 @@ export function openDashboardWearableDetail(id) {
  * @param {Event} event
  */
 export function openDashboardManualLogForm(id, event) {
-  getWearablesModuleFunction('openManualLogForm')?.(id, event);
+  const openManualLogForm = getWearablesModuleFunction('openManualLogForm');
+  if (!openManualLogForm) return;
+  const ownsLazyStylesheet = typeof document !== 'undefined'
+    && !!document.querySelector('[data-wearables-stylesheet-anchor]');
+  if (!ownsLazyStylesheet || isWearablesStylesheetLoaded()) {
+    openManualLogForm(id, event);
+  } else {
+    void loadWearablesStylesheetForAction().then(loaded => {
+      if (loaded) openManualLogForm(id, event);
+    });
+  }
 }
 
 /** @param {string} id */

--- a/js/settings.js
+++ b/js/settings.js
@@ -73,6 +73,10 @@ import {
   openImportBenchmarksModal,
   renderImportBenchmarksEntrySection,
 } from './settings-import-benchmark-controller.js';
+import {
+  isWearablesStylesheetLoaded,
+  loadWearablesStylesheetForAction,
+} from './wearables-runtime.js';
 
 /** @typedef {Window & typeof globalThis & Record<string, any>} SettingsWindow */
 
@@ -349,7 +353,7 @@ async function handleSettingsClick(event) {
   const tabButton = closestWithin(event, '[data-settings-tab]', modal);
   if (tabButton) {
     event.preventDefault();
-    switchSettingsTab(tabButton.dataset.settingsTab || 'display');
+    await switchSettingsTab(tabButton.dataset.settingsTab || 'display');
     return;
   }
 
@@ -708,6 +712,10 @@ export function openSettingsModal(tab) {
   // Legacy v1.27 tab id 'integrations' — same redirect as switchSettingsTab.
   // Older deep-links / tour steps / external links may still pass it.
   if (tab === 'integrations') tab = 'wearables';
+  if (tab === 'wearables' && !isWearablesStylesheetLoaded()) {
+    return loadWearablesStylesheetForAction()
+      .then(loaded => loaded ? openSettingsModal(tab) : false);
+  }
   if (tab) _activeSettingsTab = tab;
 
   modal.className = 'modal settings-modal';
@@ -978,6 +986,10 @@ export function switchSettingsTab(tabId) {
   // v1.30.0 split them. Land on Wearables for the back-compat redirect — most
   // pre-existing deep-links pointed at the wearable adapter rows.
   if (tabId === 'integrations') tabId = 'wearables';
+  if (tabId === 'wearables' && !isWearablesStylesheetLoaded()) {
+    return loadWearablesStylesheetForAction()
+      .then(loaded => loaded ? switchSettingsTab(tabId) : false);
+  }
   _activeSettingsTab = tabId;
   const modal = document.getElementById('settings-modal');
   if (!modal) return;

--- a/js/wearables-runtime.js
+++ b/js/wearables-runtime.js
@@ -3,6 +3,14 @@
 
 import { openEMFAssessmentEditor } from './emf-runtime.js';
 import { getSettingsModuleFunction } from './settings-runtime-bridge.js';
+import { showNotification } from './utils.js';
+
+const WEARABLES_STYLESHEET_URL = new URL('../css/wearables.css', import.meta.url).href;
+
+/** @type {Promise<HTMLLinkElement> | null} */
+let wearablesStylesheetPromise = null;
+let wearablesStylesheetLoaded = false;
+let useWearablesStylesheetRetryUrl = false;
 
 /** @type {{
  *   closeModal: (() => void) | null,
@@ -40,6 +48,83 @@ export function getWearablesModuleFunction(name) {
   return typeof wearableModuleBridge[name] === 'function'
     ? wearableModuleBridge[name]
     : null;
+}
+
+function existingWearablesStylesheet() {
+  if (typeof document === 'undefined') return null;
+  return /** @type {HTMLLinkElement | null} */ (
+    document.querySelector('link[data-wearables-stylesheet]')
+    || Array.from(document.querySelectorAll('link[rel="stylesheet"][href]'))
+      .find(link => {
+        try {
+          return new URL(/** @type {HTMLLinkElement} */ (link).href).pathname === '/css/wearables.css';
+        } catch {
+          return false;
+        }
+      })
+    || null
+  );
+}
+
+function wearablesStylesheetUrl() {
+  if (!useWearablesStylesheetRetryUrl) return WEARABLES_STYLESHEET_URL;
+  const retryUrl = new URL(WEARABLES_STYLESHEET_URL);
+  retryUrl.searchParams.set('lazy-retry', '1');
+  return retryUrl.href;
+}
+
+export function isWearablesStylesheetLoaded() {
+  return wearablesStylesheetLoaded || !!existingWearablesStylesheet()?.sheet;
+}
+
+/** @returns {Promise<HTMLLinkElement>} */
+export function loadWearablesStylesheet() {
+  const existing = existingWearablesStylesheet();
+  if (existing?.sheet) {
+    wearablesStylesheetLoaded = true;
+    return Promise.resolve(existing);
+  }
+  if (!wearablesStylesheetPromise) {
+    if (typeof document === 'undefined') {
+      return Promise.reject(new Error('Wearables stylesheet requires a document'));
+    }
+    const link = existing || document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = wearablesStylesheetUrl();
+    link.dataset.wearablesStylesheet = '';
+    wearablesStylesheetPromise = new Promise((resolve, reject) => {
+      link.addEventListener('load', () => {
+        wearablesStylesheetLoaded = true;
+        resolve(link);
+      }, { once: true });
+      link.addEventListener('error', () => {
+        reject(new Error('Wearables stylesheet could not be loaded'));
+      }, { once: true });
+      if (!link.isConnected) {
+        const anchor = document.querySelector('[data-wearables-stylesheet-anchor]');
+        const parent = anchor?.parentNode || document.head;
+        parent.insertBefore(link, anchor || null);
+      }
+    }).catch(err => {
+      link.remove();
+      wearablesStylesheetPromise = null;
+      wearablesStylesheetLoaded = false;
+      useWearablesStylesheetRetryUrl = true;
+      throw err;
+    });
+  }
+  return wearablesStylesheetPromise;
+}
+
+export async function loadWearablesStylesheetForAction() {
+  try {
+    await loadWearablesStylesheet();
+    return true;
+  } catch (err) {
+    console.error('Failed to load Wearables presentation', err);
+    showNotification('Wearables could not be loaded. Try again.', 'error');
+    return false;
+  }
 }
 
 export function configureWearablesRuntime(deps = {}) {

--- a/plans/code-quality-audit-2026-07-21.md
+++ b/plans/code-quality-audit-2026-07-21.md
@@ -48,6 +48,12 @@ security gap, a heavily cyclic import graph, and a costly cold-load footprint.
 - Recent ownership was highly concentrated: 352 of 364 commits in the prior 30
   days came from one contributor.
 
+Cold-load remediation status: subsequent focused slices moved Import, Settings,
+Client List, marker-detail, EMF, Genome, category/compare/correlation, Light &
+Sun, and Wearables presentation styles behind their first visual entry points.
+Each boundary keeps offline assets precached, preserves cascade order, and
+retains any dashboard-owned shared rules in eager dashboard bundles.
+
 ## Findings
 
 ### 1. Production proxy boundary — high priority

--- a/scripts/cold-load-budget.json
+++ b/scripts/cold-load-budget.json
@@ -3,15 +3,15 @@
   "route": "/app",
   "scenario": "Fresh mobile returning-user load with browser cache and service workers disabled",
   "maximums": {
-    "requests": 441,
-    "transferBytes": 1870000,
-    "decodedBytes": 5636000
+    "requests": 440,
+    "transferBytes": 1863000,
+    "decodedBytes": 5605000
   },
   "reference": {
-    "requests": 435,
-    "transferBytes": 1836218,
-    "decodedBytes": 5539354
+    "requests": 434,
+    "transferBytes": 1829165,
+    "decodedBytes": 5507886
   },
-  "referenceCommit": "6419855a",
+  "referenceCommit": "37b98833",
   "measuredAt": "2026-07-24"
 }

--- a/tests/playwright/cold-load-budget.spec.js
+++ b/tests/playwright/cold-load-budget.spec.js
@@ -91,6 +91,9 @@ test('cold mobile app load stays within committed resource budgets', async ({ pa
   expect(entries.some(entry => (
     new URL(entry.name).pathname === '/css/category-views.css'
   ))).toBe(false);
+  expect(entries.some(entry => (
+    new URL(entry.name).pathname === '/css/wearables.css'
+  ))).toBe(false);
   const deferredLightStylesheets = new Set([
     '/css/light-sun.css',
     '/css/light-channels.css',

--- a/tests/playwright/wearables-stylesheet-browser-coverage.spec.js
+++ b/tests/playwright/wearables-stylesheet-browser-coverage.spec.js
@@ -1,0 +1,173 @@
+import { expect, test } from './coverage-fixture.js';
+
+function moduleUrl(path) {
+  return `${path}?wearablesStylesheetCoverage=${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+async function openWearablesLoaderPage(page, path) {
+  await page.route(`**${path}`, route => route.fulfill({
+    status: 200,
+    contentType: 'text/html',
+    body: `<!doctype html><html><head>
+      <meta data-client-list-stylesheet-anchor>
+      <meta data-wearables-stylesheet-anchor>
+      <meta data-light-sun-stylesheet-anchor>
+      <link rel="stylesheet" href="/css/chat-panel.css">
+    </head><body></body></html>`,
+  }));
+  await page.goto(path, { waitUntil: 'load' });
+}
+
+test('Wearables stylesheet loader single-flights and preserves cascade order', async ({ page }) => {
+  let stylesheetRequests = 0;
+  await page.route('**/css/wearables.css*', route => {
+    stylesheetRequests += 1;
+    return route.fulfill({
+      status: 200,
+      contentType: 'text/css',
+      body: '.wearable-detail-stats { display: grid; }',
+    });
+  });
+  await openWearablesLoaderPage(page, '/wearables-stylesheet-cache-coverage');
+
+  const outcomes = await page.evaluate(async ({ runtimeUrl }) => {
+    const runtime = await import(runtimeUrl);
+    const loadedBeforeRequest = runtime.isWearablesStylesheetLoaded();
+    const [first, second] = await Promise.all([
+      runtime.loadWearablesStylesheet(),
+      runtime.loadWearablesStylesheet(),
+    ]);
+    const third = await runtime.loadWearablesStylesheet();
+    const anchor = document.querySelector('[data-wearables-stylesheet-anchor]');
+    return {
+      loadedBeforeRequest,
+      loadedAfterRequest: runtime.isWearablesStylesheetLoaded(),
+      concurrentCallsShareTheSameLink: first === second,
+      laterCallsReuseTheResolvedLink: first === third,
+      oneStylesheetLink:
+        document.querySelectorAll('link[data-wearables-stylesheet]').length === 1,
+      linkPrecedesAnchor: first.nextElementSibling === anchor,
+      lightAnchorFollowsAnchor:
+        anchor?.nextElementSibling?.hasAttribute('data-light-sun-stylesheet-anchor') === true,
+    };
+  }, { runtimeUrl: moduleUrl('/js/wearables-runtime.js') });
+
+  expect(outcomes).toEqual({
+    loadedBeforeRequest: false,
+    loadedAfterRequest: true,
+    concurrentCallsShareTheSameLink: true,
+    laterCallsReuseTheResolvedLink: true,
+    oneStylesheetLink: true,
+    linkPrecedesAnchor: true,
+    lightAnchorFollowsAnchor: true,
+  });
+  expect(stylesheetRequests).toBe(1);
+});
+
+test('Wearables stylesheet failure is contained and retries with a fresh URL', async ({ page }) => {
+  const stylesheetRequests = [];
+  await page.route('**/css/wearables.css*', route => {
+    stylesheetRequests.push(route.request().url());
+    return route.abort('failed');
+  });
+  await openWearablesLoaderPage(page, '/wearables-stylesheet-retry-coverage');
+
+  const runtimeUrl = moduleUrl('/js/wearables-runtime.js');
+  const firstLoaded = await page.evaluate(
+    async ({ runtimeUrl: url }) => (await import(url)).loadWearablesStylesheetForAction(),
+    { runtimeUrl },
+  );
+  expect(firstLoaded).toBe(false);
+  expect(stylesheetRequests).toHaveLength(1);
+  await expect(page.locator('link[data-wearables-stylesheet]')).toHaveCount(0);
+
+  await page.unroute('**/css/wearables.css*');
+  const retry = await page.evaluate(async ({ runtimeUrl: url }) => {
+    const runtime = await import(url);
+    const loaded = await runtime.loadWearablesStylesheetForAction();
+    const link = document.querySelector('link[data-wearables-stylesheet]');
+    return {
+      loaded,
+      href: link?.href || '',
+      sheetLoaded: link?.sheet !== null,
+    };
+  }, { runtimeUrl });
+
+  expect(retry.loaded).toBe(true);
+  expect(retry.sheetLoaded).toBe(true);
+  expect(new URL(retry.href).searchParams.get('lazy-retry')).toBe('1');
+});
+
+test('Dashboard biometric detail waits for Wearables presentation', async ({ page }) => {
+  let stylesheetRoute;
+  await page.route('**/css/wearables.css*', route => {
+    stylesheetRoute = route;
+  });
+  await page.goto('/app', { waitUntil: 'load' });
+
+  const opened = await page.evaluate(async () => {
+    const [dashboardRuntime, wearablesRuntime] = await Promise.all([
+      import('/js/dashboard-widget-runtime.js'),
+      import('/js/wearables-runtime.js'),
+    ]);
+    window.__wearablesDetailCalls = [];
+    wearablesRuntime.configureWearablesModuleBridge({
+      openWearableDetail: id => window.__wearablesDetailCalls.push(id),
+    });
+    return {
+      accepted: dashboardRuntime.openDashboardWearableDetail('sleep_score'),
+      callsBeforeStylesheet: [...window.__wearablesDetailCalls],
+    };
+  });
+
+  expect(opened).toEqual({
+    accepted: true,
+    callsBeforeStylesheet: [],
+  });
+  await expect.poll(() => !!stylesheetRoute).toBe(true);
+  await stylesheetRoute.fulfill({
+    status: 200,
+    contentType: 'text/css',
+    body: '.wearable-detail-stats { display: grid; }',
+  });
+  await expect.poll(() => page.evaluate(() => window.__wearablesDetailCalls)).toEqual(['sleep_score']);
+});
+
+test('Dashboard manual biometric card stays styled before Wearables presentation loads', async ({ page }) => {
+  await page.goto('/app', { waitUntil: 'load' });
+
+  const outcomes = await page.evaluate(() => {
+    const host = document.createElement('div');
+    host.innerHTML = `<div class="db-biometric-tile-wrap">
+      <div class="wearable-card wearable-card-empty db-biometric-manual-empty">
+        <div class="wearable-card-top"><span class="wearable-metric-name">Weight</span></div>
+        <div class="wearable-value-row wearable-value-row-empty">
+          <span class="wearable-value wearable-value-dash">-</span>
+        </div>
+        <div class="wearable-card-bottom"><div class="wearable-empty-cta">+ Log</div></div>
+      </div>
+    </div>`;
+    document.body.append(host);
+    const card = host.querySelector('.db-biometric-manual-empty');
+    const title = host.querySelector('.wearable-metric-name');
+    const action = host.querySelector('.wearable-empty-cta');
+    return {
+      stylesheetAbsent:
+        document.querySelector('link[data-wearables-stylesheet]') === null,
+      cardDisplay: card ? getComputedStyle(card).display : '',
+      cardBorderStyle: card ? getComputedStyle(card).borderStyle : '',
+      cardMinHeight: card ? getComputedStyle(card).minHeight : '',
+      titleTransform: title ? getComputedStyle(title).textTransform : '',
+      actionWeight: action ? getComputedStyle(action).fontWeight : '',
+    };
+  });
+
+  expect(outcomes).toEqual({
+    stylesheetAbsent: true,
+    cardDisplay: 'flex',
+    cardBorderStyle: 'solid',
+    cardMinHeight: '104px',
+    titleTransform: 'uppercase',
+    actionWeight: '600',
+  });
+});

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -235,6 +235,7 @@ assert('settings CSS lazy-load anchor preserves the original cascade position',
     indexSrc.indexOf('href="css/mobile-dashboard.css"'));
 assert('SW APP_SHELL includes settings CSS bundle', swAuditSrc.includes("'/css/settings.css'"));
 const clientListSrc = read('js/client-list.js');
+const wearablesRuntimeAuditSrc = read('js/wearables-runtime.js');
 assert('index defers client list CSS behind its ordered lazy-load anchor',
   !indexSrc.includes('href="css/client-list.css"') &&
   indexSrc.includes('data-client-list-stylesheet-anchor') &&
@@ -244,8 +245,19 @@ assert('client list CSS lazy-load anchor preserves the original cascade position
   indexSrc.indexOf('href="css/recommendations.css"') <
     indexSrc.indexOf('data-client-list-stylesheet-anchor') &&
   indexSrc.indexOf('data-client-list-stylesheet-anchor') <
-    indexSrc.indexOf('href="css/wearables.css"'));
+    indexSrc.indexOf('data-wearables-stylesheet-anchor'));
 assert('SW APP_SHELL includes client list CSS bundle', swAuditSrc.includes("'/css/client-list.css'"));
+assert('index defers wearables CSS behind its ordered lazy-load anchor',
+  !indexSrc.includes('href="css/wearables.css"') &&
+  indexSrc.includes('data-wearables-stylesheet-anchor') &&
+  wearablesRuntimeAuditSrc.includes("new URL('../css/wearables.css', import.meta.url)") &&
+  wearablesRuntimeAuditSrc.includes('data-wearables-stylesheet-anchor'));
+assert('wearables CSS lazy-load anchor preserves the original cascade position',
+  indexSrc.indexOf('data-client-list-stylesheet-anchor') <
+    indexSrc.indexOf('data-wearables-stylesheet-anchor') &&
+  indexSrc.indexOf('data-wearables-stylesheet-anchor') <
+    indexSrc.indexOf('data-light-sun-stylesheet-anchor'));
+assert('SW APP_SHELL includes wearables CSS bundle', swAuditSrc.includes("'/css/wearables.css'"));
 assert('index loads mobile dashboard CSS bundle', indexSrc.includes('href="css/mobile-dashboard.css"'));
 assert('SW APP_SHELL includes mobile dashboard CSS bundle', swAuditSrc.includes("'/css/mobile-dashboard.css'"));
 assert('index loads cycle CSS bundle', indexSrc.includes('href="css/cycle.css"'));
@@ -284,7 +296,7 @@ for (const lightCss of LIGHT_CSS_BUNDLES) {
 }
 assert('index keeps an ordered Light stylesheet anchor at the original cascade position',
   indexSrc.includes('data-light-sun-stylesheet-anchor') &&
-  indexSrc.indexOf('href="css/wearables.css"') <
+  indexSrc.indexOf('data-wearables-stylesheet-anchor') <
     indexSrc.indexOf('data-light-sun-stylesheet-anchor') &&
   indexSrc.indexOf('data-light-sun-stylesheet-anchor') <
     indexSrc.indexOf('href="css/chat-panel.css"'));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.362';
+self.APP_VERSION = '1.10.363';


### PR DESCRIPTION
## Summary

- defer `css/wearables.css` until biometric detail, inline manual logging, or Wearables settings is opened
- preserve the original cascade position, offline precache, single-flight loading, and cache-busted retry
- keep the dashboard manual biometric shell styled from the eager dashboard bundle
- ratchet the cold-load budget from 435 to 434 requests

## Cold-load result

- requests: 435 → 434
- compressed transfer: 1,836,218 → 1,829,165 bytes (-7,053)
- decoded bytes: 5,539,354 → 5,507,886 (-31,468)

## Verification

- `env PORT=8015 COVERAGE=1 ./run-tests.sh`
  - 131 verification checks
  - 487 Vitest tests
  - 417 Chromium tests
  - 472 responsive assertions
  - offline PWA and two-device sync
  - 67.21% global function coverage
- `npm run quality` (11/11)
- `npm run performance:check`
