### PR TITLE
Load JSON import on demand

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -11,7 +11,7 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | --- | ---: |
 | Modules | 468 |
 | Internal import edges | 2097 |
-| Dynamic internal edges | 65 |
+| Dynamic internal edges | 66 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
 | Largest cyclic component | 0 |
@@ -350,7 +350,7 @@ Native browser modules shipped with the static application.
 - [`js/export-report-html.js`](js/export-report-html.js) → [`js/export-report.js`](js/export-report.js), [`js/marker-analysis.js`](js/marker-analysis.js), [`js/state.js`](js/state.js), [`js/supplement-impact.js`](js/supplement-impact.js), [`js/utils.js`](js/utils.js)
 - [`js/export-report.js`](js/export-report.js) → [`js/api.js`](js/api.js), [`js/cycle.js`](js/cycle.js), [`js/data.js`](js/data.js), [`js/marker-analysis.js`](js/marker-analysis.js), [`js/profile.js`](js/profile.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/supplement-impact.js`](js/supplement-impact.js), [`js/utils.js`](js/utils.js)
 - [`js/export-runtime.js`](js/export-runtime.js) → [`js/cashu-wallet.js`](js/cashu-wallet.js), [`js/crypto.js`](js/crypto.js), [`js/state.js`](js/state.js)
-- [`js/export.js`](js/export.js) → [`js/biology-score-context-ai.js`](js/biology-score-context-ai.js) *(dynamic)*, [`js/context-cards.js`](js/context-cards.js) *(dynamic)*, [`js/crypto.js`](js/crypto.js), [`js/cycle-store.js`](js/cycle-store.js) *(dynamic)*, [`js/data.js`](js/data.js), [`js/export-import.js`](js/export-import.js), [`js/export-report-builder.js`](js/export-report-builder.js), [`js/export-report-html.js`](js/export-report-html.js), [`js/export-report.js`](js/export-report.js), [`js/export-runtime.js`](js/export-runtime.js), [`js/lab-entry-mutations.js`](js/lab-entry-mutations.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/nostr-discovery.js`](js/nostr-discovery.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js), [`js/wearables-store.js`](js/wearables-store.js) *(dynamic)*
+- [`js/export.js`](js/export.js) → [`js/biology-score-context-ai.js`](js/biology-score-context-ai.js) *(dynamic)*, [`js/context-cards.js`](js/context-cards.js) *(dynamic)*, [`js/crypto.js`](js/crypto.js), [`js/cycle-store.js`](js/cycle-store.js) *(dynamic)*, [`js/data.js`](js/data.js), [`js/export-import.js`](js/export-import.js) *(dynamic)*, [`js/export-report-builder.js`](js/export-report-builder.js), [`js/export-report-html.js`](js/export-report-html.js), [`js/export-report.js`](js/export-report.js), [`js/export-runtime.js`](js/export-runtime.js), [`js/lab-entry-mutations.js`](js/lab-entry-mutations.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/nostr-discovery.js`](js/nostr-discovery.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js), [`js/wearables-store.js`](js/wearables-store.js) *(dynamic)*
 
 </details>
 

--- a/js/export.js
+++ b/js/export.js
@@ -8,7 +8,6 @@ import { getProfiles, profileStorageKey, saveProfiles, migrateProfileData } from
 import { encryptedGetItem, getEncryptionEnabled, encryptedRemoveItem } from './crypto.js';
 import { findOrCreateLabEntry } from './lab-entry-mutations.js';
 import { setLabEntryMarker } from './lab-entry.js';
-import { importDataJSON } from './export-import.js';
 import { getSelectedNodeUrl } from './nostr-discovery.js';
 import {
   generateReportAISummary as generateReportAISummaryImpl,
@@ -28,7 +27,53 @@ import {
   refreshImportRuntimeShell,
 } from './export-runtime.js';
 
-export { importDataJSON };
+/** @typedef {typeof import('./export-import.js')} ExportImportModule */
+/** @type {Promise<ExportImportModule> | null} */
+let exportImportModulePromise = null;
+/** @type {ExportImportModule | null} */
+let exportImportModule = null;
+let useExportImportRetryUrl = false;
+
+export function isExportImportModuleLoaded() {
+  return exportImportModule !== null;
+}
+
+/** @returns {Promise<ExportImportModule>} */
+function loadExportImportRetryModule() {
+  // @ts-expect-error TypeScript resolves only the query-free source path.
+  return import('./export-import.js?lazy-retry=1');
+}
+
+/** @returns {Promise<ExportImportModule>} */
+export function loadExportImportModule() {
+  if (!exportImportModulePromise) {
+    // Failed module-map fetches are cached; retry once with a second fixed URL.
+    const load = useExportImportRetryUrl
+      ? loadExportImportRetryModule()
+      : import('./export-import.js');
+    exportImportModulePromise = load
+      .then(module => (exportImportModule = module))
+      .catch(err => {
+        exportImportModulePromise = null;
+        exportImportModule = null;
+        useExportImportRetryUrl = true;
+        throw err;
+      });
+  }
+  return exportImportModulePromise;
+}
+
+/** @param {File} file */
+export async function importDataJSON(file) {
+  try {
+    const module = exportImportModule || await loadExportImportModule();
+    return await module.importDataJSON(file);
+  } catch (err) {
+    console.error('[export] Could not load the JSON import flow:', err);
+    showNotification('JSON import could not be loaded. Try again.', 'error');
+    return undefined;
+  }
+}
 
 /** @type {{
  *   buildSidebar: null | (() => void),

--- a/plans/code-quality-audit-2026-07-21.md
+++ b/plans/code-quality-audit-2026-07-21.md
@@ -150,6 +150,11 @@ them then reduced the reference to 415 requests, 1,716,755 compressed bytes,
 and 5,059,297 decoded bytes. The result again reproduced exactly, saving one
 request, 14,255 compressed bytes, and 58,624 decoded bytes while preserving
 the synchronous close behavior once the implementation is resident.
+Deferring the JSON import implementation until a file is actually imported
+then reduced the reference to 414 requests, 1,708,324 compressed bytes, and
+5,023,634 decoded bytes. Two identical runs confirmed savings of one request,
+8,431 compressed bytes, and 35,663 decoded bytes, with the facade retaining an
+awaitable API and a fixed retry URL for failed module fetches.
 Route and feature lazy loading remains active, with the ceilings ratcheting
 downward after each reproducible slice.
 

--- a/scripts/cold-load-budget.json
+++ b/scripts/cold-load-budget.json
@@ -3,15 +3,15 @@
   "route": "/app",
   "scenario": "Fresh mobile returning-user load with browser cache and service workers disabled",
   "maximums": {
-    "requests": 421,
-    "transferBytes": 1749000,
-    "decodedBytes": 5149000
+    "requests": 420,
+    "transferBytes": 1741000,
+    "decodedBytes": 5113000
   },
   "reference": {
-    "requests": 415,
-    "transferBytes": 1716755,
-    "decodedBytes": 5059297
+    "requests": 414,
+    "transferBytes": 1708324,
+    "decodedBytes": 5023634
   },
-  "referenceCommit": "3aa8df4a",
+  "referenceCommit": "50aa5ebe",
   "measuredAt": "2026-07-25"
 }

--- a/tests/playwright/cold-load-budget.spec.js
+++ b/tests/playwright/cold-load-budget.spec.js
@@ -95,6 +95,9 @@ test('cold mobile app load stays within committed resource budgets', async ({ pa
     new URL(entry.name).pathname === '/js/light-tool-camera-modals.js'
   ))).toBe(false);
   expect(entries.some(entry => (
+    new URL(entry.name).pathname === '/js/export-import.js'
+  ))).toBe(false);
+  expect(entries.some(entry => (
     new URL(entry.name).pathname === '/css/marker-detail-modal.css'
   ))).toBe(false);
   expect(entries.some(entry => (

--- a/tests/playwright/export-import-loader-browser-coverage.spec.js
+++ b/tests/playwright/export-import-loader-browser-coverage.spec.js
@@ -1,0 +1,103 @@
+import { expect, test } from '@playwright/test';
+
+const exportUrl = () => `/js/export.js?importLoaderCoverage=${Date.now()}-${Math.random().toString(36).slice(2)}`;
+const syntheticImportModule = `
+  export async function importDataJSON(file) {
+    window.__exportImportLoaderCalls ||= [];
+    window.__exportImportLoaderCalls.push(file.name);
+    return 'imported:' + file.name;
+  }
+`;
+
+test.beforeEach(async ({ page }) => {
+  await page.route('**/export-import-loader-coverage', route => route.fulfill({
+    contentType: 'text/html',
+    body: '<!doctype html><html><body><div id="notification-container"></div></body></html>',
+  }));
+  await page.goto('/export-import-loader-coverage');
+});
+
+test('JSON import loader stays cold, shares its first load, and delegates the file', async ({ page }) => {
+  const implementationRequests = [];
+  await page.route('**/js/export-import.js*', async route => {
+    implementationRequests.push(route.request().url());
+    await new Promise(resolve => setTimeout(resolve, 25));
+    await route.fulfill({
+      contentType: 'text/javascript',
+      body: syntheticImportModule,
+    });
+  });
+
+  const outcomes = await page.evaluate(async url => {
+    const exportModule = await import(url);
+    const cold = !exportModule.isExportImportModuleLoaded();
+    const first = exportModule.loadExportImportModule();
+    const second = exportModule.loadExportImportModule();
+    const sharedPromise = first === second;
+    await Promise.all([first, second]);
+    const result = await exportModule.importDataJSON(new File(['{}'], 'profile.json'));
+    return {
+      cold,
+      sharedPromise,
+      loaded: exportModule.isExportImportModuleLoaded(),
+      result,
+      calls: window.__exportImportLoaderCalls || [],
+    };
+  }, exportUrl());
+
+  expect(implementationRequests).toHaveLength(1);
+  expect(outcomes).toEqual({
+    cold: true,
+    sharedPromise: true,
+    loaded: true,
+    result: 'imported:profile.json',
+    calls: ['profile.json'],
+  });
+});
+
+test('JSON import action contains a failed load and retries with the fixed URL', async ({ page }) => {
+  const implementationRequests = [];
+  await page.route('**/js/export-import.js*', async route => {
+    const url = route.request().url();
+    implementationRequests.push(url);
+    if (!url.includes('lazy-retry=1')) {
+      await route.fulfill({
+        status: 503,
+        contentType: 'text/javascript',
+        body: 'export {};',
+      });
+      return;
+    }
+    await route.fulfill({
+      contentType: 'text/javascript',
+      body: syntheticImportModule,
+    });
+  });
+
+  const outcomes = await page.evaluate(async url => {
+    const exportModule = await import(url);
+    const first = await exportModule.importDataJSON(new File(['{}'], 'first.json'));
+    const unloadedAfterFailure = !exportModule.isExportImportModuleLoaded();
+    const second = await exportModule.importDataJSON(new File(['{}'], 'retry.json'));
+    return {
+      first,
+      unloadedAfterFailure,
+      second,
+      loadedAfterRetry: exportModule.isExportImportModuleLoaded(),
+      calls: window.__exportImportLoaderCalls || [],
+      notification: document.body.textContent,
+    };
+  }, exportUrl());
+
+  expect(implementationRequests).toHaveLength(2);
+  expect(new URL(implementationRequests[0]).search).toBe('');
+  expect(new URL(implementationRequests[1]).searchParams.get('lazy-retry')).toBe('1');
+  expect(outcomes).toMatchObject({
+    first: undefined,
+    unloadedAfterFailure: true,
+    second: 'imported:retry.json',
+    loadedAfterRetry: true,
+    calls: ['retry.json'],
+  });
+  expect(outcomes.notification).toContain('JSON import could not be loaded. Try again.');
+});

--- a/tests/test-unit-import.js
+++ b/tests/test-unit-import.js
@@ -80,6 +80,10 @@ const importCssSrc = read('css/import.css');
       && !/\? \{ \.\.\.entry\.markerSources\[key\], at: importTs \}/.test(jsonImportBlock));
   assert('JSON import mirrors insulin through shared lab entry helper',
     /setLabEntryMarker\(existing, key, value,[\s\S]{0,180}mirrorInsulin: true/.test(jsonImportBlock));
+  assert('JSON import implementation loads only on the first import action',
+    !exportSrc.includes("from './export-import.js'")
+      && exportSrc.includes("import('./export-import.js')")
+      && exportSrc.includes("import('./export-import.js?lazy-retry=1')"));
   const removeBlock = persistenceSrc.substring(persistenceSrc.indexOf('export async function removeImportedEntry'), persistenceSrc.indexOf('export async function renameImportedEntryDate'));
   assert('import delete records entries tombstone before removing row',
     /recordTombstone\(state\.importedData,\s*['"]entries['"],\s*date\)[\s\S]{0,180}deleteImportedArrayItems\(state\.importedData,\s*['"]entries['"],\s*e => e\.date === date\)/.test(removeBlock));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.376';
+self.APP_VERSION = '1.10.377';


### PR DESCRIPTION
## Summary
- defer the JSON import implementation until the first file-import action
- preserve the existing awaitable `importDataJSON` facade with single-flight loading and a fixed retry URL after failed module fetches
- contain loader failures with an actionable notification while allowing the next action to retry
- assert the implementation is absent from cold startup, ratchet the budget, and bump the app version to 1.10.377

## Measured impact
Clean `main` baseline (reproduced):
- 415 requests
- 1,716,755 transferred bytes
- 5,059,297 decoded bytes

This branch (reproduced identically twice):
- 414 requests
- 1,708,324 transferred bytes
- 5,023,634 decoded bytes

Savings:
- 1 request
- 8,431 transferred bytes
- 35,663 decoded bytes

## Validation
- `npm test` — 490 passed
- `node tests/verify-modules.js` — 133 passed
- `npm run quality`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run architecture:check` — 468 modules, 0 cycles
- focused Chromium loader plus existing report/export/import facade flows — 8 passed
- `npm run performance:check` — reproduced twice at the exact reference above