### PR TITLE
Load Light Environment UI on demand

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -10,7 +10,7 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | Metric | Current |
 | --- | ---: |
 | Modules | 475 |
-| Internal import edges | 2124 |
+| Internal import edges | 2125 |
 | Dynamic internal edges | 76 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -42,7 +42,7 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 | [`js/state.js`](js/state.js) | 149 | [`js/app-light-sun-modules.js`](js/app-light-sun-modules.js) | 27 |
 | [`js/data.js`](js/data.js) | 73 | [`js/sync-configure.js`](js/sync-configure.js) | 27 |
 | [`js/api.js`](js/api.js) | 63 | [`js/dashboard-view-composition.js`](js/dashboard-view-composition.js) | 25 |
-| [`js/modal-lifecycle.js`](js/modal-lifecycle.js) | 57 | [`js/settings.js`](js/settings.js) | 25 |
+| [`js/modal-lifecycle.js`](js/modal-lifecycle.js) | 58 | [`js/settings.js`](js/settings.js) | 25 |
 | [`js/profile.js`](js/profile.js) | 45 | [`js/views.js`](js/views.js) | 25 |
 | [`js/schema.js`](js/schema.js) | 30 | [`js/pdf-import.js`](js/pdf-import.js) | 23 |
 | [`js/crypto.js`](js/crypto.js) | 29 | [`js/chat-send.js`](js/chat-send.js) | 22 |
@@ -468,7 +468,7 @@ Native browser modules shipped with the static application.
 - [`js/light-env-evening.js`](js/light-env-evening.js) → no in-scope imports
 - [`js/light-env-model.js`](js/light-env-model.js) → [`js/light-env-evening.js`](js/light-env-evening.js)
 - [`js/light-env-screen-ui.js`](js/light-env-screen-ui.js) → [`js/light-env-actions.js`](js/light-env-actions.js), [`js/light-env-model.js`](js/light-env-model.js), [`js/light-env-store.js`](js/light-env-store.js), [`js/utils.js`](js/utils.js)
-- [`js/light-env-shell-hooks.js`](js/light-env-shell-hooks.js) → [`js/app-event-listeners.js`](js/app-event-listeners.js), [`js/light-env.js`](js/light-env.js), [`js/light-sun-loader.js`](js/light-sun-loader.js), [`js/light-tools.js`](js/light-tools.js), [`js/nav.js`](js/nav.js), [`js/views.js`](js/views.js)
+- [`js/light-env-shell-hooks.js`](js/light-env-shell-hooks.js) → [`js/app-event-listeners.js`](js/app-event-listeners.js), [`js/light-sun-loader.js`](js/light-sun-loader.js), [`js/light-tools.js`](js/light-tools.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/nav.js`](js/nav.js), [`js/views.js`](js/views.js)
 - [`js/light-env-store.js`](js/light-env-store.js) → [`js/data-merge.js`](js/data-merge.js), [`js/data.js`](js/data.js), [`js/light-env-evening.js`](js/light-env-evening.js), [`js/light-env-model.js`](js/light-env-model.js), [`js/state.js`](js/state.js)
 - [`js/light-env.js`](js/light-env.js) → [`js/light-env-actions.js`](js/light-env-actions.js), [`js/light-env-audits.js`](js/light-env-audits.js), [`js/light-env-evening.js`](js/light-env-evening.js), [`js/light-env-model.js`](js/light-env-model.js), [`js/light-env-screen-ui.js`](js/light-env-screen-ui.js), [`js/light-env-store.js`](js/light-env-store.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/light-page-view-hooks.js`](js/light-page-view-hooks.js) → [`js/light-channel-view.js`](js/light-channel-view.js), [`js/light-channels-ai-analysis.js`](js/light-channels-ai-analysis.js), [`js/light-devices-store.js`](js/light-devices-store.js), [`js/light-devices.js`](js/light-devices.js), [`js/light-env.js`](js/light-env.js), [`js/light-page-view.js`](js/light-page-view.js), [`js/light-today-ai.js`](js/light-today-ai.js), [`js/light-tools.js`](js/light-tools.js), [`js/sun-active-session.js`](js/sun-active-session.js), [`js/sun-defaults.js`](js/sun-defaults.js), [`js/sun.js`](js/sun.js)
