### PR TITLE
Load Cycle styles only when relevant

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -197,6 +197,13 @@ empty manual-card shell retain their small shared rules in
 for offline first use, and its HTML anchor preserves its original cascade
 position between Client List and Light & Sun.
 
+Cycle presentation is loaded through `cycle-runtime.js`. Female Dashboard and
+Body routes wait for it before rendering, and editor or import-review actions
+share the same single-flight boundary. Profiles that are not female do not pay
+for `css/cycle.css` on startup. Failed loads are removed and cache-busted for a
+later retry; the deferred sheet stays precached for offline use and its anchor
+keeps the original position between Mobile Dashboard and marker-detail styles.
+
 Profile Sharing is loaded through `profile-share-loader.js` when a shell,
 Settings, or client-list action opens it, or when startup/hash routing detects
 a shared-profile link. The loader owns only lazy loading and route detection;

--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -10,7 +10,7 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | Metric | Current |
 | --- | ---: |
 | Modules | 465 |
-| Internal import edges | 2080 |
+| Internal import edges | 2082 |
 | Dynamic internal edges | 61 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -38,12 +38,12 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 
 | High fan-in | Dependants | High fan-out | Imports |
 | --- | ---: | --- | ---: |
-| [`js/utils.js`](js/utils.js) | 210 | [`js/app-shell-hooks.js`](js/app-shell-hooks.js) | 88 |
+| [`js/utils.js`](js/utils.js) | 211 | [`js/app-shell-hooks.js`](js/app-shell-hooks.js) | 88 |
 | [`js/state.js`](js/state.js) | 146 | [`js/app-light-sun-modules.js`](js/app-light-sun-modules.js) | 27 |
 | [`js/data.js`](js/data.js) | 73 | [`js/sync-configure.js`](js/sync-configure.js) | 27 |
 | [`js/api.js`](js/api.js) | 63 | [`js/dashboard-view-composition.js`](js/dashboard-view-composition.js) | 25 |
 | [`js/modal-lifecycle.js`](js/modal-lifecycle.js) | 51 | [`js/settings.js`](js/settings.js) | 25 |
-| [`js/profile.js`](js/profile.js) | 45 | [`js/views.js`](js/views.js) | 24 |
+| [`js/profile.js`](js/profile.js) | 45 | [`js/views.js`](js/views.js) | 25 |
 | [`js/schema.js`](js/schema.js) | 30 | [`js/pdf-import.js`](js/pdf-import.js) | 23 |
 | [`js/data-merge.js`](js/data-merge.js) | 29 | [`js/chat-send.js`](js/chat-send.js) | 22 |
 | [`js/crypto.js`](js/crypto.js) | 27 | [`js/wearables-connect.js`](js/wearables-connect.js) | 20 |
@@ -294,7 +294,7 @@ Native browser modules shipped with the static application.
 - [`js/cycle-import-adapters.js`](js/cycle-import-adapters.js) → [`js/cycle-summary.js`](js/cycle-summary.js)
 - [`js/cycle-import-file.js`](js/cycle-import-file.js) → no in-scope imports
 - [`js/cycle-import.js`](js/cycle-import.js) → [`js/context-cards-runtime.js`](js/context-cards-runtime.js), [`js/cycle-import-adapters.js`](js/cycle-import-adapters.js), [`js/cycle-import-file.js`](js/cycle-import-file.js), [`js/cycle-runtime.js`](js/cycle-runtime.js), [`js/cycle-store.js`](js/cycle-store.js), [`js/cycle-summary.js`](js/cycle-summary.js), [`js/data-merge.js`](js/data-merge.js), [`js/data.js`](js/data.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/tour.js`](js/tour.js), [`js/utils.js`](js/utils.js), [`js/wearables-apple-health.js`](js/wearables-apple-health.js) *(dynamic)*
-- [`js/cycle-runtime.js`](js/cycle-runtime.js) → no in-scope imports
+- [`js/cycle-runtime.js`](js/cycle-runtime.js) → [`js/utils.js`](js/utils.js)
 - [`js/cycle-store.js`](js/cycle-store.js) → no in-scope imports
 - [`js/cycle-summary.js`](js/cycle-summary.js) → no in-scope imports
 - [`js/cycle.js`](js/cycle.js) → [`js/constants.js`](js/constants.js), [`js/context-cards-runtime.js`](js/context-cards-runtime.js), [`js/cycle-import.js`](js/cycle-import.js), [`js/cycle-runtime.js`](js/cycle-runtime.js), [`js/cycle-summary.js`](js/cycle-summary.js), [`js/data.js`](js/data.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/state.js`](js/state.js), [`js/tour.js`](js/tour.js), [`js/utils.js`](js/utils.js)
