### PR TITLE
Load Chat presentation on first open

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -199,14 +199,15 @@ Cross-theme shell geometry and Sunset Mode rules remain in a final eager
 inline block after that anchor, preserving their original cascade while keeping
 the deferred sheet scoped to the four optional themes.
 
-Chat shell, message, and composer presentation remains eager because the
-persistent launcher and closed panel are part of startup chrome.
-`chat-panel.js` loads `css/chat-onboarding.css` through a single-flight boundary
-before the panel first opens, so returning users do not fetch empty-state and
-guided-setup presentation until they enter Chat. Failed links are removed and
-cache-busted for retry, an HTML anchor preserves the sheet's original position
-between composer and responsive overrides, and the service worker keeps it
-precached for offline first use.
+Only the persistent Chat launcher, closed panel shell, and final redesign
+overrides remain eager. `chat-panel.js` loads the personality, messages,
+composer, onboarding, responsive, actions, and mobile presentation sheets
+through one single-flight boundary before the panel first opens. Failed links
+are removed and cache-busted for group retry, a shared HTML anchor preserves
+the sheets' original order before redesign overrides, and the service worker
+keeps them precached for offline first use. Cold-visible mobile launcher sizing
+stays in `chat-panel.css`; marker-detail controls formerly misplaced in the
+composer sheet live with the lazy marker-detail bundle.
 
 Wearables presentation is loaded through the single-flight stylesheet boundary
 in `wearables-runtime.js` when a biometric detail, inline manual log, or the

--- a/css/chat-composer.css
+++ b/css/chat-composer.css
@@ -133,18 +133,3 @@
   .chat-attach-btn, .chat-hd-btn { width: 44px; height: 44px; }
   .chat-attach-remove { opacity: 1; width: 24px; height: 24px; }
 }
-/* Calculated marker missing inputs */
-.calc-missing-inputs {
-  color: var(--text-muted); font-size: 0.8rem; text-align: center;
-  margin-top: 12px; padding: 8px 12px; border-radius: 6px;
-  background: var(--bg-secondary); border: 1px dashed var(--border);
-}
-/* Ask AI Button in Marker Detail Modal */
-.ask-ai-btn {
-  width: 100%; padding: 10px; border-radius: 6px;
-  border: 1px solid var(--accent); background: transparent;
-  color: var(--accent); font-size: 13px; font-weight: 500;
-  cursor: pointer; font-family: inherit; transition: all 0.2s;
-  margin-top: 16px;
-}
-.ask-ai-btn:hover { background: var(--accent-gradient); color: white; border-color: transparent; box-shadow: 0 2px 12px rgba(79, 140, 255, 0.2); }

