### PR TITLE
Defer wearable vendor connections until needed

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -9,9 +9,9 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 
 | Metric | Current |
 | --- | ---: |
-| Modules | 473 |
-| Internal import edges | 2120 |
-| Dynamic internal edges | 73 |
+| Modules | 474 |
+| Internal import edges | 2121 |
+| Dynamic internal edges | 74 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
 | Largest cyclic component | 0 |
@@ -706,8 +706,8 @@ Native browser modules shipped with the static application.
 
 - [`js/startup-foundation.js`](js/startup-foundation.js) → [`js/crypto.js`](js/crypto.js), [`js/sun-uvdata.js`](js/sun-uvdata.js)
 - [`js/startup-maintenance-runtime.js`](js/startup-maintenance-runtime.js) → [`js/sun-sessions-store.js`](js/sun-sessions-store.js)
-- [`js/startup-maintenance.js`](js/startup-maintenance.js) → [`js/light-devices.js`](js/light-devices.js), [`js/startup-maintenance-runtime.js`](js/startup-maintenance-runtime.js), [`js/state.js`](js/state.js), [`js/wearables-connect.js`](js/wearables-connect.js), [`js/wearables-manual.js`](js/wearables-manual.js), [`js/wearables-summary.js`](js/wearables-summary.js) *(dynamic)*
-- [`js/startup-oauth-callbacks.js`](js/startup-oauth-callbacks.js) → [`js/api.js`](js/api.js), [`js/utils.js`](js/utils.js), [`js/wearables-connect.js`](js/wearables-connect.js)
+- [`js/startup-maintenance.js`](js/startup-maintenance.js) → [`js/light-devices.js`](js/light-devices.js), [`js/startup-maintenance-runtime.js`](js/startup-maintenance-runtime.js), [`js/state.js`](js/state.js), [`js/wearables-connect-loader.js`](js/wearables-connect-loader.js), [`js/wearables-manual.js`](js/wearables-manual.js), [`js/wearables-summary.js`](js/wearables-summary.js) *(dynamic)*
+- [`js/startup-oauth-callbacks.js`](js/startup-oauth-callbacks.js) → [`js/api.js`](js/api.js), [`js/utils.js`](js/utils.js), [`js/wearables-connect-loader.js`](js/wearables-connect-loader.js)
 - [`js/startup-orchestrator.js`](js/startup-orchestrator.js) → [`js/app-event-listeners.js`](js/app-event-listeners.js), [`js/import-loader.js`](js/import-loader.js), [`js/startup-foundation.js`](js/startup-foundation.js), [`js/startup-maintenance.js`](js/startup-maintenance.js), [`js/startup-oauth-callbacks.js`](js/startup-oauth-callbacks.js), [`js/startup-profile.js`](js/startup-profile.js), [`js/startup-ui.js`](js/startup-ui.js), [`js/sync-configure.js`](js/sync-configure.js), [`js/sync-lifecycle.js`](js/sync-lifecycle.js), [`js/sync.js`](js/sync.js), [`js/utils.js`](js/utils.js)
 - [`js/startup-profile.js`](js/startup-profile.js) → [`js/crypto.js`](js/crypto.js), [`js/data-merge.js`](js/data-merge.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js)
 - [`js/startup-ui.js`](js/startup-ui.js) → [`js/changelog.js`](js/changelog.js), [`js/chat-runtime.js`](js/chat-runtime.js), [`js/crypto.js`](js/crypto.js), [`js/data.js`](js/data.js), [`js/dna.js`](js/dna.js), [`js/import-file-input.js`](js/import-file-input.js), [`js/legal-consent.js`](js/legal-consent.js), [`js/nav.js`](js/nav.js), [`js/startup-profile.js`](js/startup-profile.js), [`js/sync.js`](js/sync.js), [`js/theme.js`](js/theme.js), [`js/utils-runtime.js`](js/utils-runtime.js), [`js/utils.js`](js/utils.js)
@@ -890,12 +890,13 @@ Native browser modules shipped with the static application.
 
 </details>
 
