### PR TITLE
Load Knowledge Base UI on demand

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -11,7 +11,7 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | --- | ---: |
 | Modules | 474 |
 | Internal import edges | 2121 |
-| Dynamic internal edges | 74 |
+| Dynamic internal edges | 75 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
 | Largest cyclic component | 0 |
@@ -438,7 +438,7 @@ Native browser modules shipped with the static application.
 - [`js/lens-page-shell.js`](js/lens-page-shell.js) → [`js/context-cards-runtime.js`](js/context-cards-runtime.js), [`js/dna-runtime-bridge.js`](js/dna-runtime-bridge.js), [`js/emf-runtime.js`](js/emf-runtime.js), [`js/profile.js`](js/profile.js), [`js/settings-runtime-bridge.js`](js/settings-runtime-bridge.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/lens-pages.js`](js/lens-pages.js) → [`js/biology-score-context-ai.js`](js/biology-score-context-ai.js), [`js/biology-scores.js`](js/biology-scores.js), [`js/context-cards.js`](js/context-cards.js), [`js/cycle.js`](js/cycle.js), [`js/data.js`](js/data.js), [`js/dna.js`](js/dna.js), [`js/profile-context.js`](js/profile-context.js), [`js/recommendations-runtime.js`](js/recommendations-runtime.js), [`js/state.js`](js/state.js), [`js/supplements.js`](js/supplements.js), [`js/utils.js`](js/utils.js)
 - [`js/lens-url.js`](js/lens-url.js) → no in-scope imports
-- [`js/lens.js`](js/lens.js) → [`js/api.js`](js/api.js), [`js/chat-runtime.js`](js/chat-runtime.js), [`js/crypto.js`](js/crypto.js), [`js/lens-cache.js`](js/lens-cache.js), [`js/lens-knowledge-base-ui.js`](js/lens-knowledge-base-ui.js), [`js/lens-local.js`](js/lens-local.js) *(dynamic)*, [`js/lens-url.js`](js/lens-url.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
+- [`js/lens.js`](js/lens.js) → [`js/api.js`](js/api.js), [`js/chat-runtime.js`](js/chat-runtime.js), [`js/crypto.js`](js/crypto.js), [`js/lens-cache.js`](js/lens-cache.js), [`js/lens-knowledge-base-ui.js`](js/lens-knowledge-base-ui.js) *(dynamic)*, [`js/lens-local.js`](js/lens-local.js) *(dynamic)*, [`js/lens-url.js`](js/lens-url.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 
 </details>
 

--- a/js/lens-knowledge-base-ui.js
+++ b/js/lens-knowledge-base-ui.js
@@ -17,14 +17,13 @@ export function createLensKnowledgeBaseUi(deps) {
     getLensKey,
     saveLensKey,
     removeLens,
-    hasLens,
     clearLensCache,
     getLensStatus,
     updateLensStatus,
     updateLensIndicator,
     isValidLensUrl,
     testLensConnection,
-    hasAIProvider,
+    recordLocalLensStats,
   } = deps;
 
   function renderCustomLensSection() {
@@ -394,12 +393,6 @@ export function createLensKnowledgeBaseUi(deps) {
     return mod.openLocalLens();
   }
 
-  // Module-level cache of the most recent in-browser lens stats. Used by
-  // getLensSummary() so the dashboard's Knowledge Base row can render
-  // synchronously without re-awaiting the worker on every paint. Refreshed
-  // every time _loadLocalLensStats() runs successfully.
-  let _lastLocalStats = null;
-
   async function _loadLocalLensStats() {
     const stats = document.getElementById('lens-local-stats');
     const list = document.getElementById('lens-local-doc-list');
@@ -408,7 +401,7 @@ export function createLensKnowledgeBaseUi(deps) {
     try {
       const lens = await _getLocalLens();
       const s = await lens.getStats();
-      _lastLocalStats = s;
+      recordLocalLensStats(s);
       // Notify dashboard listeners that summary numbers may have changed.
       updateLensStatus({});
       if (!stats) return;
@@ -430,45 +423,6 @@ export function createLensKnowledgeBaseUi(deps) {
     } catch (e) {
       if (stats) stats.innerHTML = `<span style="color:#fbbf24">Failed to load stats: ${escapeHTML(e?.message || String(e))}</span>`;
     }
-  }
-
-  // Synchronous summary used by the dashboard Knowledge Base row.
-  // Returns enough to render a one-line status without awaiting the
-  // worker. Numbers are best-effort — if no successful stats fetch has
-  // happened yet, docCount/chunkCount come back as null and the caller
-  // can render a softer "loading…" affordance.
-  function getLensSummary() {
-    const cfg = getLensConfig();
-    const configured = hasLens();
-    const aiAvailable = hasAIProvider();
-    const summary = {
-      configured,
-      backend: cfg.backend,
-      enabled: !!cfg.enabled,
-      multiQueryOn: configured && aiAvailable && cfg.multiQuery !== false,
-      aiAvailable,
-      displayName: '',
-      docCount: null,
-      chunkCount: null,
-    };
-    if (cfg.backend === 'in-browser') {
-      summary.displayName = (cfg.name || '').trim() || 'My Library';
-      // Only surface doc/chunk counts when there's actually a configured
-      // library — otherwise stale cache from a prior session would leak
-      // numbers into the dashboard's empty-state stub.
-      if (configured && _lastLocalStats) {
-        summary.docCount = Array.isArray(_lastLocalStats.documents) ? _lastLocalStats.documents.length : null;
-        summary.chunkCount = typeof _lastLocalStats.total_chunks === 'number' ? _lastLocalStats.total_chunks : null;
-      }
-    } else {
-      // external-server: take the user-named label, or fall back to the URL host
-      let label = (cfg.name || '').trim();
-      if (!label && cfg.url) {
-        try { label = new URL(cfg.url).host; } catch { label = cfg.url; }
-      }
-      summary.displayName = label || 'Knowledge Base';
-    }
-    return summary;
   }
 
   function _renderLocalDocList(docs) {
@@ -743,7 +697,6 @@ export function createLensKnowledgeBaseUi(deps) {
 
   return {
     closeKnowledgeBaseModal,
-    getLensSummary,
     handleClearLensCache,
     handleLensBackendChange,
     handleLibraryActivate,

--- a/js/lens.js
+++ b/js/lens.js
@@ -3,11 +3,10 @@
 // User-configured RAG endpoint that backs the Interpretive Lens with retrieved chunks.
 import { state } from './state.js';
 import { getCachedKey, updateKeyCache, encryptedSetItem } from './crypto.js';
-import { hashString, isDebugMode } from './utils.js';
+import { hashString, isDebugMode, showNotification } from './utils.js';
 import { hasAIProvider, callClaudeAPI } from './api.js';
 import { isValidLensUrl as isValidLensUrlImpl } from './lens-url.js';
 import { clearLensCache as clearLensCacheImpl, getLensCacheEntry, setLensCacheEntry } from './lens-cache.js';
-import { createLensKnowledgeBaseUi } from './lens-knowledge-base-ui.js';
 import { updateChatHeaderModelRuntime } from './chat-runtime.js';
 const CONFIG_KEY = 'labcharts-lens-config';
 const SECRET_KEY = 'labcharts-lens-key';
@@ -465,37 +464,196 @@ export function updateLensIndicator() {
 subscribeLensStatus(updateLensIndicator);
 
 // ═══════════════════════════════════════════════
-// KNOWLEDGE BASE UI FACADE
+// KNOWLEDGE BASE SUMMARY + LAZY UI FACADE
 // ═══════════════════════════════════════════════
-const lensKnowledgeBaseUi = createLensKnowledgeBaseUi({
+
+// The dashboard summary must stay synchronous and cold-safe. The UI reports
+// richer local-library stats after it loads; until then the localStorage count
+// used by hasLens() is enough to distinguish configured from empty.
+let lastLocalLensStats = null;
+
+function recordLocalLensStats(stats) {
+  lastLocalLensStats = stats;
+}
+
+export function getLensSummary() {
+  const cfg = getLensConfig();
+  const configured = hasLens();
+  const aiAvailable = hasAIProvider();
+  const summary = {
+    configured,
+    backend: cfg.backend,
+    enabled: !!cfg.enabled,
+    multiQueryOn: configured && aiAvailable && cfg.multiQuery !== false,
+    aiAvailable,
+    displayName: '',
+    docCount: null,
+    chunkCount: null,
+  };
+  if (cfg.backend === 'in-browser') {
+    summary.displayName = (cfg.name || '').trim() || 'My Library';
+    if (configured && lastLocalLensStats) {
+      summary.docCount = Array.isArray(lastLocalLensStats.documents)
+        ? lastLocalLensStats.documents.length
+        : null;
+      summary.chunkCount = typeof lastLocalLensStats.total_chunks === 'number'
+        ? lastLocalLensStats.total_chunks
+        : null;
+    }
+  } else {
+    let label = (cfg.name || '').trim();
+    if (!label && cfg.url) {
+      try { label = new URL(cfg.url).host; } catch { label = cfg.url; }
+    }
+    summary.displayName = label || 'Knowledge Base';
+  }
+  return summary;
+}
+
+/** @typedef {ReturnType<import('./lens-knowledge-base-ui.js')['createLensKnowledgeBaseUi']>} LensKnowledgeBaseUi */
+/** @type {Promise<LensKnowledgeBaseUi> | null} */
+let lensKnowledgeBaseUiPromise = null;
+/** @type {LensKnowledgeBaseUi | null} */
+let lensKnowledgeBaseUi = null;
+let useLensKnowledgeBaseUiRetryUrl = false;
+
+const lensKnowledgeBaseUiDeps = {
   defaultTestProbe: DEFAULT_TEST_PROBE,
   getLensConfig,
   saveLensConfig,
   getLensKey,
   saveLensKey,
   removeLens,
-  hasLens,
   clearLensCache,
   getLensStatus,
   updateLensStatus,
   updateLensIndicator,
   isValidLensUrl,
   testLensConnection,
-  hasAIProvider,
-});
+  recordLocalLensStats,
+};
 
-export function renderCustomLensSection() { return lensKnowledgeBaseUi.renderCustomLensSection(); }
-export function openKnowledgeBaseModal() { return lensKnowledgeBaseUi.openKnowledgeBaseModal(); }
-export function closeKnowledgeBaseModal() { return lensKnowledgeBaseUi.closeKnowledgeBaseModal(); }
-export async function handleSaveLensConfig() { return lensKnowledgeBaseUi.handleSaveLensConfig(); }
-export function handleLensBackendChange(backend) { return lensKnowledgeBaseUi.handleLensBackendChange(backend); }
-export function getLensSummary() { return lensKnowledgeBaseUi.getLensSummary(); }
-export async function handleLocalLensDeleteDoc(source) { return lensKnowledgeBaseUi.handleLocalLensDeleteDoc(source); }
-export async function handleLocalLensClear() { return lensKnowledgeBaseUi.handleLocalLensClear(); }
-export function handleLibraryActivate(libraryId) { return lensKnowledgeBaseUi.handleLibraryActivate(libraryId); }
-export function handleLibraryNew() { return lensKnowledgeBaseUi.handleLibraryNew(); }
-export function handleLibraryRename() { return lensKnowledgeBaseUi.handleLibraryRename(); }
-export function handleLibraryDelete() { return lensKnowledgeBaseUi.handleLibraryDelete(); }
-export function handleToggleLens(checked) { return lensKnowledgeBaseUi.handleToggleLens(checked); }
-export function handleClearLensCache() { return lensKnowledgeBaseUi.handleClearLensCache(); }
-export async function handleRemoveLens() { return lensKnowledgeBaseUi.handleRemoveLens(); }
+export function isLensKnowledgeBaseUiLoaded() {
+  return lensKnowledgeBaseUi !== null;
+}
+
+function loadLensKnowledgeBaseUiRetryModule() {
+  // @ts-expect-error TypeScript resolves only the query-free source path.
+  return import('./lens-knowledge-base-ui.js?lazy-retry=1');
+}
+
+/** @returns {Promise<LensKnowledgeBaseUi>} */
+export function loadLensKnowledgeBaseUi() {
+  if (!lensKnowledgeBaseUiPromise) {
+    const load = useLensKnowledgeBaseUiRetryUrl
+      ? loadLensKnowledgeBaseUiRetryModule()
+      : import('./lens-knowledge-base-ui.js');
+    lensKnowledgeBaseUiPromise = load
+      .then(module => {
+        lensKnowledgeBaseUi = module.createLensKnowledgeBaseUi(lensKnowledgeBaseUiDeps);
+        return lensKnowledgeBaseUi;
+      })
+      .catch(err => {
+        lensKnowledgeBaseUiPromise = null;
+        lensKnowledgeBaseUi = null;
+        useLensKnowledgeBaseUiRetryUrl = true;
+        throw err;
+      });
+  }
+  return lensKnowledgeBaseUiPromise;
+}
+
+/**
+ * @param {keyof LensKnowledgeBaseUi} name
+ * @param {any[]} args
+ * @param {boolean} [shouldLoad]
+ */
+function runLensKnowledgeBaseUiAction(name, args, shouldLoad = true) {
+  const run = (/** @type {LensKnowledgeBaseUi} */ ui) => {
+    const action = ui[name];
+    if (typeof action !== 'function') {
+      throw new Error(`Knowledge Base UI action ${String(name)} is unavailable`);
+    }
+    return Reflect.apply(action, ui, args);
+  };
+  if (!lensKnowledgeBaseUi && !shouldLoad) return undefined;
+  try {
+    if (lensKnowledgeBaseUi) return run(lensKnowledgeBaseUi);
+    return loadLensKnowledgeBaseUi()
+      .then(run)
+      .catch(err => {
+        console.error(`[lens] Could not run ${String(name)}:`, err);
+        showNotification('Knowledge Base controls could not be loaded. Try again.', 'error');
+        return false;
+      });
+  } catch (err) {
+    console.error(`[lens] Could not run ${String(name)}:`, err);
+    if (shouldLoad) showNotification('Knowledge Base controls could not be loaded. Try again.', 'error');
+    return shouldLoad ? false : undefined;
+  }
+}
+
+export function renderCustomLensSection() {
+  if (lensKnowledgeBaseUi) return lensKnowledgeBaseUi.renderCustomLensSection();
+  void loadLensKnowledgeBaseUi()
+    .then(ui => {
+      const section = document.getElementById('custom-lens-section');
+      if (section?.querySelector('[data-lens-ui-loading]')) {
+        section.innerHTML = ui.renderCustomLensSection();
+      }
+    })
+    .catch(() => {});
+  return '<div class="settings-loading-placeholder" data-lens-ui-loading>Loading Knowledge Base controls…</div>';
+}
+
+export function openKnowledgeBaseModal() {
+  return runLensKnowledgeBaseUiAction('openKnowledgeBaseModal', []);
+}
+
+export function closeKnowledgeBaseModal() {
+  return runLensKnowledgeBaseUiAction('closeKnowledgeBaseModal', [], false);
+}
+
+export function handleSaveLensConfig() {
+  return runLensKnowledgeBaseUiAction('handleSaveLensConfig', []);
+}
+
+export function handleLensBackendChange(backend) {
+  return runLensKnowledgeBaseUiAction('handleLensBackendChange', [backend]);
+}
+
+export function handleLocalLensDeleteDoc(source) {
+  return runLensKnowledgeBaseUiAction('handleLocalLensDeleteDoc', [source]);
+}
+
+export function handleLocalLensClear() {
+  return runLensKnowledgeBaseUiAction('handleLocalLensClear', []);
+}
+
+export function handleLibraryActivate(libraryId) {
+  return runLensKnowledgeBaseUiAction('handleLibraryActivate', [libraryId]);
+}
+
+export function handleLibraryNew() {
+  return runLensKnowledgeBaseUiAction('handleLibraryNew', []);
+}
+
+export function handleLibraryRename() {
+  return runLensKnowledgeBaseUiAction('handleLibraryRename', []);
+}
+
+export function handleLibraryDelete() {
+  return runLensKnowledgeBaseUiAction('handleLibraryDelete', []);
+}
+
+export function handleToggleLens(checked) {
+  return runLensKnowledgeBaseUiAction('handleToggleLens', [checked]);
+}
+
+export function handleClearLensCache() {
+  return runLensKnowledgeBaseUiAction('handleClearLensCache', []);
+}
+
+export function handleRemoveLens() {
+  return runLensKnowledgeBaseUiAction('handleRemoveLens', []);
+}

--- a/scripts/cold-load-budget.json
+++ b/scripts/cold-load-budget.json
@@ -8,10 +8,10 @@
     "decodedBytes": 5099000
   },
   "reference": {
-    "requests": 396,
-    "transferBytes": 1575122,
-    "decodedBytes": 4563299
+    "requests": 393,
+    "transferBytes": 1558957,
+    "decodedBytes": 4507515
   },
-  "referenceCommit": "152e77cd",
+  "referenceCommit": "3702506a",
   "measuredAt": "2026-07-25"
 }

--- a/tests/playwright/cold-load-budget.spec.js
+++ b/tests/playwright/cold-load-budget.spec.js
@@ -139,6 +139,14 @@ test('cold mobile app load stays within committed resource budgets', async ({ pa
   expect(entries.some(entry => (
     new URL(entry.name).pathname === '/js/cashu-wallet-store.js'
   ))).toBe(false);
+  const deferredKnowledgeBaseUiModules = new Set([
+    '/js/lens-actions.js',
+    '/js/lens-knowledge-base-ui.js',
+    '/js/lens-library.js',
+  ]);
+  expect(entries.some(entry => (
+    deferredKnowledgeBaseUiModules.has(new URL(entry.name).pathname)
+  ))).toBe(false);
   expect(entries.some(entry => (
     new URL(entry.name).pathname === '/js/sun-defaults.js'
   ))).toBe(false);

--- a/tests/playwright/custom-lens.spec.js
+++ b/tests/playwright/custom-lens.spec.js
@@ -32,7 +32,7 @@ test('knowledge base modal renders lens controls and settings AI does not', asyn
       testProbe: 'vitamin D deficiency supplementation',
       multiQuery: true,
     }));
-    openKnowledgeBaseModal();
+    await openKnowledgeBaseModal();
   });
 
   const lensSection = page.locator('#custom-lens-section');
@@ -47,7 +47,7 @@ test('knowledge base modal renders lens controls and settings AI does not', asyn
   await page.evaluate(async () => {
     const { closeKnowledgeBaseModal } = await import('/js/lens.js');
     const settings = await import('/js/settings.js');
-    closeKnowledgeBaseModal();
+    await closeKnowledgeBaseModal();
     settings.openSettingsModal('ai');
   });
 

--- a/tests/playwright/dashboard-ai-browser-coverage.spec.js
+++ b/tests/playwright/dashboard-ai-browser-coverage.spec.js
@@ -215,6 +215,8 @@ test('dashboard AI browser coverage exercises CTA rendering picker routing and D
 
       const lensPickerClosed = await clickPickerCard(dashboardAi.openPersonalizeAIPicker, '[data-pick="lens"]');
       const kbPickerClosed = await clickPickerCard(dashboardAi.openPersonalizeAIPicker, '[data-pick="kb"]');
+      await lens.loadLensKnowledgeBaseUi();
+      await Promise.resolve();
       outcomes.personalizePickerRoutesLensAndKnowledgeBase =
         lensPickerClosed
         && kbPickerClosed

--- a/tests/playwright/lens-hardware-browser-coverage.spec.js
+++ b/tests/playwright/lens-hardware-browser-coverage.spec.js
@@ -304,7 +304,7 @@ test('external lens browser contract covers validation fetch cache save and remo
         return makeJsonResponse({ chunks: [] });
       };
 
-      lens.openKnowledgeBaseModal();
+      await lens.openKnowledgeBaseModal();
       document.getElementById('lens-name-input').value = 'Saved KB';
       document.getElementById('lens-url-input').value = 'https://kb.example.test/query///';
       document.getElementById('lens-key-input').value = 'new-token';
@@ -407,6 +407,7 @@ test('in-browser lens render covers local panel status and backend switching wit
       }));
       cryptoStore.updateKeyCache('labcharts-lens-key', '');
 
+      await lens.loadLensKnowledgeBaseUi();
       section.innerHTML = lens.renderCustomLensSection();
       document.body.appendChild(section);
       const remoteFields = /** @type {HTMLElement | null} */ (section.querySelector('#lens-remote-fields'));

--- a/tests/playwright/lens-local-library-browser-coverage.spec.js
+++ b/tests/playwright/lens-local-library-browser-coverage.spec.js
@@ -304,7 +304,7 @@ test('knowledge base modal covers local document ingest and library controls', a
       localStorage.setItem('labcharts-lens-local-count', '3');
 
       lens = await import(lensUrl);
-      lens.openKnowledgeBaseModal();
+      await lens.openKnowledgeBaseModal();
       const initialRendered = await waitFor(() => document.getElementById('lens-local-doc-list')?.textContent.includes('alpha "quote".md')
         && document.getElementById('lens-local-stats')?.textContent.includes('3 excerpts from 2 documents')
         && document.getElementById('lens-library-select')?.textContent.includes('Alpha Papers'));

--- a/tests/playwright/lens-ui-loader-browser-coverage.spec.js
+++ b/tests/playwright/lens-ui-loader-browser-coverage.spec.js
@@ -1,0 +1,184 @@
+import { expect, test } from './coverage-fixture.js';
+
+const facadeUrl = () => `/js/lens.js?uiLoaderCoverage=${Date.now()}-${Math.random().toString(36).slice(2)}`;
+const syntheticLensUi = `
+  const record = (name, ...args) => {
+    window.__lensUiLoaderCalls ||= [];
+    window.__lensUiLoaderCalls.push([name, ...args]);
+  };
+  export function createLensKnowledgeBaseUi(deps) {
+    record('create');
+    deps.recordLocalLensStats({
+      documents: [{ source: 'notes.md' }],
+      total_chunks: 2,
+    });
+    return {
+      renderCustomLensSection() {
+        record('renderCustomLensSection');
+        return 'lens controls';
+      },
+      openKnowledgeBaseModal() {
+        record('openKnowledgeBaseModal');
+        return 'opened';
+      },
+      closeKnowledgeBaseModal() {
+        record('closeKnowledgeBaseModal');
+        return 'closed';
+      },
+      handleSaveLensConfig() { return 'saved'; },
+      handleLensBackendChange(backend) { return backend; },
+      handleLocalLensDeleteDoc(source) { return source; },
+      handleLocalLensClear() { return 'cleared'; },
+      handleLibraryActivate(id) { return id; },
+      handleLibraryNew() { return 'new'; },
+      handleLibraryRename() { return 'renamed'; },
+      handleLibraryDelete() { return 'deleted'; },
+      handleToggleLens(checked) { return checked; },
+      handleClearLensCache() { return 'cache-cleared'; },
+      handleRemoveLens() { return 'removed'; },
+    };
+  }
+`;
+
+test.beforeEach(async ({ page }) => {
+  await page.route('**/lens-ui-loader-coverage', route => route.fulfill({
+    contentType: 'text/html',
+    body: '<!doctype html><html><body><div id="notification-container"></div></body></html>',
+  }));
+  await page.goto('/lens-ui-loader-coverage');
+});
+
+test('Knowledge Base UI stays cold, single-flights, and enriches the core summary after loading', async ({ page }) => {
+  const implementationRequests = [];
+  await page.route('**/js/lens-knowledge-base-ui.js*', async route => {
+    implementationRequests.push(route.request().url());
+    await new Promise(resolve => setTimeout(resolve, 25));
+    await route.fulfill({
+      contentType: 'text/javascript',
+      body: syntheticLensUi,
+    });
+  });
+
+  const outcomes = await page.evaluate(async url => {
+    localStorage.setItem('labcharts-lens-config', JSON.stringify({
+      name: 'Local Notes',
+      enabled: true,
+      backend: 'in-browser',
+      multiQuery: true,
+    }));
+    localStorage.setItem('labcharts-lens-local-count', '2');
+    const facade = await import(url);
+    const cold = !facade.isLensKnowledgeBaseUiLoaded();
+    const coldSummary = facade.getLensSummary();
+    const coldClose = facade.closeKnowledgeBaseModal();
+    const section = document.createElement('section');
+    section.id = 'custom-lens-section';
+    document.body.appendChild(section);
+    section.innerHTML = facade.renderCustomLensSection();
+    const coldMarkup = section.textContent;
+    const first = facade.loadLensKnowledgeBaseUi();
+    const second = facade.loadLensKnowledgeBaseUi();
+    const sharedPromise = first === second;
+    await Promise.all([first, second]);
+    const warmSummary = facade.getLensSummary();
+    return {
+      cold,
+      coldClose,
+      coldDocCount: coldSummary.docCount,
+      coldMarkup,
+      sharedPromise,
+      loaded: facade.isLensKnowledgeBaseUiLoaded(),
+      warmDocCount: warmSummary.docCount,
+      warmChunkCount: warmSummary.chunkCount,
+      hydratedMarkup: section.textContent,
+      markup: facade.renderCustomLensSection(),
+      opened: facade.openKnowledgeBaseModal(),
+      closed: facade.closeKnowledgeBaseModal(),
+      saved: facade.handleSaveLensConfig(),
+      backend: facade.handleLensBackendChange('external-server'),
+      deletedDoc: facade.handleLocalLensDeleteDoc('notes.md'),
+      clearedLocal: facade.handleLocalLensClear(),
+      activated: facade.handleLibraryActivate('library-2'),
+      created: facade.handleLibraryNew(),
+      renamed: facade.handleLibraryRename(),
+      deleted: facade.handleLibraryDelete(),
+      toggled: facade.handleToggleLens(true),
+      cacheCleared: facade.handleClearLensCache(),
+      removed: facade.handleRemoveLens(),
+      calls: window.__lensUiLoaderCalls || [],
+    };
+  }, facadeUrl());
+
+  expect(implementationRequests).toHaveLength(1);
+  expect(outcomes).toEqual({
+    cold: true,
+    coldClose: undefined,
+    coldDocCount: null,
+    coldMarkup: 'Loading Knowledge Base controls…',
+    sharedPromise: true,
+    loaded: true,
+    warmDocCount: 1,
+    warmChunkCount: 2,
+    hydratedMarkup: 'lens controls',
+    markup: 'lens controls',
+    opened: 'opened',
+    closed: 'closed',
+    saved: 'saved',
+    backend: 'external-server',
+    deletedDoc: 'notes.md',
+    clearedLocal: 'cleared',
+    activated: 'library-2',
+    created: 'new',
+    renamed: 'renamed',
+    deleted: 'deleted',
+    toggled: true,
+    cacheCleared: 'cache-cleared',
+    removed: 'removed',
+    calls: [
+      ['create'],
+      ['renderCustomLensSection'],
+      ['renderCustomLensSection'],
+      ['openKnowledgeBaseModal'],
+      ['closeKnowledgeBaseModal'],
+    ],
+  });
+});
+
+test('Knowledge Base UI retries with a fixed URL and reports the first failure', async ({ page }) => {
+  const implementationRequests = [];
+  await page.route('**/js/lens-knowledge-base-ui.js*', async route => {
+    const url = route.request().url();
+    implementationRequests.push(url);
+    if (!url.includes('lazy-retry=1')) {
+      await route.abort('failed');
+      return;
+    }
+    await route.fulfill({
+      contentType: 'text/javascript',
+      body: syntheticLensUi,
+    });
+  });
+
+  const outcomes = await page.evaluate(async url => {
+    const facade = await import(url);
+    const first = await facade.openKnowledgeBaseModal();
+    const notification = document.querySelector('#notification-container')?.textContent || '';
+    const second = await facade.openKnowledgeBaseModal();
+    return {
+      first,
+      second,
+      loaded: facade.isLensKnowledgeBaseUiLoaded(),
+      notification,
+    };
+  }, facadeUrl());
+
+  expect(implementationRequests).toHaveLength(2);
+  expect(new URL(implementationRequests[0]).search).toBe('');
+  expect(new URL(implementationRequests[1]).search).toBe('?lazy-retry=1');
+  expect(outcomes).toEqual({
+    first: false,
+    second: 'opened',
+    loaded: true,
+    notification: '✗ Knowledge Base controls could not be loaded. Try again.',
+  });
+});

--- a/tests/test-custom-lens.js
+++ b/tests/test-custom-lens.js
@@ -55,6 +55,13 @@ assert('handleRemoveLens exists', lensSrc.includes('function handleRemoveLens()'
 assert('handleToggleLens exists', lensSrc.includes('function handleToggleLens('));
 assert('handleClearLensCache exists', lensSrc.includes('function handleClearLensCache()'));
 assert('updateLensIndicator exists', lensSrc.includes('function updateLensIndicator()'));
+assert('Knowledge Base UI is dynamically imported',
+  lensSrc.includes("import('./lens-knowledge-base-ui.js')") &&
+    !lensSrc.includes("from './lens-knowledge-base-ui.js'"));
+assert('Knowledge Base UI loader retries through a stable URL',
+  lensSrc.includes("import('./lens-knowledge-base-ui.js?lazy-retry=1')"));
+assert('dashboard summary stays in the cold-safe lens facade',
+  lensSrc.includes('function getLensSummary()'));
 assert("fetch uses credentials:'omit'", lensSrc.includes("credentials: 'omit'"));
 assert("fetch uses referrerPolicy:'no-referrer'", lensSrc.includes("referrerPolicy: 'no-referrer'"));
 assert("fetch uses redirect:'error'", lensSrc.includes("redirect: 'error'"));
@@ -147,6 +154,7 @@ for (const name of [
   'queryLens', 'buildLensSnippet', 'testLensConnection', 'clearLensCache',
   'isValidLensUrl', 'renderCustomLensSection', 'handleSaveLensConfig',
   'handleRemoveLens', 'updateLensIndicator', 'subscribeLensStatus',
+  'getLensSummary', 'loadLensKnowledgeBaseUi', 'isLensKnowledgeBaseUiLoaded',
 ]) {
   assert(`lens.${name} is function`, typeof lens[name] === 'function');
 }

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -316,7 +316,7 @@
     'createLineChart','getMarkerDescription'
   ];
 
-  // lens.js (28, module-only)
+  // lens.js (31, module-only)
   const lensExports = [
     'getLensConfig','saveLensConfig','getLensKey','saveLensKey',
     'hasLens','queryLens','queryLensMulti','buildLensSnippet','testLensConnection','clearLensCache',
@@ -327,6 +327,7 @@
     'handleLensBackendChange',
     'handleLocalLensDeleteDoc','handleLocalLensClear',
     'handleLibraryActivate','handleLibraryNew','handleLibraryRename','handleLibraryDelete',
+    'getLensSummary','loadLensKnowledgeBaseUi','isLensKnowledgeBaseUiLoaded',
   ];
 
   // light-tools.js (17 selected exports, module-only)

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.386';
+self.APP_VERSION = '1.10.387';


### PR DESCRIPTION
## Summary
- keep Lens query, configuration, status, and dashboard summary logic in the cold-safe facade
- defer the Knowledge Base modal plus its action and library helpers behind a single-flight loader with fixed-URL retry
- preserve synchronous dashboard summaries and hydrate richer local-library stats after the UI loads
- add cold-load assertions and focused browser coverage for cold state, placeholder hydration, action delegation, and retry behavior

## Cold-load impact
- requests: 396 -> 393 (-3)
- compressed bytes: 1,575,122 -> 1,558,957 (-16,165)
- decoded bytes: 4,563,299 -> 4,507,515 (-55,784)

The final baseline was reproduced identically twice.

## Validation
- CI-equivalent coverage suite: 490 unit tests and 467 Playwright tests passed
- responsive E2E matrix: 472 cases passed
- global function coverage: 67.19% (threshold 67.10%)
- typecheck and checkJs passed
- quality, architecture (474 modules / 0 cycles), vendor, and module verification passed