--- a/css/chat-mobile.css
+++ b/css/chat-mobile.css
@@ -1,8 +1,3 @@
-@media (max-width: 480px) {
-  .chat-fab { width: 48px; height: 48px; bottom: 16px; right: 16px; }
-  .chat-fab svg { width: 22px; height: 22px; }
-}
-
 @media (max-width: 375px) {
   .chat-messages { padding: 14px 12px; }
   .chat-input-area { padding: 10px 12px; }

--- a/css/chat-panel.css
+++ b/css/chat-panel.css
@@ -42,6 +42,10 @@ body.chat-autostart-reserved:has(#chat-thread-rail.open):not(.chat-fullscreen) .
 .chat-fab:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .chat-fab svg { width: 26px; height: 26px; fill: none; stroke: white; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
 .chat-fab.hidden { display: none; }
+@media (max-width: 480px) {
+  .chat-fab { width: 48px; height: 48px; bottom: 16px; right: 16px; }
+  .chat-fab svg { width: 22px; height: 22px; }
+}
 .chat-fab-badge {
   position: absolute; top: -2px; right: -2px;
   width: 14px; height: 14px; border-radius: 50%;
@@ -444,4 +448,3 @@ body.chat-autostart-reserved:has(#chat-thread-rail.open):not(.chat-fullscreen) .
   white-space: pre-wrap;
   word-wrap: break-word;
 }
-

--- a/css/marker-detail-modal.css
+++ b/css/marker-detail-modal.css
@@ -848,6 +848,22 @@
 .marker-detail-modal .marker-note-editor textarea:focus { outline: none; border-color: var(--accent); }
 .marker-detail-modal .marker-note-actions { display: flex; gap: 6px; margin-top: 6px; }
 
+/* Calculated marker missing inputs */
+.calc-missing-inputs {
+  color: var(--text-muted); font-size: 0.8rem; text-align: center;
+  margin-top: 12px; padding: 8px 12px; border-radius: 6px;
+  background: var(--bg-secondary); border: 1px dashed var(--border);
+}
+/* Ask AI Button in Marker Detail Modal */
+.ask-ai-btn {
+  width: 100%; padding: 10px; border-radius: 6px;
+  border: 1px solid var(--accent); background: transparent;
+  color: var(--accent); font-size: 13px; font-weight: 500;
+  cursor: pointer; font-family: inherit; transition: all 0.2s;
+  margin-top: 16px;
+}
+.ask-ai-btn:hover { background: var(--accent-gradient); color: white; border-color: transparent; box-shadow: 0 2px 12px rgba(79, 140, 255, 0.2); }
+
 @media (max-width: 480px) {
   .modal.marker-detail-modal { padding: 0; }
 }

--- a/index.html
+++ b/index.html
@@ -72,13 +72,7 @@
   <meta data-wearables-stylesheet-anchor>
   <meta data-light-sun-stylesheet-anchor>
   <link rel="stylesheet" href="css/chat-panel.css">
-  <link rel="stylesheet" href="css/chat-personality.css">
-  <link rel="stylesheet" href="css/chat-messages.css">
-  <link rel="stylesheet" href="css/chat-composer.css">
-  <meta data-chat-onboarding-stylesheet-anchor>
-  <link rel="stylesheet" href="css/chat-responsive.css">
-  <link rel="stylesheet" href="css/chat-actions.css">
-  <link rel="stylesheet" href="css/chat-mobile.css">
+  <meta data-chat-presentation-stylesheet-anchor>
   <link rel="stylesheet" href="css/redesign-shell.css">
   <link rel="stylesheet" href="css/chat-redesign.css">
   <meta data-extra-themes-stylesheet-anchor>

--- a/js/chat-panel.js
+++ b/js/chat-panel.js
@@ -16,12 +16,20 @@ import { showNotification } from './utils.js';
 
 export { setChatNudge, updateChatNudge } from './chat-nudge.js';
 
-const CHAT_ONBOARDING_STYLESHEET_URL = new URL('../css/chat-onboarding.css', import.meta.url).href;
+const CHAT_PRESENTATION_STYLESHEETS = [
+  { name: 'personality', url: new URL('../css/chat-personality.css', import.meta.url).href },
+  { name: 'messages', url: new URL('../css/chat-messages.css', import.meta.url).href },
+  { name: 'composer', url: new URL('../css/chat-composer.css', import.meta.url).href },
+  { name: 'onboarding', url: new URL('../css/chat-onboarding.css', import.meta.url).href },
+  { name: 'responsive', url: new URL('../css/chat-responsive.css', import.meta.url).href },
+  { name: 'actions', url: new URL('../css/chat-actions.css', import.meta.url).href },
+  { name: 'mobile', url: new URL('../css/chat-mobile.css', import.meta.url).href },
+];
 
-/** @type {Promise<HTMLLinkElement> | null} */
-let chatOnboardingStylesheetPromise = null;
-let chatOnboardingStylesheetLoaded = false;
-let useChatOnboardingStylesheetRetryUrl = false;
+/** @type {Promise<HTMLLinkElement[]> | null} */
+let chatPresentationStylesheetPromise = null;
+let chatPresentationStylesheetsLoaded = false;
+let useChatPresentationStylesheetRetryUrl = false;
 
 const panelCallbacks = {
   restoreDiscussionContinuePrompt: null,
@@ -61,14 +69,16 @@ export function isChatThreadInputBlocked() {
   return chatThreadInputBlocked;
 }
 
-function existingChatOnboardingStylesheet() {
+/** @param {{ name: string, url: string }} stylesheet */
+function existingChatPresentationStylesheet(stylesheet) {
   if (typeof document === 'undefined') return null;
   return /** @type {HTMLLinkElement | null} */ (
-    document.querySelector('link[data-chat-onboarding-stylesheet]')
+    document.querySelector(`link[data-chat-presentation-stylesheet="${stylesheet.name}"]`)
     || Array.from(document.querySelectorAll('link[rel="stylesheet"][href]'))
       .find(link => {
         try {
-          return new URL(/** @type {HTMLLinkElement} */ (link).href).pathname === '/css/chat-onboarding.css';
+          return new URL(/** @type {HTMLLinkElement} */ (link).href).pathname
+            === new URL(stylesheet.url).pathname;
         } catch {
           return false;
         }
@@ -77,62 +87,84 @@ function existingChatOnboardingStylesheet() {
   );
 }
 
-function chatOnboardingStylesheetUrl() {
-  if (!useChatOnboardingStylesheetRetryUrl) return CHAT_ONBOARDING_STYLESHEET_URL;
-  const retryUrl = new URL(CHAT_ONBOARDING_STYLESHEET_URL);
+/** @param {{ url: string }} stylesheet */
+function chatPresentationStylesheetUrl(stylesheet) {
+  if (!useChatPresentationStylesheetRetryUrl) return stylesheet.url;
+  const retryUrl = new URL(stylesheet.url);
   retryUrl.searchParams.set('lazy-retry', '1');
   return retryUrl.href;
 }
 
-export function isChatOnboardingStylesheetLoaded() {
-  return chatOnboardingStylesheetLoaded || !!existingChatOnboardingStylesheet()?.sheet;
+export function areChatPresentationStylesheetsLoaded() {
+  return chatPresentationStylesheetsLoaded || CHAT_PRESENTATION_STYLESHEETS.every(
+    stylesheet => !!existingChatPresentationStylesheet(stylesheet)?.sheet,
+  );
 }
 
-/** @returns {Promise<HTMLLinkElement>} */
-export function loadChatOnboardingStylesheet() {
-  const existing = existingChatOnboardingStylesheet();
+/**
+ * @param {{ name: string, url: string }} stylesheet
+ * @param {Element | null} anchor
+ * @returns {Promise<HTMLLinkElement>}
+ */
+function loadChatPresentationStylesheet(stylesheet, anchor) {
+  const existing = existingChatPresentationStylesheet(stylesheet);
   if (existing?.sheet) {
-    chatOnboardingStylesheetLoaded = true;
     return Promise.resolve(existing);
   }
-  if (!chatOnboardingStylesheetPromise) {
-    if (typeof document === 'undefined') {
-      return Promise.reject(new Error('Chat onboarding stylesheet requires a document'));
-    }
-    const link = existing || document.createElement('link');
+  const link = existing || document.createElement('link');
+  if (!existing) {
     link.rel = 'stylesheet';
-    link.href = chatOnboardingStylesheetUrl();
-    link.dataset.chatOnboardingStylesheet = '';
-    chatOnboardingStylesheetPromise = new Promise(function beginChatOnboardingStylesheetLoad(resolve, reject) {
-      link.addEventListener('load', function markChatOnboardingStylesheetLoaded() {
-        chatOnboardingStylesheetLoaded = true;
-        resolve(link);
-      }, { once: true });
-      link.addEventListener('error', function rejectChatOnboardingStylesheetLoad() {
-        reject(new Error('Chat onboarding stylesheet could not be loaded'));
-      }, { once: true });
-      if (!link.isConnected) {
-        const anchor = document.querySelector('[data-chat-onboarding-stylesheet-anchor]');
-        const parent = anchor?.parentNode || document.head;
-        parent.insertBefore(link, anchor || null);
-      }
-    }).catch(function resetChatOnboardingStylesheetLoad(err) {
+    link.href = chatPresentationStylesheetUrl(stylesheet);
+    link.dataset.chatPresentationStylesheet = stylesheet.name;
+  }
+  return new Promise(function beginChatPresentationStylesheetLoad(resolve, reject) {
+    link.addEventListener('load', function markChatPresentationStylesheetLoaded() {
+      resolve(link);
+    }, { once: true });
+    link.addEventListener('error', function rejectChatPresentationStylesheetLoad() {
       link.remove();
-      chatOnboardingStylesheetPromise = null;
-      chatOnboardingStylesheetLoaded = false;
-      useChatOnboardingStylesheetRetryUrl = true;
+      reject(new Error(`Chat ${stylesheet.name} stylesheet could not be loaded`));
+    }, { once: true });
+    if (!link.isConnected) {
+      const parent = anchor?.parentNode || document.head;
+      parent.insertBefore(link, anchor || null);
+    }
+  });
+}
+
+/** @returns {Promise<HTMLLinkElement[]>} */
+export function loadChatPresentationStylesheets() {
+  if (areChatPresentationStylesheetsLoaded()) {
+    return Promise.resolve(CHAT_PRESENTATION_STYLESHEETS.map(
+      stylesheet => /** @type {HTMLLinkElement} */ (existingChatPresentationStylesheet(stylesheet)),
+    ));
+  }
+  if (!chatPresentationStylesheetPromise) {
+    if (typeof document === 'undefined') {
+      return Promise.reject(new Error('Chat presentation stylesheets require a document'));
+    }
+    const anchor = document.querySelector('[data-chat-presentation-stylesheet-anchor]');
+    chatPresentationStylesheetPromise = Promise.all(
+      CHAT_PRESENTATION_STYLESHEETS.map(stylesheet => loadChatPresentationStylesheet(stylesheet, anchor)),
+    ).then(function markChatPresentationStylesheetsLoaded(links) {
+      chatPresentationStylesheetsLoaded = true;
+      return links;
+    }).catch(function resetChatPresentationStylesheetLoad(err) {
+      chatPresentationStylesheetPromise = null;
+      chatPresentationStylesheetsLoaded = false;
+      useChatPresentationStylesheetRetryUrl = true;
       throw err;
     });
   }
-  return chatOnboardingStylesheetPromise;
+  return chatPresentationStylesheetPromise;
 }
 
-export async function loadChatOnboardingStylesheetForAction() {
+export async function loadChatPresentationStylesheetsForAction() {
   try {
-    await loadChatOnboardingStylesheet();
+    await loadChatPresentationStylesheets();
     return true;
   } catch (err) {
-    console.error('Failed to load Chat onboarding presentation', err);
+    console.error('Failed to load Chat presentation', err);
     showNotification('Chat could not be opened. Try again.', 'error');
     return false;
   }
@@ -169,7 +201,7 @@ export async function openChatPanel(prefillMessage) {
   const panel = document.getElementById('chat-panel');
   const backdrop = document.getElementById('chat-backdrop');
   if (!panel || !backdrop) return false;
-  if (!(await loadChatOnboardingStylesheetForAction())) return false;
+  if (!(await loadChatPresentationStylesheetsForAction())) return false;
   panel.classList.add('open');
   // Restore the user's last fullscreen preference. Persisted in
   // localStorage so reopening chat keeps the mode they chose last.

--- a/plans/code-quality-audit-2026-07-21.md
+++ b/plans/code-quality-audit-2026-07-21.md
@@ -54,10 +54,11 @@ Sun, Wearables, and conditionally relevant Cycle presentation styles behind
 their first visual entry points. Optional-theme presentation is now conditional
 too: dark/light startup stays cold, while saved or newly selected visual themes
 load at the original final cascade position. Cross-theme shell and Sunset Mode
-rules remain eager after that anchor. Chat onboarding presentation now waits
-for the first Chat open while its persistent launcher and shell remain eager.
-Each boundary keeps offline assets precached, preserves cascade order, and
-retains shared rules in eager bundles or the HTML shell.
+rules remain eager after that anchor. Chat personality, messages, composer,
+onboarding, responsive, actions, and mobile presentation now wait for the first
+Chat open while its persistent launcher, closed panel shell, and redesign
+overrides remain eager. Each boundary keeps offline assets precached, preserves
+cascade order, and retains shared rules in eager bundles or the HTML shell.
 
 ## Findings
 

--- a/scripts/cold-load-budget.json
+++ b/scripts/cold-load-budget.json
@@ -3,15 +3,15 @@
   "route": "/app",
   "scenario": "Fresh mobile returning-user load with browser cache and service workers disabled",
   "maximums": {
-    "requests": 437,
-    "transferBytes": 1851000,
-    "decodedBytes": 5541000
+    "requests": 431,
+    "transferBytes": 1843000,
+    "decodedBytes": 5520000
   },
   "reference": {
-    "requests": 431,
-    "transferBytes": 1819210,
-    "decodedBytes": 5450230
+    "requests": 425,
+    "transferBytes": 1811205,
+    "decodedBytes": 5429764
   },
-  "referenceCommit": "3a9c178f",
+  "referenceCommit": "497dabff",
   "measuredAt": "2026-07-24"
 }

--- a/tests/chat-runtime.test.js
+++ b/tests/chat-runtime.test.js
@@ -179,6 +179,94 @@ describe('chat discussion callback bridge runtime behavior', () => {
   });
 });
 
+describe('chat presentation stylesheet runtime behavior', () => {
+  it('loads the ordered group, resets after failure, and reuses successful links', async () => {
+    const originalCreateElement = document.createElement;
+    const originalQuerySelector = document.querySelector;
+    const originalQuerySelectorAll = document.querySelectorAll;
+    const originalHeadInsertBefore = document.head.insertBefore;
+    const links = [];
+    const failOnce = new Set(['onboarding']);
+    const anchorParent = {
+      insertBefore(link) {
+        links.push(link);
+        link.isConnected = true;
+        queueMicrotask(() => {
+          if (failOnce.delete(link.dataset.chatPresentationStylesheet)) {
+            link.dispatchEvent(new Event('error'));
+          } else {
+            link.sheet = {};
+            link.dispatchEvent(new Event('load'));
+          }
+        });
+      },
+    };
+    const anchor = { parentNode: anchorParent };
+
+    function createLink() {
+      const events = new EventTarget();
+      return {
+        rel: '',
+        href: '',
+        dataset: {},
+        isConnected: false,
+        sheet: null,
+        addEventListener: events.addEventListener.bind(events),
+        dispatchEvent: events.dispatchEvent.bind(events),
+        remove() {
+          this.isConnected = false;
+          const index = links.indexOf(this);
+          if (index >= 0) links.splice(index, 1);
+        },
+      };
+    }
+
+    document.createElement = vi.fn(tag => tag === 'link' ? createLink() : originalCreateElement(tag));
+    document.querySelector = vi.fn(selector => {
+      if (selector === '[data-chat-presentation-stylesheet-anchor]') return anchor;
+      const match = selector.match(/^link\[data-chat-presentation-stylesheet="([^"]+)"\]$/);
+      return match ? links.find(link => link.dataset.chatPresentationStylesheet === match[1]) || null : null;
+    });
+    document.querySelectorAll = vi.fn(selector => (
+      selector === 'link[rel="stylesheet"][href]' ? links : []
+    ));
+    document.head.insertBefore = anchorParent.insertBefore;
+
+    try {
+      const chatPanel = await import('../js/chat-panel.js');
+      expect(chatPanel.configureChatPanel({})).toEqual({
+        restoreDiscussionContinuePrompt: null,
+        refreshMobileDashboardActiveTab: null,
+      });
+      expect(chatPanel.isChatThreadInputBlocked()).toBe(false);
+      await expect(chatPanel.loadChatPresentationStylesheets()).rejects.toThrow(
+        'Chat onboarding stylesheet could not be loaded',
+      );
+      expect(chatPanel.areChatPresentationStylesheetsLoaded()).toBe(false);
+      expect(links).toHaveLength(6);
+
+      const loaded = await chatPanel.loadChatPresentationStylesheets();
+      expect(loaded).toHaveLength(7);
+      expect(chatPanel.areChatPresentationStylesheetsLoaded()).toBe(true);
+      expect(links).toHaveLength(7);
+      expect(links.find(link => link.dataset.chatPresentationStylesheet === 'onboarding')?.href)
+        .toContain('lazy-retry=1');
+
+      await expect(chatPanel.loadChatPresentationStylesheetsForAction()).resolves.toBe(true);
+      await expect(chatPanel.loadChatPresentationStylesheets()).resolves.toEqual(loaded);
+
+      const chatImages = await import('../js/chat-images.js');
+      chatImages.removeImageAttachment(0);
+      expect(chatImages.hasPendingAttachments()).toBe(false);
+    } finally {
+      document.createElement = originalCreateElement;
+      document.querySelector = originalQuerySelector;
+      document.querySelectorAll = originalQuerySelectorAll;
+      document.head.insertBefore = originalHeadInsertBefore;
+    }
+  });
+});
+
 function installRoundStateMocks() {
   const deps = {
     state: {

--- a/tests/playwright/chat-presentation-stylesheet-browser-coverage.spec.js
+++ b/tests/playwright/chat-presentation-stylesheet-browser-coverage.spec.js
@@ -1,6 +1,16 @@
 import { expect, test } from './coverage-fixture.js';
 
-test('Chat onboarding presentation stays cold until the panel opens and preserves cascade order', async ({ page }) => {
+const CHAT_PRESENTATION_PATHS = [
+  '/css/chat-personality.css',
+  '/css/chat-messages.css',
+  '/css/chat-composer.css',
+  '/css/chat-onboarding.css',
+  '/css/chat-responsive.css',
+  '/css/chat-actions.css',
+  '/css/chat-mobile.css',
+];
+
+test('Chat presentation stays cold until the panel opens and preserves cascade order', async ({ page }) => {
   let stylesheetRoute;
   let stylesheetRequests = 0;
   await page.route('**/css/chat-onboarding.css*', route => {
@@ -9,7 +19,7 @@ test('Chat onboarding presentation stays cold until the panel opens and preserve
   });
   await page.goto('/app', { waitUntil: 'load' });
 
-  await expect(page.locator('link[data-chat-onboarding-stylesheet]')).toHaveCount(0);
+  await expect(page.locator('link[data-chat-presentation-stylesheet]')).toHaveCount(0);
   expect(stylesheetRequests).toBe(0);
 
   await page.evaluate(async () => {
@@ -17,7 +27,7 @@ test('Chat onboarding presentation stays cold until the panel opens and preserve
   });
   await expect.poll(() => !!stylesheetRoute).toBe(true);
   await expect(page.locator('#chat-panel')).not.toHaveClass(/open/);
-  await expect(page.locator('link[data-chat-onboarding-stylesheet]')).toHaveCount(1);
+  await expect(page.locator('link[data-chat-presentation-stylesheet]')).toHaveCount(7);
 
   await stylesheetRoute.fulfill({
     status: 200,
@@ -27,23 +37,23 @@ test('Chat onboarding presentation stays cold until the panel opens and preserve
 
   const outcome = await page.evaluate(async () => {
     const opened = await window.__chatOpenResult;
-    const link = document.querySelector('link[data-chat-onboarding-stylesheet]');
-    const anchor = document.querySelector('[data-chat-onboarding-stylesheet-anchor]');
+    const links = Array.from(document.querySelectorAll('link[data-chat-presentation-stylesheet]'));
+    const anchor = document.querySelector('[data-chat-presentation-stylesheet-anchor]');
     return {
       opened,
       panelOpen: document.getElementById('chat-panel')?.classList.contains('open'),
       token: getComputedStyle(document.getElementById('chat-panel')).getPropertyValue('--coverage-chat-onboarding').trim(),
-      linkPrecedesAnchor: link?.nextElementSibling === anchor,
+      paths: links.map(link => new URL(link.href).pathname),
+      finalLinkPrecedesAnchor: links.at(-1)?.nextElementSibling === anchor,
     };
   });
 
   expect(stylesheetRequests).toBe(1);
-  expect(outcome).toEqual({
-    opened: true,
-    panelOpen: true,
-    token: 'ready',
-    linkPrecedesAnchor: true,
-  });
+  expect(outcome.opened).toBe(true);
+  expect(outcome.panelOpen).toBe(true);
+  expect(outcome.token).toBe('ready');
+  expect(outcome.paths).toEqual(CHAT_PRESENTATION_PATHS);
+  expect(outcome.finalLinkPrecedesAnchor).toBe(true);
 
   await page.evaluate(async () => {
     const chatPanel = await import('/js/chat-panel.js');
@@ -53,9 +63,10 @@ test('Chat onboarding presentation stays cold until the panel opens and preserve
   expect(stylesheetRequests).toBe(1);
 });
 
-test('Chat onboarding stylesheet failure is contained and retries with a fresh URL', async ({ page }) => {
+test('Chat presentation failure is contained and retries the group with fresh URLs', async ({ page }) => {
   const stylesheetRequests = [];
-  await page.route('**/css/chat-onboarding.css*', route => {
+  const presentationPattern = /\/css\/chat-(?:personality|messages|composer|onboarding|responsive|actions|mobile)\.css/;
+  await page.route(presentationPattern, route => {
     stylesheetRequests.push(route.request().url());
     return route.abort('failed');
   });
@@ -64,22 +75,23 @@ test('Chat onboarding stylesheet failure is contained and retries with a fresh U
   const firstOpened = await page.evaluate(async () => (await import('/js/chat-panel.js')).openChatPanel());
   expect(firstOpened).toBe(false);
   await expect(page.locator('#chat-panel')).not.toHaveClass(/open/);
-  await expect(page.locator('link[data-chat-onboarding-stylesheet]')).toHaveCount(0);
+  await expect(page.locator('link[data-chat-presentation-stylesheet]')).toHaveCount(0);
   await expect(page.locator('.notification-toast')).toContainText('Chat could not be opened');
 
-  await page.unroute('**/css/chat-onboarding.css*');
+  await page.unroute(presentationPattern);
   const retry = await page.evaluate(async () => {
     const opened = await (await import('/js/chat-panel.js')).openChatPanel();
-    const link = document.querySelector('link[data-chat-onboarding-stylesheet]');
+    const links = Array.from(document.querySelectorAll('link[data-chat-presentation-stylesheet]'));
     return {
       opened,
       panelOpen: document.getElementById('chat-panel')?.classList.contains('open'),
-      href: link?.href || '',
+      hrefs: links.map(link => link.href),
     };
   });
 
-  expect(stylesheetRequests).toHaveLength(1);
+  expect(stylesheetRequests).toHaveLength(7);
   expect(retry.opened).toBe(true);
   expect(retry.panelOpen).toBe(true);
-  expect(new URL(retry.href).searchParams.get('lazy-retry')).toBe('1');
+  expect(retry.hrefs).toHaveLength(7);
+  expect(retry.hrefs.every(href => new URL(href).searchParams.get('lazy-retry') === '1')).toBe(true);
 });

--- a/tests/playwright/cold-load-budget.spec.js
+++ b/tests/playwright/cold-load-budget.spec.js
@@ -100,8 +100,17 @@ test('cold mobile app load stays within committed resource budgets', async ({ pa
   expect(entries.some(entry => (
     new URL(entry.name).pathname === '/themes-extra.css'
   ))).toBe(false);
+  const deferredChatStylesheets = new Set([
+    '/css/chat-personality.css',
+    '/css/chat-messages.css',
+    '/css/chat-composer.css',
+    '/css/chat-onboarding.css',
+    '/css/chat-responsive.css',
+    '/css/chat-actions.css',
+    '/css/chat-mobile.css',
+  ]);
   expect(entries.some(entry => (
-    new URL(entry.name).pathname === '/css/chat-onboarding.css'
+    deferredChatStylesheets.has(new URL(entry.name).pathname)
   ))).toBe(false);
   const deferredLightStylesheets = new Set([
     '/css/light-sun.css',

--- a/tests/playwright/custom-personality-dom.spec.js
+++ b/tests/playwright/custom-personality-dom.spec.js
@@ -85,6 +85,7 @@ test('custom personality DOM renders editor controls and delegated discuss actio
       outcomes.editInactiveLoadsFields = document.getElementById('chat-personality-custom-name')?.value === 'Functional Doc'
         && document.querySelector('.chat-personality-custom-textarea')?.value === 'Functional prompt';
 
+      await (await import('/js/chat-panel.js')).loadChatPresentationStylesheets();
       const selectors = new Set();
       for (const sheet of Array.from(document.styleSheets)) {
         try {

--- a/tests/playwright/image-utils-dom.spec.js
+++ b/tests/playwright/image-utils-dom.spec.js
@@ -1,6 +1,6 @@
 import { expect, test } from './coverage-fixture.js';
 
-test('chat image attachment DOM and CSS are loaded', async ({ page }) => {
+test('chat image attachment DOM is present and its CSS loads on demand', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
 
   await expect(page.locator('#chat-attach-btn')).toHaveCount(1);
@@ -9,7 +9,8 @@ test('chat image attachment DOM and CSS are loaded', async ({ page }) => {
   await expect(page.locator('.chat-input-row')).toHaveCount(1);
   await expect(page.locator('#chat-image-input')).toHaveAttribute('accept', /image\//);
 
-  const loadedRules = await page.evaluate(() => {
+  const loadedRules = await page.evaluate(async () => {
+    await (await import('/js/chat-panel.js')).loadChatPresentationStylesheets();
     const selectors = [
       '.chat-attach-btn',
       '.chat-attach-preview',

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -351,41 +351,62 @@ assert('light CSS split preserves override order',
   swAuditSrc.indexOf("'/css/light-tools.css'") < swAuditSrc.indexOf("'/css/light-env.css'"));
 assert('index loads chat panel CSS bundle', indexSrc.includes('href="css/chat-panel.css"'));
 assert('SW APP_SHELL includes chat panel CSS bundle', swAuditSrc.includes("'/css/chat-panel.css'"));
-const CHAT_CSS_BUNDLES = [
+assert('index loads Chat redesign overrides eagerly',
+  indexSrc.includes('href="css/chat-redesign.css"') &&
+  swAuditSrc.includes("'/css/chat-redesign.css'"));
+const DEFERRED_CHAT_PRESENTATION_BUNDLES = [
   'css/chat-personality.css',
   'css/chat-messages.css',
   'css/chat-composer.css',
+  'css/chat-onboarding.css',
   'css/chat-responsive.css',
   'css/chat-actions.css',
   'css/chat-mobile.css',
-  'css/chat-redesign.css',
 ];
-for (const chatCss of CHAT_CSS_BUNDLES) {
-  assert(`index loads ${chatCss}`, indexSrc.includes(`href="${chatCss}"`));
-  assert(`SW APP_SHELL includes ${chatCss}`, swAuditSrc.includes(`'/${chatCss}'`));
-}
 const chatPanelAuditSrc = read('js/chat-panel.js');
-assert('index defers Chat onboarding CSS behind its ordered lazy-load anchor',
-  !indexSrc.includes('href="css/chat-onboarding.css"') &&
-  indexSrc.includes('data-chat-onboarding-stylesheet-anchor') &&
-  chatPanelAuditSrc.includes("new URL('../css/chat-onboarding.css', import.meta.url)") &&
-  chatPanelAuditSrc.includes('loadChatOnboardingStylesheetForAction'));
-assert('Chat panel waits for onboarding presentation before opening',
-  chatPanelAuditSrc.includes('await loadChatOnboardingStylesheetForAction()') &&
-  chatPanelAuditSrc.indexOf('await loadChatOnboardingStylesheetForAction()') <
+for (const chatCss of DEFERRED_CHAT_PRESENTATION_BUNDLES) {
+  assert(`index defers ${chatCss} through the Chat presentation boundary`,
+    !indexSrc.includes(`href="${chatCss}"`) &&
+    chatPanelAuditSrc.includes(`new URL('../${chatCss}', import.meta.url)`) &&
+    swAuditSrc.includes(`'/${chatCss}'`));
+}
+assert('index defers Chat presentation behind its ordered lazy-load anchor',
+  indexSrc.includes('data-chat-presentation-stylesheet-anchor') &&
+  chatPanelAuditSrc.includes('loadChatPresentationStylesheetsForAction'));
+assert('Chat panel waits for complete presentation before opening',
+  chatPanelAuditSrc.includes('await loadChatPresentationStylesheetsForAction()') &&
+  chatPanelAuditSrc.indexOf('await loadChatPresentationStylesheetsForAction()') <
     chatPanelAuditSrc.indexOf("panel.classList.add('open')"));
-assert('Chat onboarding CSS lazy-load anchor preserves the original cascade position',
-  indexSrc.indexOf('href="css/chat-composer.css"') <
-    indexSrc.indexOf('data-chat-onboarding-stylesheet-anchor') &&
-  indexSrc.indexOf('data-chat-onboarding-stylesheet-anchor') <
-    indexSrc.indexOf('href="css/chat-responsive.css"'));
-assert('SW APP_SHELL includes Chat onboarding CSS bundle',
-  swAuditSrc.includes("'/css/chat-onboarding.css'"));
-assert('chat CSS split loads before chat redesign overrides',
-  indexSrc.indexOf('href="css/chat-mobile.css"') < indexSrc.indexOf('href="css/redesign-shell.css"') &&
+assert('Chat presentation loader and service worker preserve stylesheet cascade order',
+  DEFERRED_CHAT_PRESENTATION_BUNDLES.every((chatCss, index) => (
+    index === 0 ||
+    chatPanelAuditSrc.indexOf(`new URL('../${DEFERRED_CHAT_PRESENTATION_BUNDLES[index - 1]}'`) <
+      chatPanelAuditSrc.indexOf(`new URL('../${chatCss}'`)
+  )) &&
+  DEFERRED_CHAT_PRESENTATION_BUNDLES.every((chatCss, index) => (
+    index === 0 ||
+    swAuditSrc.indexOf(`'/${DEFERRED_CHAT_PRESENTATION_BUNDLES[index - 1]}'`) <
+      swAuditSrc.indexOf(`'/${chatCss}'`)
+  )));
+assert('Chat presentation lazy-load anchor precedes redesign overrides',
+  indexSrc.indexOf('data-chat-presentation-stylesheet-anchor') <
+    indexSrc.indexOf('href="css/redesign-shell.css"') &&
   indexSrc.indexOf('href="css/redesign-shell.css"') < indexSrc.indexOf('href="css/chat-redesign.css"') &&
   swAuditSrc.indexOf("'/css/chat-mobile.css'") < swAuditSrc.indexOf("'/css/redesign-shell.css'") &&
   swAuditSrc.indexOf("'/css/redesign-shell.css'") < swAuditSrc.indexOf("'/css/chat-redesign.css'"));
+const chatComposerCssSrc = read('css/chat-composer.css');
+const chatPanelCssSrc = read('css/chat-panel.css');
+const chatMobileCssSrc = read('css/chat-mobile.css');
+const markerDetailCssSrc = read('css/marker-detail-modal.css');
+assert('cold-visible mobile Chat launcher sizing remains in the eager panel bundle',
+  chatPanelCssSrc.includes('@media (max-width: 480px)') &&
+  chatPanelCssSrc.includes('.chat-fab { width: 48px; height: 48px;') &&
+  !chatMobileCssSrc.includes('.chat-fab'));
+assert('marker detail presentation no longer depends on deferred Chat composer CSS',
+  markerDetailCssSrc.includes('.calc-missing-inputs') &&
+  markerDetailCssSrc.includes('.ask-ai-btn') &&
+  !chatComposerCssSrc.includes('.calc-missing-inputs') &&
+  !chatComposerCssSrc.includes('.ask-ai-btn'));
 assert('Umami analytics script present (self-hosted)', indexSrc.includes('umami-iota-olive.vercel.app/script.js'));
 assert('Umami blocked on file:// protocol', /location\.protocol\s*!==\s*['"]file:['"]/.test(indexSrc));
 

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.366';
+self.APP_VERSION = '1.10.367';


### PR DESCRIPTION
## Summary
- defer Chat personality, messages, composer, onboarding, responsive, actions, and mobile styles behind one ordered first-open boundary
- keep the persistent launcher, closed panel shell, and final redesign overrides eager; retain the mobile launcher breakpoint in the eager shell
- move marker-detail-only controls out of the Chat composer bundle and into the existing lazy marker-detail presentation
- preserve single-flight loading, original cascade order, offline precache availability, contained failures, and fresh-URL retry behavior

## Cold-load impact
Fresh mobile returning-user load with cache and service workers disabled:

| Metric | Before | After | Delta |
| --- | ---: | ---: | ---: |
| Requests | 431 | 425 | -6 |
| Transfer bytes | 1,819,210 | 1,811,205 | -8,005 |
| Decoded bytes | 5,450,230 | 5,429,764 | -20,466 |

Two unchanged measurements and the full browser run reproduced the same result.

## Verification
- 131 verification checks
- 488 Vitest tests
- 427 Chromium tests
- 472 responsive checks
- 67.10% global function coverage (67.10% ratchet)
- architecture: 465 modules, 0 cycles
- typecheck and check-JS typecheck
- quality checks: 11/11
- 350/350 pre-release audit assertions
- `git diff --check`