@@ -872,7 +872,7 @@ Native browser modules shipped with the static application.
 
 - [`js/views-router-runtime.js`](js/views-router-runtime.js) → [`js/pdf-import-progress.js`](js/pdf-import-progress.js)
 - [`js/views-router.js`](js/views-router.js) → [`js/data.js`](js/data.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js), [`js/views-router-runtime.js`](js/views-router-runtime.js)
-- [`js/views.js`](js/views.js) → [`js/category-customization.js`](js/category-customization.js), [`js/category-glyphs.js`](js/category-glyphs.js), [`js/category-page-runtime.js`](js/category-page-runtime.js), [`js/category-page-view.js`](js/category-page-view.js), [`js/category-view-renderers.js`](js/category-view-renderers.js), [`js/compare-correlations.js`](js/compare-correlations.js), [`js/data.js`](js/data.js), [`js/dna-runtime.js`](js/dna-runtime.js), [`js/focus-card.js`](js/focus-card.js), [`js/import-drop-zone.js`](js/import-drop-zone.js), [`js/lens-page-shell.js`](js/lens-page-shell.js), [`js/lens-pages.js`](js/lens-pages.js), [`js/light-channel-view.js`](js/light-channel-view.js), [`js/light-conditions-now.js`](js/light-conditions-now.js), [`js/light-page-view.js`](js/light-page-view.js), [`js/light-sessions-view.js`](js/light-sessions-view.js), [`js/light-sun-loader.js`](js/light-sun-loader.js), [`js/marker-detail-modal.js`](js/marker-detail-modal.js), [`js/mobile-dashboard.js`](js/mobile-dashboard.js), [`js/nav.js`](js/nav.js), [`js/onboarding-view.js`](js/onboarding-view.js), [`js/recommendation-actions.js`](js/recommendation-actions.js), [`js/state.js`](js/state.js), [`js/views-router.js`](js/views-router.js)
+- [`js/views.js`](js/views.js) → [`js/category-customization.js`](js/category-customization.js), [`js/category-glyphs.js`](js/category-glyphs.js), [`js/category-page-runtime.js`](js/category-page-runtime.js), [`js/category-page-view.js`](js/category-page-view.js), [`js/category-view-renderers.js`](js/category-view-renderers.js), [`js/compare-correlations.js`](js/compare-correlations.js), [`js/cycle-runtime.js`](js/cycle-runtime.js), [`js/data.js`](js/data.js), [`js/dna-runtime.js`](js/dna-runtime.js), [`js/focus-card.js`](js/focus-card.js), [`js/import-drop-zone.js`](js/import-drop-zone.js), [`js/lens-page-shell.js`](js/lens-page-shell.js), [`js/lens-pages.js`](js/lens-pages.js), [`js/light-channel-view.js`](js/light-channel-view.js), [`js/light-conditions-now.js`](js/light-conditions-now.js), [`js/light-page-view.js`](js/light-page-view.js), [`js/light-sessions-view.js`](js/light-sessions-view.js), [`js/light-sun-loader.js`](js/light-sun-loader.js), [`js/marker-detail-modal.js`](js/marker-detail-modal.js), [`js/mobile-dashboard.js`](js/mobile-dashboard.js), [`js/nav.js`](js/nav.js), [`js/onboarding-view.js`](js/onboarding-view.js), [`js/recommendation-actions.js`](js/recommendation-actions.js), [`js/state.js`](js/state.js), [`js/views-router.js`](js/views-router.js)
 
 </details>
 

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
   <link rel="stylesheet" href="css/data-protection.css">
   <meta data-settings-stylesheet-anchor>
   <link rel="stylesheet" href="css/mobile-dashboard.css">
-  <link rel="stylesheet" href="css/cycle.css">
+  <meta data-cycle-stylesheet-anchor>
   <meta data-marker-detail-stylesheet-anchor>
   <link rel="stylesheet" href="css/recommendations.css">
   <meta data-client-list-stylesheet-anchor>

--- a/js/cycle-runtime.js
+++ b/js/cycle-runtime.js
@@ -1,6 +1,15 @@
 // @ts-check
 // cycle-runtime.js - Explicit application callbacks for Cycle views.
 
