### PR TITLE
Load Light camera tools on demand

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -11,7 +11,7 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | --- | ---: |
 | Modules | 468 |
 | Internal import edges | 2097 |
-| Dynamic internal edges | 64 |
+| Dynamic internal edges | 65 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
 | Largest cyclic component | 0 |
@@ -479,7 +479,7 @@ Native browser modules shipped with the static application.
 - [`js/light-tool-camera.js`](js/light-tool-camera.js) → [`js/utils.js`](js/utils.js)
 - [`js/light-tools-ai-analysis.js`](js/light-tools-ai-analysis.js) → [`js/ai-action-delegates.js`](js/ai-action-delegates.js), [`js/ai-verdict-engine.js`](js/ai-verdict-engine.js), [`js/api.js`](js/api.js), [`js/health-goals-utils.js`](js/health-goals-utils.js), [`js/lighting-hardware-caveats.js`](js/lighting-hardware-caveats.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/light-tools-ui-hooks.js`](js/light-tools-ui-hooks.js) → [`js/light-tools.js`](js/light-tools.js), [`js/views.js`](js/views.js)
-- [`js/light-tools.js`](js/light-tools.js) → [`js/data-merge.js`](js/data-merge.js), [`js/data.js`](js/data.js), [`js/light-tool-camera-modals.js`](js/light-tool-camera-modals.js), [`js/light-tool-camera.js`](js/light-tool-camera.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
+- [`js/light-tools.js`](js/light-tools.js) → [`js/data-merge.js`](js/data-merge.js), [`js/data.js`](js/data.js), [`js/light-tool-camera-modals.js`](js/light-tool-camera-modals.js) *(dynamic)*, [`js/light-tool-camera.js`](js/light-tool-camera.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 
 </details>
 

--- a/js/light-tools.js
+++ b/js/light-tools.js
@@ -1,21 +1,9 @@
 // @ts-check
 // light-tools.js — In-browser measurement tools for the Light lens.
-//
 // All tools run fully on-device. Camera frames are processed in-browser
-// and never leave the user's device. Eight tools ship:
-//
-//   Tool 1: Lux Meter             — AmbientLightSensor (Chrome Android) or
-//                                    camera fallback with one-shot calibration.
-//   Tool 2: Flicker Detector      — getUserMedia at the highest-available
-//                                    frame rate, FFT on intensity to find PWM.
-//   Tool 3: CCT Meter             — color temperature with solar-coherence check.
-//   Tool 4: Spectrum Classifier   — LED / fluorescent / incandescent / daylight.
-//   Tool 5: Glass Transmission    — two-step bare/through-glass camera capture.
-//   Tool 6: Sleep Darkness Meter  — long-exposure pillow-level reading.
-//   Tool 7: Sunrise/Sunset Logger — solar-geometry session entry.
-//   Tool 8: Eye-Level Audit       — 4 fps walkthrough with pause-detection
-//                                    that auto-snapshots a reading per room.
-//
+// and never leave the user's device. Camera tools cover lux, flicker, CCT,
+// spectrum, glass transmission, and sleep darkness; the remaining tools log
+// sunrise/sunset sessions and run a room-by-room eye-level walkthrough.
 // Measurements persist via importedData.lightMeasurements[]. Each entry
 // stores tool, timestamp, value, confidence, optional location label.
 
@@ -24,20 +12,11 @@ import { escapeHTML, escapeAttr, queryRequired, showNotification } from './utils
 import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
 import { saveImportedData } from './data.js';
 import { deleteImportedArrayItem } from './data-merge.js';
-import {
-  aimingGuideHTML,
-  lockCameraForMeasurement,
-  loadLuxCalibration,
-} from './light-tool-camera.js';
-import {
-  openLuxMeter as openLuxMeterModal,
-  openFlickerDetector as openFlickerDetectorModal,
-  openDarknessMeter as openDarknessMeterModal,
-  openCCTMeter as openCCTMeterModal,
-  openSpectrumClassifier as openSpectrumClassifierModal,
-  openGlassTransmission as openGlassTransmissionModal,
-} from './light-tool-camera-modals.js';
-export { closeLuxMeter, closeFlickerDetector, closeDarknessMeter, closeCCTMeter, closeSpectrumClassifier, closeGlassTransmission } from './light-tool-camera-modals.js';
+import { aimingGuideHTML, lockCameraForMeasurement, loadLuxCalibration } from './light-tool-camera.js';
+/** @typedef {typeof import('./light-tool-camera-modals.js')} LightToolCameraModals */
+/** @type {Promise<LightToolCameraModals> | null} */ let lightToolCameraModalsPromise = null;
+/** @type {LightToolCameraModals | null} */ let lightToolCameraModals = null;
+let useLightToolCameraModalsRetryUrl = false;
 
 const LIGHT_TOOLS_ACTION_ATTR = 'data-light-tools-action';
 const LIGHT_TOOL_ID_ATTR = 'data-light-tool-id';
@@ -306,13 +285,53 @@ export async function deleteMeasurement(id) {
 }
 
 // ─── Camera-backed tool modal facade ──────────────────────────────────
-
-export async function openLuxMeter(opts = {}) { return openLuxMeterModal(opts, { saveMeasurement }); }
-export async function openFlickerDetector(opts = {}) { return openFlickerDetectorModal(opts, { saveMeasurement }); }
-export async function openDarknessMeter(opts = {}) { return openDarknessMeterModal(opts, { saveMeasurement }); }
-export async function openCCTMeter(opts = {}) { return openCCTMeterModal(opts, { saveMeasurement }); }
-export async function openSpectrumClassifier(opts = {}) { return openSpectrumClassifierModal(opts, { saveMeasurement }); }
-export async function openGlassTransmission(opts = {}) { return openGlassTransmissionModal(opts, { saveMeasurement }); }
+export function isLightToolCameraModalsLoaded() { return lightToolCameraModals !== null; }
+/** @returns {Promise<LightToolCameraModals>} */
+function loadLightToolCameraModalsRetryModule() {
+  // @ts-expect-error TypeScript resolves only the query-free source path.
+  return import('./light-tool-camera-modals.js?lazy-retry=1');
+}
+/** @returns {Promise<LightToolCameraModals>} */
+export function loadLightToolCameraModals() {
+  if (lightToolCameraModalsPromise) return lightToolCameraModalsPromise;
+  // Failed module-map fetches are cached; retry once with a second fixed URL.
+  const load = useLightToolCameraModalsRetryUrl
+    ? loadLightToolCameraModalsRetryModule()
+    : import('./light-tool-camera-modals.js');
+  lightToolCameraModalsPromise = load.then(module => (lightToolCameraModals = module)).catch(err => {
+    lightToolCameraModalsPromise = null; lightToolCameraModals = null;
+    useLightToolCameraModalsRetryUrl = true; throw err;
+  });
+  return lightToolCameraModalsPromise;
+}
+/** @param {keyof LightToolCameraModals} name @param {any[]} args @param {boolean} [shouldLoad] */
+function runLightToolCameraAction(name, args, shouldLoad = true) {
+  const run = (/** @type {LightToolCameraModals} */ module) => {
+    const action = module[name];
+    if (typeof action !== 'function') throw new Error(`Light tool camera action ${String(name)} is unavailable`);
+    return Reflect.apply(action, module, args);
+  };
+  if (!lightToolCameraModals && !shouldLoad) return undefined;
+  try {
+    if (lightToolCameraModals) return run(lightToolCameraModals);
+    return loadLightToolCameraModals().then(run).catch(err => {
+      console.error(`[light-tools] Could not run ${String(name)}:`, err);
+      showNotification('Camera tool could not be loaded. Try again.', 'error');
+      return false;
+    });
+  } catch (err) {
+    console.error(`[light-tools] Could not ${shouldLoad ? 'run' : 'clean up'} ${String(name)}:`, err);
+    if (shouldLoad) showNotification('Camera tool could not be loaded. Try again.', 'error');
+    return shouldLoad ? false : undefined;
+  }
+}
+/** @param {keyof LightToolCameraModals} name */
+const openCameraTool = name => async (opts = {}) => runLightToolCameraAction(name, [opts, { saveMeasurement }]);
+/** @param {keyof LightToolCameraModals} name */
+const closeCameraToolIfLoaded = name => () => runLightToolCameraAction(name, [], false);
+export const openLuxMeter = openCameraTool('openLuxMeter'), openFlickerDetector = openCameraTool('openFlickerDetector'), openDarknessMeter = openCameraTool('openDarknessMeter'), openCCTMeter = openCameraTool('openCCTMeter'), openSpectrumClassifier = openCameraTool('openSpectrumClassifier'), openGlassTransmission = openCameraTool('openGlassTransmission');
+// Escape/teardown cleanup must not fetch an implementation that was never used.
+export const closeLuxMeter = closeCameraToolIfLoaded('closeLuxMeter'), closeFlickerDetector = closeCameraToolIfLoaded('closeFlickerDetector'), closeDarknessMeter = closeCameraToolIfLoaded('closeDarknessMeter'), closeCCTMeter = closeCameraToolIfLoaded('closeCCTMeter'), closeSpectrumClassifier = closeCameraToolIfLoaded('closeSpectrumClassifier'), closeGlassTransmission = closeCameraToolIfLoaded('closeGlassTransmission');
 
 // ─── Tool 7: Sunrise / Sunset Logger ──────────────────────────────────
 

--- a/plans/code-quality-audit-2026-07-21.md
+++ b/plans/code-quality-audit-2026-07-21.md
@@ -145,6 +145,11 @@ and manual-form helpers behind the first Wearables action then reduced the
 reference from that same 423-request baseline to 416 requests, 1,731,010
 compressed bytes, and 5,117,921 decoded bytes. The result reproduced exactly,
 saving seven requests, 40,483 compressed bytes, and 136,911 decoded bytes.
+Loading the six camera-backed Light tool modals only after a user opens one of
+them then reduced the reference to 415 requests, 1,716,755 compressed bytes,
+and 5,059,297 decoded bytes. The result again reproduced exactly, saving one
+request, 14,255 compressed bytes, and 58,624 decoded bytes while preserving
+the synchronous close behavior once the implementation is resident.
 Route and feature lazy loading remains active, with the ceilings ratcheting
 downward after each reproducible slice.
 

--- a/scripts/cold-load-budget.json
+++ b/scripts/cold-load-budget.json
@@ -3,15 +3,15 @@
   "route": "/app",
   "scenario": "Fresh mobile returning-user load with browser cache and service workers disabled",
   "maximums": {
-    "requests": 422,
-    "transferBytes": 1763000,
-    "decodedBytes": 5208000
+    "requests": 421,
+    "transferBytes": 1749000,
+    "decodedBytes": 5149000
   },
   "reference": {
-    "requests": 416,
-    "transferBytes": 1731010,
-    "decodedBytes": 5117921
+    "requests": 415,
+    "transferBytes": 1716755,
+    "decodedBytes": 5059297
   },
-  "referenceCommit": "f5781e6d",
+  "referenceCommit": "3aa8df4a",
   "measuredAt": "2026-07-25"
 }

--- a/tests/playwright/cold-load-budget.spec.js
+++ b/tests/playwright/cold-load-budget.spec.js
@@ -92,6 +92,9 @@ test('cold mobile app load stays within committed resource budgets', async ({ pa
     new URL(entry.name).pathname === '/js/wearables.js'
   ))).toBe(false);
   expect(entries.some(entry => (
+    new URL(entry.name).pathname === '/js/light-tool-camera-modals.js'
+  ))).toBe(false);
+  expect(entries.some(entry => (
     new URL(entry.name).pathname === '/css/marker-detail-modal.css'
   ))).toBe(false);
   expect(entries.some(entry => (

--- a/tests/playwright/light-tool-camera-loader-browser-coverage.spec.js
+++ b/tests/playwright/light-tool-camera-loader-browser-coverage.spec.js
@@ -1,0 +1,120 @@
+import { expect, test } from '@playwright/test';
+
+const lightToolsUrl = () => `/js/light-tools.js?cameraLoaderCoverage=${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+const syntheticCameraModals = `
+  const record = (name, args) => {
+    window.__lightToolCameraLoaderCalls ||= [];
+    window.__lightToolCameraLoaderCalls.push([name, ...args]);
+    return name;
+  };
+  export async function openLuxMeter(...args) { return record('openLuxMeter', args); }
+  export async function openFlickerDetector(...args) { return record('openFlickerDetector', args); }
+  export async function openDarknessMeter(...args) { return record('openDarknessMeter', args); }
+  export async function openCCTMeter(...args) { return record('openCCTMeter', args); }
+  export async function openSpectrumClassifier(...args) { return record('openSpectrumClassifier', args); }
+  export async function openGlassTransmission(...args) { return record('openGlassTransmission', args); }
+  export function closeLuxMeter() { return record('closeLuxMeter', []); }
+  export function closeFlickerDetector() { return record('closeFlickerDetector', []); }
+  export function closeDarknessMeter() { return record('closeDarknessMeter', []); }
+  export function closeCCTMeter() { return record('closeCCTMeter', []); }
+  export function closeSpectrumClassifier() { return record('closeSpectrumClassifier', []); }
+  export function closeGlassTransmission() { return record('closeGlassTransmission', []); }
+`;
+
+test.beforeEach(async ({ page }) => {
+  await page.route('**/light-tool-camera-loader-coverage', route => route.fulfill({
+    contentType: 'text/html',
+    body: '<!doctype html><html><body><div id="notification-container"></div></body></html>',
+  }));
+  await page.goto('/light-tool-camera-loader-coverage');
+});
+
+test('camera modal loader stays cold, shares its first load, and delegates cleanup only after load', async ({ page }) => {
+  const implementationRequests = [];
+  await page.route('**/js/light-tool-camera-modals.js*', async route => {
+    implementationRequests.push(route.request().url());
+    await new Promise(resolve => setTimeout(resolve, 25));
+    await route.fulfill({
+      contentType: 'text/javascript',
+      body: syntheticCameraModals,
+    });
+  });
+
+  const outcomes = await page.evaluate(async url => {
+    const lightTools = await import(url);
+    const cold = !lightTools.isLightToolCameraModalsLoaded();
+    lightTools.closeLuxMeter();
+    const first = lightTools.loadLightToolCameraModals();
+    const second = lightTools.loadLightToolCameraModals();
+    const sharedPromise = first === second;
+    await Promise.all([first, second]);
+    const opened = await lightTools.openLuxMeter({ roomId: 'room-1' });
+    lightTools.closeLuxMeter();
+    return {
+      cold,
+      sharedPromise,
+      loaded: lightTools.isLightToolCameraModalsLoaded(),
+      opened,
+      calls: window.__lightToolCameraLoaderCalls || [],
+    };
+  }, lightToolsUrl());
+
+  expect(implementationRequests).toHaveLength(1);
+  expect(outcomes).toMatchObject({
+    cold: true,
+    sharedPromise: true,
+    loaded: true,
+    opened: 'openLuxMeter',
+  });
+  expect(outcomes.calls.map(call => call[0])).toEqual(['openLuxMeter', 'closeLuxMeter']);
+});
+
+test('camera modal action contains a failed load and retries with the fixed URL', async ({ page }) => {
+  const implementationRequests = [];
+  await page.route('**/js/light-tool-camera-modals.js*', async route => {
+    const url = route.request().url();
+    implementationRequests.push(url);
+    if (!url.includes('lazy-retry=1')) {
+      await route.fulfill({
+        status: 503,
+        contentType: 'text/javascript',
+        body: 'export {};',
+      });
+      return;
+    }
+    await route.fulfill({
+      contentType: 'text/javascript',
+      body: syntheticCameraModals,
+    });
+  });
+
+  const outcomes = await page.evaluate(async url => {
+    const lightTools = await import(url);
+    lightTools.closeFlickerDetector();
+    const first = await lightTools.openFlickerDetector({ roomId: 'failed-first' });
+    const unloadedAfterFailure = !lightTools.isLightToolCameraModalsLoaded();
+    const second = await lightTools.openFlickerDetector({ roomId: 'retry' });
+    lightTools.closeFlickerDetector();
+    return {
+      first,
+      unloadedAfterFailure,
+      second,
+      loadedAfterRetry: lightTools.isLightToolCameraModalsLoaded(),
+      calls: window.__lightToolCameraLoaderCalls || [],
+      notification: document.body.textContent,
+    };
+  }, lightToolsUrl());
+
+  expect(implementationRequests).toHaveLength(2);
+  expect(new URL(implementationRequests[0]).search).toBe('');
+  expect(new URL(implementationRequests[1]).searchParams.get('lazy-retry')).toBe('1');
+  expect(outcomes).toMatchObject({
+    first: false,
+    unloadedAfterFailure: true,
+    second: 'openFlickerDetector',
+    loadedAfterRetry: true,
+  });
+  expect(outcomes.calls.map(call => call[0])).toEqual(['openFlickerDetector', 'closeFlickerDetector']);
+  expect(outcomes.notification).toContain('Camera tool could not be loaded. Try again.');
+});

--- a/tests/test-light-tools.js
+++ b/tests/test-light-tools.js
@@ -233,9 +233,11 @@ const tools = await import('../js/light-tools.js');
     // ─── 10. Camera lifecycle regressions ────────────────────────────────
     console.log('%c 10. Camera lifecycle source guards ', 'font-weight:bold;color:#f59e0b');
 
-    assert('light-tools.js delegates camera-backed tools to extracted module',
-      lightToolsSrc.includes("from './light-tool-camera-modals.js'") &&
-      lightToolsSrc.includes('return openLuxMeterModal(opts, { saveMeasurement });'));
+    assert('light-tools.js lazy-loads camera-backed tools through its facade',
+      !lightToolsSrc.includes("from './light-tool-camera-modals.js'") &&
+      lightToolsSrc.includes("import('./light-tool-camera-modals.js')") &&
+      lightToolsSrc.includes("import('./light-tool-camera-modals.js?lazy-retry=1')") &&
+      lightToolsSrc.includes("openLuxMeter = openCameraTool('openLuxMeter')"));
     assert('light-tools AI save hook routes through startup wiring',
       lightToolsSrc.includes('export function configureLightTools') &&
       lightToolsSrc.includes('maybeAnalyzeMeasurementAfterSave: () => {}') &&
@@ -281,7 +283,8 @@ const tools = await import('../js/light-tools.js');
       lightToolCameraModalsSrc.includes('export function closeCCTMeter()') &&
       lightToolCameraModalsSrc.includes('export function closeSpectrumClassifier()') &&
       lightToolCameraModalsSrc.includes('export function closeGlassTransmission()') &&
-      lightToolsSrc.includes('export { closeLuxMeter, closeFlickerDetector') &&
+      lightToolsSrc.includes("closeLuxMeter = closeCameraToolIfLoaded('closeLuxMeter')") &&
+      lightToolsSrc.includes("closeFlickerDetector = closeCameraToolIfLoaded('closeFlickerDetector')") &&
       lightToolsSrc.includes('export function closeEyeLevelAudit()') &&
       !lightToolCameraModalsSrc.includes('window._close') &&
       !lightToolsSrc.includes('window._close') &&

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.375';
+self.APP_VERSION = '1.10.376';


### PR DESCRIPTION
## Summary
- defer the six camera-backed Light tool modal flows until the first user action
- preserve single-flight loading, a fixed retry URL after failed module fetches, and close cleanup that stays cold
- assert the implementation is absent from cold startup and add focused browser coverage for load, retry, delegation, and cleanup
- ratchet the cold-load budget and bump the app version to 1.10.376

## Measured impact
Clean `main` baseline (reproduced):
- 416 requests
- 1,731,010 transferred bytes
- 5,117,921 decoded bytes

This branch (reproduced identically twice):
- 415 requests
- 1,716,755 transferred bytes
- 5,059,297 decoded bytes

Savings:
- 1 request
- 14,255 transferred bytes
- 58,624 decoded bytes

## Validation
- `npm test` — 490 passed
- `node tests/verify-modules.js` — 133 passed
- `npm run quality`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run architecture:check` — 468 modules, 0 cycles
- focused Chromium loader and Light-tool flows — 3 passed
- `npm run performance:check` — reproduced twice at the exact reference above