### PR TITLE
Load data protection presentation on demand

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -10,7 +10,7 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | Metric | Current |
 | --- | ---: |
 | Modules | 465 |
-| Internal import edges | 2084 |
+| Internal import edges | 2087 |
 | Dynamic internal edges | 61 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -42,7 +42,7 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 | [`js/state.js`](js/state.js) | 146 | [`js/app-light-sun-modules.js`](js/app-light-sun-modules.js) | 27 |
 | [`js/data.js`](js/data.js) | 73 | [`js/sync-configure.js`](js/sync-configure.js) | 27 |
 | [`js/api.js`](js/api.js) | 63 | [`js/dashboard-view-composition.js`](js/dashboard-view-composition.js) | 25 |
-| [`js/modal-lifecycle.js`](js/modal-lifecycle.js) | 51 | [`js/settings.js`](js/settings.js) | 25 |
+| [`js/modal-lifecycle.js`](js/modal-lifecycle.js) | 54 | [`js/settings.js`](js/settings.js) | 25 |
 | [`js/profile.js`](js/profile.js) | 45 | [`js/views.js`](js/views.js) | 25 |
 | [`js/schema.js`](js/schema.js) | 30 | [`js/pdf-import.js`](js/pdf-import.js) | 23 |
 | [`js/data-merge.js`](js/data-merge.js) | 29 | [`js/chat-send.js`](js/chat-send.js) | 22 |
@@ -285,7 +285,7 @@ Native browser modules shipped with the static application.
 <details><summary><code>crypto</code> family — 2 modules</summary>
 
 - [`js/crypto-key-cache.js`](js/crypto-key-cache.js) → no in-scope imports
-- [`js/crypto.js`](js/crypto.js) → [`js/backup.js`](js/backup.js), [`js/blob-storage.js`](js/blob-storage.js), [`js/cashu-wallet-store.js`](js/cashu-wallet-store.js) *(dynamic)*, [`js/crypto-key-cache.js`](js/crypto-key-cache.js), [`js/cycle-store.js`](js/cycle-store.js), [`js/data-merge.js`](js/data-merge.js), [`js/data-wipe.js`](js/data-wipe.js) *(dynamic)*, [`js/profile-storage-key.js`](js/profile-storage-key.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js), [`js/wearables-store.js`](js/wearables-store.js)
+- [`js/crypto.js`](js/crypto.js) → [`js/backup.js`](js/backup.js), [`js/blob-storage.js`](js/blob-storage.js), [`js/cashu-wallet-store.js`](js/cashu-wallet-store.js) *(dynamic)*, [`js/crypto-key-cache.js`](js/crypto-key-cache.js), [`js/cycle-store.js`](js/cycle-store.js), [`js/data-merge.js`](js/data-merge.js), [`js/data-wipe.js`](js/data-wipe.js) *(dynamic)*, [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/profile-storage-key.js`](js/profile-storage-key.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js), [`js/wearables-store.js`](js/wearables-store.js)
 
 </details>
 
@@ -395,7 +395,7 @@ Native browser modules shipped with the static application.
 - [`js/import-drop-zone-runtime.js`](js/import-drop-zone-runtime.js) → [`js/dna-runtime-bridge.js`](js/dna-runtime-bridge.js), [`js/export.js`](js/export.js), [`js/pdf-import-progress.js`](js/pdf-import-progress.js), [`js/utils.js`](js/utils.js)
 - [`js/import-drop-zone.js`](js/import-drop-zone.js) → [`js/import-drop-zone-runtime.js`](js/import-drop-zone-runtime.js), [`js/import-loader.js`](js/import-loader.js)
 - [`js/import-file-input.js`](js/import-file-input.js) → [`js/import-drop-zone-runtime.js`](js/import-drop-zone-runtime.js), [`js/import-loader.js`](js/import-loader.js)
-- [`js/import-loader.js`](js/import-loader.js) → [`js/import-review-draft.js`](js/import-review-draft.js), [`js/pdf-import-review.js`](js/pdf-import-review.js) *(dynamic)*, [`js/pdf-import.js`](js/pdf-import.js) *(dynamic)*
+- [`js/import-loader.js`](js/import-loader.js) → [`js/import-review-draft.js`](js/import-review-draft.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/pdf-import-review.js`](js/pdf-import-review.js) *(dynamic)*, [`js/pdf-import.js`](js/pdf-import.js) *(dynamic)*
 - [`js/import-marker-map-modal.js`](js/import-marker-map-modal.js) → [`js/adapters.js`](js/adapters.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/pdf-import-marker-mapping.js`](js/pdf-import-marker-mapping.js), [`js/schema.js`](js/schema.js), [`js/utils.js`](js/utils.js)
 - [`js/import-reference-benchmark.js`](js/import-reference-benchmark.js) → [`js/api.js`](js/api.js), [`js/import-benchmarks.js`](js/import-benchmarks.js), [`js/import-loader.js`](js/import-loader.js), [`js/pdf-import-ai-utils.js`](js/pdf-import-ai-utils.js), [`js/pdf-import-marker-mapping.js`](js/pdf-import-marker-mapping.js), [`js/schema.js`](js/schema.js)
 - [`js/import-review-draft.js`](js/import-review-draft.js) → no in-scope imports
@@ -672,7 +672,7 @@ Native browser modules shipped with the static application.
 - [`js/settings-agent-access-panel.js`](js/settings-agent-access-panel.js) → [`js/data.js`](js/data.js), [`js/state.js`](js/state.js), [`js/sync.js`](js/sync.js), [`js/utils-runtime.js`](js/utils-runtime.js), [`js/utils.js`](js/utils.js)
 - [`js/settings-data.js`](js/settings-data.js) → [`js/api.js`](js/api.js), [`js/import-benchmarks.js`](js/import-benchmarks.js), [`js/import-loader.js`](js/import-loader.js), [`js/import-reference-benchmark.js`](js/import-reference-benchmark.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/settings-import-benchmark-controller.js`](js/settings-import-benchmark-controller.js) → [`js/import-benchmarks.js`](js/import-benchmarks.js), [`js/import-reference-benchmark.js`](js/import-reference-benchmark.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/settings-data.js`](js/settings-data.js), [`js/utils.js`](js/utils.js)
-- [`js/settings-loader.js`](js/settings-loader.js) → [`js/settings-runtime-bridge.js`](js/settings-runtime-bridge.js), [`js/settings.js`](js/settings.js) *(dynamic)*, [`js/theme.js`](js/theme.js), [`js/utils.js`](js/utils.js)
+- [`js/settings-loader.js`](js/settings-loader.js) → [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/settings-runtime-bridge.js`](js/settings-runtime-bridge.js), [`js/settings.js`](js/settings.js) *(dynamic)*, [`js/theme.js`](js/theme.js), [`js/utils.js`](js/utils.js)
 - [`js/settings-privacy.js`](js/settings-privacy.js) → [`js/api.js`](js/api.js), [`js/pii.js`](js/pii.js), [`js/settings-runtime.js`](js/settings-runtime.js), [`js/utils.js`](js/utils.js)
 - [`js/settings-provider-bridge.js`](js/settings-provider-bridge.js) → [`js/api.js`](js/api.js), [`js/provider-panels.js`](js/provider-panels.js) *(dynamic)*
 - [`js/settings-runtime-bridge.js`](js/settings-runtime-bridge.js) → no in-scope imports

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
   <meta data-category-views-stylesheet-anchor>
   <link rel="stylesheet" href="css/context-profile.css">
   <meta data-genetics-stylesheet-anchor>
