### PR TITLE
Load chat onboarding styles on first open

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -199,6 +199,15 @@ Cross-theme shell geometry and Sunset Mode rules remain in a final eager
 inline block after that anchor, preserving their original cascade while keeping
 the deferred sheet scoped to the four optional themes.
 
+Chat shell, message, and composer presentation remains eager because the
+persistent launcher and closed panel are part of startup chrome.
+`chat-panel.js` loads `css/chat-onboarding.css` through a single-flight boundary
+before the panel first opens, so returning users do not fetch empty-state and
+guided-setup presentation until they enter Chat. Failed links are removed and
+cache-busted for retry, an HTML anchor preserves the sheet's original position
+between composer and responsive overrides, and the service worker keeps it
+precached for offline first use.
+
 Wearables presentation is loaded through the single-flight stylesheet boundary
 in `wearables-runtime.js` when a biometric detail, inline manual log, or the
 Wearables settings tab is opened. The dashboard's compact biometric tiles and

--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -10,7 +10,7 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | Metric | Current |
 | --- | ---: |
 | Modules | 465 |
-| Internal import edges | 2083 |
+| Internal import edges | 2084 |
 | Dynamic internal edges | 61 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -38,7 +38,7 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 
 | High fan-in | Dependants | High fan-out | Imports |
 | --- | ---: | --- | ---: |
-| [`js/utils.js`](js/utils.js) | 212 | [`js/app-shell-hooks.js`](js/app-shell-hooks.js) | 88 |
+| [`js/utils.js`](js/utils.js) | 213 | [`js/app-shell-hooks.js`](js/app-shell-hooks.js) | 88 |
 | [`js/state.js`](js/state.js) | 146 | [`js/app-light-sun-modules.js`](js/app-light-sun-modules.js) | 27 |
 | [`js/data.js`](js/data.js) | 73 | [`js/sync-configure.js`](js/sync-configure.js) | 27 |
 | [`js/api.js`](js/api.js) | 63 | [`js/dashboard-view-composition.js`](js/dashboard-view-composition.js) | 25 |
