### PR TITLE
Recommend Claude Opus 5

### DIFF
--- a/js/api-models.js
+++ b/js/api-models.js
@@ -41,7 +41,8 @@ export function deduplicateModels(models, familyFn) {
 
 // Curated: latest-gen medically capable models only (prefixes matched against IDs)
 const OPENROUTER_CURATED = [
-  'anthropic/claude-sonnet-5', 'anthropic/claude-sonnet-4', 'anthropic/claude-opus-4',
+  'anthropic/claude-sonnet-5', 'anthropic/claude-sonnet-4',
+  'anthropic/claude-opus-5', 'anthropic/claude-opus-4',
   'openai/gpt-5',
   'google/gemini-3', 'google/gemini-2',
   'deepseek/deepseek',
@@ -58,7 +59,7 @@ const OPENROUTER_CURATED = [
 // Venice: "model-version" (hyphens: 4-6, no provider prefix)
 const OPENROUTER_RECOMMENDED = [
   'anthropic/claude-sonnet-5', 'anthropic/claude-sonnet-4.6',
-  'anthropic/claude-opus-4.8', 'anthropic/claude-opus-4.7',
+  'anthropic/claude-opus-5', 'anthropic/claude-opus-4.7',
   'openai/gpt-5.6-sol', 'openai/gpt-5.4',
   'google/gemini-3.5-flash', 'google/gemini-3-flash-preview',
   'z-ai/glm-5.2',
@@ -68,11 +69,11 @@ const OPENROUTER_RECOMMENDED = [
 const OPENROUTER_DEFAULT_CANDIDATES = ['openai/gpt-5.6-sol', 'anthropic/claude-sonnet-5', 'anthropic/claude-sonnet-4.6'];
 
 // Routstr uses bare model IDs (no provider prefix, dots: claude-sonnet-4.6)
-const ROUTSTR_RECOMMENDED = ['claude-sonnet-5', 'claude-sonnet-4.6', 'claude-opus-4.8', 'claude-opus-4.7', 'gpt-5.5', 'gpt-5.4', 'gemini-3.5-flash', 'gemini-3-flash-preview', 'glm-5.2', 'z-ai/glm-5.2', 'kimi-k3', 'moonshotai/kimi-k3', 'x-ai/grok-4.3', 'grok-4.3', 'grok-4'];
+const ROUTSTR_RECOMMENDED = ['claude-sonnet-5', 'claude-sonnet-4.6', 'claude-opus-5', 'claude-opus-4.7', 'gpt-5.5', 'gpt-5.4', 'gemini-3.5-flash', 'gemini-3-flash-preview', 'glm-5.2', 'z-ai/glm-5.2', 'kimi-k3', 'moonshotai/kimi-k3', 'x-ai/grok-4.3', 'grok-4.3', 'grok-4'];
 const ROUTSTR_PRIVATE_RECOMMENDED = ['tinfoil-gemma4-31b', 'tinfoil-kimi-k2-6', 'tinfoil-deepseek-v4-pro', 'tinfoil-glm-5-2'];
 
 // PPQ uses bare model IDs for regular routing and private/ IDs for Tinfoil TEE models.
-const PPQ_RECOMMENDED = ['claude-sonnet-5', 'claude-sonnet-4.6', 'claude-opus-4.8', 'claude-opus-4.7', 'gpt-5.5', 'gpt-5.4', 'gemini-3.5-flash', 'gemini-3-flash-preview', 'z-ai/glm-5.2', 'glm-5.2', 'moonshotai/kimi-k3', 'kimi-k3', 'x-ai/grok-4.3', 'grok-4'];
+const PPQ_RECOMMENDED = ['claude-sonnet-5', 'claude-sonnet-4.6', 'claude-opus-5', 'claude-opus-4.7', 'gpt-5.5', 'gpt-5.4', 'gemini-3.5-flash', 'gemini-3-flash-preview', 'z-ai/glm-5.2', 'glm-5.2', 'moonshotai/kimi-k3', 'kimi-k3', 'x-ai/grok-4.3', 'grok-4'];
 const PPQ_PRIVATE_RECOMMENDED = ['private/kimi-k2-6', 'private/glm-5-2', 'private/gpt-oss-120b'];
 
 function normalizedModelId(modelId) {
@@ -85,7 +86,7 @@ function isClaudeSonnet5Model(modelId) {
 
 function isCustomRecommendedModel(modelId) {
   if (isClaudeSonnet5Model(modelId)) return true;
-  return /(^|[/-])claude-(sonnet-4-6|opus-4-8|opus-4-7)($|[-:])/.test(normalizedModelId(modelId))
+  return /(^|[/-])claude-(sonnet-4-6|opus-5|opus-4-7)($|[-:])/.test(normalizedModelId(modelId))
     || /(^|[/-])gpt-5-[45]($|[-:])/.test(normalizedModelId(modelId))
     || /(^|[/-])gemini-3-(5-flash|flash-preview)($|[-:])/.test(normalizedModelId(modelId))
     || /(^|[/-])glm-5-2($|[-:])/.test(normalizedModelId(modelId))
@@ -125,9 +126,9 @@ export function isRecommendedModel(provider, modelId) {
   if (provider === 'openrouter') return OPENROUTER_RECOMMENDED.some(function(prefix) { return modelStartsWithRecommended(modelId, prefix); });
   if (provider === 'venice') {
     if (modelId.startsWith('e2ee-')) return /qwen3-5-122b|gpt-oss-120b|qwen3-30b|glm-5/.test(modelId);
-    // claude-(sonnet-5|sonnet-4-6|opus-4-8|opus-4-7) is intentionally narrow. When newer
+    // claude-(sonnet-5|sonnet-4-6|opus-5|opus-4-7) is intentionally narrow. When newer
     // versions land, broaden the alternation rather than matching all 4.x.
-    return /^(claude-(sonnet-5|sonnet-4-6|opus-4-8|opus-4-7)|openai-gpt-5[2345](-codex)?|gemini-3-(5-flash|flash-preview)|zai-org-glm-5-2|z-ai-glm-5-2|glm-5-2|kimi-k3|grok-4[1-9]?)(-|$)/.test(modelId);
+    return /^(claude-(sonnet-5|sonnet-4-6|opus-5|opus-4-7)|openai-gpt-5[2345](-codex)?|gemini-3-(5-flash|flash-preview)|zai-org-glm-5-2|z-ai-glm-5-2|glm-5-2|kimi-k3|grok-4[1-9]?)(-|$)/.test(modelId);
   }
   if (provider === 'routstr') {
     if (modelId.startsWith('tinfoil-')) return ROUTSTR_PRIVATE_RECOMMENDED.includes(modelId);

--- a/tests/api-provider-runtime.test.js
+++ b/tests/api-provider-runtime.test.js
@@ -465,6 +465,8 @@ describe('API provider runtime behavior', () => {
 
     expect(isRecommendedModel('openrouter', 'anthropic/claude-sonnet-5')).toBe(true);
     expect(isRecommendedModel('openrouter', 'anthropic/claude-sonnet-4.6')).toBe(true);
+    expect(isRecommendedModel('openrouter', 'anthropic/claude-opus-5')).toBe(true);
+    expect(isRecommendedModel('openrouter', 'anthropic/claude-opus-4.8')).toBe(false);
     expect(isRecommendedModel('openrouter', 'openai/gpt-5.6-sol')).toBe(true);
     expect(isRecommendedModel('openrouter', 'openai/gpt-5.5')).toBe(false);
     expect(isRecommendedModel('openrouter', 'google/gemini-3.5-flash')).toBe(true);
@@ -474,6 +476,8 @@ describe('API provider runtime behavior', () => {
     expect(isRecommendedModel('openrouter', 'moonshotai/kimi-k3')).toBe(true);
     expect(isRecommendedModel('openrouter', 'google/gemini-3.1-pro')).toBe(false);
     expect(isRecommendedModel('venice', 'claude-sonnet-5')).toBe(true);
+    expect(isRecommendedModel('venice', 'claude-opus-5')).toBe(true);
+    expect(isRecommendedModel('venice', 'claude-opus-4-8')).toBe(false);
     expect(isRecommendedModel('venice', 'gemini-3-5-flash')).toBe(true);
     expect(isRecommendedModel('venice', 'zai-org-glm-5-2')).toBe(true);
     expect(isRecommendedModel('venice', 'kimi-k2-7-code')).toBe(false);
@@ -482,11 +486,15 @@ describe('API provider runtime behavior', () => {
     expect(isRecommendedModel('venice', 'e2ee-qwen3-5-122b')).toBe(true);
     expect(isRecommendedModel('routstr', 'claude-sonnet-5')).toBe(true);
     expect(isRecommendedModel('routstr', 'claude-sonnet-4.6')).toBe(true);
+    expect(isRecommendedModel('routstr', 'claude-opus-5')).toBe(true);
+    expect(isRecommendedModel('routstr', 'claude-opus-4.8')).toBe(false);
     expect(isRecommendedModel('routstr', 'x-ai/grok-4.3')).toBe(true);
     expect(isRecommendedModel('routstr', 'moonshotai/kimi-k3')).toBe(true);
     expect(isRecommendedModel('routstr', 'moonshotai/kimi-k2.7-code')).toBe(false);
     expect(isRecommendedModel('routstr', 'moonshotai/kimi-k2.6')).toBe(false);
     expect(isRecommendedModel('ppq', 'claude-sonnet-5')).toBe(true);
+    expect(isRecommendedModel('ppq', 'claude-opus-5')).toBe(true);
+    expect(isRecommendedModel('ppq', 'claude-opus-4.8')).toBe(false);
     expect(isRecommendedModel('ppq', 'x-ai/grok-4.3')).toBe(true);
     expect(isRecommendedModel('ppq', 'google/gemini-3.5-flash')).toBe(true);
     expect(isRecommendedModel('ppq', 'z-ai/glm-5.2')).toBe(true);
@@ -495,6 +503,8 @@ describe('API provider runtime behavior', () => {
     expect(isRecommendedModel('ppq', 'moonshotai/kimi-k3')).toBe(true);
     expect(isRecommendedModel('ppq', 'gemini-3-flash-preview')).toBe(true);
     expect(isRecommendedModel('custom', 'claude-sonnet-5')).toBe(true);
+    expect(isRecommendedModel('custom', 'anthropic/claude-opus-5')).toBe(true);
+    expect(isRecommendedModel('custom', 'anthropic/claude-opus-4.8')).toBe(false);
     expect(isRecommendedModel('custom', 'gemini-3.5-flash')).toBe(true);
     expect(isRecommendedModel('custom', 'z-ai/glm-5.2')).toBe(true);
     expect(isRecommendedModel('custom', 'moonshotai/kimi-k2.7-code')).toBe(false);

--- a/tests/test-openrouter.js
+++ b/tests/test-openrouter.js
@@ -81,6 +81,7 @@ assert('getModelPricing checks openrouter-pricing cache', schemaSrc.includes('la
 assert('OPENROUTER_CURATED whitelist exists', apiModelsSrc.includes('OPENROUTER_CURATED'));
 assert('Curated: anthropic/claude-sonnet-5 prefix', apiModelsSrc.includes("'anthropic/claude-sonnet-5'"));
 assert('Curated: anthropic/claude-sonnet prefix', apiModelsSrc.includes("'anthropic/claude-sonnet-4'"));
+assert('Curated: anthropic/claude-opus-5 prefix', apiModelsSrc.includes("'anthropic/claude-opus-5'"));
 assert('Curated: anthropic/claude-opus prefix', apiModelsSrc.includes("'anthropic/claude-opus-4'"));
 assert('Curated: openai/gpt prefix', apiModelsSrc.includes("'openai/gpt-5'"));
 assert('Curated: google/gemini-3 prefix', apiModelsSrc.includes("'google/gemini-3'"));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.372';
+self.APP_VERSION = '1.10.373';


### PR DESCRIPTION
## Summary
- replace Claude Opus 4.8 with Claude Opus 5 in the recommended model groups for OpenRouter, Venice, Routstr, PPQ, and compatible custom catalogs
- add the Opus 5 OpenRouter curation prefix so the new model reaches the recommendation sorter
- keep Opus 4.8 available as a normal selectable model while explicitly testing that it is no longer recommended
- bump the app version to 1.10.373

## Why
Claude Opus 5 launched on July 24, 2026. Live model-catalog checks confirmed the production IDs used by every curated cloud path:
- OpenRouter: `anthropic/claude-opus-5`
- Venice: `claude-opus-5`
- PPQ: `claude-opus-5`
- Routstr: `claude-opus-5` on six of eleven currently reachable advertised nodes

Routstr remains node-dependent, but the provider path now promotes Opus 5 whenever a selected node exposes it.

## Impact
Provider model pickers place Opus 5 in the recommended group and move Opus 4.8 back to the regular catalog. Existing Opus 4.8 selections remain valid.

## Validation
- `npm test` — 488 passed
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality` — 11/11 checks
- `node tests/test-openrouter.js` — 163 passed
- `npx playwright test tests/playwright/provider-coverage-batch.spec.js --workers=1` — 4 passed
- `git diff --check`