### PR TITLE
Load Cashu wallet on demand

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -10,8 +10,8 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | Metric | Current |
 | --- | ---: |
 | Modules | 473 |
-| Internal import edges | 2121 |
-| Dynamic internal edges | 72 |
+| Internal import edges | 2120 |
+| Dynamic internal edges | 73 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
 | Largest cyclic component | 0 |
@@ -106,7 +106,7 @@ Native browser modules shipped with the static application.
 
 <details><summary><code>app</code> family — 8 modules</summary>
 
-- [`js/app-ai-interaction-modules.js`](js/app-ai-interaction-modules.js) → [`js/cashu-wallet.js`](js/cashu-wallet.js), [`js/chat.js`](js/chat.js), [`js/image-utils.js`](js/image-utils.js), [`js/lens.js`](js/lens.js), [`js/nostr-discovery.js`](js/nostr-discovery.js)
+- [`js/app-ai-interaction-modules.js`](js/app-ai-interaction-modules.js) → [`js/chat.js`](js/chat.js), [`js/image-utils.js`](js/image-utils.js), [`js/lens.js`](js/lens.js), [`js/nostr-discovery.js`](js/nostr-discovery.js)
 - [`js/app-event-listeners.js`](js/app-event-listeners.js) → [`js/data.js`](js/data.js), [`js/nav.js`](js/nav.js), [`js/state.js`](js/state.js), [`js/tour.js`](js/tour.js)
 - [`js/app-feature-modules.js`](js/app-feature-modules.js) → [`js/app-ai-interaction-modules.js`](js/app-ai-interaction-modules.js), [`js/app-foundation-modules.js`](js/app-foundation-modules.js), [`js/app-health-data-modules.js`](js/app-health-data-modules.js), [`js/app-ui-shell-modules.js`](js/app-ui-shell-modules.js), [`js/light-sun-loader.js`](js/light-sun-loader.js), [`js/sun-context-hooks.js`](js/sun-context-hooks.js)
 - [`js/app-foundation-modules.js`](js/app-foundation-modules.js) → [`js/constants.js`](js/constants.js), [`js/legal-consent.js`](js/legal-consent.js), [`js/pii.js`](js/pii.js), [`js/schema.js`](js/schema.js), [`js/utils.js`](js/utils.js)
@@ -353,7 +353,7 @@ Native browser modules shipped with the static application.
 - [`js/export-report-builder.js`](js/export-report-builder.js) → [`js/data.js`](js/data.js), [`js/export-report-html.js`](js/export-report-html.js), [`js/export-report.js`](js/export-report.js), [`js/marker-analysis.js`](js/marker-analysis.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/utils.js`](js/utils.js)
 - [`js/export-report-html.js`](js/export-report-html.js) → [`js/export-report.js`](js/export-report.js), [`js/marker-analysis.js`](js/marker-analysis.js), [`js/state.js`](js/state.js), [`js/supplement-impact.js`](js/supplement-impact.js), [`js/utils.js`](js/utils.js)
 - [`js/export-report.js`](js/export-report.js) → [`js/api.js`](js/api.js), [`js/cycle.js`](js/cycle.js), [`js/data.js`](js/data.js), [`js/marker-analysis.js`](js/marker-analysis.js), [`js/profile.js`](js/profile.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/supplement-impact.js`](js/supplement-impact.js), [`js/utils.js`](js/utils.js)