@@ -224,7 +224,7 @@ Native browser modules shipped with the static application.
 - [`js/chat-nudge.js`](js/chat-nudge.js) → [`js/api.js`](js/api.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js)
 - [`js/chat-onboarding-host-bindings.js`](js/chat-onboarding-host-bindings.js) → [`js/api.js`](js/api.js), [`js/chat-onboarding.js`](js/chat-onboarding.js), [`js/context-cards.js`](js/context-cards.js), [`js/cycle.js`](js/cycle.js), [`js/data.js`](js/data.js), [`js/nav.js`](js/nav.js), [`js/onboarding-view.js`](js/onboarding-view.js), [`js/profile.js`](js/profile.js), [`js/settings-loader.js`](js/settings-loader.js), [`js/settings-provider-bridge.js`](js/settings-provider-bridge.js), [`js/supplements.js`](js/supplements.js), [`js/views.js`](js/views.js)
 - [`js/chat-onboarding.js`](js/chat-onboarding.js) → [`js/api.js`](js/api.js), [`js/constants.js`](js/constants.js), [`js/data-merge.js`](js/data-merge.js), [`js/data.js`](js/data.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
-- [`js/chat-panel.js`](js/chat-panel.js) → [`js/api.js`](js/api.js), [`js/chat-history.js`](js/chat-history.js), [`js/chat-nudge.js`](js/chat-nudge.js), [`js/chat-personalities.js`](js/chat-personalities.js), [`js/chat-summaries.js`](js/chat-summaries.js), [`js/chat-threads.js`](js/chat-threads.js), [`js/lens.js`](js/lens.js)
+- [`js/chat-panel.js`](js/chat-panel.js) → [`js/api.js`](js/api.js), [`js/chat-history.js`](js/chat-history.js), [`js/chat-nudge.js`](js/chat-nudge.js), [`js/chat-personalities.js`](js/chat-personalities.js), [`js/chat-summaries.js`](js/chat-summaries.js), [`js/chat-threads.js`](js/chat-threads.js), [`js/lens.js`](js/lens.js), [`js/utils.js`](js/utils.js)
 - [`js/chat-personalities.js`](js/chat-personalities.js) → [`js/api.js`](js/api.js), [`js/chat-attestation.js`](js/chat-attestation.js), [`js/chat-icons.js`](js/chat-icons.js), [`js/chat-runtime.js`](js/chat-runtime.js), [`js/chat-threads.js`](js/chat-threads.js), [`js/constants.js`](js/constants.js), [`js/context-source-registry.js`](js/context-source-registry.js), [`js/lens.js`](js/lens.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/chat-prompt-context.js`](js/chat-prompt-context.js) → no in-scope imports
 - [`js/chat-render-runtime.js`](js/chat-render-runtime.js) → [`js/recommendations-runtime.js`](js/recommendations-runtime.js)

--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
   <link rel="stylesheet" href="css/chat-personality.css">
   <link rel="stylesheet" href="css/chat-messages.css">
   <link rel="stylesheet" href="css/chat-composer.css">
-  <link rel="stylesheet" href="css/chat-onboarding.css">
+  <meta data-chat-onboarding-stylesheet-anchor>
   <link rel="stylesheet" href="css/chat-responsive.css">
   <link rel="stylesheet" href="css/chat-actions.css">
   <link rel="stylesheet" href="css/chat-mobile.css">

--- a/js/chat-panel.js
+++ b/js/chat-panel.js
@@ -12,8 +12,16 @@ import {
 import { renderSavedSummaries } from './chat-summaries.js';
 import { updateLensIndicator } from './lens.js';
 import { dismissCurrentChatNudge } from './chat-nudge.js';
+import { showNotification } from './utils.js';
 
 export { setChatNudge, updateChatNudge } from './chat-nudge.js';
+
+const CHAT_ONBOARDING_STYLESHEET_URL = new URL('../css/chat-onboarding.css', import.meta.url).href;
+
+/** @type {Promise<HTMLLinkElement> | null} */
+let chatOnboardingStylesheetPromise = null;
+let chatOnboardingStylesheetLoaded = false;
+let useChatOnboardingStylesheetRetryUrl = false;
 
 const panelCallbacks = {
   restoreDiscussionContinuePrompt: null,
@@ -53,16 +61,94 @@ export function isChatThreadInputBlocked() {
   return chatThreadInputBlocked;
 }
 
+function existingChatOnboardingStylesheet() {
+  if (typeof document === 'undefined') return null;
+  return /** @type {HTMLLinkElement | null} */ (
+    document.querySelector('link[data-chat-onboarding-stylesheet]')
+    || Array.from(document.querySelectorAll('link[rel="stylesheet"][href]'))
+      .find(link => {
+        try {
+          return new URL(/** @type {HTMLLinkElement} */ (link).href).pathname === '/css/chat-onboarding.css';
+        } catch {
+          return false;
+        }
+      })
+    || null
+  );
+}
+
+function chatOnboardingStylesheetUrl() {
+  if (!useChatOnboardingStylesheetRetryUrl) return CHAT_ONBOARDING_STYLESHEET_URL;
+  const retryUrl = new URL(CHAT_ONBOARDING_STYLESHEET_URL);
+  retryUrl.searchParams.set('lazy-retry', '1');
+  return retryUrl.href;
+}
+
+export function isChatOnboardingStylesheetLoaded() {
+  return chatOnboardingStylesheetLoaded || !!existingChatOnboardingStylesheet()?.sheet;
+}
+
+/** @returns {Promise<HTMLLinkElement>} */
+export function loadChatOnboardingStylesheet() {
+  const existing = existingChatOnboardingStylesheet();
+  if (existing?.sheet) {
+    chatOnboardingStylesheetLoaded = true;
+    return Promise.resolve(existing);
+  }
+  if (!chatOnboardingStylesheetPromise) {
+    if (typeof document === 'undefined') {
+      return Promise.reject(new Error('Chat onboarding stylesheet requires a document'));
+    }
+    const link = existing || document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = chatOnboardingStylesheetUrl();
+    link.dataset.chatOnboardingStylesheet = '';
+    chatOnboardingStylesheetPromise = new Promise(function beginChatOnboardingStylesheetLoad(resolve, reject) {
+      link.addEventListener('load', function markChatOnboardingStylesheetLoaded() {
+        chatOnboardingStylesheetLoaded = true;
+        resolve(link);
+      }, { once: true });
+      link.addEventListener('error', function rejectChatOnboardingStylesheetLoad() {
+        reject(new Error('Chat onboarding stylesheet could not be loaded'));
+      }, { once: true });
+      if (!link.isConnected) {
+        const anchor = document.querySelector('[data-chat-onboarding-stylesheet-anchor]');
+        const parent = anchor?.parentNode || document.head;
+        parent.insertBefore(link, anchor || null);
+      }
+    }).catch(function resetChatOnboardingStylesheetLoad(err) {
+      link.remove();
+      chatOnboardingStylesheetPromise = null;
+      chatOnboardingStylesheetLoaded = false;
+      useChatOnboardingStylesheetRetryUrl = true;
+      throw err;
+    });
+  }
+  return chatOnboardingStylesheetPromise;
+}
+
+export async function loadChatOnboardingStylesheetForAction() {
+  try {
+    await loadChatOnboardingStylesheet();
+    return true;
+  } catch (err) {
+    console.error('Failed to load Chat onboarding presentation', err);
+    showNotification('Chat could not be opened. Try again.', 'error');
+    return false;
+  }
+}
+
 // ═══════════════════════════════════════════════
 // PANEL OPEN/CLOSE
 // ═══════════════════════════════════════════════
 export function toggleChatPanel() {
   const panel = document.getElementById('chat-panel');
-  if (!panel) return;
+  if (!panel) return false;
   if (panel.classList.contains('open')) {
     closeChatPanel();
+    return false;
   } else {
-    openChatPanel();
+    return openChatPanel();
   }
 }
 
@@ -82,7 +168,8 @@ export function toggleChatFullscreen() {
 export async function openChatPanel(prefillMessage) {
   const panel = document.getElementById('chat-panel');
   const backdrop = document.getElementById('chat-backdrop');
-  if (!panel || !backdrop) return;
+  if (!panel || !backdrop) return false;
+  if (!(await loadChatOnboardingStylesheetForAction())) return false;
   panel.classList.add('open');
   // Restore the user's last fullscreen preference. Persisted in
   // localStorage so reopening chat keeps the mode they chose last.
@@ -127,6 +214,7 @@ export async function openChatPanel(prefillMessage) {
     if (prefillMessage) input.value = prefillMessage;
     input.focus();
   }
+  return true;
 }
 
 export function updateChatInputState() {

--- a/plans/code-quality-audit-2026-07-21.md
+++ b/plans/code-quality-audit-2026-07-21.md
@@ -54,9 +54,10 @@ Sun, Wearables, and conditionally relevant Cycle presentation styles behind
 their first visual entry points. Optional-theme presentation is now conditional
 too: dark/light startup stays cold, while saved or newly selected visual themes
 load at the original final cascade position. Cross-theme shell and Sunset Mode
-rules remain eager after that anchor. Each boundary keeps offline assets
-precached, preserves cascade order, and retains shared rules in eager bundles
-or the HTML shell.
+rules remain eager after that anchor. Chat onboarding presentation now waits
+for the first Chat open while its persistent launcher and shell remain eager.
+Each boundary keeps offline assets precached, preserves cascade order, and
+retains shared rules in eager bundles or the HTML shell.
 
 ## Findings
 

--- a/scripts/cold-load-budget.json
+++ b/scripts/cold-load-budget.json
@@ -3,15 +3,15 @@
   "route": "/app",
   "scenario": "Fresh mobile returning-user load with browser cache and service workers disabled",
   "maximums": {
-    "requests": 438,
-    "transferBytes": 1854000,
-    "decodedBytes": 5553000
+    "requests": 437,
+    "transferBytes": 1851000,
+    "decodedBytes": 5541000
   },
   "reference": {
-    "requests": 432,
-    "transferBytes": 1821605,
-    "decodedBytes": 5461806
+    "requests": 431,
+    "transferBytes": 1819210,
+    "decodedBytes": 5450230
   },
-  "referenceCommit": "8639a54a",
+  "referenceCommit": "3a9c178f",
   "measuredAt": "2026-07-24"
 }

--- a/tests/playwright/chat-onboarding-stylesheet-browser-coverage.spec.js
+++ b/tests/playwright/chat-onboarding-stylesheet-browser-coverage.spec.js
@@ -1,0 +1,85 @@
+import { expect, test } from './coverage-fixture.js';
+
+test('Chat onboarding presentation stays cold until the panel opens and preserves cascade order', async ({ page }) => {
+  let stylesheetRoute;
+  let stylesheetRequests = 0;
+  await page.route('**/css/chat-onboarding.css*', route => {
+    stylesheetRequests += 1;
+    stylesheetRoute = route;
+  });
+  await page.goto('/app', { waitUntil: 'load' });
+
+  await expect(page.locator('link[data-chat-onboarding-stylesheet]')).toHaveCount(0);
+  expect(stylesheetRequests).toBe(0);
+
+  await page.evaluate(async () => {
+    window.__chatOpenResult = (await import('/js/chat-panel.js')).openChatPanel();
+  });
+  await expect.poll(() => !!stylesheetRoute).toBe(true);
+  await expect(page.locator('#chat-panel')).not.toHaveClass(/open/);
+  await expect(page.locator('link[data-chat-onboarding-stylesheet]')).toHaveCount(1);
+
+  await stylesheetRoute.fulfill({
+    status: 200,
+    contentType: 'text/css',
+    body: '.chat-panel { --coverage-chat-onboarding: ready; }',
+  });
+
+  const outcome = await page.evaluate(async () => {
+    const opened = await window.__chatOpenResult;
+    const link = document.querySelector('link[data-chat-onboarding-stylesheet]');
+    const anchor = document.querySelector('[data-chat-onboarding-stylesheet-anchor]');
+    return {
+      opened,
+      panelOpen: document.getElementById('chat-panel')?.classList.contains('open'),
+      token: getComputedStyle(document.getElementById('chat-panel')).getPropertyValue('--coverage-chat-onboarding').trim(),
+      linkPrecedesAnchor: link?.nextElementSibling === anchor,
+    };
+  });
+
+  expect(stylesheetRequests).toBe(1);
+  expect(outcome).toEqual({
+    opened: true,
+    panelOpen: true,
+    token: 'ready',
+    linkPrecedesAnchor: true,
+  });
+
+  await page.evaluate(async () => {
+    const chatPanel = await import('/js/chat-panel.js');
+    chatPanel.closeChatPanel();
+    await chatPanel.openChatPanel();
+  });
+  expect(stylesheetRequests).toBe(1);
+});
+
+test('Chat onboarding stylesheet failure is contained and retries with a fresh URL', async ({ page }) => {
+  const stylesheetRequests = [];
+  await page.route('**/css/chat-onboarding.css*', route => {
+    stylesheetRequests.push(route.request().url());
+    return route.abort('failed');
+  });
+  await page.goto('/app', { waitUntil: 'load' });
+
+  const firstOpened = await page.evaluate(async () => (await import('/js/chat-panel.js')).openChatPanel());
+  expect(firstOpened).toBe(false);
+  await expect(page.locator('#chat-panel')).not.toHaveClass(/open/);
+  await expect(page.locator('link[data-chat-onboarding-stylesheet]')).toHaveCount(0);
+  await expect(page.locator('.notification-toast')).toContainText('Chat could not be opened');
+
+  await page.unroute('**/css/chat-onboarding.css*');
+  const retry = await page.evaluate(async () => {
+    const opened = await (await import('/js/chat-panel.js')).openChatPanel();
+    const link = document.querySelector('link[data-chat-onboarding-stylesheet]');
+    return {
+      opened,
+      panelOpen: document.getElementById('chat-panel')?.classList.contains('open'),
+      href: link?.href || '',
+    };
+  });
+
+  expect(stylesheetRequests).toHaveLength(1);
+  expect(retry.opened).toBe(true);
+  expect(retry.panelOpen).toBe(true);
+  expect(new URL(retry.href).searchParams.get('lazy-retry')).toBe('1');
+});

--- a/tests/playwright/chat-ui-browser-coverage.spec.js
+++ b/tests/playwright/chat-ui-browser-coverage.spec.js
@@ -393,7 +393,7 @@ test('chat panel browser coverage toggles web search and panel chrome', async ({
       localStorage.removeItem(threadIndexKey);
       mobileRefreshes = 0;
       localStorage.setItem('labcharts-ai-provider', 'openrouter');
-      chatPanel.toggleChatPanel();
+      await chatPanel.toggleChatPanel();
       outcomes.togglePanelOpensChrome =
         panel?.classList.contains('open') === true
         && backdrop?.classList.contains('open') === true
@@ -401,7 +401,7 @@ test('chat panel browser coverage toggles web search and panel chrome', async ({
         && fab?.classList.contains('hidden') === true
         && checkbox?.checked === false;
 
-      chatPanel.toggleChatPanel();
+      await chatPanel.toggleChatPanel();
       outcomes.togglePanelClosesChrome =
         panel?.classList.contains('open') === false
         && backdrop?.classList.contains('open') === false

--- a/tests/playwright/cold-load-budget.spec.js
+++ b/tests/playwright/cold-load-budget.spec.js
@@ -100,6 +100,9 @@ test('cold mobile app load stays within committed resource budgets', async ({ pa
   expect(entries.some(entry => (
     new URL(entry.name).pathname === '/themes-extra.css'
   ))).toBe(false);
+  expect(entries.some(entry => (
+    new URL(entry.name).pathname === '/css/chat-onboarding.css'
+  ))).toBe(false);
   const deferredLightStylesheets = new Set([
     '/css/light-sun.css',
     '/css/light-channels.css',

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -355,7 +355,6 @@ const CHAT_CSS_BUNDLES = [
   'css/chat-personality.css',
   'css/chat-messages.css',
   'css/chat-composer.css',
-  'css/chat-onboarding.css',
   'css/chat-responsive.css',
   'css/chat-actions.css',
   'css/chat-mobile.css',
@@ -365,6 +364,23 @@ for (const chatCss of CHAT_CSS_BUNDLES) {
   assert(`index loads ${chatCss}`, indexSrc.includes(`href="${chatCss}"`));
   assert(`SW APP_SHELL includes ${chatCss}`, swAuditSrc.includes(`'/${chatCss}'`));
 }
+const chatPanelAuditSrc = read('js/chat-panel.js');
+assert('index defers Chat onboarding CSS behind its ordered lazy-load anchor',
+  !indexSrc.includes('href="css/chat-onboarding.css"') &&
+  indexSrc.includes('data-chat-onboarding-stylesheet-anchor') &&
+  chatPanelAuditSrc.includes("new URL('../css/chat-onboarding.css', import.meta.url)") &&
+  chatPanelAuditSrc.includes('loadChatOnboardingStylesheetForAction'));
+assert('Chat panel waits for onboarding presentation before opening',
+  chatPanelAuditSrc.includes('await loadChatOnboardingStylesheetForAction()') &&
+  chatPanelAuditSrc.indexOf('await loadChatOnboardingStylesheetForAction()') <
+    chatPanelAuditSrc.indexOf("panel.classList.add('open')"));
+assert('Chat onboarding CSS lazy-load anchor preserves the original cascade position',
+  indexSrc.indexOf('href="css/chat-composer.css"') <
+    indexSrc.indexOf('data-chat-onboarding-stylesheet-anchor') &&
+  indexSrc.indexOf('data-chat-onboarding-stylesheet-anchor') <
+    indexSrc.indexOf('href="css/chat-responsive.css"'));
+assert('SW APP_SHELL includes Chat onboarding CSS bundle',
+  swAuditSrc.includes("'/css/chat-onboarding.css'"));
 assert('chat CSS split loads before chat redesign overrides',
   indexSrc.indexOf('href="css/chat-mobile.css"') < indexSrc.indexOf('href="css/redesign-shell.css"') &&
   indexSrc.indexOf('href="css/redesign-shell.css"') < indexSrc.indexOf('href="css/chat-redesign.css"') &&

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.365';
+self.APP_VERSION = '1.10.366';


### PR DESCRIPTION
## Summary
- defer `css/chat-onboarding.css` until the first Chat open while retaining the persistent launcher and closed shell styles on the cold path
- preserve the original cascade position with an ordered anchor and make loading single-flight, retryable, offline-compatible, and failure-contained
- cover cold-load exclusion, first-open synchronization, cascade order, one-request reuse, and fresh-URL retry behavior

## Cold-load impact
Fresh mobile returning-user load with cache and service workers disabled:

| Metric | Before | After | Delta |
| --- | ---: | ---: | ---: |
| Requests | 432 | 431 | -1 |
| Transfer bytes | 1,821,605 | 1,819,210 | -2,395 |
| Decoded bytes | 5,461,806 | 5,450,230 | -11,576 |

Two unchanged measurements and the full release run reproduced the same result.

## Verification
- 131 verification checks
- 487 Vitest tests
- 427 Chromium tests
- 472 responsive tests
- 67.19% global function coverage (baseline 67.10%)
- architecture: 465 modules, 0 cycles
- typecheck and check-JS typecheck
- quality checks: 11/11
- `git diff --check`