-<details><summary><code>wearables</code> family — 29 modules</summary>
+<details><summary><code>wearables</code> family — 30 modules</summary>
 
 - [`js/wearables-apple-health-runtime.js`](js/wearables-apple-health-runtime.js) → no in-scope imports
 - [`js/wearables-apple-health.js`](js/wearables-apple-health.js) → [`js/data.js`](js/data.js) *(dynamic)*, [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js) *(dynamic)*, [`js/utils.js`](js/utils.js), [`js/wearable-adapters.js`](js/wearable-adapters.js), [`js/wearables-apple-health-runtime.js`](js/wearables-apple-health-runtime.js), [`js/wearables-connect.js`](js/wearables-connect.js) *(dynamic)*, [`js/wearables-store.js`](js/wearables-store.js), [`js/wearables-summary.js`](js/wearables-summary.js)
 - [`js/wearables-auth-runtime.js`](js/wearables-auth-runtime.js) → no in-scope imports
 - [`js/wearables-bp-detail-chart.js`](js/wearables-bp-detail-chart.js) → [`js/charts-runtime.js`](js/charts-runtime.js), [`js/charts.js`](js/charts.js), [`js/state.js`](js/state.js), [`js/theme.js`](js/theme.js), [`js/wearable-adapters.js`](js/wearable-adapters.js), [`js/wearables-formatters.js`](js/wearables-formatters.js)