-  <link rel="stylesheet" href="css/data-protection.css">
+  <meta data-data-protection-stylesheet-anchor>
   <meta data-settings-stylesheet-anchor>
   <link rel="stylesheet" href="css/mobile-dashboard.css">
   <meta data-cycle-stylesheet-anchor>

--- a/js/crypto.js
+++ b/js/crypto.js
@@ -9,12 +9,23 @@ import { ensureImportedArray } from './data-merge.js';
 import { clearKeyCache, getCachedKey, updateKeyCache } from './crypto-key-cache.js';
 import { configureCycleStoreCrypto } from './cycle-store.js';
 import { configureWearablesStoreCrypto } from './wearables-store.js';
+import { isDataProtectionStylesheetLoaded, loadDataProtectionStylesheetForAction } from './modal-lifecycle.js';
 
 export { getCachedKey, updateKeyCache } from './crypto-key-cache.js';
 
 const appWindow = /** @type {Window & typeof globalThis & {
   __WEARABLES_TEST?: boolean,
 }} */ (typeof window !== 'undefined' ? window : {});
+
+const needsDataProtectionStylesheet = () => typeof document !== 'undefined' && !!document.querySelector('[data-data-protection-stylesheet-anchor]') && !isDataProtectionStylesheetLoaded();
+function runWithDataProtectionStylesheet(action) {
+  if (!needsDataProtectionStylesheet()) return action();
+  return loadDataProtectionStylesheetForAction().then(loaded => {
+    if (loaded) return action();
+    showNotification('Data protection controls could not be loaded. Try again.', 'error');
+    return false;
+  });
+}
 /**
  * @typedef {{
  *   buildSidebar: null | (() => void),
@@ -429,6 +440,7 @@ export async function encryptedRemoveItem(key) {
 // ═══════════════════════════════════════════════
 export async function initEncryption() {
   if (!getEncryptionEnabled()) return;
+  if (needsDataProtectionStylesheet()) await loadDataProtectionStylesheetForAction();
   await new Promise((resolve) => {
     showPassphraseModal(resolve);
   });
@@ -576,6 +588,7 @@ function getPassphraseStrength(p) {
 // ENABLE / DISABLE ENCRYPTION
 // ═══════════════════════════════════════════════
 export function showEnableEncryptionModal() {
+  if (needsDataProtectionStylesheet()) return runWithDataProtectionStylesheet(() => showEnableEncryptionModal());
   let overlay = document.getElementById('passphrase-overlay');
   if (!overlay) {
     overlay = document.createElement('div');
@@ -689,6 +702,7 @@ export function showEnableEncryptionModal() {
 export function maybeShowEncryptionNudge() {
   if (getEncryptionEnabled()) return;
   if (localStorage.getItem('labcharts-encryption-nudge-dismissed')) return;
+  if (needsDataProtectionStylesheet()) return void runWithDataProtectionStylesheet(() => maybeShowEncryptionNudge());
   setTimeout(() => {
     let overlay = document.getElementById('passphrase-overlay');
     if (!overlay) {
@@ -755,6 +769,10 @@ export function maybeShowBackupNudge() {
   // Skip if another overlay is already showing
   const overlay = document.getElementById('passphrase-overlay');
   if (overlay && overlay.style.display === 'flex') return;
+  if (needsDataProtectionStylesheet()) {
+    void runWithDataProtectionStylesheet(() => maybeShowBackupNudge());
+    return;
+  }
 
   setTimeout(() => {
     // Re-check overlay (encryption nudge may have appeared during delay)
@@ -928,6 +946,9 @@ export async function disableEncryption() {
 }
 
 export async function changePassphrase() {
+  if (needsDataProtectionStylesheet()) {
+    return runWithDataProtectionStylesheet(() => changePassphrase());
+  }
   let overlay = document.getElementById('passphrase-overlay');
   if (!overlay) {
     overlay = document.createElement('div');

--- a/js/import-loader.js
+++ b/js/import-loader.js
@@ -2,6 +2,7 @@
 // import-loader.js — shared lazy loaders for heavyweight import flows
 
 import { hasImportReviewDraft } from './import-review-draft.js';
+import { loadDataProtectionStylesheet } from './modal-lifecycle.js';
 
 const IMPORT_STYLESHEET_URL = new URL('../css/import.css', import.meta.url).href;
 
@@ -62,13 +63,17 @@ export async function loadImportUI() {
   const [importModule] = await Promise.all([
     loadPdfImport(),
     loadImportStylesheet(),
+    loadDataProtectionStylesheet(),
   ]);
   return importModule;
 }
 
 export async function restorePendingImportReviewDraft() {
   if (!hasImportReviewDraft()) return false;
-  await loadImportStylesheet();
+  await Promise.all([
+    loadImportStylesheet(),
+    loadDataProtectionStylesheet(),
+  ]);
   const review = await import('./pdf-import-review.js');
   return review.restoreImportReviewDraft();
 }

--- a/js/modal-lifecycle.js
+++ b/js/modal-lifecycle.js
@@ -1,6 +1,89 @@
 // @ts-check
 // modal-lifecycle.js — shared modal backdrop, focus trap, and scroll lock.
 
+const DATA_PROTECTION_STYLESHEET_URL = new URL('../css/data-protection.css', import.meta.url).href;
+
+/** @type {Promise<HTMLLinkElement> | null} */
+let dataProtectionStylesheetPromise = null;
+let dataProtectionStylesheetLoaded = false;
+let useDataProtectionStylesheetRetryUrl = false;
+
+function existingDataProtectionStylesheet() {
+  if (typeof document === 'undefined') return null;
+  return /** @type {HTMLLinkElement | null} */ (
+    document.querySelector('link[data-data-protection-stylesheet]')
+    || Array.from(document.querySelectorAll('link[rel="stylesheet"][href]'))
+      .find(link => {
+        try {
+          return new URL(/** @type {HTMLLinkElement} */ (link).href).pathname === '/css/data-protection.css';
+        } catch {
+          return false;
+        }
+      })
+    || null
+  );
+}
+
+function dataProtectionStylesheetUrl() {
+  if (!useDataProtectionStylesheetRetryUrl) return DATA_PROTECTION_STYLESHEET_URL;
+  const retryUrl = new URL(DATA_PROTECTION_STYLESHEET_URL);
+  retryUrl.searchParams.set('lazy-retry', '1');
+  return retryUrl.href;
+}
+
+export function isDataProtectionStylesheetLoaded() {
+  return dataProtectionStylesheetLoaded || !!existingDataProtectionStylesheet()?.sheet;
+}
+
+/** @returns {Promise<HTMLLinkElement>} */
+export function loadDataProtectionStylesheet() {
+  const existing = existingDataProtectionStylesheet();
+  if (existing?.sheet) {
+    dataProtectionStylesheetLoaded = true;
+    return Promise.resolve(existing);
+  }
+  if (!dataProtectionStylesheetPromise) {
+    if (typeof document === 'undefined') {
+      return Promise.reject(new Error('Data protection stylesheet requires a document'));
+    }
+    const link = existing || document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = dataProtectionStylesheetUrl();
+    link.dataset.dataProtectionStylesheet = '';
+    dataProtectionStylesheetPromise = new Promise((resolve, reject) => {
+      link.addEventListener('load', () => {
+        dataProtectionStylesheetLoaded = true;
+        resolve(link);
+      }, { once: true });
+      link.addEventListener('error', () => {
+        reject(new Error('Data protection stylesheet could not be loaded'));
+      }, { once: true });
+      if (!link.isConnected) {
+        const anchor = document.querySelector('[data-data-protection-stylesheet-anchor]');
+        const parent = anchor?.parentNode || document.head;
+        parent.insertBefore(link, anchor || null);
+      }
+    }).catch(err => {
+      link.remove();
+      dataProtectionStylesheetPromise = null;
+      dataProtectionStylesheetLoaded = false;
+      useDataProtectionStylesheetRetryUrl = true;
+      throw err;
+    });
+  }
+  return dataProtectionStylesheetPromise;
+}
+
+export async function loadDataProtectionStylesheetForAction() {
+  try {
+    await loadDataProtectionStylesheet();
+    return true;
+  } catch (err) {
+    console.error('Failed to load data protection presentation', err);
+    return false;
+  }
+}
+
 export function wireBackdropClose(overlay, closeFn) {
   const close = typeof closeFn === 'function' ? closeFn : () => overlay.remove();
   let mouseDownInside = false;

--- a/js/pii.js
+++ b/js/pii.js
@@ -14,7 +14,13 @@ import {
 } from './local-ai-discovery.js';
 import { createInitialResponseTimeout } from './api-transport.js';
 import { getLocalAiProviderAdapter } from './local-ai-provider-registry.js';
-import { openModalOverlay, removeModalOverlay, trapModalFocus } from './modal-lifecycle.js';
+import {
+  isDataProtectionStylesheetLoaded,
+  loadDataProtectionStylesheetForAction,
+  openModalOverlay,
+  removeModalOverlay,
+  trapModalFocus,
+} from './modal-lifecycle.js';
 import { state } from './state.js';
 
 export { checkOllama, checkOpenAICompatible };
@@ -592,6 +598,13 @@ function closePIIOverlay(overlay) {
 }
 
 export function showPIIDiffViewer(originalText, obfuscatedText) {
+  if (!isDataProtectionStylesheetLoaded()) {
+    return loadDataProtectionStylesheetForAction().then(loaded => {
+      if (loaded) return showPIIDiffViewer(originalText, obfuscatedText);
+      showNotification('Privacy review could not be loaded. Try again.', 'error');
+      return false;
+    });
+  }
   const overlay = document.createElement('div');
   overlay.className = 'pii-warning-overlay';
   const { leftHtml, rightHtml } = buildPIIDiffHTML(originalText, obfuscatedText);
@@ -629,6 +642,13 @@ function wirePIIOverlayNudge(overlay) {
 }
 
 export function reviewPIIBeforeSend(originalText, { obfuscatedText = '', streamFn = null } = {}) {
+  if (!isDataProtectionStylesheetLoaded()) {
+    return loadDataProtectionStylesheetForAction().then(loaded => {
+      if (loaded) return reviewPIIBeforeSend(originalText, { obfuscatedText, streamFn });
+      showNotification('Privacy review could not be loaded. Try again.', 'error');
+      return 'cancel';
+    });
+  }
   return new Promise(resolve => {
     const isStreaming = typeof streamFn === 'function';
     const overlay = document.createElement('div');

--- a/js/settings-loader.js
+++ b/js/settings-loader.js
@@ -4,6 +4,7 @@
 import { applyAccentOverride } from './theme.js';
 import { showNotification } from './utils.js';
 import { configureSettingsModuleBridge } from './settings-runtime-bridge.js';
+import { loadDataProtectionStylesheet } from './modal-lifecycle.js';
 
 /** @typedef {typeof import('./settings.js')} SettingsModule */
 
@@ -99,10 +100,11 @@ function loadSettingsStylesheet() {
 export function loadSettingsModule() {
   if (!_settingsModuleLoad) {
     _settingsModuleLoad = Promise.all([
+      loadDataProtectionStylesheet(),
       loadSettingsJavaScript(),
       loadSettingsStylesheet(),
     ])
-      .then(([module]) => {
+      .then(([, module]) => {
         _configureSettingsModule(module);
         _settingsModuleLoaded = true;
         return module;

--- a/plans/code-quality-audit-2026-07-21.md
+++ b/plans/code-quality-audit-2026-07-21.md
@@ -57,7 +57,9 @@ load at the original final cascade position. Cross-theme shell and Sunset Mode
 rules remain eager after that anchor. Chat personality, messages, composer,
 onboarding, responsive, actions, and mobile presentation now wait for the first
 Chat open while its persistent launcher, closed panel shell, and redesign
-overrides remain eager. Each boundary keeps offline assets precached, preserves
+overrides remain eager. Data-protection presentation now joins the first Import,
+Settings, privacy-review, encryption, or backup surface that needs it; ordinary
+startup remains cold. Each boundary keeps offline assets precached, preserves
 cascade order, and retains shared rules in eager bundles or the HTML shell.
 
 ## Findings
@@ -117,12 +119,13 @@ decoded bytes. The initial reference was 474 requests, 2,017,210 compressed
 bytes, and 6,252,286 decoded bytes. Lazy-loading the PDF import review,
 Light/Sun analysis hooks, Settings/Tweaks, Profile Sharing, and the Settings,
 Light/Sun, Client List, Import review, Marker Detail, EMF, Genetics, and
-Category/Compare stylesheets reduced that reference to 435 requests, 1,836,218
-compressed bytes, and 5,539,354 decoded bytes. The Category/Compare stylesheet
-slice saved one request, 4,968 compressed bytes, and 22,986 decoded bytes in
-identical before/after runs on the same machine. Route and feature lazy loading
-remains active, with the ceilings ratcheting downward after each reproducible
-slice.
+Category/Compare, Wearables, Cycle, optional-theme, Chat, and data-protection
+stylesheets reduced that reference to 424 requests, 1,809,362 compressed bytes,
+and 5,422,477 decoded bytes. The data-protection stylesheet slice saved one
+request, 1,843 compressed bytes, and 7,287 decoded bytes net of its shared
+loader in identical before/after runs on the same machine. Route and feature
+lazy loading remains active, with the ceilings ratcheting downward after each
+reproducible slice.
 
 ### 4. Guardrails and test gaps
 

--- a/scripts/cold-load-budget.json
+++ b/scripts/cold-load-budget.json
@@ -3,15 +3,15 @@
   "route": "/app",
   "scenario": "Fresh mobile returning-user load with browser cache and service workers disabled",
   "maximums": {
-    "requests": 431,
-    "transferBytes": 1843000,
-    "decodedBytes": 5520000
+    "requests": 430,
+    "transferBytes": 1841000,
+    "decodedBytes": 5512000
   },
   "reference": {
-    "requests": 425,
-    "transferBytes": 1811205,
-    "decodedBytes": 5429764
+    "requests": 424,
+    "transferBytes": 1809362,
+    "decodedBytes": 5422477
   },
-  "referenceCommit": "497dabff",
+  "referenceCommit": "4f1239bb",
   "measuredAt": "2026-07-24"
 }

--- a/tests/playwright/cold-load-budget.spec.js
+++ b/tests/playwright/cold-load-budget.spec.js
@@ -74,6 +74,9 @@ test('cold mobile app load stays within committed resource budgets', async ({ pa
     new URL(entry.name).pathname === '/css/settings.css'
   ))).toBe(false);
   expect(entries.some(entry => (
+    new URL(entry.name).pathname === '/css/data-protection.css'
+  ))).toBe(false);
+  expect(entries.some(entry => (
     new URL(entry.name).pathname === '/css/import.css'
   ))).toBe(false);
   expect(entries.some(entry => (

--- a/tests/playwright/data-protection-stylesheet-browser-coverage.spec.js
+++ b/tests/playwright/data-protection-stylesheet-browser-coverage.spec.js
@@ -1,0 +1,146 @@
+import { expect, test } from './coverage-fixture.js';
+
+function moduleUrl() {
+  return `/js/modal-lifecycle.js?dataProtectionStylesheetCoverage=${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+async function openLoaderPage(page, path) {
+  await page.route(`**${path}`, route => route.fulfill({
+    status: 200,
+    contentType: 'text/html',
+    body: `<!doctype html><html><head>
+      <meta data-genetics-stylesheet-anchor>
+      <meta data-data-protection-stylesheet-anchor>
+      <meta data-settings-stylesheet-anchor>
+    </head><body><div id="notification-container"></div></body></html>`,
+  }));
+  await page.goto(path, { waitUntil: 'load' });
+}
+
+test('data protection stylesheet loader single-flights and preserves cascade order', async ({ page }) => {
+  let stylesheetRequests = 0;
+  await page.route('**/css/data-protection.css*', route => {
+    stylesheetRequests += 1;
+    return route.fulfill({
+      status: 200,
+      contentType: 'text/css',
+      body: '.passphrase-overlay { position: fixed; }',
+    });
+  });
+  await openLoaderPage(page, '/data-protection-stylesheet-cache-coverage');
+
+  const outcomes = await page.evaluate(async ({ runtimeUrl }) => {
+    const runtime = await import(runtimeUrl);
+    const loadedBeforeRequest = runtime.isDataProtectionStylesheetLoaded();
+    const [first, second] = await Promise.all([
+      runtime.loadDataProtectionStylesheet(),
+      runtime.loadDataProtectionStylesheet(),
+    ]);
+    const third = await runtime.loadDataProtectionStylesheet();
+    const anchor = document.querySelector('[data-data-protection-stylesheet-anchor]');
+    return {
+      loadedBeforeRequest,
+      loadedAfterRequest: runtime.isDataProtectionStylesheetLoaded(),
+      concurrentCallsShareTheSameLink: first === second,
+      laterCallsReuseTheResolvedLink: first === third,
+      oneStylesheetLink:
+        document.querySelectorAll('link[data-data-protection-stylesheet]').length === 1,
+      linkPrecedesAnchor: first.nextElementSibling === anchor,
+      anchorPreservesCascade:
+        anchor?.previousElementSibling === first
+        && anchor?.nextElementSibling?.hasAttribute('data-settings-stylesheet-anchor') === true,
+    };
+  }, { runtimeUrl: moduleUrl() });
+
+  expect(outcomes).toEqual({
+    loadedBeforeRequest: false,
+    loadedAfterRequest: true,
+    concurrentCallsShareTheSameLink: true,
+    laterCallsReuseTheResolvedLink: true,
+    oneStylesheetLink: true,
+    linkPrecedesAnchor: true,
+    anchorPreservesCascade: true,
+  });
+  expect(stylesheetRequests).toBe(1);
+});
+
+test('data protection stylesheet failure is contained and retries with a fresh URL', async ({ page }) => {
+  const stylesheetRequests = [];
+  await page.route('**/css/data-protection.css*', route => {
+    stylesheetRequests.push(route.request().url());
+    return route.abort('failed');
+  });
+  await openLoaderPage(page, '/data-protection-stylesheet-retry-coverage');
+  const runtimeUrl = moduleUrl();
+
+  const firstAttempt = await page.evaluate(async ({ runtimeUrl: url }) => {
+    const runtime = await import(url);
+    return {
+      loaded: await runtime.loadDataProtectionStylesheetForAction(),
+      links: document.querySelectorAll('link[data-data-protection-stylesheet]').length,
+    };
+  }, { runtimeUrl });
+
+  expect(firstAttempt).toEqual({ loaded: false, links: 0 });
+  expect(stylesheetRequests).toHaveLength(1);
+
+  const encryptedStartup = await page.evaluate(async () => {
+    localStorage.setItem('labcharts-encryption-enabled', 'true');
+    const cryptoStore = await import(`/js/crypto.js?stylesheetFailure=${Date.now()}`);
+    void cryptoStore.initEncryption();
+    for (let attempt = 0; attempt < 50; attempt += 1) {
+      if (document.getElementById('passphrase-overlay')) break;
+      await new Promise(resolve => setTimeout(resolve, 10));
+    }
+    return {
+      unlockStillRenders: !!document.getElementById('passphrase-unlock-btn'),
+      failedLinkRemoved:
+        document.querySelectorAll('link[data-data-protection-stylesheet]').length === 0,
+    };
+  });
+  expect(encryptedStartup).toEqual({
+    unlockStillRenders: true,
+    failedLinkRemoved: true,
+  });
+
+  await page.unroute('**/css/data-protection.css*');
+  const retry = await page.evaluate(async ({ runtimeUrl: url }) => {
+    const runtime = await import(url);
+    const loaded = await runtime.loadDataProtectionStylesheetForAction();
+    const link = document.querySelector('link[data-data-protection-stylesheet]');
+    return {
+      loaded,
+      href: link?.href || '',
+      sheetLoaded: link?.sheet !== null,
+    };
+  }, { runtimeUrl });
+
+  expect(retry.loaded).toBe(true);
+  expect(retry.sheetLoaded).toBe(true);
+  expect(new URL(retry.href).searchParams.get('lazy-retry')).toBe('1');
+});
+
+test('cold startup defers data protection presentation until an encryption action', async ({ page }) => {
+  let stylesheetRequests = 0;
+  page.on('request', request => {
+    if (new URL(request.url()).pathname === '/css/data-protection.css') stylesheetRequests += 1;
+  });
+
+  await page.goto('/app', { waitUntil: 'networkidle' });
+  expect(stylesheetRequests).toBe(0);
+  await expect(page.locator('link[data-data-protection-stylesheet]')).toHaveCount(0);
+
+  const opened = await page.evaluate(async () => {
+    const cryptoStore = await import('/js/crypto.js');
+    await cryptoStore.showEnableEncryptionModal();
+    const overlay = document.getElementById('passphrase-overlay');
+    return {
+      display: overlay ? getComputedStyle(overlay).display : '',
+      position: overlay ? getComputedStyle(overlay).position : '',
+    };
+  });
+
+  expect(stylesheetRequests).toBe(1);
+  await expect(page.locator('link[data-data-protection-stylesheet]')).toHaveCount(1);
+  expect(opened).toEqual({ display: 'flex', position: 'fixed' });
+});

--- a/tests/playwright/import-loader-browser-coverage.spec.js
+++ b/tests/playwright/import-loader-browser-coverage.spec.js
@@ -52,6 +52,8 @@ test('import loader browser coverage caches the successful pdf import module', a
       sharedUiLoaderReturnsTheCachedModule: uiModule === first,
       sharedUiLoaderLoadsTheStylesheet:
         document.querySelectorAll('link[data-import-stylesheet]').length === 1,
+      sharedUiLoaderLoadsDataProtectionPresentation:
+        document.querySelectorAll('link[data-data-protection-stylesheet]').length === 1,
       pdfImportModuleEvaluatesOnce: globalThis.__pdfImportSuccessEvalCount === 1,
       exportedPdfImportFunctionsRemainAvailable:
         first.marker === 'success-stub'

--- a/tests/playwright/pii-browser-coverage.spec.js
+++ b/tests/playwright/pii-browser-coverage.spec.js
@@ -329,7 +329,7 @@ test('PII browser coverage exercises config probes regex obfuscation and diff he
       check('PII diff long-line fallback highlights whole changed lines',
         longDiff.leftHtml.includes('pii-word-removed') && longDiff.rightHtml.includes('pii-word-added'));
 
-      pii.showPIIDiffViewer('Name: Alice', 'Name: Jana');
+      await pii.showPIIDiffViewer('Name: Alice', 'Name: Jana');
       await wait(25);
       const viewer = document.querySelector('.pii-warning-overlay');
       check('showPIIDiffViewer opens modal and locks body scroll',

--- a/tests/playwright/settings-loader-browser-coverage.spec.js
+++ b/tests/playwright/settings-loader-browser-coverage.spec.js
@@ -233,15 +233,17 @@ test('returning-user startup defers Settings until a shell action opens it', asy
   expect(settingsRequests).toBe(0);
   expect(settingsStylesheetRequests).toBe(0);
   await expect(page.locator('link[data-settings-stylesheet]')).toHaveCount(0);
+  await expect(page.locator('link[data-data-protection-stylesheet]')).toHaveCount(0);
   await expect.poll(() => page.evaluate(() => (
     document.documentElement.style.getPropertyValue('--accent')
   ))).toBe('#4f8cff');
-  await page.locator('[data-shell-action="open-settings"]').click();
+  await page.locator('[data-shell-action="open-settings"]').evaluate(button => button.click());
   await expect(page.locator('#settings-modal-overlay')).toHaveClass(/show/);
   await expect(page.locator('[data-settings-tab="display"]')).toHaveAttribute('aria-selected', 'true');
   expect(settingsRequests).toBe(1);
   expect(settingsStylesheetRequests).toBe(1);
   await expect(page.locator('link[data-settings-stylesheet]')).toHaveCount(1);
+  await expect(page.locator('link[data-data-protection-stylesheet]')).toHaveCount(1);
   await expect(page.locator('#settings-modal .settings-layout')).toHaveCSS('display', 'grid');
   await expect.poll(() => page.evaluate(async () => (
     (await import('/js/settings-loader.js')).isSettingsModuleLoaded()

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -221,15 +221,30 @@ assert('genetics CSS lazy-load anchor preserves the original cascade position',
   indexSrc.indexOf('href="css/context-profile.css"') <
     indexSrc.indexOf('data-genetics-stylesheet-anchor') &&
   indexSrc.indexOf('data-genetics-stylesheet-anchor') <
-    indexSrc.indexOf('href="css/data-protection.css"'));
+    indexSrc.indexOf('data-data-protection-stylesheet-anchor'));
 assert('SW APP_SHELL includes genetics CSS bundle', swAuditSrc.includes("'/css/genetics.css'"));
-assert('index loads data protection CSS bundle', indexSrc.includes('href="css/data-protection.css"'));
+const dataProtectionLifecycleAuditSrc = read('js/modal-lifecycle.js');
+const settingsLoaderAuditSrc = read('js/settings-loader.js');
+const cryptoAuditSrc = read('js/crypto.js');
+const piiAuditSrc = read('js/pii.js');
+assert('index defers data protection CSS behind its ordered lazy-load anchor',
+  !indexSrc.includes('href="css/data-protection.css"') &&
+  indexSrc.includes('data-data-protection-stylesheet-anchor') &&
+  dataProtectionLifecycleAuditSrc.includes("new URL('../css/data-protection.css', import.meta.url)") &&
+  dataProtectionLifecycleAuditSrc.includes('data-data-protection-stylesheet-anchor'));
+assert('data protection presentation joins every owning first-open boundary',
+  importLoaderAuditSrc.includes('loadDataProtectionStylesheet()') &&
+  settingsLoaderAuditSrc.includes('loadDataProtectionStylesheet()') &&
+  cryptoAuditSrc.includes('runWithDataProtectionStylesheet') &&
+  piiAuditSrc.includes('loadDataProtectionStylesheetForAction'));
 assert('SW APP_SHELL includes data protection CSS bundle', swAuditSrc.includes("'/css/data-protection.css'"));
 assert('index defers settings CSS behind its ordered lazy-load anchor',
   !indexSrc.includes('href="css/settings.css"') &&
   indexSrc.includes('data-settings-stylesheet-anchor'));
-assert('settings CSS lazy-load anchor preserves the original cascade position',
-  indexSrc.indexOf('href="css/data-protection.css"') <
+assert('data protection and settings lazy-load anchors preserve cascade order',
+  indexSrc.indexOf('data-genetics-stylesheet-anchor') <
+    indexSrc.indexOf('data-data-protection-stylesheet-anchor') &&
+  indexSrc.indexOf('data-data-protection-stylesheet-anchor') <
     indexSrc.indexOf('data-settings-stylesheet-anchor') &&
   indexSrc.indexOf('data-settings-stylesheet-anchor') <
     indexSrc.indexOf('href="css/mobile-dashboard.css"'));

--- a/tests/test-mobile.js
+++ b/tests/test-mobile.js
@@ -35,7 +35,8 @@ return (async function() {
   // startup resources.
   const css = `${getCSS()}
 ${await fetchWithRetry('css/settings.css')}
-${await fetchWithRetry('css/category-views.css')}`;
+${await fetchWithRetry('css/category-views.css')}
+${await fetchWithRetry('css/data-protection.css')}`;
 
   // ═══ Section 1: Header mobile layout ═══
   console.log('%c[1] Header Mobile Layout', 'font-weight:bold');

--- a/tests/test-modal-lifecycle-integrations.js
+++ b/tests/test-modal-lifecycle-integrations.js
@@ -379,7 +379,10 @@ assert('PDF import dialogs and review modal use shared overlay lifecycle helpers
     !pdfImportSrc.includes("document.getElementById('ai-needed-or').focus()"));
 
 assert('PII diff and review overlays use shared overlay lifecycle helpers',
-  piiSrc.includes("import { openModalOverlay, removeModalOverlay, trapModalFocus } from './modal-lifecycle.js';") &&
+  piiSrc.includes("from './modal-lifecycle.js';") &&
+    piiSrc.includes('openModalOverlay,') &&
+    piiSrc.includes('removeModalOverlay,') &&
+    piiSrc.includes('trapModalFocus,') &&
     piiSrc.includes('function openPIIOverlay(overlay, options = {})') &&
     piiSrc.includes('requestAnimationFrame(() => {') &&
     piiSrc.includes('if (!overlay.isConnected) return;') &&

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.367';
+self.APP_VERSION = '1.10.368';


### PR DESCRIPTION
## Summary

- replace the eager data-protection stylesheet with an ordered lazy-load anchor
- single-flight the stylesheet across Settings, Import, privacy review, encryption, and backup entry points
- contain load failures, clean up failed links, and retry with a fresh URL
- add browser coverage for cascade order, concurrency, failure/retry, encrypted startup resilience, and a real encryption action

## Cold-load impact

Identical before/after mobile returning-user measurements with browser cache and service workers disabled:

| | Requests | Transfer bytes | Decoded bytes |
| --- | ---: | ---: | ---: |
| Before | 425 | 1,811,205 | 5,429,764 |
| After | 424 | 1,809,362 | 5,422,477 |
| Savings | **1** | **1,843** | **7,287** |

## Verification

- full coverage-gated suite: 131 verification, 488 Vitest/Node, 430 Chromium, and 472 responsive tests passed; combined coverage 67.22%
- Firefox smoke: 3 passed
- final focused Chromium matrix: 21 passed
- final stylesheet loader browser coverage: 3 passed, including failure containment
- TypeScript and check-JS typechecks passed
- quality guardrails passed (11/11)
- architecture checks passed (465 modules, 0 cycles)
- cold-load measurement passed twice with identical results
- diff whitespace check passed