@@ -728,7 +728,7 @@ Native browser modules shipped with the static application.
 - [`js/sun-body-silhouette-runtime.js`](js/sun-body-silhouette-runtime.js) → [`js/profile.js`](js/profile.js)
 - [`js/sun-body-silhouette.js`](js/sun-body-silhouette.js) → [`js/silhouette-paths.js`](js/silhouette-paths.js), [`js/sun-body-silhouette-runtime.js`](js/sun-body-silhouette-runtime.js), [`js/utils.js`](js/utils.js)
 - [`js/sun-channel-metrics.js`](js/sun-channel-metrics.js) → [`js/state.js`](js/state.js), [`js/sun-active-session.js`](js/sun-active-session.js), [`js/sun-body-silhouette.js`](js/sun-body-silhouette.js), [`js/sun-sessions-store.js`](js/sun-sessions-store.js), [`js/sun-spectrum.js`](js/sun-spectrum.js), [`js/supplement-impact.js`](js/supplement-impact.js)
-- [`js/sun-context-hooks.js`](js/sun-context-hooks.js) → [`js/data.js`](js/data.js), [`js/lab-context.js`](js/lab-context.js), [`js/light-devices-store.js`](js/light-devices-store.js), [`js/light-env.js`](js/light-env.js), [`js/sun-context.js`](js/sun-context.js), [`js/sun-spectrum.js`](js/sun-spectrum.js), [`js/sun-uvdata.js`](js/sun-uvdata.js), [`js/sun.js`](js/sun.js), [`js/utils.js`](js/utils.js)
+- [`js/sun-context-hooks.js`](js/sun-context-hooks.js) → [`js/data.js`](js/data.js), [`js/lab-context.js`](js/lab-context.js), [`js/light-devices-store.js`](js/light-devices-store.js), [`js/light-env-model.js`](js/light-env-model.js), [`js/light-env-store.js`](js/light-env-store.js), [`js/sun-context.js`](js/sun-context.js), [`js/sun-spectrum.js`](js/sun-spectrum.js), [`js/sun-uvdata.js`](js/sun-uvdata.js), [`js/sun.js`](js/sun.js), [`js/utils.js`](js/utils.js)
 - [`js/sun-context.js`](js/sun-context.js) → [`js/lab-context.js`](js/lab-context.js), [`js/light-env-evening.js`](js/light-env-evening.js), [`js/state.js`](js/state.js), [`js/sun-correlations.js`](js/sun-correlations.js)
 - [`js/sun-correlations.js`](js/sun-correlations.js) → [`js/state.js`](js/state.js), [`js/sun.js`](js/sun.js)
 - [`js/sun-defaults-runtime.js`](js/sun-defaults-runtime.js) → [`js/profile.js`](js/profile.js)

--- a/js/app-light-sun-modules.js
+++ b/js/app-light-sun-modules.js
@@ -13,7 +13,7 @@ import './light-sessions-view-hooks.js';
 import './light-sun-ai-hooks.js';
 import './light-tools.js';
 import './light-tools-ai-analysis.js';
-import './light-env.js';
+export { configureLightEnv, openLightEnvironmentAssessment } from './light-env.js';
 import './sun-context-hooks.js';
 import './light-conditions-now-hooks.js';
 import './light-env-ai-analysis.js';

--- a/js/light-env-shell-hooks.js
+++ b/js/light-env-shell-hooks.js
@@ -2,18 +2,28 @@
 // light-env-shell-hooks.js - wire Light Environment shell actions without window lookups.
 
 import { configureAppEventListeners } from './app-event-listeners.js';
-import { closeLightEnvironmentAssessment, configureLightEnv, openLightEnvironmentAssessment } from './light-env.js';
-import { loadLightSunUI } from './light-sun-loader.js';
+import {
+  configureLightEnvironmentLoaderDeps,
+  loadLightSunUI,
+} from './light-sun-loader.js';
 import { getMeasurementsForRoom } from './light-tools.js';
+import { closeModalOverlay } from './modal-lifecycle.js';
 import { configureNavActions } from './nav.js';
 import { navigate } from './views.js';
 