-- [`js/export-runtime.js`](js/export-runtime.js) → [`js/cashu-wallet.js`](js/cashu-wallet.js), [`js/crypto.js`](js/crypto.js), [`js/state.js`](js/state.js)
+- [`js/export-runtime.js`](js/export-runtime.js) → [`js/cashu-wallet.js`](js/cashu-wallet.js) *(dynamic)*, [`js/crypto.js`](js/crypto.js), [`js/state.js`](js/state.js)
 - [`js/export.js`](js/export.js) → [`js/biology-score-context-ai.js`](js/biology-score-context-ai.js) *(dynamic)*, [`js/context-cards.js`](js/context-cards.js) *(dynamic)*, [`js/crypto.js`](js/crypto.js), [`js/cycle-store.js`](js/cycle-store.js) *(dynamic)*, [`js/data.js`](js/data.js), [`js/export-import.js`](js/export-import.js) *(dynamic)*, [`js/export-report-builder.js`](js/export-report-builder.js) *(dynamic)*, [`js/export-report-html.js`](js/export-report-html.js), [`js/export-report.js`](js/export-report.js), [`js/export-runtime.js`](js/export-runtime.js), [`js/lab-entry-mutations.js`](js/lab-entry-mutations.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/nostr-discovery.js`](js/nostr-discovery.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js), [`js/wearables-store.js`](js/wearables-store.js) *(dynamic)*
 
 </details>

--- a/js/app-ai-interaction-modules.js
+++ b/js/app-ai-interaction-modules.js
@@ -4,5 +4,4 @@
 import './chat.js';
 import './image-utils.js';
 import './lens.js';
-import './cashu-wallet.js';
 import './nostr-discovery.js';

--- a/js/export-runtime.js
+++ b/js/export-runtime.js
@@ -3,7 +3,41 @@
 
 import { encryptedGetItem } from './crypto.js';
 import { state } from './state.js';
-import { destroyWalletDB } from './cashu-wallet.js';
+
+/** @typedef {typeof import('./cashu-wallet.js')} CashuWalletModule */
+/** @type {Promise<CashuWalletModule> | null} */
+let cashuWalletModulePromise = null;
+/** @type {CashuWalletModule | null} */
+let cashuWalletModule = null;
+let useCashuWalletRetryUrl = false;
+
+export function isCashuWalletModuleLoaded() {
+  return cashuWalletModule !== null;
+}
+
+/** @returns {Promise<CashuWalletModule>} */
+function loadCashuWalletRetryModule() {
+  // @ts-expect-error TypeScript resolves only the query-free source path.
+  return import('./cashu-wallet.js?lazy-retry=1');
+}
+
+/** @returns {Promise<CashuWalletModule>} */
+export function loadCashuWalletModule() {
+  if (!cashuWalletModulePromise) {
+    const load = useCashuWalletRetryUrl
+      ? loadCashuWalletRetryModule()
+      : import('./cashu-wallet.js');
+    cashuWalletModulePromise = load
+      .then(module => (cashuWalletModule = module))
+      .catch(err => {
+        cashuWalletModulePromise = null;
+        cashuWalletModule = null;
+        useCashuWalletRetryUrl = true;
+        throw err;
+      });
+  }
+  return cashuWalletModulePromise;
+}
 
 /** @typedef {{
  * buildSidebar: null | (() => void),
@@ -179,7 +213,8 @@ async function refreshChatThreadsRuntime() {
 }
 
 export async function destroyWalletRuntimeDB() {
-  await destroyWalletDB();
+  const wallet = cashuWalletModule || await loadCashuWalletModule();
+  await wallet.destroyWalletDB();
 }
 
 export function markDemoLoadingProfile(profileId) {

--- a/scripts/cold-load-budget.json
+++ b/scripts/cold-load-budget.json
@@ -8,10 +8,10 @@
     "decodedBytes": 5099000
   },
   "reference": {
-    "requests": 411,
-    "transferBytes": 1642179,
-    "decodedBytes": 4780687
+    "requests": 410,
+    "transferBytes": 1632250,
+    "decodedBytes": 4736910
   },
-  "referenceCommit": "c3e3f871",
+  "referenceCommit": "7a421fd3",
   "measuredAt": "2026-07-25"
 }

--- a/tests/playwright/cashu-wallet-loader-browser-coverage.spec.js
+++ b/tests/playwright/cashu-wallet-loader-browser-coverage.spec.js
@@ -1,0 +1,95 @@
+import { expect, test } from './coverage-fixture.js';
+
+const runtimeUrl = () => `/js/export-runtime.js?cashuLoaderCoverage=${Date.now()}-${Math.random().toString(36).slice(2)}`;
+const syntheticWallet = `
+  export async function destroyWalletDB() {
+    window.__cashuWalletLoaderCalls ||= [];
+    window.__cashuWalletLoaderCalls.push('destroyWalletDB');
+    return 'destroyed';
+  }
+`;
+
+test.beforeEach(async ({ page }) => {
+  await page.route('**/cashu-wallet-loader-coverage', route => route.fulfill({
+    contentType: 'text/html',
+    body: '<!doctype html><html><body></body></html>',
+  }));
+  await page.goto('/cashu-wallet-loader-coverage');
+});
+
+test('Cashu wallet stays cold, single-flights, and loads for explicit database destruction', async ({ page }) => {
+  const implementationRequests = [];
+  await page.route('**/js/cashu-wallet.js*', async route => {
+    implementationRequests.push(route.request().url());
+    await new Promise(resolve => setTimeout(resolve, 25));
+    await route.fulfill({
+      contentType: 'text/javascript',
+      body: syntheticWallet,
+    });
+  });
+
+  const outcomes = await page.evaluate(async url => {
+    const runtime = await import(url);
+    const cold = !runtime.isCashuWalletModuleLoaded();
+    const first = runtime.loadCashuWalletModule();
+    const second = runtime.loadCashuWalletModule();
+    const sharedPromise = first === second;
+    await Promise.all([first, second]);
+    await runtime.destroyWalletRuntimeDB();
+    return {
+      cold,
+      sharedPromise,
+      loaded: runtime.isCashuWalletModuleLoaded(),
+      calls: window.__cashuWalletLoaderCalls || [],
+    };
+  }, runtimeUrl());
+
+  expect(implementationRequests).toHaveLength(1);
+  expect(outcomes).toEqual({
+    cold: true,
+    sharedPromise: true,
+    loaded: true,
+    calls: ['destroyWalletDB'],
+  });
+});
+
+test('Cashu wallet database destruction retries with a fixed module URL', async ({ page }) => {
+  const implementationRequests = [];
+  await page.route('**/js/cashu-wallet.js*', async route => {
+    const url = route.request().url();
+    implementationRequests.push(url);
+    if (!url.includes('lazy-retry=1')) {
+      await route.abort('failed');
+      return;
+    }
+    await route.fulfill({
+      contentType: 'text/javascript',
+      body: syntheticWallet,
+    });
+  });
+
+  const outcomes = await page.evaluate(async url => {
+    const runtime = await import(url);
+    let firstRejected = false;
+    try {
+      await runtime.destroyWalletRuntimeDB();
+    } catch {
+      firstRejected = true;
+    }
+    await runtime.destroyWalletRuntimeDB();
+    return {
+      firstRejected,
+      loaded: runtime.isCashuWalletModuleLoaded(),
+      calls: window.__cashuWalletLoaderCalls || [],
+    };
+  }, runtimeUrl());
+
+  expect(implementationRequests).toHaveLength(2);
+  expect(new URL(implementationRequests[0]).search).toBe('');
+  expect(new URL(implementationRequests[1]).search).toBe('?lazy-retry=1');
+  expect(outcomes).toEqual({
+    firstRejected: true,
+    loaded: true,
+    calls: ['destroyWalletDB'],
+  });
+});

--- a/tests/playwright/cold-load-budget.spec.js
+++ b/tests/playwright/cold-load-budget.spec.js
@@ -116,6 +116,9 @@ test('cold mobile app load stays within committed resource budgets', async ({ pa
     new URL(entry.name).pathname === '/js/settings-sync-panel-impl.js'
   ))).toBe(false);
   expect(entries.some(entry => (
+    new URL(entry.name).pathname === '/js/cashu-wallet.js'
+  ))).toBe(false);
+  expect(entries.some(entry => (
     new URL(entry.name).pathname === '/js/sun-defaults.js'
   ))).toBe(false);
   expect(entries.some(entry => (

--- a/tests/test-cashu-wallet.js
+++ b/tests/test-cashu-wallet.js
@@ -52,6 +52,7 @@ const discoveryModule = await import('../js/nostr-discovery.js');
 
 const walletSrc = await fetchWithRetry('js/cashu-wallet.js');
 const walletStoreSrc = await fetchWithRetry('js/cashu-wallet-store.js');
+const appAIInteractionSrc = await fetchWithRetry('js/app-ai-interaction-modules.js');
 const appShellHooksSrc = await fetchWithRetry('js/app-shell-hooks.js');
 const discoverySrc = await fetchWithRetry('js/nostr-discovery.js');
 const apiRoutstrSrc = await fetchWithRetry('js/api-routstr.js');
@@ -309,8 +310,10 @@ assert('Bundle restores node URL through the Nostr module',
   exportImportSrc.includes('setSelectedNodeUrl(json.wallet.nodeUrl)'));
 assert('clearAllData destroys wallet DB through export runtime',
   exportSrc.includes('destroyWalletRuntimeDB') &&
-  exportRuntimeSrc.includes("import { destroyWalletDB } from './cashu-wallet.js'") &&
-  exportRuntimeSrc.includes('await destroyWalletDB()'));
+  !appAIInteractionSrc.includes("import './cashu-wallet.js'") &&
+  exportRuntimeSrc.includes("import('./cashu-wallet.js')") &&
+  exportRuntimeSrc.includes("import('./cashu-wallet.js?lazy-retry=1')") &&
+  exportRuntimeSrc.includes('await wallet.destroyWalletDB()'));
 assert('clearAllData removes wallet localStorage keys', exportSrc.includes("'labcharts-cashu-wallet-mint'") && exportSrc.includes("'labcharts-cashu-wallet-mnemonic'") && exportSrc.includes("'labcharts-routstr-node'"));
 
 // ═══════════════════════════════════════

--- a/tests/test-export-import.js
+++ b/tests/test-export-import.js
@@ -456,8 +456,9 @@ return (async function() {
   assert('Resets to single default profile via saveProfiles', exportSrc.includes('saveProfiles([{'));
   assert('Clears Cashu wallet DB through export runtime',
     exportSrc.includes('destroyWalletRuntimeDB') &&
-    exportRuntimeSrc.includes("import { destroyWalletDB } from './cashu-wallet.js'") &&
-    exportRuntimeSrc.includes('await destroyWalletDB()'));
+    exportRuntimeSrc.includes("import('./cashu-wallet.js')") &&
+    exportRuntimeSrc.includes("import('./cashu-wallet.js?lazy-retry=1')") &&
+    exportRuntimeSrc.includes('await wallet.destroyWalletDB()'));
   assert('Clears Cashu wallet mint', exportSrc.includes("localStorage.removeItem('labcharts-cashu-wallet-mint')"));
   assert('Calls navigate(dashboard) after clear through export runtime',
     exportSrc.includes('refreshImportRuntimeShell({ chat: true, profileButton: true })') &&

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.383';
+self.APP_VERSION = '1.10.384';


### PR DESCRIPTION
## Summary
- remove the Cashu wallet from the application cold-start import graph
- load it only when wallet functionality or explicit wallet database cleanup needs it
- preserve single-flight loading and recover from a failed module request with a fixed retry URL
- lock the cold-path absence and loader behavior with browser coverage

## Cold-load measurement
Stable across two runs:
- requests: 411 -> 410
- compressed bytes: 1,642,179 -> 1,632,250 (-9,929)
- decoded bytes: 4,780,687 -> 4,736,910 (-43,777)

## Validation
- npm test (490 passed)
- npm run quality
- npm run architecture:check
- npm run typecheck
- npm run typecheck:checkjs
- focused Playwright wallet loader, wallet behavior, export/import, and core browser flows (8 passed)
- cold-load budget repeated twice with identical metrics