+import { showNotification } from './utils.js';
+
+const CYCLE_STYLESHEET_URL = new URL('../css/cycle.css', import.meta.url).href;
+
+/** @type {Promise<HTMLLinkElement> | null} */
+let cycleStylesheetPromise = null;
+let cycleStylesheetLoaded = false;
+let useCycleStylesheetRetryUrl = false;
+
 /** @type {{ closeModal: (() => void) | null, loadImportStylesheet: (() => Promise<unknown>) | null, navigate: ((category: string) => void) | null, openEditor: (() => void) | null, renderProfileButton: (() => void) | null }} */
 const cycleRuntimeDeps = {
   closeModal: null,
@@ -9,6 +18,83 @@ const cycleRuntimeDeps = {
   openEditor: null,
   renderProfileButton: null,
 };
+
+function existingCycleStylesheet() {
+  if (typeof document === 'undefined') return null;
+  return /** @type {HTMLLinkElement | null} */ (
+    document.querySelector('link[data-cycle-stylesheet]')
+    || Array.from(document.querySelectorAll('link[rel="stylesheet"][href]'))
+      .find(link => {
+        try {
+          return new URL(/** @type {HTMLLinkElement} */ (link).href).pathname === '/css/cycle.css';
+        } catch {
+          return false;
+        }
+      })
+    || null
+  );
+}
+
+function cycleStylesheetUrl() {
+  if (!useCycleStylesheetRetryUrl) return CYCLE_STYLESHEET_URL;
+  const retryUrl = new URL(CYCLE_STYLESHEET_URL);
+  retryUrl.searchParams.set('lazy-retry', '1');
+  return retryUrl.href;
+}
+
+export function isCycleStylesheetLoaded() {
+  return cycleStylesheetLoaded || !!existingCycleStylesheet()?.sheet;
+}
+
+/** @returns {Promise<HTMLLinkElement>} */
+export function loadCycleStylesheet() {
+  const existing = existingCycleStylesheet();
+  if (existing?.sheet) {
+    cycleStylesheetLoaded = true;
+    return Promise.resolve(existing);
+  }
+  if (!cycleStylesheetPromise) {
+    if (typeof document === 'undefined') {
+      return Promise.reject(new Error('Cycle stylesheet requires a document'));
+    }
+    const link = existing || document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = cycleStylesheetUrl();
+    link.dataset.cycleStylesheet = '';
+    cycleStylesheetPromise = new Promise(function beginCycleStylesheetLoad(resolve, reject) {
+      link.addEventListener('load', function markCycleStylesheetLoaded() {
+        cycleStylesheetLoaded = true;
+        resolve(link);
+      }, { once: true });
+      link.addEventListener('error', function rejectCycleStylesheetLoad() {
+        reject(new Error('Cycle stylesheet could not be loaded'));
+      }, { once: true });
+      if (!link.isConnected) {
+        const anchor = document.querySelector('[data-cycle-stylesheet-anchor]');
+        const parent = anchor?.parentNode || document.head;
+        parent.insertBefore(link, anchor || null);
+      }
+    }).catch(function resetCycleStylesheetLoad(err) {
+      link.remove();
+      cycleStylesheetPromise = null;
+      cycleStylesheetLoaded = false;
+      useCycleStylesheetRetryUrl = true;
+      throw err;
+    });
+  }
+  return cycleStylesheetPromise;
+}
+
+export async function loadCycleStylesheetForAction() {
+  try {
+    await loadCycleStylesheet();
+    return true;
+  } catch (err) {
+    console.error('Failed to load Cycle presentation', err);
+    showNotification('Cycle tools could not be loaded. Try again.', 'error');
+    return false;
+  }
+}
 
 /**
  * @param {{ closeModal?: (() => void) | null, loadImportStylesheet?: (() => Promise<unknown>) | null, navigate?: ((category: string) => void) | null, openEditor?: (() => void) | null, renderProfileButton?: (() => void) | null }} deps
@@ -38,7 +124,10 @@ export function closeCycleModalRuntime() {
 }
 
 export async function loadCycleImportStylesheetRuntime() {
-  await cycleRuntimeDeps.loadImportStylesheet?.();
+  await Promise.all([
+    loadCycleStylesheet(),
+    cycleRuntimeDeps.loadImportStylesheet?.(),
+  ]);
 }
 
 /** @param {string} category */

--- a/js/cycle.js
+++ b/js/cycle.js
@@ -8,7 +8,7 @@ import { startCycleTour } from './tour.js';
 import { createCyclePeriod, recentCyclePeriods, upgradeMenstrualCycleProfile } from './cycle-summary.js';
 import { clearCycleProfileData, renderCycleImportPickerControls, renderCycleImportSummarySection } from './cycle-import.js';
 import { recordContextCardChangeRuntime } from './context-cards-runtime.js';
-import { closeCycleModalRuntime, navigateCycleViewRuntime } from './cycle-runtime.js';
+import { closeCycleModalRuntime, isCycleStylesheetLoaded, loadCycleStylesheetForAction, navigateCycleViewRuntime } from './cycle-runtime.js';
 const CYCLE_ACTIVE_STATUSES = new Set(['regular', 'perimenopause']);
 const CYCLE_ICONS = {
   calendar: '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><rect x="3" y="4" width="18" height="18" rx="2"></rect><path d="M16 2v4M8 2v4M3 10h18"></path></svg>',
@@ -402,10 +402,13 @@ export function detectCycleIronAlerts(mc, data) {
 }
 
 export function openMenstrualCycleEditor() {
+  if (typeof document !== 'undefined' && document.querySelector('[data-cycle-stylesheet-anchor]') && !isCycleStylesheetLoaded()) {
+    return loadCycleStylesheetForAction().then(function openCycleEditorAfterStylesheet(loaded) { return loaded ? openMenstrualCycleEditor() : false; });
+  }
   const modal = document.getElementById("detail-modal");
   const overlay = document.getElementById("modal-overlay");
   const mc = state.importedData.menstrualCycle || {};
-  const periods = (mc.periods || []).slice().sort((a, b) => b.startDate.localeCompare(a.startDate));
+  const periods = (mc.periods || []).slice().sort(function newestCyclePeriodFirst(a, b) { return b.startDate.localeCompare(a.startDate); });
   const stats = calculateCycleStats(mc.periods);
   const regLabels = { regular: 'Regular', irregular: 'Irregular', very_irregular: 'Very Irregular' };
   const activeCycle = isActiveCycleStatus(mc.cycleStatus);

--- a/js/views.js
+++ b/js/views.js
@@ -23,6 +23,7 @@ import { renderCategoryGlyph } from './category-glyphs.js';
 import { renderChartCard, renderTableColgroup, renderScrollableTableShell, renderTableView, renderHeatmapView, renderFattyAcidsView, renderFattyAcidsCharts } from './category-view-renderers.js';
 import { showCategory, switchView } from './category-page-view.js';
 import { isCategoryViewsStylesheetLoaded, loadCategoryViewsStylesheet } from './category-page-runtime.js';
+import { isCycleStylesheetLoaded, loadCycleStylesheet } from './cycle-runtime.js';
 import { configureCategoryCustomization, renameCategory, renameMarker, revertMarkerName, showEmojiPicker, changeCategoryIcon } from './category-customization.js';
 import { renderConditionsNow, _refreshConditionsNow, _inspectConditionsNow, _setManualUvi, _clearManualUvi } from './light-conditions-now.js';
 import { _openAllSessionsModal as openAllSessionsModal } from './light-sessions-view.js';
@@ -298,13 +299,52 @@ function showCategoryPresentationRoute(route, label, render) {
     });
 }
 
+/**
+ * @param {string} route
+ * @param {string} label
+ * @param {(...args: any[]) => any} render
+ * @param {any[]} [args]
+ */
+function showCycleAwareRoute(route, label, render, args = []) {
+  if (state.profileSex !== 'female' || isCycleStylesheetLoaded()) return render(...args);
+
+  const content = typeof document !== 'undefined' ? document.getElementById('main-content') : null;
+  if (content) renderDeferredRouteStatus(content, `Loading ${label}…`, { busy: true });
+
+  return loadCycleStylesheet()
+    .then(function renderCycleRouteAfterStylesheet() {
+      if (state.currentView !== route) return false;
+      render(...args);
+      return true;
+    })
+    .catch(function handleCycleRouteLoadFailure(err) {
+      console.error(`Failed to load ${label} Cycle presentation`, err);
+      if (state.currentView === route && content) {
+        renderDeferredRouteStatus(
+          content,
+          `${label} could not be loaded. Try opening the page again.`,
+          { error: true },
+        );
+      }
+      return false;
+    });
+}
+
+function showDashboardRoute(data) {
+  return showCycleAwareRoute('dashboard', 'Dashboard', showDashboard, [data]);
+}
+
+function showBodyRoute() {
+  return showCycleAwareRoute('body', 'Body', showBodyLens);
+}
+
 const _navigate = createNavigate({
   routeHandlers: {
-    dashboard: showDashboard,
+    dashboard: showDashboardRoute,
     labs: showLabs,
     biologyScores: showBiologyScoresLens,
     genome: showGenomeRoute,
-    body: showBodyLens,
+    body: showBodyRoute,
     insight: showInsightLens,
     recommendations: showRecommendations,
     correlations: data => showCategoryPresentationRoute(

--- a/plans/code-quality-audit-2026-07-21.md
+++ b/plans/code-quality-audit-2026-07-21.md
@@ -50,9 +50,10 @@ security gap, a heavily cyclic import graph, and a costly cold-load footprint.
 
 Cold-load remediation status: subsequent focused slices moved Import, Settings,
 Client List, marker-detail, EMF, Genome, category/compare/correlation, Light &
-Sun, and Wearables presentation styles behind their first visual entry points.
-Each boundary keeps offline assets precached, preserves cascade order, and
-retains any dashboard-owned shared rules in eager dashboard bundles.
+Sun, Wearables, and conditionally relevant Cycle presentation styles behind
+their first visual entry points. Each boundary keeps offline assets precached,
+preserves cascade order, and retains any dashboard-owned shared rules in eager
+dashboard bundles.
 
 ## Findings
 

--- a/scripts/cold-load-budget.json
+++ b/scripts/cold-load-budget.json
@@ -3,15 +3,15 @@
   "route": "/app",
   "scenario": "Fresh mobile returning-user load with browser cache and service workers disabled",
   "maximums": {
-    "requests": 440,
-    "transferBytes": 1863000,
-    "decodedBytes": 5605000
+    "requests": 439,
+    "transferBytes": 1861000,
+    "decodedBytes": 5595000
   },
   "reference": {
-    "requests": 434,
-    "transferBytes": 1829165,
-    "decodedBytes": 5507886
+    "requests": 433,
+    "transferBytes": 1827334,
+    "decodedBytes": 5497927
   },
-  "referenceCommit": "37b98833",
+  "referenceCommit": "37ce8ad5",
   "measuredAt": "2026-07-24"
 }

--- a/tests/playwright/chat-empty-state.spec.js
+++ b/tests/playwright/chat-empty-state.spec.js
@@ -111,6 +111,15 @@ test('chat empty-state delegated actions update scoped profile UI', async ({ pag
       chatEmptyState.renderEmptyChatState(container, panel);
       const bubbledBeforeOptionalActions = bubbledClicks;
       container.querySelector('[data-chat-empty-action="open-cycle-editor"]')?.click();
+      await new Promise(resolve => {
+        const started = performance.now();
+        const waitForEditor = () => {
+          if (document.querySelector('#detail-modal .gb-modal-title')?.textContent === 'Menstrual Cycle'
+            || performance.now() - started >= 2000) resolve();
+          else requestAnimationFrame(waitForEditor);
+        };
+        waitForEditor();
+      });
       const cycleEditorOpenedThroughModule = document.getElementById('modal-overlay')?.classList.contains('show') === true
         && document.querySelector('#detail-modal .gb-modal-title')?.textContent === 'Menstrual Cycle';
       container.querySelector('[data-chat-empty-action="open-supplements-editor"]')?.click();

--- a/tests/playwright/cold-load-budget.spec.js
+++ b/tests/playwright/cold-load-budget.spec.js
@@ -94,6 +94,9 @@ test('cold mobile app load stays within committed resource budgets', async ({ pa
   expect(entries.some(entry => (
     new URL(entry.name).pathname === '/css/wearables.css'
   ))).toBe(false);
+  expect(entries.some(entry => (
+    new URL(entry.name).pathname === '/css/cycle.css'
+  ))).toBe(false);
   const deferredLightStylesheets = new Set([
     '/css/light-sun.css',
     '/css/light-channels.css',

--- a/tests/playwright/cycle-browser-coverage.spec.js
+++ b/tests/playwright/cycle-browser-coverage.spec.js
@@ -195,7 +195,7 @@ test('cycle browser coverage exercises editor save clear and period guards', asy
         && promptHtml.includes('Track your cycle for better lab interpretation');
       state.importedData.menstrualCycle = savedCycle;
 
-      cycle.openMenstrualCycleEditor();
+      await cycle.openMenstrualCycleEditor();
       const statusSelect = document.getElementById('mc-cycle-status');
       statusSelect.value = 'postmenopause';
       statusSelect.dispatchEvent(new Event('change', { bubbles: true }));
@@ -272,7 +272,7 @@ test('cycle browser coverage exercises editor save clear and period guards', asy
       clearToasts();
       tour.endTour();
 
-      cycle.openMenstrualCycleEditor();
+      await cycle.openMenstrualCycleEditor();
       const clearCancel = cycle.clearMenstrualCycle();
       await waitForDialog('#confirm-cancel');
       document.getElementById('confirm-cancel')?.click();

--- a/tests/playwright/cycle-import-browser-coverage.spec.js
+++ b/tests/playwright/cycle-import-browser-coverage.spec.js
@@ -73,6 +73,7 @@ test('Drip CSV import previews, commits, and opens cycle history', async ({ page
   const preview = page.locator('#import-modal-overlay');
   await expect(preview).toHaveClass(/show/);
   await expect(page.locator('link[data-import-stylesheet]')).toHaveCount(1);
+  await expect(page.locator('link[data-cycle-stylesheet]')).toHaveCount(1);
   await expect(page.locator('#import-modal .import-review-summary')).toHaveCSS('display', 'grid');
   await expect(page.locator('#import-modal .cycle-import-table-heading')).toHaveCSS('display', 'flex');
   await expect(page.locator('#import-modal .gb-modal-title')).toHaveText('Review cycle import');

--- a/tests/playwright/cycle-stylesheet-browser-coverage.spec.js
+++ b/tests/playwright/cycle-stylesheet-browser-coverage.spec.js
@@ -1,0 +1,167 @@
+import { expect, test } from './coverage-fixture.js';
+
+function moduleUrl(path) {
+  return `${path}?cycleStylesheetCoverage=${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+async function openCycleLoaderPage(page, path) {
+  await page.route(`**${path}`, route => route.fulfill({
+    status: 200,
+    contentType: 'text/html',
+    body: `<!doctype html><html><head>
+      <link rel="stylesheet" href="/css/mobile-dashboard.css">
+      <meta data-cycle-stylesheet-anchor>
+      <meta data-marker-detail-stylesheet-anchor>
+    </head><body></body></html>`,
+  }));
+  await page.goto(path, { waitUntil: 'load' });
+}
+
+test('Cycle stylesheet loader single-flights and preserves cascade order', async ({ page }) => {
+  let stylesheetRequests = 0;
+  await page.route('**/css/cycle.css*', route => {
+    stylesheetRequests += 1;
+    return route.fulfill({
+      status: 200,
+      contentType: 'text/css',
+      body: '.cycle-section { display: grid; }',
+    });
+  });
+  await openCycleLoaderPage(page, '/cycle-stylesheet-cache-coverage');
+
+  const outcomes = await page.evaluate(async ({ runtimeUrl }) => {
+    const runtime = await import(runtimeUrl);
+    const loadedBeforeRequest = runtime.isCycleStylesheetLoaded();
+    const [first, second] = await Promise.all([
+      runtime.loadCycleStylesheet(),
+      runtime.loadCycleStylesheet(),
+    ]);
+    const third = await runtime.loadCycleStylesheet();
+    const anchor = document.querySelector('[data-cycle-stylesheet-anchor]');
+    return {
+      loadedBeforeRequest,
+      loadedAfterRequest: runtime.isCycleStylesheetLoaded(),
+      concurrentCallsShareTheSameLink: first === second,
+      laterCallsReuseTheResolvedLink: first === third,
+      oneStylesheetLink:
+        document.querySelectorAll('link[data-cycle-stylesheet]').length === 1,
+      linkPrecedesAnchor: first.nextElementSibling === anchor,
+      markerAnchorFollowsAnchor:
+        anchor?.nextElementSibling?.hasAttribute('data-marker-detail-stylesheet-anchor') === true,
+    };
+  }, { runtimeUrl: moduleUrl('/js/cycle-runtime.js') });
+
+  expect(outcomes).toEqual({
+    loadedBeforeRequest: false,
+    loadedAfterRequest: true,
+    concurrentCallsShareTheSameLink: true,
+    laterCallsReuseTheResolvedLink: true,
+    oneStylesheetLink: true,
+    linkPrecedesAnchor: true,
+    markerAnchorFollowsAnchor: true,
+  });
+  expect(stylesheetRequests).toBe(1);
+});
+
+test('Cycle stylesheet failure is contained and retries with a fresh URL', async ({ page }) => {
+  const stylesheetRequests = [];
+  await page.route('**/css/cycle.css*', route => {
+    stylesheetRequests.push(route.request().url());
+    return route.abort('failed');
+  });
+  await openCycleLoaderPage(page, '/cycle-stylesheet-retry-coverage');
+
+  const runtimeUrl = moduleUrl('/js/cycle-runtime.js');
+  const firstLoaded = await page.evaluate(
+    async ({ runtimeUrl: url }) => (await import(url)).loadCycleStylesheetForAction(),
+    { runtimeUrl },
+  );
+  expect(firstLoaded).toBe(false);
+  expect(stylesheetRequests).toHaveLength(1);
+  await expect(page.locator('link[data-cycle-stylesheet]')).toHaveCount(0);
+
+  await page.unroute('**/css/cycle.css*');
+  const retry = await page.evaluate(async ({ runtimeUrl: url }) => {
+    const runtime = await import(url);
+    const loaded = await runtime.loadCycleStylesheetForAction();
+    const link = document.querySelector('link[data-cycle-stylesheet]');
+    return {
+      loaded,
+      href: link?.href || '',
+      sheetLoaded: link?.sheet !== null,
+    };
+  }, { runtimeUrl });
+
+  expect(retry.loaded).toBe(true);
+  expect(retry.sheetLoaded).toBe(true);
+  expect(new URL(retry.href).searchParams.get('lazy-retry')).toBe('1');
+});
+
+test('Female Body route contains a Cycle stylesheet failure and retries', async ({ page }) => {
+  await page.route('**/css/cycle.css*', route => route.abort('failed'));
+  await page.goto('/app', { waitUntil: 'load' });
+
+  const firstOpened = await page.evaluate(async () => {
+    const [{ state }, views] = await Promise.all([
+      import('/js/state.js'),
+      import('/js/views.js'),
+    ]);
+    state.profileSex = 'female';
+    return views.navigate('body');
+  });
+  expect(firstOpened).toBe(false);
+  await expect(page.locator('#main-content [role="alert"]')).toContainText('Body could not be loaded');
+  await expect(page.locator('link[data-cycle-stylesheet]')).toHaveCount(0);
+
+  await page.unroute('**/css/cycle.css*');
+  const retryOpened = await page.evaluate(async () => (await import('/js/views.js')).navigate('body'));
+  expect(retryOpened).toBe(true);
+  await expect(page.locator('link[data-cycle-stylesheet]')).toHaveCount(1);
+  await expect(page.locator('.cycle-section')).toBeVisible();
+});
+
+test('Female Body route waits for Cycle presentation while the default path stays cold', async ({ page }) => {
+  let stylesheetRoute;
+  await page.route('**/css/cycle.css*', route => {
+    stylesheetRoute = route;
+  });
+  await page.goto('/app', { waitUntil: 'load' });
+  await expect(page.locator('link[data-cycle-stylesheet]')).toHaveCount(0);
+
+  const beforeLoad = await page.evaluate(async () => {
+    const [{ state }, views] = await Promise.all([
+      import('/js/state.js'),
+      import('/js/views.js'),
+    ]);
+    state.profileSex = 'female';
+    window.__cycleBodyNavigation = views.navigate('body');
+    return {
+      status: document.getElementById('main-content')?.textContent || '',
+      links: document.querySelectorAll('link[data-cycle-stylesheet]').length,
+    };
+  });
+
+  expect(beforeLoad.status).toContain('Loading Body');
+  expect(beforeLoad.links).toBe(1);
+  await expect.poll(() => !!stylesheetRoute).toBe(true);
+  await stylesheetRoute.fulfill({
+    status: 200,
+    contentType: 'text/css',
+    body: '.cycle-section { display: grid; }',
+  });
+
+  const afterLoad = await page.evaluate(async () => {
+    const opened = await window.__cycleBodyNavigation;
+    const section = document.querySelector('.cycle-section');
+    return {
+      opened,
+      hasCycleSection: !!section,
+      display: section ? getComputedStyle(section).display : '',
+    };
+  });
+  expect(afterLoad).toEqual({
+    opened: true,
+    hasCycleSection: true,
+    display: 'grid',
+  });
+});

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -236,6 +236,8 @@ assert('settings CSS lazy-load anchor preserves the original cascade position',
 assert('SW APP_SHELL includes settings CSS bundle', swAuditSrc.includes("'/css/settings.css'"));
 const clientListSrc = read('js/client-list.js');
 const wearablesRuntimeAuditSrc = read('js/wearables-runtime.js');
+const cycleRuntimeAuditSrc = read('js/cycle-runtime.js');
+const cycleViewsAuditSrc = read('js/views.js');
 assert('index defers client list CSS behind its ordered lazy-load anchor',
   !indexSrc.includes('href="css/client-list.css"') &&
   indexSrc.includes('data-client-list-stylesheet-anchor') &&
@@ -260,7 +262,23 @@ assert('wearables CSS lazy-load anchor preserves the original cascade position',
 assert('SW APP_SHELL includes wearables CSS bundle', swAuditSrc.includes("'/css/wearables.css'"));
 assert('index loads mobile dashboard CSS bundle', indexSrc.includes('href="css/mobile-dashboard.css"'));
 assert('SW APP_SHELL includes mobile dashboard CSS bundle', swAuditSrc.includes("'/css/mobile-dashboard.css'"));
-assert('index loads cycle CSS bundle', indexSrc.includes('href="css/cycle.css"'));
+assert('index defers cycle CSS behind its ordered lazy-load anchor',
+  !indexSrc.includes('href="css/cycle.css"') &&
+  indexSrc.includes('data-cycle-stylesheet-anchor') &&
+  cycleRuntimeAuditSrc.includes("new URL('../css/cycle.css', import.meta.url)") &&
+  cycleRuntimeAuditSrc.includes('data-cycle-stylesheet-anchor'));
+assert('cycle CSS lazy-load anchor preserves the original cascade position',
+  indexSrc.indexOf('href="css/mobile-dashboard.css"') <
+    indexSrc.indexOf('data-cycle-stylesheet-anchor') &&
+  indexSrc.indexOf('data-cycle-stylesheet-anchor') <
+    indexSrc.indexOf('data-marker-detail-stylesheet-anchor'));
+assert('female Dashboard and Body routes wait for Cycle presentation',
+  cycleViewsAuditSrc.includes('showCycleAwareRoute') &&
+  cycleViewsAuditSrc.includes("state.profileSex !== 'female'") &&
+  cycleViewsAuditSrc.includes("showCycleAwareRoute('dashboard', 'Dashboard', showDashboard") &&
+  cycleViewsAuditSrc.includes("showCycleAwareRoute('body', 'Body', showBodyLens") &&
+  cycleViewsAuditSrc.includes('dashboard: showDashboardRoute') &&
+  cycleViewsAuditSrc.includes('body: showBodyRoute'));
 assert('SW APP_SHELL includes cycle CSS bundle', swAuditSrc.includes("'/css/cycle.css'"));
 const markerDetailSrc = read('js/marker-detail-modal.js');
 const markerDetailRuntimeSrc = read('js/marker-detail-runtime.js');
@@ -271,7 +289,7 @@ assert('index defers marker detail CSS behind its ordered lazy-load anchor',
   markerDetailRuntimeSrc.includes("new URL('../css/marker-detail-modal.css', import.meta.url)") &&
   markerDetailRuntimeSrc.includes('data-marker-detail-stylesheet-anchor'));
 assert('marker detail CSS lazy-load anchor preserves the original cascade position',
-  indexSrc.indexOf('href="css/cycle.css"') <
+  indexSrc.indexOf('data-cycle-stylesheet-anchor') <
     indexSrc.indexOf('data-marker-detail-stylesheet-anchor') &&
     indexSrc.indexOf('data-marker-detail-stylesheet-anchor') <
     indexSrc.indexOf('href="css/recommendations.css"'));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.363';
+self.APP_VERSION = '1.10.364';


### PR DESCRIPTION
## Summary

- defer `css/cycle.css` on profiles that do not need Cycle presentation
- load the stylesheet through a single-flight, cascade-preserving boundary for female Dashboard/Body routes, editor actions, and import review
- contain failures, surface action errors, and retry with a cache-busted URL while retaining offline precache support
- ratchet the cold-load budget and cover cold, success, failure, retry, route-staleness, editor, and import paths

## Cold-load result

Fresh mobile returning-user load with browser cache and service workers disabled:

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Requests | 434 | 433 | -1 |
| Transfer bytes | 1,829,165 | 1,827,334 | -1,831 |
| Decoded bytes | 5,507,886 | 5,497,927 | -9,959 |

## Verification

- `env PORT=8023 COVERAGE=1 ./run-tests.sh`
  - 131 verification checks
  - 487 Vitest tests
  - 421 Chromium tests
  - 472 responsive/theme checks
  - 67.20% global function coverage (67.10% required)
- `env PORT=8024 npm run performance:check`
- architecture: 465 modules, 0 cycles
- typecheck, checkJs, vendor integrity, quality guardrails, and diff checks