+- [`js/wearables-connect-loader.js`](js/wearables-connect-loader.js) → [`js/wearables-connect.js`](js/wearables-connect.js) *(dynamic)*
 - [`js/wearables-connect-runtime.js`](js/wearables-connect-runtime.js) → no in-scope imports
 - [`js/wearables-connect.js`](js/wearables-connect.js) → [`js/data.js`](js/data.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js), [`js/wearable-adapters.js`](js/wearable-adapters.js), [`js/wearables-connect-runtime.js`](js/wearables-connect-runtime.js), [`js/wearables-fitbit-auth.js`](js/wearables-fitbit-auth.js), [`js/wearables-fitbit.js`](js/wearables-fitbit.js), [`js/wearables-oura-auth.js`](js/wearables-oura-auth.js), [`js/wearables-oura.js`](js/wearables-oura.js), [`js/wearables-polar-auth.js`](js/wearables-polar-auth.js), [`js/wearables-polar.js`](js/wearables-polar.js), [`js/wearables-store.js`](js/wearables-store.js), [`js/wearables-summary.js`](js/wearables-summary.js), [`js/wearables-ultrahuman-auth.js`](js/wearables-ultrahuman-auth.js), [`js/wearables-ultrahuman.js`](js/wearables-ultrahuman.js), [`js/wearables-whoop-auth.js`](js/wearables-whoop-auth.js), [`js/wearables-whoop.js`](js/wearables-whoop.js), [`js/wearables-withings-auth.js`](js/wearables-withings-auth.js), [`js/wearables-withings.js`](js/wearables-withings.js)
 - [`js/wearables-detail-modal.js`](js/wearables-detail-modal.js) → [`js/charts.js`](js/charts.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/theme.js`](js/theme.js), [`js/utils.js`](js/utils.js), [`js/wearable-adapters.js`](js/wearable-adapters.js), [`js/wearables-bp-detail-chart.js`](js/wearables-bp-detail-chart.js), [`js/wearables-detail-runtime.js`](js/wearables-detail-runtime.js), [`js/wearables-formatters.js`](js/wearables-formatters.js), [`js/wearables-manual-form-ui.js`](js/wearables-manual-form-ui.js), [`js/wearables-manual.js`](js/wearables-manual.js), [`js/wearables-store.js`](js/wearables-store.js)
@@ -904,7 +905,7 @@ Native browser modules shipped with the static application.
 - [`js/wearables-fitbit.js`](js/wearables-fitbit.js) → [`js/utils.js`](js/utils.js)
 - [`js/wearables-formatters.js`](js/wearables-formatters.js) → [`js/wearable-adapters.js`](js/wearable-adapters.js)
 - [`js/wearables-manual-form-ui.js`](js/wearables-manual-form-ui.js) → [`js/utils.js`](js/utils.js)
-- [`js/wearables-manual.js`](js/wearables-manual.js) → [`js/data.js`](js/data.js), [`js/state.js`](js/state.js), [`js/wearables-connect.js`](js/wearables-connect.js) *(dynamic)*, [`js/wearables-oura.js`](js/wearables-oura.js), [`js/wearables-store.js`](js/wearables-store.js), [`js/wearables-summary.js`](js/wearables-summary.js) *(dynamic)*
+- [`js/wearables-manual.js`](js/wearables-manual.js) → [`js/data.js`](js/data.js), [`js/state.js`](js/state.js), [`js/wearable-adapters.js`](js/wearable-adapters.js), [`js/wearables-connect.js`](js/wearables-connect.js) *(dynamic)*, [`js/wearables-store.js`](js/wearables-store.js), [`js/wearables-summary.js`](js/wearables-summary.js) *(dynamic)*
 - [`js/wearables-oura-auth.js`](js/wearables-oura-auth.js) → [`js/utils.js`](js/utils.js), [`js/wearables-auth-runtime.js`](js/wearables-auth-runtime.js)
 - [`js/wearables-oura.js`](js/wearables-oura.js) → [`js/utils.js`](js/utils.js), [`js/wearable-adapters.js`](js/wearable-adapters.js)
 - [`js/wearables-polar-auth.js`](js/wearables-polar-auth.js) → [`js/utils.js`](js/utils.js), [`js/wearables-auth-runtime.js`](js/wearables-auth-runtime.js)

--- a/js/startup-maintenance.js
+++ b/js/startup-maintenance.js
@@ -2,9 +2,9 @@
 // startup-maintenance.js - startup service boot and non-blocking maintenance
 
 import { state } from './state.js';
-import { initWearableScheduler, loadWearableRuntimeConfig, syncStaleWearablesNow } from './wearables-connect.js';
 import { migrateBiometricsToManual, hasManualData } from './wearables-manual.js';
 import { hydrateDevicesFromPresets } from './light-devices.js';
+import { loadWearablesConnectModule } from './wearables-connect-loader.js';
 import {
   getStartupSunEngineVersionRuntime,
   hasSunSessionRehydrateRuntime,
@@ -12,21 +12,26 @@ import {
   rehydrateStaleSunSessionsRuntime,
 } from './startup-maintenance-runtime.js';
 
-export function initializeStartupServices() {
-  // Self-host OAuth client_id overrides - fire-and-forget. Resolves before
-  // any user can click Connect (UI renders well after this microtask), so
-  // beginConnectOAuth() picks up the overridden client_id when present.
-  loadWearableRuntimeConfig();
-
-  // Scheduled wearable sync (only fires when a source is connected).
-  initWearableScheduler();
-}
-
 export function runPostProfileStartupMaintenance() {
-  syncStaleWearablesNow().catch(() => {});
+  startConnectedWearableServices().catch(() => {});
   scheduleSunSessionRehydrate();
   hydrateUserLightDevicesFromPresets();
   migrateLegacyBiometrics();
+}
+
+function hasConnectedOAuthWearable() {
+  return Object.values(state.importedData?.wearableConnections || {})
+    .some(connection => Boolean(connection?.accessToken));
+}
+
+export async function startConnectedWearableServices() {
+  if (!hasConnectedOAuthWearable()) return false;
+  const connect = await loadWearablesConnectModule();
+  // Start the runtime-config request before the scheduler. Its first sync
+  // waits for this bounded request, preserving self-host client overrides.
+  connect.loadWearableRuntimeConfig();
+  connect.initWearableScheduler();
+  return true;
 }
 
 function scheduleSunSessionRehydrate() {
@@ -74,9 +79,22 @@ function migrateLegacyBiometrics() {
       // (shouldWriteL2) prevents redundant writes when nothing has shifted.
       if (await hasManualData(state.currentProfile)) {
         const { syncWearableSummary } = await import('./wearables-summary.js');
-        const { listConnectedSources } = await import('./wearables-connect.js');
-        await syncWearableSummary(state.currentProfile, listConnectedSources());
+        await syncWearableSummary(state.currentProfile, listStoredConnectedSources());
       }
     })
     .catch(() => { /* non-fatal; Safari can refuse IDB in some contexts */ });
+}
+
+function listStoredConnectedSources() {
+  const out = {};
+  for (const [sourceId, connection] of Object.entries(
+    state.importedData?.wearableConnections || {},
+  )) {
+    if (!connection?.connectedAt) continue;
+    out[sourceId] = {
+      connectedSince: connection.connectedAt,
+      lastSyncAt: connection.lastSyncAt || 0,
+    };
+  }
+  return out;
 }

--- a/js/startup-oauth-callbacks.js
+++ b/js/startup-oauth-callbacks.js
@@ -12,8 +12,8 @@ import {
   hasPendingOpenRouterOAuthSession,
   markOpenRouterOAuthSettingsLocal,
 } from './api.js';
-import { handleOAuthCallbackOnLoad } from './wearables-connect.js';
 import { showNotification as showAppNotification } from './utils.js';
+import { loadWearablesConnectModule } from './wearables-connect-loader.js';
 
 /** @type {{ showNotification: Function | null, showInsufficientBalanceDialog: Function | null }} */
 const startupOAuthCallbackDeps = {
@@ -51,6 +51,24 @@ function currentPathname() {
 
 function currentSearch() {
   return startupRuntime().location?.search || '';
+}
+
+export function hasPendingWearableOAuthCallback(search = currentSearch()) {
+  const returnedState = new URLSearchParams(search).get('state');
+  if (!returnedState) return false;
+  try {
+    const storage = startupRuntime().sessionStorage;
+    for (let index = 0; index < storage.length; index += 1) {
+      const key = storage.key(index);
+      if (!key?.endsWith('-oauth-pending')) continue;
+      const pendingRaw = storage.getItem(key);
+      if (!pendingRaw) continue;
+      try {
+        if (JSON.parse(pendingRaw).state === returnedState) return true;
+      } catch {}
+    }
+  } catch {}
+  return false;
 }
 
 function replaceCurrentUrl() {
@@ -118,12 +136,21 @@ function handleOpenRouterOAuthError(error, description) {
 }
 
 export async function handleStartupOAuthCallbacks() {
+  const search = currentSearch();
+  const urlParams = new URLSearchParams(search);
   // Wearable OAuth2 callbacks must run after profile load so saveConnection
   // writes to the active profile. If handled, skip OpenRouter so the same
   // `?code=` is not processed twice.
-  const wearableHandled = await handleOAuthCallbackOnLoad();
+  let wearableHandled = false;
+  if (hasPendingWearableOAuthCallback(search)) {
+    const wearables = await loadWearablesConnectModule();
+    // The old eager startup path had already installed the scheduler by the
+    // time a callback completed. Preserve that behavior on callback loads.
+    wearables.loadWearableRuntimeConfig();
+    wearables.initWearableScheduler();
+    wearableHandled = await wearables.handleOAuthCallbackOnLoad();
+  }
 
-  const urlParams = new URLSearchParams(currentSearch());
   const oauthCode = urlParams.get('code');
   const oauthState = urlParams.get('state');
   const oauthError = urlParams.get('error');

--- a/js/startup-orchestrator.js
+++ b/js/startup-orchestrator.js
@@ -5,7 +5,7 @@ import { initializeStartupFoundation } from './startup-foundation.js';
 import { initializeProfileData } from './startup-profile.js';
 import { handleStartupOAuthCallbacks } from './startup-oauth-callbacks.js';
 import { renderStartupUI } from './startup-ui.js';
-import { initializeStartupServices, runPostProfileStartupMaintenance } from './startup-maintenance.js';
+import { runPostProfileStartupMaintenance } from './startup-maintenance.js';
 import { installGlobalEventListeners, registerAppRefreshCallback } from './app-event-listeners.js';
 import { showNotification } from './utils.js';
 import { restorePendingImportReviewDraft } from './import-loader.js';
@@ -17,8 +17,6 @@ let appStarted = false;
 
 async function runStartupSequence() {
   await initializeStartupFoundation();
-
-  initializeStartupServices();
 
   await initializeProfileData();
 

--- a/js/wearables-connect-loader.js
+++ b/js/wearables-connect-loader.js
@@ -1,0 +1,37 @@
+// @ts-check
+// wearables-connect-loader.js — shared on-demand loader for vendor OAuth/sync code
+
+/** @typedef {typeof import('./wearables-connect.js')} WearablesConnectModule */
+/** @type {Promise<WearablesConnectModule> | null} */
+let wearablesConnectModulePromise = null;
+/** @type {WearablesConnectModule | null} */
+let wearablesConnectModule = null;
+let useWearablesConnectRetryUrl = false;
+
+export function isWearablesConnectModuleLoaded() {
+  return wearablesConnectModule !== null;
+}
+
+/** @returns {Promise<WearablesConnectModule>} */
+function loadWearablesConnectRetryModule() {
+  // @ts-expect-error TypeScript resolves only the query-free source path.
+  return import('./wearables-connect.js?lazy-retry=1');
+}
+
+/** @returns {Promise<WearablesConnectModule>} */
+export function loadWearablesConnectModule() {
+  if (!wearablesConnectModulePromise) {
+    const load = useWearablesConnectRetryUrl
+      ? loadWearablesConnectRetryModule()
+      : import('./wearables-connect.js');
+    wearablesConnectModulePromise = load
+      .then(module => (wearablesConnectModule = module))
+      .catch(error => {
+        wearablesConnectModulePromise = null;
+        wearablesConnectModule = null;
+        useWearablesConnectRetryUrl = true;
+        throw error;
+      });
+  }
+  return wearablesConnectModulePromise;
+}

--- a/js/wearables-manual.js
+++ b/js/wearables-manual.js
@@ -13,7 +13,7 @@
 import { upsertDaily, upsertDailyBatch, countSource, getDaily, deleteDaily, getMeta, setMeta } from './wearables-store.js';
 import { state } from './state.js';
 import { saveImportedData } from './data.js';
-import { isoDay } from './wearables-oura.js';
+import { isoDay } from './wearable-adapters.js';
 
 // Merge helper — read the existing manual row for `date` (if any), shallow-merge
 // the new patch on top, write back. Needed because IDB `put` replaces the whole

--- a/js/wearables-settings-panel.js
+++ b/js/wearables-settings-panel.js
@@ -14,6 +14,7 @@ import {
   syncNow,
   listConnectedSources,
   getConnection,
+  loadWearableRuntimeConfig,
 } from './wearables-connect.js';
 import { syncWearableSummary } from './wearables-summary.js';
 import { getActiveProfileId } from './profile.js';
@@ -487,8 +488,9 @@ document.addEventListener('settings:wearables-rendered', () => {
   queueMicrotask(_updateManualCounts);
 });
 
-function handleWearableConnect(adapterId) {
+async function handleWearableConnect(adapterId) {
   try {
+    await loadWearableRuntimeConfig();
     beginConnectOAuth(adapterId);
     // beginOAuth navigates away — nothing else to do here.
   } catch (e) {

--- a/scripts/cold-load-budget.json
+++ b/scripts/cold-load-budget.json
@@ -8,10 +8,10 @@
     "decodedBytes": 5099000
   },
   "reference": {
-    "requests": 410,
-    "transferBytes": 1632250,
-    "decodedBytes": 4736910
+    "requests": 397,
+    "transferBytes": 1580946,
+    "decodedBytes": 4588554
   },
-  "referenceCommit": "7a421fd3",
+  "referenceCommit": "d5074e61",
   "measuredAt": "2026-07-25"
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -451,6 +451,7 @@ const APP_SHELL = [
   '/js/wearables-store.js',
   '/js/wearables-summary.js',
   '/js/wearables-connect-runtime.js',
+  '/js/wearables-connect-loader.js',
   '/js/wearables-connect.js',
   '/js/wearables-oura.js',
   '/js/wearables-oura-auth.js',

--- a/tests/playwright/cold-load-budget.spec.js
+++ b/tests/playwright/cold-load-budget.spec.js
@@ -91,6 +91,24 @@ test('cold mobile app load stays within committed resource budgets', async ({ pa
   expect(entries.some(entry => (
     new URL(entry.name).pathname === '/js/wearables.js'
   ))).toBe(false);
+  const deferredWearableConnectionModules = new Set([
+    '/js/wearables-connect.js',
+    '/js/wearables-oura.js',
+    '/js/wearables-oura-auth.js',
+    '/js/wearables-whoop.js',
+    '/js/wearables-whoop-auth.js',
+    '/js/wearables-fitbit.js',
+    '/js/wearables-fitbit-auth.js',
+    '/js/wearables-withings.js',
+    '/js/wearables-withings-auth.js',
+    '/js/wearables-ultrahuman.js',
+    '/js/wearables-ultrahuman-auth.js',
+    '/js/wearables-polar.js',
+    '/js/wearables-polar-auth.js',
+  ]);
+  expect(entries.some(entry => (
+    deferredWearableConnectionModules.has(new URL(entry.name).pathname)
+  ))).toBe(false);
   expect(entries.some(entry => (
     new URL(entry.name).pathname === '/js/light-tool-camera-modals.js'
   ))).toBe(false);

--- a/tests/playwright/startup-helpers-browser-coverage.spec.js
+++ b/tests/playwright/startup-helpers-browser-coverage.spec.js
@@ -205,17 +205,10 @@ test('startup maintenance starts services and runs non-blocking migrations', asy
     '**/js/wearables-connect.js*': `
       export function loadWearableRuntimeConfig() {
         window.__startupMaintenanceCalls.push('loadWearableRuntimeConfig');
+        return Promise.resolve();
       }
       export function initWearableScheduler() {
         window.__startupMaintenanceCalls.push('initWearableScheduler');
-      }
-      export function syncStaleWearablesNow() {
-        window.__startupMaintenanceCalls.push('syncStaleWearablesNow');
-        return Promise.reject(new Error('offline'));
-      }
-      export function listConnectedSources() {
-        window.__startupMaintenanceCalls.push('listConnectedSources');
-        return ['manual', 'oura'];
       }
     `,
     '**/js/wearables-manual.js*': `
@@ -247,7 +240,20 @@ test('startup maintenance starts services and runs non-blocking migrations', asy
     window.__startupMaintenanceCalls = [];
     window.__startupMaintenanceState = {
       currentProfile: 'startup-maintenance-profile',
-      importedData: { biometrics: { weight: 70 } },
+      importedData: {
+        biometrics: { weight: 70 },
+        wearableConnections: {
+          manual: {
+            connectedAt: '2026-07-01T00:00:00.000Z',
+            lastSyncAt: 11,
+          },
+          oura: {
+            accessToken: 'coverage-token',
+            connectedAt: '2026-07-02T00:00:00.000Z',
+            lastSyncAt: 22,
+          },
+        },
+      },
     };
     const startupRuntime = await import('/js/startup-maintenance-runtime.js');
     const previousStartupSunDeps = startupRuntime.configureStartupMaintenanceSunDeps({
@@ -276,17 +282,17 @@ test('startup maintenance starts services and runs non-blocking migrations', asy
 
     try {
       const maintenance = await import(maintenanceUrl);
-      maintenance.initializeStartupServices();
       maintenance.runPostProfileStartupMaintenance();
       const summarySynced = await waitUntil(() => window.__startupMaintenanceCalls
-        .some(call => Array.isArray(call) && call[0] === 'syncWearableSummary'));
+        .some(call => Array.isArray(call) && call[0] === 'syncWearableSummary')
+        && window.__startupMaintenanceCalls.includes('initWearableScheduler'));
 
       return {
         startupServicesInitializeWearableConfigAndScheduler:
           window.__startupMaintenanceCalls.includes('loadWearableRuntimeConfig')
           && window.__startupMaintenanceCalls.includes('initWearableScheduler'),
-        staleWearableSyncIsStartedAndIgnoredOnFailure:
-          window.__startupMaintenanceCalls.includes('syncStaleWearablesNow'),
+        connectedWearableSchedulerStartsAfterProfileLoad:
+          window.__startupMaintenanceCalls.includes('initWearableScheduler'),
         sunSessionRehydrateIsDeferredAndLogged:
           window.__startupMaintenanceCalls.some(call => Array.isArray(call) && call[0] === 'setTimeout' && call[1] === 1500)
           && window.__startupMaintenanceCalls.includes('rehydrateStaleSessions')
@@ -303,7 +309,16 @@ test('startup maintenance starts services and runs non-blocking migrations', asy
           && window.__startupMaintenanceCalls.some(call => Array.isArray(call)
             && call[0] === 'syncWearableSummary'
             && call[1] === 'startup-maintenance-profile'
-            && JSON.stringify(call[2]) === JSON.stringify(['manual', 'oura'])),
+            && JSON.stringify(call[2]) === JSON.stringify({
+              manual: {
+                connectedSince: '2026-07-01T00:00:00.000Z',
+                lastSyncAt: 11,
+              },
+              oura: {
+                connectedSince: '2026-07-02T00:00:00.000Z',
+                lastSyncAt: 22,
+              },
+            })),
       };
     } finally {
       window.setTimeout = originalSetTimeout;

--- a/tests/playwright/startup-oauth-browser-coverage.spec.js
+++ b/tests/playwright/startup-oauth-browser-coverage.spec.js
@@ -247,6 +247,9 @@ test('startup OAuth browser coverage handles OpenRouter and wearable callback ro
         && window.location.search === '';
 
       resetCase('?code=openrouter-code&state=wearable-state&coverageWearable=1');
+      sessionStorage.setItem('coverage-oauth-pending', JSON.stringify({
+        state: 'wearable-state',
+      }));
       wearables.OAUTH_DISPATCH.coverage = {
         isCallback: params => params.get('coverageWearable') === '1',
         complete: async () => {
@@ -259,7 +262,7 @@ test('startup OAuth browser coverage handles OpenRouter and wearable callback ro
       sessionStorage.setItem('or_oauth_state', 'wearable-state');
       await startup.handleStartupOAuthCallbacks();
       outcomes.wearableCallbackSkipsOpenRouterProcessing = fakeWearableCompletes === 1
-        && fetchCalls.length === 0
+        && !fetchCalls.some(call => call.url.endsWith('/auth/keys'))
         && sessionStorage.getItem('or_pkce_verifier') === 'verifier-skipped'
         && window.location.search === '';
 

--- a/tests/playwright/startup-orchestrator-browser-coverage.spec.js
+++ b/tests/playwright/startup-orchestrator-browser-coverage.spec.js
@@ -46,9 +46,6 @@ async function openStartupOrchestratorPage(page) {
   await page.route('**/js/startup-maintenance.js*', route => route.fulfill({
     contentType: 'application/javascript',
     body: `
-      export function initializeStartupServices() {
-        window.__startupCalls.push('services');
-      }
       export function runPostProfileStartupMaintenance() {
         window.__startupCalls.push('maintenance');
       }
@@ -144,7 +141,6 @@ test('startup orchestrator browser coverage reports startup sequence failures', 
         && !('_getActiveProfileId' in window);
       outcomes.startupFailureStopsLaterPhasesAndReportsError =
         window.__startupCalls.includes('foundation')
-        && !window.__startupCalls.includes('services')
         && !window.__startupCalls.includes('maintenance')
         && !window.__startupCalls.includes('profile')
         && !window.__startupCalls.includes('oauth')

--- a/tests/playwright/wearables-connect-loader-browser-coverage.spec.js
+++ b/tests/playwright/wearables-connect-loader-browser-coverage.spec.js
@@ -1,0 +1,100 @@
+import { expect, test } from './coverage-fixture.js';
+
+const loaderUrl = () => `/js/wearables-connect-loader.js?wearablesConnectLoaderCoverage=${Date.now()}-${Math.random().toString(36).slice(2)}`;
+const syntheticConnect = `
+  export async function handleOAuthCallbackOnLoad() {
+    return true;
+  }
+  export function loadWearableRuntimeConfig() {
+    return Promise.resolve();
+  }
+  export function initWearableScheduler() {
+    window.__wearablesConnectLoaderCalls ||= [];
+    window.__wearablesConnectLoaderCalls.push('initWearableScheduler');
+  }
+`;
+
+test.beforeEach(async ({ page }) => {
+  await page.route('**/wearables-connect-loader-coverage', route => route.fulfill({
+    contentType: 'text/html',
+    body: '<!doctype html><html><body></body></html>',
+  }));
+  await page.goto('/wearables-connect-loader-coverage');
+});
+
+test('wearable vendor connection code stays cold and single-flights on demand', async ({ page }) => {
+  const implementationRequests = [];
+  await page.route('**/js/wearables-connect.js*', async route => {
+    implementationRequests.push(route.request().url());
+    await new Promise(resolve => setTimeout(resolve, 25));
+    await route.fulfill({
+      contentType: 'text/javascript',
+      body: syntheticConnect,
+    });
+  });
+
+  const outcomes = await page.evaluate(async url => {
+    const loader = await import(url);
+    const cold = !loader.isWearablesConnectModuleLoaded();
+    const first = loader.loadWearablesConnectModule();
+    const second = loader.loadWearablesConnectModule();
+    const sharedPromise = first === second;
+    const [connect] = await Promise.all([first, second]);
+    connect.initWearableScheduler();
+    return {
+      cold,
+      sharedPromise,
+      loaded: loader.isWearablesConnectModuleLoaded(),
+      calls: window.__wearablesConnectLoaderCalls || [],
+    };
+  }, loaderUrl());
+
+  expect(implementationRequests).toHaveLength(1);
+  expect(outcomes).toEqual({
+    cold: true,
+    sharedPromise: true,
+    loaded: true,
+    calls: ['initWearableScheduler'],
+  });
+});
+
+test('wearable connection loader retries a failed module request with a fixed URL', async ({ page }) => {
+  const implementationRequests = [];
+  await page.route('**/js/wearables-connect.js*', async route => {
+    const url = route.request().url();
+    implementationRequests.push(url);
+    if (!url.includes('lazy-retry=1')) {
+      await route.abort('failed');
+      return;
+    }
+    await route.fulfill({
+      contentType: 'text/javascript',
+      body: syntheticConnect,
+    });
+  });
+
+  const outcomes = await page.evaluate(async url => {
+    const loader = await import(url);
+    let firstRejected = false;
+    try {
+      await loader.loadWearablesConnectModule();
+    } catch {
+      firstRejected = true;
+    }
+    const connect = await loader.loadWearablesConnectModule();
+    return {
+      firstRejected,
+      loaded: loader.isWearablesConnectModuleLoaded(),
+      handled: await connect.handleOAuthCallbackOnLoad(),
+    };
+  }, loaderUrl());
+
+  expect(implementationRequests).toHaveLength(2);
+  expect(new URL(implementationRequests[0]).search).toBe('');
+  expect(new URL(implementationRequests[1]).search).toBe('?lazy-retry=1');
+  expect(outcomes).toEqual({
+    firstRejected: true,
+    loaded: true,
+    handled: true,
+  });
+});

--- a/tests/test-wearables-connect-runtime.js
+++ b/tests/test-wearables-connect-runtime.js
@@ -90,6 +90,7 @@ try {
 
   const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
   const connectSrc = fs.readFileSync(path.join(root, 'js/wearables-connect.js'), 'utf8');
+  const connectLoaderSrc = fs.readFileSync(path.join(root, 'js/wearables-connect-loader.js'), 'utf8');
   const connectRuntimeSrc = fs.readFileSync(path.join(root, 'js/wearables-connect-runtime.js'), 'utf8');
   const settingsRuntimeSrc = fs.readFileSync(path.join(root, 'js/wearables-settings-runtime.js'), 'utf8');
   const appShellHooksSrc = fs.readFileSync(path.join(root, 'js/app-shell-hooks.js'), 'utf8');
@@ -98,6 +99,10 @@ try {
     connectSrc.includes("from './wearables-connect-runtime.js'") &&
       !/\bwindow(?:\.|\s*\[)/.test(connectSrc) &&
       swSrc.includes("'/js/wearables-connect-runtime.js'"));
+  assert('wearables connect loader is retryable and available offline',
+    connectLoaderSrc.includes("import('./wearables-connect.js')") &&
+      connectLoaderSrc.includes("import('./wearables-connect.js?lazy-retry=1')") &&
+      swSrc.includes("'/js/wearables-connect-loader.js'"));
   assert('wearable navigation stays dependency-injected from the app shell',
     !connectRuntimeSrc.includes('getViewRuntimeFunction') &&
       !settingsRuntimeSrc.includes('getViewRuntimeFunction') &&

--- a/tests/test-wearables.js
+++ b/tests/test-wearables.js
@@ -1738,14 +1738,19 @@ assert('importDataJSON prunes wearablePrimaryOverride to live sources only',
 
 // P2: commitAfterWriteIfAny accepts pre-await connection snapshot.
 const connectSrcP2 = await fetch('/js/wearables-connect.js').then(r => r.text());
+const connectLoaderSrcP2 = await fetch('/js/wearables-connect-loader.js').then(r => r.text());
 const startupMaintenanceSrcP2 = await fetch('/js/startup-maintenance.js').then(r => r.text());
 assert('commitAfterWriteIfAny accepts a connection snapshot (profile-swap safety)',
   /async function commitAfterWriteIfAny\(adapterId,\s*rows,\s*connSnapshot\)/.test(connectSrcP2));
 assert('Backfill + incremental pass the pre-await `conn` snapshot to commitAfterWriteIfAny',
   /commitAfterWriteIfAny\(adapterId,\s*rows,\s*conn\)/.test(connectSrcP2));
-assert('Post-profile startup kicks stale wearable sync after importedData loads',
-  /import\s*\{[^}]*syncStaleWearablesNow[^}]*\}\s*from\s*['"]\.\/wearables-connect\.js['"]/.test(startupMaintenanceSrcP2) &&
-  /runPostProfileStartupMaintenance[\s\S]*?syncStaleWearablesNow\(\)\.catch/.test(startupMaintenanceSrcP2));
+assert('Post-profile startup loads wearable vendors only for connected OAuth sources',
+  !startupMaintenanceSrcP2.includes("from './wearables-connect.js'") &&
+  startupMaintenanceSrcP2.includes("from './wearables-connect-loader.js'") &&
+  startupMaintenanceSrcP2.includes('connection?.accessToken') &&
+  startupMaintenanceSrcP2.includes('connect.initWearableScheduler()') &&
+  connectLoaderSrcP2.includes("import('./wearables-connect.js')") &&
+  connectLoaderSrcP2.includes("import('./wearables-connect.js?lazy-retry=1')"));
 assert('Wearable scheduler routes stale sync through a shared in-flight guard',
   /let\s+_staleSyncInFlight\s*=\s*null/.test(connectSrcP2) &&
   /export\s+function\s+syncStaleWearablesNow\(\)/.test(connectSrcP2) &&

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -279,6 +279,7 @@
     "js/wearables-apple-health.js",
     "js/wearables-auth-runtime.js",
     "js/wearables-connect-runtime.js",
+    "js/wearables-connect-loader.js",
     "js/wearables-connect.js",
     "js/wearables-bp-detail-chart.js",
     "js/wearables-detail-runtime.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.384';
+self.APP_VERSION = '1.10.385';


### PR DESCRIPTION
## Summary
- keep the wearable vendor OAuth and sync cluster out of startup for profiles without a connected OAuth wearable
- load vendor code only for a matching OAuth callback, an existing token-backed connection, or the Wearables settings interaction
- preserve self-host OAuth override loading, post-callback scheduling, connected-profile stale sync, and manual wearable summary migration
- add a shared single-flight loader with deterministic retry coverage and cold-path regression assertions for all 13 deferred modules

## Cold-load measurement
Stable across two runs:
- requests: 410 -> 397 (-13)
- compressed bytes: 1,632,250 -> 1,580,946 (-51,304)
- decoded bytes: 4,736,910 -> 4,588,554 (-148,356)

## Validation
- npm test (490 passed)
- npm run quality
- npm run architecture:check (474 modules, 0 cycles)
- npm run typecheck
- npm run typecheck:checkjs
- npm run vendor:check
- wearable domain suite (588 passed)
- focused startup, OAuth, scheduler, settings, vendor orchestration, and loader Playwright coverage
- cold-load budget repeated twice with identical metrics