### PR TITLE
Load report builder on demand

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -11,7 +11,7 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | --- | ---: |
 | Modules | 468 |
 | Internal import edges | 2097 |
-| Dynamic internal edges | 66 |
+| Dynamic internal edges | 67 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
 | Largest cyclic component | 0 |
@@ -350,7 +350,7 @@ Native browser modules shipped with the static application.
 - [`js/export-report-html.js`](js/export-report-html.js) → [`js/export-report.js`](js/export-report.js), [`js/marker-analysis.js`](js/marker-analysis.js), [`js/state.js`](js/state.js), [`js/supplement-impact.js`](js/supplement-impact.js), [`js/utils.js`](js/utils.js)
 - [`js/export-report.js`](js/export-report.js) → [`js/api.js`](js/api.js), [`js/cycle.js`](js/cycle.js), [`js/data.js`](js/data.js), [`js/marker-analysis.js`](js/marker-analysis.js), [`js/profile.js`](js/profile.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/supplement-impact.js`](js/supplement-impact.js), [`js/utils.js`](js/utils.js)
 - [`js/export-runtime.js`](js/export-runtime.js) → [`js/cashu-wallet.js`](js/cashu-wallet.js), [`js/crypto.js`](js/crypto.js), [`js/state.js`](js/state.js)
-- [`js/export.js`](js/export.js) → [`js/biology-score-context-ai.js`](js/biology-score-context-ai.js) *(dynamic)*, [`js/context-cards.js`](js/context-cards.js) *(dynamic)*, [`js/crypto.js`](js/crypto.js), [`js/cycle-store.js`](js/cycle-store.js) *(dynamic)*, [`js/data.js`](js/data.js), [`js/export-import.js`](js/export-import.js) *(dynamic)*, [`js/export-report-builder.js`](js/export-report-builder.js), [`js/export-report-html.js`](js/export-report-html.js), [`js/export-report.js`](js/export-report.js), [`js/export-runtime.js`](js/export-runtime.js), [`js/lab-entry-mutations.js`](js/lab-entry-mutations.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/nostr-discovery.js`](js/nostr-discovery.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js), [`js/wearables-store.js`](js/wearables-store.js) *(dynamic)*
+- [`js/export.js`](js/export.js) → [`js/biology-score-context-ai.js`](js/biology-score-context-ai.js) *(dynamic)*, [`js/context-cards.js`](js/context-cards.js) *(dynamic)*, [`js/crypto.js`](js/crypto.js), [`js/cycle-store.js`](js/cycle-store.js) *(dynamic)*, [`js/data.js`](js/data.js), [`js/export-import.js`](js/export-import.js) *(dynamic)*, [`js/export-report-builder.js`](js/export-report-builder.js) *(dynamic)*, [`js/export-report-html.js`](js/export-report-html.js), [`js/export-report.js`](js/export-report.js), [`js/export-runtime.js`](js/export-runtime.js), [`js/lab-entry-mutations.js`](js/lab-entry-mutations.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/nostr-discovery.js`](js/nostr-discovery.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js), [`js/wearables-store.js`](js/wearables-store.js) *(dynamic)*
 
 </details>
 

--- a/js/export.js
+++ b/js/export.js
@@ -17,10 +17,6 @@ import {
   exportPDFReport as exportPDFReportImpl,
 } from './export-report-html.js';
 import {
-  closeReportBuilder as closeReportBuilderImpl,
-  openReportBuilder as openReportBuilderImpl,
-} from './export-report-builder.js';
-import {
   clearDemoLoadingProfile,
   destroyWalletRuntimeDB,
   markDemoLoadingProfile,
@@ -33,6 +29,12 @@ let exportImportModulePromise = null;
 /** @type {ExportImportModule | null} */
 let exportImportModule = null;
 let useExportImportRetryUrl = false;
+/** @typedef {typeof import('./export-report-builder.js')} ReportBuilderModule */
+/** @type {Promise<ReportBuilderModule> | null} */
+let reportBuilderModulePromise = null;
+/** @type {ReportBuilderModule | null} */
+let reportBuilderModule = null;
+let useReportBuilderRetryUrl = false;
 
 export function isExportImportModuleLoaded() {
   return exportImportModule !== null;
@@ -75,6 +77,41 @@ export async function importDataJSON(file) {
   }
 }
 
+export function isReportBuilderModuleLoaded() {
+  return reportBuilderModule !== null;
+}
+
+/** @returns {Promise<ReportBuilderModule>} */
+function loadReportBuilderRetryModule() {
+  // @ts-expect-error TypeScript resolves only the query-free source path.
+  return import('./export-report-builder.js?lazy-retry=1');
+}
+
+/** @returns {Promise<ReportBuilderModule>} */
+export function loadReportBuilderModule() {
+  if (!reportBuilderModulePromise) {
+    const load = useReportBuilderRetryUrl
+      ? loadReportBuilderRetryModule()
+      : import('./export-report-builder.js');
+    reportBuilderModulePromise = load
+      .then(module => (reportBuilderModule = module))
+      .catch(err => {
+        reportBuilderModulePromise = null;
+        reportBuilderModule = null;
+        useReportBuilderRetryUrl = true;
+        throw err;
+      });
+  }
+  return reportBuilderModulePromise;
+}
+
+/** @param {unknown} err */
+function reportReportBuilderLoadError(err) {
+  console.error('[export] Could not load the report builder:', err);
+  showNotification('Report builder could not be loaded. Try again.', 'error');
+  return false;
+}
+
 /** @type {{
  *   buildSidebar: null | (() => void),
  *   navigate: null | ((route?: string) => void),
@@ -112,11 +149,24 @@ export function buildReportHTML(profileName, sexLabel, data, flags, notes, supps
 }
 
 export function openReportBuilder(presetId) {
-  return openReportBuilderImpl(presetId);
+  try {
+    if (reportBuilderModule) return reportBuilderModule.openReportBuilder(presetId);
+    return loadReportBuilderModule()
+      .then(module => module.openReportBuilder(presetId))
+      .catch(reportReportBuilderLoadError);
+  } catch (err) {
+    return reportReportBuilderLoadError(err);
+  }
 }
 
 export function closeReportBuilder() {
-  return closeReportBuilderImpl();
+  if (!reportBuilderModule) return undefined;
+  try {
+    return reportBuilderModule.closeReportBuilder();
+  } catch (err) {
+    console.error('[export] Could not close the report builder:', err);
+    return undefined;
+  }
 }
 
 // ═══════════════════════════════════════════════

--- a/plans/code-quality-audit-2026-07-21.md
+++ b/plans/code-quality-audit-2026-07-21.md
@@ -155,6 +155,11 @@ then reduced the reference to 414 requests, 1,708,324 compressed bytes, and
 5,023,634 decoded bytes. Two identical runs confirmed savings of one request,
 8,431 compressed bytes, and 35,663 decoded bytes, with the facade retaining an
 awaitable API and a fixed retry URL for failed module fetches.
+Loading the Reports modal builder only when the user opens it then reduced the
+reference to 413 requests, 1,704,671 compressed bytes, and 5,009,775 decoded
+bytes. The result reproduced exactly, saving one request, 3,653 compressed
+bytes, and 13,859 decoded bytes without moving the synchronous report renderer
+or preview-window path behind an asynchronous boundary.
 Route and feature lazy loading remains active, with the ceilings ratcheting
 downward after each reproducible slice.
 

--- a/scripts/cold-load-budget.json
+++ b/scripts/cold-load-budget.json
@@ -3,15 +3,15 @@
   "route": "/app",
   "scenario": "Fresh mobile returning-user load with browser cache and service workers disabled",
   "maximums": {
-    "requests": 420,
-    "transferBytes": 1741000,
-    "decodedBytes": 5113000
+    "requests": 419,
+    "transferBytes": 1737000,
+    "decodedBytes": 5099000
   },
   "reference": {
-    "requests": 414,
-    "transferBytes": 1708324,
-    "decodedBytes": 5023634
+    "requests": 413,
+    "transferBytes": 1704671,
+    "decodedBytes": 5009775
   },
-  "referenceCommit": "50aa5ebe",
+  "referenceCommit": "fd0e347f",
   "measuredAt": "2026-07-25"
 }

--- a/tests/playwright/cold-load-budget.spec.js
+++ b/tests/playwright/cold-load-budget.spec.js
@@ -98,6 +98,9 @@ test('cold mobile app load stays within committed resource budgets', async ({ pa
     new URL(entry.name).pathname === '/js/export-import.js'
   ))).toBe(false);
   expect(entries.some(entry => (
+    new URL(entry.name).pathname === '/js/export-report-builder.js'
+  ))).toBe(false);
+  expect(entries.some(entry => (
     new URL(entry.name).pathname === '/css/marker-detail-modal.css'
   ))).toBe(false);
   expect(entries.some(entry => (

--- a/tests/playwright/report-builder-loader-browser-coverage.spec.js
+++ b/tests/playwright/report-builder-loader-browser-coverage.spec.js
@@ -1,0 +1,112 @@
+import { expect, test } from '@playwright/test';
+
+const exportUrl = () => `/js/export.js?reportBuilderLoaderCoverage=${Date.now()}-${Math.random().toString(36).slice(2)}`;
+const syntheticReportBuilder = `
+  const record = (name, value) => {
+    window.__reportBuilderLoaderCalls ||= [];
+    window.__reportBuilderLoaderCalls.push([name, value]);
+    return name + ':' + String(value ?? '');
+  };
+  export function openReportBuilder(presetId) { return record('open', presetId); }
+  export function closeReportBuilder() { return record('close'); }
+`;
+
+test.beforeEach(async ({ page }) => {
+  await page.route('**/report-builder-loader-coverage', route => route.fulfill({
+    contentType: 'text/html',
+    body: '<!doctype html><html><body><div id="notification-container"></div></body></html>',
+  }));
+  await page.goto('/report-builder-loader-coverage');
+});
+
+test('report builder loader stays cold, shares its first load, and delegates open and close', async ({ page }) => {
+  const implementationRequests = [];
+  await page.route('**/js/export-report-builder.js*', async route => {
+    implementationRequests.push(route.request().url());
+    await new Promise(resolve => setTimeout(resolve, 25));
+    await route.fulfill({
+      contentType: 'text/javascript',
+      body: syntheticReportBuilder,
+    });
+  });
+
+  const outcomes = await page.evaluate(async url => {
+    const exportModule = await import(url);
+    const cold = !exportModule.isReportBuilderModuleLoaded();
+    const coldClose = exportModule.closeReportBuilder();
+    const first = exportModule.loadReportBuilderModule();
+    const second = exportModule.loadReportBuilderModule();
+    const sharedPromise = first === second;
+    await Promise.all([first, second]);
+    const opened = await exportModule.openReportBuilder('personal');
+    const closed = exportModule.closeReportBuilder();
+    return {
+      cold,
+      coldClose,
+      sharedPromise,
+      loaded: exportModule.isReportBuilderModuleLoaded(),
+      opened,
+      closed,
+      calls: window.__reportBuilderLoaderCalls || [],
+    };
+  }, exportUrl());
+
+  expect(implementationRequests).toHaveLength(1);
+  expect(outcomes).toEqual({
+    cold: true,
+    coldClose: undefined,
+    sharedPromise: true,
+    loaded: true,
+    opened: 'open:personal',
+    closed: 'close:',
+    calls: [['open', 'personal'], ['close', undefined]],
+  });
+});
+
+test('report builder open contains a failed load and retries with the fixed URL', async ({ page }) => {
+  const implementationRequests = [];
+  await page.route('**/js/export-report-builder.js*', async route => {
+    const url = route.request().url();
+    implementationRequests.push(url);
+    if (!url.includes('lazy-retry=1')) {
+      await route.fulfill({
+        status: 503,
+        contentType: 'text/javascript',
+        body: 'export {};',
+      });
+      return;
+    }
+    await route.fulfill({
+      contentType: 'text/javascript',
+      body: syntheticReportBuilder,
+    });
+  });
+
+  const outcomes = await page.evaluate(async url => {
+    const exportModule = await import(url);
+    const first = await exportModule.openReportBuilder('clinician');
+    const unloadedAfterFailure = !exportModule.isReportBuilderModuleLoaded();
+    const second = await exportModule.openReportBuilder('personal');
+    exportModule.closeReportBuilder();
+    return {
+      first,
+      unloadedAfterFailure,
+      second,
+      loadedAfterRetry: exportModule.isReportBuilderModuleLoaded(),
+      calls: window.__reportBuilderLoaderCalls || [],
+      notification: document.body.textContent,
+    };
+  }, exportUrl());
+
+  expect(implementationRequests).toHaveLength(2);
+  expect(new URL(implementationRequests[0]).search).toBe('');
+  expect(new URL(implementationRequests[1]).searchParams.get('lazy-retry')).toBe('1');
+  expect(outcomes).toMatchObject({
+    first: false,
+    unloadedAfterFailure: true,
+    second: 'open:personal',
+    loadedAfterRetry: true,
+  });
+  expect(outcomes.calls).toEqual([['open', 'personal'], ['close', undefined]]);
+  expect(outcomes.notification).toContain('Report builder could not be loaded. Try again.');
+});

--- a/tests/test-export-import.js
+++ b/tests/test-export-import.js
@@ -178,6 +178,9 @@ return (async function() {
       reportSrc.includes("reportBuilderActionAttrs('export')"));
   assert('Report builder facade delegates default preset to implementation',
     exportSrc.includes('export function openReportBuilder(presetId)') &&
+      !exportSrc.includes("from './export-report-builder.js'") &&
+      exportSrc.includes("import('./export-report-builder.js')") &&
+      exportSrc.includes("import('./export-report-builder.js?lazy-retry=1')") &&
       !exportSrc.includes("openReportBuilder(presetId = 'clinician')"));
   assert('Report builder supports AI overview generation',
     reportSrc.includes('export async function generateReportAISummary') &&
@@ -636,8 +639,7 @@ return (async function() {
   assert('Module has clearAllData', typeof exportModule.clearAllData === 'function');
   assert('Module has loadDemoData', typeof exportModule.loadDemoData === 'function');
 
-  exportModule.openReportBuilder();
-  await wait(20);
+  await exportModule.openReportBuilder();
   const reportBuilder = document.getElementById('report-builder-overlay');
   assert('Report builder modal renders', !!reportBuilder);
   assert('Report builder has presets, sections, date range, and categories',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.377';
+self.APP_VERSION = '1.10.378';


### PR DESCRIPTION
## Summary
- defer the Reports modal builder until the first Reports action
- preserve single-flight loading, a fixed retry URL after failed module fetches, and close cleanup that remains cold
- keep the synchronous report HTML renderer and preview-window path eager so popup behavior and public return values do not change
- assert the builder is absent from cold startup, ratchet the budget, and bump the app version to 1.10.378

## Measured impact
Clean main baseline (reproduced):
- 414 requests
- 1,708,324 transferred bytes
- 5,023,634 decoded bytes

This branch (reproduced identically twice):
- 413 requests
- 1,704,671 transferred bytes
- 5,009,775 decoded bytes

Savings:
- 1 request
- 3,653 transferred bytes
- 13,859 decoded bytes

## Validation
- npm test — 490 passed
- node tests/verify-modules.js — 133 passed
- npm run quality
- npm run typecheck
- npm run typecheck:checkjs
- npm run architecture:check — 468 modules, 0 cycles
- focused report-builder loader plus existing report/export browser flows — 8 passed
- npm run performance:check — reproduced twice at the exact reference above