-configureLightEnv({ getMeasurementsForRoom, navigate });
+configureLightEnvironmentLoaderDeps({ getMeasurementsForRoom, navigate });
+
+function closeLightEnvironmentAssessment() {
+  const overlay = document.getElementById('light-env-assessment-overlay');
+  if (!overlay) return;
+  closeModalOverlay(overlay);
+  overlay.remove();
+}
 
 configureNavActions({
   openLightEnvironmentAssessment() {
     void loadLightSunUI()
-      .then(() => openLightEnvironmentAssessment())
+      .then(module => module.openLightEnvironmentAssessment())
       .catch(err => console.error('Failed to load Light & Sun modules', err));
   },
 });

--- a/js/light-sun-loader.js
+++ b/js/light-sun-loader.js
@@ -23,6 +23,26 @@ let _lightSunUILoad = null;
 let _lightSunModulesLoaded = false;
 let _lightSunUILoaded = false;
 let _useLightSunStylesheetRetryUrls = false;
+const _lightEnvironmentLoaderDeps = {};
+
+function applyLightEnvironmentLoaderDeps(module) {
+  if (
+    Object.keys(_lightEnvironmentLoaderDeps).length > 0
+    && typeof module.configureLightEnv === 'function'
+  ) {
+    module.configureLightEnv(_lightEnvironmentLoaderDeps);
+  }
+  return module;
+}
+
+export function configureLightEnvironmentLoaderDeps(deps = {}) {
+  for (const [key, value] of Object.entries(deps || {})) {
+    if (typeof value === 'function') _lightEnvironmentLoaderDeps[key] = value;
+  }
+  if (_lightSunModulesLoad) {
+    void _lightSunModulesLoad.then(applyLightEnvironmentLoaderDeps).catch(() => {});
+  }
+}
 
 export function isLightSunModulesLoaded() {
   return _lightSunModulesLoaded;
@@ -37,6 +57,7 @@ export function loadLightSunModules() {
   if (!_lightSunModulesLoad) {
     _lightSunModulesLoad = import('./app-light-sun-modules.js')
       .then(module => {
+        applyLightEnvironmentLoaderDeps(module);
         _lightSunModulesLoaded = true;
         return module;
       })

--- a/js/sun-context-hooks.js
+++ b/js/sun-context-hooks.js
@@ -17,11 +17,23 @@ import {
 } from './sun-spectrum.js';
 import { getMeteoConfig } from './sun-uvdata.js';
 import { rollingDeviceTotals } from './light-devices-store.js';
-import { computeDeficitAxes, computeIndoorBurden } from './light-env.js';
+import {
+  computeDeficitAxesForEnvironment,
+  computeIndoorBurdenForEnvironment,
+} from './light-env-model.js';
+import { getEnvironment, isActiveToday } from './light-env-store.js';
 import { configureDataContextDependencies } from './data.js';
 import { configureLabContext, invalidateLabContextCache } from './lab-context.js';
 import { isDebugMode } from './utils.js';
 import { buildSunContext, configureSunContext } from './sun-context.js';
+
+function computeDeficitAxes() {
+  return computeDeficitAxesForEnvironment(getEnvironment(), { isActiveToday });
+}
+
+function computeIndoorBurden() {
+  return computeIndoorBurdenForEnvironment(getEnvironment(), { isActiveToday });
+}
 
 configureLabContext({ buildSunContext });
 configureDataContextDependencies({ invalidateLabContextCache });

--- a/scripts/cold-load-budget.json
+++ b/scripts/cold-load-budget.json
@@ -8,10 +8,10 @@
     "decodedBytes": 5099000
   },
   "reference": {
-    "requests": 391,
-    "transferBytes": 1545186,
-    "decodedBytes": 4454212
+    "requests": 387,
+    "transferBytes": 1517738,
+    "decodedBytes": 4359250
   },
-  "referenceCommit": "dcb75e6b",
+  "referenceCommit": "90a3f89a",
   "measuredAt": "2026-07-25"
 }

--- a/tests/light-env-shell-hooks-runtime.test.js
+++ b/tests/light-env-shell-hooks-runtime.test.js
@@ -2,9 +2,9 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const MOCKED_MODULES = [
   '../js/app-event-listeners.js',
-  '../js/light-env.js',
   '../js/light-sun-loader.js',
   '../js/light-tools.js',
+  '../js/modal-lifecycle.js',
   '../js/nav.js',
   '../js/views.js',
 ];
@@ -19,14 +19,14 @@ describe('Light environment shell hooks', () => {
   it('opens after lazy UI readiness and contains lazy-load failures', async () => {
     let appEventActions;
     let navActions;
-    const closeLightEnvironmentAssessment = vi.fn();
-    const configureLightEnv = vi.fn();
+    const closeModalOverlay = vi.fn();
+    const configureLightEnvironmentLoaderDeps = vi.fn();
     const getMeasurementsForRoom = vi.fn();
     const navigate = vi.fn();
     const openLightEnvironmentAssessment = vi.fn();
     const loadError = new Error('Light UI unavailable');
     const loadLightSunUI = vi.fn()
-      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ openLightEnvironmentAssessment })
       .mockRejectedValueOnce(loadError);
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
 
@@ -35,13 +35,12 @@ describe('Light environment shell hooks', () => {
         appEventActions = actions;
       },
     }));
-    vi.doMock('../js/light-env.js', () => ({
-      closeLightEnvironmentAssessment,
-      configureLightEnv,
-      openLightEnvironmentAssessment,
+    vi.doMock('../js/light-sun-loader.js', () => ({
+      configureLightEnvironmentLoaderDeps,
+      loadLightSunUI,
     }));
-    vi.doMock('../js/light-sun-loader.js', () => ({ loadLightSunUI }));
     vi.doMock('../js/light-tools.js', () => ({ getMeasurementsForRoom }));
+    vi.doMock('../js/modal-lifecycle.js', () => ({ closeModalOverlay }));
     vi.doMock('../js/nav.js', () => ({
       configureNavActions(actions) {
         navActions = actions;
@@ -51,8 +50,16 @@ describe('Light environment shell hooks', () => {
 
     await import('../js/light-env-shell-hooks.js');
 
-    expect(configureLightEnv).toHaveBeenCalledWith({ getMeasurementsForRoom, navigate });
-    expect(appEventActions).toEqual({ closeLightEnvironmentAssessment });
+    expect(configureLightEnvironmentLoaderDeps).toHaveBeenCalledWith({ getMeasurementsForRoom, navigate });
+    expect(appEventActions.closeLightEnvironmentAssessment).toBeTypeOf('function');
+
+    const overlay = { remove: vi.fn() };
+    vi.spyOn(document, 'getElementById').mockImplementation(
+      id => id === 'light-env-assessment-overlay' ? overlay : null,
+    );
+    appEventActions.closeLightEnvironmentAssessment();
+    expect(closeModalOverlay).toHaveBeenCalledWith(overlay);
+    expect(overlay.remove).toHaveBeenCalledOnce();
 
     navActions.openLightEnvironmentAssessment();
     await vi.waitFor(() => {

--- a/tests/playwright/cold-load-budget.spec.js
+++ b/tests/playwright/cold-load-budget.spec.js
@@ -155,6 +155,15 @@ test('cold mobile app load stays within committed resource budgets', async ({ pa
   expect(entries.some(entry => (
     deferredCycleImportModules.has(new URL(entry.name).pathname)
   ))).toBe(false);
+  const deferredLightEnvironmentUiModules = new Set([
+    '/js/light-env.js',
+    '/js/light-env-actions.js',
+    '/js/light-env-audits.js',
+    '/js/light-env-screen-ui.js',
+  ]);
+  expect(entries.some(entry => (
+    deferredLightEnvironmentUiModules.has(new URL(entry.name).pathname)
+  ))).toBe(false);
   expect(entries.some(entry => (
     new URL(entry.name).pathname === '/js/sun-defaults.js'
   ))).toBe(false);

--- a/tests/playwright/environment-coverage-batch.spec.js
+++ b/tests/playwright/environment-coverage-batch.spec.js
@@ -474,10 +474,11 @@ test('Light audit history covers save expand update compare interpret and delete
   await page.goto('/app', { waitUntil: 'load' });
 
   const results = await page.evaluate(async () => {
-    const [{ state }, data, audits] = await Promise.all([
+    const [{ state }, data, audits, { installLightEnvActionDelegates }] = await Promise.all([
       import('/js/state.js'),
       import('/js/data.js'),
       import('/js/light-env-audits.js'),
+      import('/js/light-env-actions.js'),
     ]);
 
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
@@ -622,6 +623,7 @@ test('Light audit history covers save expand update compare interpret and delete
       });
 
       const host = renderHost();
+      installLightEnvActionDelegates(audits.lightEnvAuditActionHandlers, host);
       outcomes.auditRenderUsesDelegatedActions =
         host.querySelector('[onclick],[onchange],[oninput],[onkeydown],[onblur],[onsubmit],[ontoggle]') === null
         && host.querySelector('[data-light-env-action="save-audit"]') !== null

--- a/tests/playwright/light-env-browser-coverage.spec.js
+++ b/tests/playwright/light-env-browser-coverage.spec.js
@@ -26,10 +26,11 @@ test('light environment browser coverage handles summary modal prompt and source
   await waitForInitialView(page);
 
   const outcomes = await page.evaluate(async () => {
-    const [{ state }, data, lightEnv] = await Promise.all([
+    const [{ state }, data, lightEnv, lightTools] = await Promise.all([
       import('/js/state.js'),
       import('/js/data.js'),
       import('/js/light-env.js'),
+      import('/js/light-tools.js'),
     ]);
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
     const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
@@ -56,6 +57,7 @@ test('light environment browser coverage handles summary modal prompt and source
     const outcomes = {};
     const calls = [];
     const savedLightEnvDeps = lightEnv.configureLightEnv({
+      getMeasurementsForRoom: lightTools.getMeasurementsForRoom,
       navigate: (route, meta) => calls.push(['navigate', route, meta || null]),
     });
     const env = () => state.importedData.lightEnvironment;
@@ -214,10 +216,11 @@ test('light environment browser coverage handles screens tools and confirm delet
   await waitForInitialView(page);
 
   const outcomes = await page.evaluate(async () => {
-    const [{ state }, data, lightEnv] = await Promise.all([
+    const [{ state }, data, lightEnv, lightTools] = await Promise.all([
       import('/js/state.js'),
       import('/js/data.js'),
       import('/js/light-env.js'),
+      import('/js/light-tools.js'),
     ]);
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
     const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
@@ -244,6 +247,7 @@ test('light environment browser coverage handles screens tools and confirm delet
     const outcomes = {};
     const calls = [];
     const savedLightEnvDeps = lightEnv.configureLightEnv({
+      getMeasurementsForRoom: lightTools.getMeasurementsForRoom,
       navigate: (route, meta) => calls.push(['navigate', route, meta || null]),
       openSpectrumClassifier: opts => calls.push(['spectrum', opts?.roomId || null]),
       openLuxMeter: opts => calls.push(['lux', opts?.roomId || null]),

--- a/tests/playwright/light-sun-loader-browser-coverage.spec.js
+++ b/tests/playwright/light-sun-loader-browser-coverage.spec.js
@@ -20,6 +20,9 @@ test('Light & Sun module loader caches background initialization without loading
       body: `
         globalThis.__lightSunModuleEvalCount = (globalThis.__lightSunModuleEvalCount || 0) + 1;
         export const marker = 'light-sun-ready';
+        export function configureLightEnv(deps) {
+          globalThis.__lightEnvironmentLoaderDepKeys = Object.keys(deps).sort();
+        }
       `,
     });
   });
@@ -53,6 +56,10 @@ test('Light & Sun module loader caches background initialization without loading
 
   const results = await page.evaluate(async ({ loaderUrl }) => {
     const loader = await import(loaderUrl);
+    loader.configureLightEnvironmentLoaderDeps({
+      getMeasurementsForRoom() {},
+      navigate() {},
+    });
     const startsUnloaded = loader.isLightSunModulesLoaded() === false;
     const startsUIUnloaded = loader.isLightSunUILoaded() === false;
     const [first, second] = await Promise.all([
@@ -101,6 +108,8 @@ test('Light & Sun module loader caches background initialization without loading
       lazyModuleEvaluatesOnce:
         globalThis.__lightSunModuleEvalCount === 1
         && first.marker === 'light-sun-ready',
+      lightEnvironmentDepsAppliedOnLazyLoad:
+        globalThis.__lightEnvironmentLoaderDepKeys?.join(',') === 'getMeasurementsForRoom,navigate',
       deferredSunCompletionAnalyzedOnce:
         globalThis.__deferredSunAnalysisIds?.length === 1
         && globalThis.__deferredSunAnalysisIds[0] === sunId,

--- a/tests/test-light-env-delegated-actions.js
+++ b/tests/test-light-env-delegated-actions.js
@@ -13,7 +13,9 @@ const actionSrc = fs.readFileSync(path.join(root, 'js/light-env-actions.js'), 'u
 const auditSrc = fs.readFileSync(path.join(root, 'js/light-env-audits.js'), 'utf8');
 const appEventSrc = fs.readFileSync(path.join(root, 'js/app-event-listeners.js'), 'utf8');
 const appUiShellSrc = fs.readFileSync(path.join(root, 'js/app-ui-shell-modules.js'), 'utf8');
+const appLightSunSrc = fs.readFileSync(path.join(root, 'js/app-light-sun-modules.js'), 'utf8');
 const envShellHooksSrc = fs.readFileSync(path.join(root, 'js/light-env-shell-hooks.js'), 'utf8');
+const lightSunLoaderSrc = fs.readFileSync(path.join(root, 'js/light-sun-loader.js'), 'utf8');
 const navSrc = fs.readFileSync(path.join(root, 'js/nav.js'), 'utf8');
 const swSrc = fs.readFileSync(path.join(root, 'service-worker.js'), 'utf8');
 const envUiSrc = `${envSrc}\n${screenSrc}`;
@@ -105,12 +107,17 @@ assert('Light environment modal shell actions are wired through startup hooks',
     !appEventSrc.includes('window.closeLightEnvironmentAssessment') &&
     envShellHooksSrc.includes("import { configureNavActions } from './nav.js';") &&
     envShellHooksSrc.includes("import { configureAppEventListeners } from './app-event-listeners.js';") &&
-    envShellHooksSrc.includes("import { closeLightEnvironmentAssessment, configureLightEnv, openLightEnvironmentAssessment } from './light-env.js';") &&
-    envShellHooksSrc.includes("import { loadLightSunUI } from './light-sun-loader.js';") &&
+    !envShellHooksSrc.includes("from './light-env.js'") &&
+    envShellHooksSrc.includes('configureLightEnvironmentLoaderDeps,') &&
+    envShellHooksSrc.includes('loadLightSunUI,') &&
     envShellHooksSrc.includes("import { getMeasurementsForRoom } from './light-tools.js';") &&
+    envShellHooksSrc.includes("import { closeModalOverlay } from './modal-lifecycle.js';") &&
     envShellHooksSrc.includes("import { navigate } from './views.js';") &&
-    envShellHooksSrc.includes('configureLightEnv({ getMeasurementsForRoom, navigate });') &&
+    envShellHooksSrc.includes('configureLightEnvironmentLoaderDeps({ getMeasurementsForRoom, navigate });') &&
+    envShellHooksSrc.includes('.then(module => module.openLightEnvironmentAssessment())') &&
     envShellHooksSrc.includes('loadLightSunUI()') &&
+    appLightSunSrc.includes("export { configureLightEnv, openLightEnvironmentAssessment } from './light-env.js';") &&
+    lightSunLoaderSrc.includes('applyLightEnvironmentLoaderDeps(module);') &&
     !envSrc.includes('globalThis.navigate') &&
     appUiShellSrc.includes("import './light-env-shell-hooks.js';"));
 assert('light-env screen renderer takes AI renderer from options instead of global lookup',

--- a/tests/test-light-env.js
+++ b/tests/test-light-env.js
@@ -603,11 +603,13 @@ const {
   const aiSaveHooksSrc = await fs.readFile(new URL('../js/light-ai-save-hooks.js', import.meta.url), 'utf8');
   const globalsSrc = await fs.readFile(new URL('../types/globals.d.ts', import.meta.url), 'utf8');
   const lightEnvShellHooksSrc = await fs.readFile(new URL('../js/light-env-shell-hooks.js', import.meta.url), 'utf8');
+  const lightSunLoaderSrc = await fs.readFile(new URL('../js/light-sun-loader.js', import.meta.url), 'utf8');
   const navSrc = await fs.readFile(new URL('../js/nav.js', import.meta.url), 'utf8');
   const screenUiSrc = await fs.readFile(new URL('../js/light-env-screen-ui.js', import.meta.url), 'utf8');
   const measurementAiSrc = await fs.readFile(new URL('../js/light-tools-ai-analysis.js', import.meta.url), 'utf8');
   const roomAiSrc = await fs.readFile(new URL('../js/light-env-ai-analysis.js', import.meta.url), 'utf8');
   const screenAiSrc = await fs.readFile(new URL('../js/light-screen-ai-analysis.js', import.meta.url), 'utf8');
+  const sunContextHooksSrc = await fs.readFile(new URL('../js/sun-context-hooks.js', import.meta.url), 'utf8');
   assert('Light audit renderer emits no inline event attributes',
     !/\bon(?:click|keydown|change|input|submit|blur|toggle)=/.test(auditSrc));
   assert('Light environment render/data helpers stay module exports, not window facade',
@@ -726,13 +728,21 @@ const {
   assert('Light assessment modal shell actions route through startup wiring instead of window lookup',
     appUiShellSrc.includes("import './light-env-shell-hooks.js';") &&
     lightEnvShellHooksSrc.includes("import { configureAppEventListeners } from './app-event-listeners.js';") &&
-    lightEnvShellHooksSrc.includes("import { closeLightEnvironmentAssessment, configureLightEnv, openLightEnvironmentAssessment } from './light-env.js';") &&
-    lightEnvShellHooksSrc.includes("import { loadLightSunUI } from './light-sun-loader.js';") &&
+    !lightEnvShellHooksSrc.includes("from './light-env.js'") &&
+    lightEnvShellHooksSrc.includes('configureLightEnvironmentLoaderDeps,') &&
+    lightEnvShellHooksSrc.includes('loadLightSunUI,') &&
     lightEnvShellHooksSrc.includes("import { getMeasurementsForRoom } from './light-tools.js';") &&
+    lightEnvShellHooksSrc.includes("import { closeModalOverlay } from './modal-lifecycle.js';") &&
     lightEnvShellHooksSrc.includes("import { navigate } from './views.js';") &&
-    lightEnvShellHooksSrc.includes('configureLightEnv({ getMeasurementsForRoom, navigate });') &&
+    lightEnvShellHooksSrc.includes('configureLightEnvironmentLoaderDeps({ getMeasurementsForRoom, navigate });') &&
+    lightEnvShellHooksSrc.includes('.then(module => module.openLightEnvironmentAssessment())') &&
     lightEnvShellHooksSrc.includes('loadLightSunUI()') &&
     lightEnvShellHooksSrc.includes("import { configureNavActions } from './nav.js';") &&
+    appLightSunSrc.includes("export { configureLightEnv, openLightEnvironmentAssessment } from './light-env.js';") &&
+    lightSunLoaderSrc.includes('applyLightEnvironmentLoaderDeps(module);') &&
+    !sunContextHooksSrc.includes("from './light-env.js'") &&
+    sunContextHooksSrc.includes("from './light-env-model.js'") &&
+    sunContextHooksSrc.includes("from './light-env-store.js'") &&
     navSrc.includes("typeof value === 'function'") &&
     appEventSrc.includes("typeof value === 'function'") &&
     !envSrc.includes('globalThis.navigate') &&

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.388';
+self.APP_VERSION = '1.10.389';


### PR DESCRIPTION
## Summary

- keep Light Environment model and store calculations eager while moving its four UI modules behind the existing Light and Sun loader
- carry shell dependencies across the lazy boundary and keep modal close handling cold-safe
- guard the deferred modules in the cold-load browser test and cover lazy dependency injection

## Cold-load impact

Compared with main at 90a3f89a:

- requests: 391 to 387 (-4)
- transferred: 1,545,186 to 1,517,738 bytes (-27,448)
- decoded: 4,454,212 to 4,359,250 bytes (-94,962)

The post-change result reproduced exactly across three fresh Chromium runs.

## Validation

- npm test (490 passed)
- npm run typecheck
- npm run typecheck:checkjs
- npm run architecture:check
- npm run quality
- npm run vendor:check
- targeted Chromium Light Environment and loader batch (11 passed)
- npm run test:firefox (3 passed)
- npm run performance:check