### PR TITLE
Load Light device modals on demand

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -9,9 +9,9 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 
 | Metric | Current |
 | --- | ---: |
-| Modules | 476 |
-| Internal import edges | 2127 |
-| Dynamic internal edges | 77 |
+| Modules | 477 |
+| Internal import edges | 2129 |
+| Dynamic internal edges | 79 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
 | Largest cyclic component | 0 |
@@ -38,7 +38,7 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 
 | High fan-in | Dependants | High fan-out | Imports |
 | --- | ---: | --- | ---: |
-| [`js/utils.js`](js/utils.js) | 221 | [`js/app-shell-hooks.js`](js/app-shell-hooks.js) | 88 |
+| [`js/utils.js`](js/utils.js) | 222 | [`js/app-shell-hooks.js`](js/app-shell-hooks.js) | 88 |
 | [`js/state.js`](js/state.js) | 149 | [`js/app-light-sun-modules.js`](js/app-light-sun-modules.js) | 27 |
 | [`js/data.js`](js/data.js) | 73 | [`js/sync-configure.js`](js/sync-configure.js) | 27 |
 | [`js/api.js`](js/api.js) | 63 | [`js/dashboard-view-composition.js`](js/dashboard-view-composition.js) | 25 |
@@ -444,7 +444,7 @@ Native browser modules shipped with the static application.
 
 </details>
 
-<details><summary><code>light</code> family — 40 modules</summary>
+<details><summary><code>light</code> family — 41 modules</summary>
 
 - [`js/light-ai-save-hooks.js`](js/light-ai-save-hooks.js) → [`js/api.js`](js/api.js), [`js/chat-panel.js`](js/chat-panel.js), [`js/light-audit-ai-analysis.js`](js/light-audit-ai-analysis.js), [`js/light-env-ai-analysis.js`](js/light-env-ai-analysis.js), [`js/light-env-audits.js`](js/light-env-audits.js), [`js/light-env.js`](js/light-env.js), [`js/light-screen-ai-analysis.js`](js/light-screen-ai-analysis.js), [`js/light-tools-ai-analysis.js`](js/light-tools-ai-analysis.js), [`js/light-tools.js`](js/light-tools.js), [`js/sun-defaults.js`](js/sun-defaults.js), [`js/sun-onboarding-ai.js`](js/sun-onboarding-ai.js), [`js/sun-sessions-store.js`](js/sun-sessions-store.js), [`js/sun-uvdata.js`](js/sun-uvdata.js), [`js/sun.js`](js/sun.js)
 - [`js/light-audit-ai-analysis.js`](js/light-audit-ai-analysis.js) → [`js/ai-action-delegates.js`](js/ai-action-delegates.js), [`js/ai-verdict-engine.js`](js/ai-verdict-engine.js), [`js/api.js`](js/api.js), [`js/health-goals-utils.js`](js/health-goals-utils.js), [`js/light-env-evening.js`](js/light-env-evening.js), [`js/lighting-hardware-caveats.js`](js/lighting-hardware-caveats.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
@@ -456,13 +456,14 @@ Native browser modules shipped with the static application.
 - [`js/light-conditions-now-hooks.js`](js/light-conditions-now-hooks.js) → [`js/data.js`](js/data.js), [`js/light-conditions-now.js`](js/light-conditions-now.js), [`js/sun-uvdata.js`](js/sun-uvdata.js), [`js/sun.js`](js/sun.js), [`js/utils.js`](js/utils.js)
 - [`js/light-conditions-now.js`](js/light-conditions-now.js) → [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/light-device-ai-analysis.js`](js/light-device-ai-analysis.js) → [`js/ai-action-delegates.js`](js/ai-action-delegates.js), [`js/ai-verdict-engine.js`](js/ai-verdict-engine.js), [`js/api.js`](js/api.js), [`js/health-goals-utils.js`](js/health-goals-utils.js), [`js/light-devices-store.js`](js/light-devices-store.js), [`js/state.js`](js/state.js), [`js/sun-defaults.js`](js/sun-defaults.js), [`js/sun.js`](js/sun.js), [`js/utils.js`](js/utils.js)
+- [`js/light-device-modal-loader.js`](js/light-device-modal-loader.js) → [`js/light-device-session-modal.js`](js/light-device-session-modal.js) *(dynamic)*, [`js/light-device-setup-modal.js`](js/light-device-setup-modal.js) *(dynamic)*, [`js/utils.js`](js/utils.js)
 - [`js/light-device-session-engine.js`](js/light-device-session-engine.js) → [`js/sun-body-silhouette.js`](js/sun-body-silhouette.js), [`js/sun-spectrum.js`](js/sun-spectrum.js)
 - [`js/light-device-session-modal.js`](js/light-device-session-modal.js) → [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/state.js`](js/state.js), [`js/sun-body-silhouette.js`](js/sun-body-silhouette.js), [`js/sun-spectrum.js`](js/sun-spectrum.js), [`js/utils.js`](js/utils.js)
 - [`js/light-device-setup-modal.js`](js/light-device-setup-modal.js) → [`js/api.js`](js/api.js), [`js/image-utils.js`](js/image-utils.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/state.js`](js/state.js), [`js/utils-runtime.js`](js/utils-runtime.js), [`js/utils.js`](js/utils.js)
 - [`js/light-devices-actions.js`](js/light-devices-actions.js) → no in-scope imports
 - [`js/light-devices-runtime.js`](js/light-devices-runtime.js) → [`js/recommendations-runtime.js`](js/recommendations-runtime.js), [`js/state.js`](js/state.js), [`js/sun.js`](js/sun.js), [`js/utils.js`](js/utils.js)
 - [`js/light-devices-store.js`](js/light-devices-store.js) → [`js/data-merge.js`](js/data-merge.js), [`js/data.js`](js/data.js), [`js/light-device-session-engine.js`](js/light-device-session-engine.js), [`js/state.js`](js/state.js)
-- [`js/light-devices.js`](js/light-devices.js) → [`js/light-device-session-modal.js`](js/light-device-session-modal.js), [`js/light-device-setup-modal.js`](js/light-device-setup-modal.js), [`js/light-devices-actions.js`](js/light-devices-actions.js), [`js/light-devices-runtime.js`](js/light-devices-runtime.js), [`js/light-devices-store.js`](js/light-devices-store.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/sun-body-silhouette.js`](js/sun-body-silhouette.js), [`js/sun-spectrum.js`](js/sun-spectrum.js), [`js/sun.js`](js/sun.js), [`js/utils.js`](js/utils.js)
+- [`js/light-devices.js`](js/light-devices.js) → [`js/light-device-modal-loader.js`](js/light-device-modal-loader.js), [`js/light-devices-actions.js`](js/light-devices-actions.js), [`js/light-devices-runtime.js`](js/light-devices-runtime.js), [`js/light-devices-store.js`](js/light-devices-store.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/sun-body-silhouette.js`](js/sun-body-silhouette.js), [`js/sun-spectrum.js`](js/sun-spectrum.js), [`js/sun.js`](js/sun.js), [`js/utils.js`](js/utils.js)
 - [`js/light-env-actions.js`](js/light-env-actions.js) → [`js/utils.js`](js/utils.js)
 - [`js/light-env-ai-analysis.js`](js/light-env-ai-analysis.js) → [`js/ai-action-delegates.js`](js/ai-action-delegates.js), [`js/ai-verdict-engine.js`](js/ai-verdict-engine.js), [`js/api.js`](js/api.js), [`js/health-goals-utils.js`](js/health-goals-utils.js), [`js/light-env-evening.js`](js/light-env-evening.js), [`js/lighting-hardware-caveats.js`](js/lighting-hardware-caveats.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/light-env-audits.js`](js/light-env-audits.js) → [`js/data-merge.js`](js/data-merge.js), [`js/data.js`](js/data.js), [`js/light-env-actions.js`](js/light-env-actions.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)

--- a/js/light-device-modal-loader.js
+++ b/js/light-device-modal-loader.js
@@ -1,0 +1,123 @@
+// @ts-check
+// light-device-modal-loader.js — cold facade for Light device form modals.
+
+import { showNotification } from './utils.js';
+
+/** @typedef {typeof import('./light-device-setup-modal.js')} LightDeviceSetupModule */
+/** @typedef {typeof import('./light-device-session-modal.js')} LightDeviceSessionModule */
+
+/** @type {Record<string, any>} */
+const setupDeps = {};
+/** @type {Record<string, any>} */
+const sessionDeps = {};
+
+/** @type {Promise<LightDeviceSetupModule> | null} */
+let setupModulePromise = null;
+/** @type {LightDeviceSetupModule | null} */
+let setupModule = null;
+let useSetupRetryUrl = false;
+
+/** @type {Promise<LightDeviceSessionModule> | null} */
+let sessionModulePromise = null;
+/** @type {LightDeviceSessionModule | null} */
+let sessionModule = null;
+let useSessionRetryUrl = false;
+
+export function configureLightDeviceModalLoader(deps = {}) {
+  if (deps.setup && typeof deps.setup === 'object') Object.assign(setupDeps, deps.setup);
+  if (deps.session && typeof deps.session === 'object') Object.assign(sessionDeps, deps.session);
+  setupModule?.configureLightDeviceSetup(setupDeps);
+}
+
+export function isLightDeviceSetupModuleLoaded() {
+  return setupModule !== null;
+}
+
+/** @returns {Promise<LightDeviceSetupModule>} */
+function loadSetupRetryModule() {
+  // @ts-expect-error TypeScript resolves only the query-free source path.
+  return import('./light-device-setup-modal.js?lazy-retry=1');
+}
+
+/** @returns {Promise<LightDeviceSetupModule>} */
+export function loadLightDeviceSetupModule() {
+  if (!setupModulePromise) {
+    const load = useSetupRetryUrl
+      ? loadSetupRetryModule()
+      : import('./light-device-setup-modal.js');
+    setupModulePromise = load
+      .then(module => {
+        setupModule = module;
+        module.configureLightDeviceSetup(setupDeps);
+        return module;
+      })
+      .catch(error => {
+        setupModulePromise = null;
+        setupModule = null;
+        useSetupRetryUrl = true;
+        throw error;
+      });
+  }
+  return setupModulePromise;
+}
+
+export async function openAddDeviceDialog() {
+  try {
+    const module = setupModule || await loadLightDeviceSetupModule();
+    return await module.openAddDeviceDialog();
+  } catch (error) {
+    console.error('[light-devices] Could not open device setup:', error);
+    showNotification('Light device setup could not be loaded. Try again.', 'error');
+    return false;
+  }
+}
+
+export async function openCustomDeviceDialog() {
+  try {
+    const module = setupModule || await loadLightDeviceSetupModule();
+    return await module.openCustomDeviceDialog();
+  } catch (error) {
+    console.error('[light-devices] Could not open custom device setup:', error);
+    showNotification('Light device setup could not be loaded. Try again.', 'error');
+    return false;
+  }
+}
+
+export function isLightDeviceSessionModuleLoaded() {
+  return sessionModule !== null;
+}
+
+/** @returns {Promise<LightDeviceSessionModule>} */
+function loadSessionRetryModule() {
+  // @ts-expect-error TypeScript resolves only the query-free source path.
+  return import('./light-device-session-modal.js?lazy-retry=1');
+}
+
+/** @returns {Promise<LightDeviceSessionModule>} */
+export function loadLightDeviceSessionModule() {
+  if (!sessionModulePromise) {
+    const load = useSessionRetryUrl
+      ? loadSessionRetryModule()
+      : import('./light-device-session-modal.js');
+    sessionModulePromise = load
+      .then(module => (sessionModule = module))
+      .catch(error => {
+        sessionModulePromise = null;
+        sessionModule = null;
+        useSessionRetryUrl = true;
+        throw error;
+      });
+  }
+  return sessionModulePromise;
+}
+
+export async function openDeviceSessionDialog(deviceId) {
+  try {
+    const module = sessionModule || await loadLightDeviceSessionModule();
+    return await module.openDeviceSessionDialog(deviceId, sessionDeps);
+  } catch (error) {
+    console.error('[light-devices] Could not open session dialog:', error);
+    showNotification('Light device session tools could not be loaded. Try again.', 'error');
+    return false;
+  }
+}

--- a/js/light-devices.js
+++ b/js/light-devices.js
@@ -38,9 +38,13 @@ import {
   stopDeviceSession,
   updateDeviceSession,
 } from './light-devices-store.js';
-import { openDeviceSessionDialog as openDeviceSessionDialogModal } from './light-device-session-modal.js';
-import { configureLightDeviceSetup, openAddDeviceDialog, openCustomDeviceDialog } from './light-device-setup-modal.js';
 import { configureLightDevicesActions, installLightDevicesActionDelegates } from './light-devices-actions.js';
+import {
+  configureLightDeviceModalLoader,
+  openAddDeviceDialog,
+  openCustomDeviceDialog,
+  openDeviceSessionDialog,
+} from './light-device-modal-loader.js';
 import {
   getLightDeviceChannelDisplay,
   getLightDeviceChannelHelpers,
@@ -64,7 +68,7 @@ export function configureLightDevices(deps = {}) {
 if (typeof document !== 'undefined') installLightDevicesActionDelegates();
 
 export { installLightDevicesActionDelegates };
-export { openAddDeviceDialog, openCustomDeviceDialog };
+export { openAddDeviceDialog, openCustomDeviceDialog, openDeviceSessionDialog };
 export {
   addCustomDevice,
   deleteDevice,
@@ -89,6 +93,28 @@ function _wireModal(overlay, closeFn) {
   if (typeof window === 'undefined') { document.body.appendChild(overlay); return; }
   openAppendedModalOverlay(overlay, closeFn);
 }
+
+configureLightDeviceModalLoader({
+  setup: {
+    loadPresets: loadLightDevicePresets,
+    addDeviceFromPreset,
+    addCustomDevice,
+    wireModal: _wireModal,
+    refreshLightView: () => refreshLightDevicesView(),
+  },
+  session: {
+    hydrateDevicesFromPresets,
+    getDevices,
+    logDeviceSession,
+    getActiveDeviceSession,
+    startDeviceSession,
+    ensureActiveDeviceTicker,
+    validateModeCoupling,
+    renderBodySilhouette,
+    bindBodySilhouette,
+    navigate: navigateLightDevicesRoute,
+  },
+});
 
 export async function loadLightDevicePresets() {
   if (_PRESETS) return { presets: _PRESETS, types: _PRESET_TYPES };
@@ -634,33 +660,6 @@ function _relativeTimeShort(ts) {
   }
   const y = Math.floor(days / 365);
   return `${y} year${y !== 1 ? 's' : ''} ago`;
-}
-
-configureLightDeviceSetup({
-  loadPresets: loadLightDevicePresets,
-  addDeviceFromPreset,
-  addCustomDevice,
-  wireModal: _wireModal,
-  refreshLightView: () => {
-    refreshLightDevicesView();
-  },
-});
-
-// ─── UI: log device session modal ──────────────────────────────────────
-
-export async function openDeviceSessionDialog(deviceId) {
-  return openDeviceSessionDialogModal(deviceId, {
-    hydrateDevicesFromPresets,
-    getDevices,
-    logDeviceSession,
-    getActiveDeviceSession,
-    startDeviceSession,
-    ensureActiveDeviceTicker,
-    validateModeCoupling,
-    renderBodySilhouette,
-    bindBodySilhouette,
-    navigate: navigateLightDevicesRoute,
-  });
 }
 
 // ─── Quick-log entry point ────────────────────────────────────────────

--- a/scripts/cold-load-budget.json
+++ b/scripts/cold-load-budget.json
@@ -8,10 +8,10 @@
     "decodedBytes": 5099000
   },
   "reference": {
-    "requests": 384,
-    "transferBytes": 1491640,
-    "decodedBytes": 4264060
+    "requests": 383,
+    "transferBytes": 1480294,
+    "decodedBytes": 4227736
   },
-  "referenceCommit": "cd21288f",
+  "referenceCommit": "c5fbb1ec",
   "measuredAt": "2026-07-25"
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -506,6 +506,7 @@ const APP_SHELL = [
   '/js/light-devices-actions.js',
   '/js/light-devices-store.js',
   '/js/light-device-session-engine.js',
+  '/js/light-device-modal-loader.js',
   '/js/light-device-setup-modal.js',
   '/js/light-device-session-modal.js',
   '/js/light-env.js',

--- a/tests/playwright/cold-load-budget.spec.js
+++ b/tests/playwright/cold-load-budget.spec.js
@@ -172,6 +172,13 @@ test('cold mobile app load stays within committed resource budgets', async ({ pa
   expect(entries.some(entry => (
     deferredLightEnvironmentUiModules.has(new URL(entry.name).pathname)
   ))).toBe(false);
+  const deferredLightDeviceModalModules = new Set([
+    '/js/light-device-setup-modal.js',
+    '/js/light-device-session-modal.js',
+  ]);
+  expect(entries.some(entry => (
+    deferredLightDeviceModalModules.has(new URL(entry.name).pathname)
+  ))).toBe(false);
   expect(entries.some(entry => (
     new URL(entry.name).pathname === '/js/sun-defaults.js'
   ))).toBe(false);

--- a/tests/playwright/light-device-modal-loader-browser-coverage.spec.js
+++ b/tests/playwright/light-device-modal-loader-browser-coverage.spec.js
@@ -1,32 +1,16 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './coverage-fixture.js';
 
 const loaderUrl = () => (
   `/js/light-device-modal-loader.js?coverage=${Date.now()}-${Math.random().toString(36).slice(2)}`
 );
 
-const syntheticSetupModule = `
-  globalThis.__lightDeviceSetupEvalCount = (globalThis.__lightDeviceSetupEvalCount || 0) + 1;
-  export function configureLightDeviceSetup(deps) {
-    globalThis.__lightDeviceSetupDepKeys = Object.keys(deps).sort();
-  }
-  export function openAddDeviceDialog() {
-    (globalThis.__lightDeviceModalCalls ||= []).push(['setup', 'add']);
-    return 'add-opened';
-  }
-  export function openCustomDeviceDialog() {
-    (globalThis.__lightDeviceModalCalls ||= []).push(['setup', 'custom']);
-    return 'custom-opened';
-  }
-`;
-
-const syntheticSessionModule = `
-  globalThis.__lightDeviceSessionEvalCount = (globalThis.__lightDeviceSessionEvalCount || 0) + 1;
-  export function openDeviceSessionDialog(deviceId, deps) {
-    globalThis.__lightDeviceSessionDepKeys = Object.keys(deps).sort();
-    (globalThis.__lightDeviceModalCalls ||= []).push(['session', deviceId]);
-    return 'session-opened:' + deviceId;
-  }
-`;
+async function openCoveragePage(page) {
+  await page.route('**/light-device-modal-loader-coverage', route => route.fulfill({
+    contentType: 'text/html',
+    body: '<!doctype html><html><body><div id="notification-container"></div></body></html>',
+  }));
+  await page.goto('/light-device-modal-loader-coverage');
+}
 
 test('Light device form modals stay cold, load independently, and single-flight', async ({ page }) => {
   const setupRequests = [];
@@ -34,26 +18,60 @@ test('Light device form modals stay cold, load independently, and single-flight'
   await page.route('**/js/light-device-setup-modal.js*', async route => {
     setupRequests.push(route.request().url());
     await new Promise(resolve => setTimeout(resolve, 25));
-    await route.fulfill({ contentType: 'text/javascript', body: syntheticSetupModule });
+    await route.continue();
   });
   await page.route('**/js/light-device-session-modal.js*', async route => {
     sessionRequests.push(route.request().url());
     await new Promise(resolve => setTimeout(resolve, 25));
-    await route.fulfill({ contentType: 'text/javascript', body: syntheticSessionModule });
+    await route.continue();
   });
-  await page.goto('/js/light-device-modal-loader.js', { waitUntil: 'load' });
+  await openCoveragePage(page);
 
   const outcomes = await page.evaluate(async url => {
     const loader = await import(url);
+    const calls = [];
+    const device = {
+      id: 'device-7',
+      brand: 'CoverageLight',
+      model: 'Panel',
+      recommendedDistanceCm: 15,
+      lastSession: { bodyAreas: ['breast-chest'], durationMin: 8 },
+      modes: [
+        { id: 'all', label: 'All on', default: true },
+        { id: 'red', label: 'Red only' },
+      ],
+    };
     loader.configureLightDeviceModalLoader({
       setup: {
-        addCustomDevice() {},
-        addDeviceFromPreset() {},
-        loadPresets() {},
+        loadPresets: async () => ({
+          types: { combined: { label: 'Red + NIR' } },
+          presets: [{
+            id: 'preset-7',
+            type: 'combined',
+            brand: 'CoverageLight',
+            model: 'Preset',
+            peakWavelengths: [660, 850],
+          }],
+        }),
+        addDeviceFromPreset: async presetId => calls.push(['add-preset', presetId]),
+        addCustomDevice: async spec => calls.push(['add-custom', spec.brand, spec.model]),
+        wireModal: overlay => document.body.appendChild(overlay),
+        refreshLightView: () => calls.push(['refresh']),
       },
       session: {
-        getDevices() {},
-        logDeviceSession() {},
+        hydrateDevicesFromPresets: async () => calls.push(['hydrate']),
+        getDevices: () => {
+          calls.push(['get-devices']);
+          return [device];
+        },
+        logDeviceSession: async payload => calls.push(['log', payload.deviceId, payload.durationMin]),
+        getActiveDeviceSession: () => null,
+        startDeviceSession: async payload => calls.push(['start', payload.deviceId]),
+        ensureActiveDeviceTicker: () => calls.push(['ticker']),
+        validateModeCoupling: () => ({ ok: true }),
+        renderBodySilhouette: () => '<button type="button" data-region="breast-chest">Chest</button>',
+        bindBodySilhouette() {},
+        navigate: route => calls.push(['navigate', route]),
       },
     });
     const startsCold = {
@@ -63,26 +81,50 @@ test('Light device form modals stay cold, load independently, and single-flight'
     const firstSetupLoad = loader.loadLightDeviceSetupModule();
     const secondSetupLoad = loader.loadLightDeviceSetupModule();
     const setupPromiseShared = firstSetupLoad === secondSetupLoad;
-    const [add, custom] = await Promise.all([
-      loader.openAddDeviceDialog(),
-      loader.openCustomDeviceDialog(),
-      firstSetupLoad,
-      secondSetupLoad,
-    ]);
-    const session = await loader.openDeviceSessionDialog('device-7');
+    await Promise.all([firstSetupLoad, secondSetupLoad]);
+    await Promise.all([loader.openAddDeviceDialog(), loader.openCustomDeviceDialog()]);
+
+    const addOverlay = document.querySelector('[aria-label="Add light device"]')?.closest('.modal-overlay');
+    addOverlay?.querySelector('.light-device-preset-row')?.click();
+    addOverlay?.querySelector('#add-device-confirm')?.click();
+    const customOverlay = document.querySelector('[aria-label="Add custom light device"]')?.closest('.modal-overlay');
+    if (customOverlay) {
+      customOverlay.querySelector('#custom-dev-brand').value = 'Manual';
+      customOverlay.querySelector('#custom-dev-model').value = 'Panel';
+      customOverlay.querySelector('#custom-dev-save')?.click();
+    }
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    const firstSessionLoad = loader.loadLightDeviceSessionModule();
+    const secondSessionLoad = loader.loadLightDeviceSessionModule();
+    const sessionPromiseShared = firstSessionLoad === secondSessionLoad;
+    await Promise.all([firstSessionLoad, secondSessionLoad]);
+    await loader.openDeviceSessionDialog('device-7');
+    const sessionOverlay = document.querySelector('[aria-label="Log device session"]')?.closest('.modal-overlay');
+    sessionOverlay?.querySelector('#dev-session-save')?.click();
+    await new Promise(resolve => setTimeout(resolve, 0));
+
     return {
       startsCold,
       setupPromiseShared,
-      add,
-      custom,
-      session,
+      sessionPromiseShared,
       setupLoaded: loader.isLightDeviceSetupModuleLoaded(),
       sessionLoaded: loader.isLightDeviceSessionModuleLoaded(),
-      setupEvalCount: globalThis.__lightDeviceSetupEvalCount,
-      sessionEvalCount: globalThis.__lightDeviceSessionEvalCount,
-      setupDepKeys: globalThis.__lightDeviceSetupDepKeys,
-      sessionDepKeys: globalThis.__lightDeviceSessionDepKeys,
-      calls: globalThis.__lightDeviceModalCalls,
+      addDialogOpened: !!addOverlay,
+      customDialogOpened: !!customOverlay,
+      sessionDialogOpened: !!sessionOverlay,
+      depsDelegated: {
+        preset: calls.some(call => call[0] === 'add-preset' && call[1] === 'preset-7'),
+        custom: calls.some(call => (
+          call[0] === 'add-custom' && call[1] === 'Manual' && call[2] === 'Panel'
+        )),
+        refreshes: calls.filter(call => call[0] === 'refresh').length,
+        session: calls.some(call => (
+          call[0] === 'log' && call[1] === 'device-7' && call[2] === 8
+        )),
+        hydrated: calls.some(call => call[0] === 'hydrate'),
+        navigated: calls.some(call => call[0] === 'navigate' && call[1] === 'light'),
+      },
     };
   }, loaderUrl());
 
@@ -91,20 +133,20 @@ test('Light device form modals stay cold, load independently, and single-flight'
   expect(outcomes).toEqual({
     startsCold: { setup: true, session: true },
     setupPromiseShared: true,
-    add: 'add-opened',
-    custom: 'custom-opened',
-    session: 'session-opened:device-7',
+    sessionPromiseShared: true,
     setupLoaded: true,
     sessionLoaded: true,
-    setupEvalCount: 1,
-    sessionEvalCount: 1,
-    setupDepKeys: ['addCustomDevice', 'addDeviceFromPreset', 'loadPresets'],
-    sessionDepKeys: ['getDevices', 'logDeviceSession'],
-    calls: [
-      ['setup', 'add'],
-      ['setup', 'custom'],
-      ['session', 'device-7'],
-    ],
+    addDialogOpened: true,
+    customDialogOpened: true,
+    sessionDialogOpened: true,
+    depsDelegated: {
+      preset: true,
+      custom: true,
+      refreshes: 2,
+      session: true,
+      hydrated: true,
+      navigated: true,
+    },
   });
 });
 
@@ -115,24 +157,24 @@ test('failed Light device modal loads retry with fixed URLs', async ({ page }) =
     const url = route.request().url();
     setupRequests.push(url);
     if (!url.includes('lazy-retry=1')) return route.abort('failed');
-    return route.fulfill({ contentType: 'text/javascript', body: syntheticSetupModule });
+    return route.continue();
   });
   await page.route('**/js/light-device-session-modal.js*', route => {
     const url = route.request().url();
     sessionRequests.push(url);
     if (!url.includes('lazy-retry=1')) return route.abort('failed');
-    return route.fulfill({ contentType: 'text/javascript', body: syntheticSessionModule });
+    return route.continue();
   });
-  await page.goto('/js/light-device-modal-loader.js', { waitUntil: 'load' });
+  await openCoveragePage(page);
 
   const outcomes = await page.evaluate(async url => {
     const loader = await import(url);
-    const setupFirst = await loader.openAddDeviceDialog();
+    const setupFirst = await loader.loadLightDeviceSetupModule().catch(() => false);
     const setupUnloaded = !loader.isLightDeviceSetupModuleLoaded();
-    const setupSecond = await loader.openAddDeviceDialog();
-    const sessionFirst = await loader.openDeviceSessionDialog('first');
+    const setupSecond = await loader.loadLightDeviceSetupModule().then(() => true);
+    const sessionFirst = await loader.loadLightDeviceSessionModule().catch(() => false);
     const sessionUnloaded = !loader.isLightDeviceSessionModuleLoaded();
-    const sessionSecond = await loader.openDeviceSessionDialog('second');
+    const sessionSecond = await loader.loadLightDeviceSessionModule().then(() => true);
     return {
       setupFirst,
       setupUnloaded,
@@ -148,11 +190,11 @@ test('failed Light device modal loads retry with fixed URLs', async ({ page }) =
   expect(outcomes).toEqual({
     setupFirst: false,
     setupUnloaded: true,
-    setupSecond: 'add-opened',
+    setupSecond: true,
     setupLoaded: true,
     sessionFirst: false,
     sessionUnloaded: true,
-    sessionSecond: 'session-opened:second',
+    sessionSecond: true,
     sessionLoaded: true,
   });
   expect(setupRequests).toHaveLength(2);

--- a/tests/playwright/light-device-modal-loader-browser-coverage.spec.js
+++ b/tests/playwright/light-device-modal-loader-browser-coverage.spec.js
@@ -1,0 +1,164 @@
+import { expect, test } from '@playwright/test';
+
+const loaderUrl = () => (
+  `/js/light-device-modal-loader.js?coverage=${Date.now()}-${Math.random().toString(36).slice(2)}`
+);
+
+const syntheticSetupModule = `
+  globalThis.__lightDeviceSetupEvalCount = (globalThis.__lightDeviceSetupEvalCount || 0) + 1;
+  export function configureLightDeviceSetup(deps) {
+    globalThis.__lightDeviceSetupDepKeys = Object.keys(deps).sort();
+  }
+  export function openAddDeviceDialog() {
+    (globalThis.__lightDeviceModalCalls ||= []).push(['setup', 'add']);
+    return 'add-opened';
+  }
+  export function openCustomDeviceDialog() {
+    (globalThis.__lightDeviceModalCalls ||= []).push(['setup', 'custom']);
+    return 'custom-opened';
+  }
+`;
+
+const syntheticSessionModule = `
+  globalThis.__lightDeviceSessionEvalCount = (globalThis.__lightDeviceSessionEvalCount || 0) + 1;
+  export function openDeviceSessionDialog(deviceId, deps) {
+    globalThis.__lightDeviceSessionDepKeys = Object.keys(deps).sort();
+    (globalThis.__lightDeviceModalCalls ||= []).push(['session', deviceId]);
+    return 'session-opened:' + deviceId;
+  }
+`;
+
+test('Light device form modals stay cold, load independently, and single-flight', async ({ page }) => {
+  const setupRequests = [];
+  const sessionRequests = [];
+  await page.route('**/js/light-device-setup-modal.js*', async route => {
+    setupRequests.push(route.request().url());
+    await new Promise(resolve => setTimeout(resolve, 25));
+    await route.fulfill({ contentType: 'text/javascript', body: syntheticSetupModule });
+  });
+  await page.route('**/js/light-device-session-modal.js*', async route => {
+    sessionRequests.push(route.request().url());
+    await new Promise(resolve => setTimeout(resolve, 25));
+    await route.fulfill({ contentType: 'text/javascript', body: syntheticSessionModule });
+  });
+  await page.goto('/js/light-device-modal-loader.js', { waitUntil: 'load' });
+
+  const outcomes = await page.evaluate(async url => {
+    const loader = await import(url);
+    loader.configureLightDeviceModalLoader({
+      setup: {
+        addCustomDevice() {},
+        addDeviceFromPreset() {},
+        loadPresets() {},
+      },
+      session: {
+        getDevices() {},
+        logDeviceSession() {},
+      },
+    });
+    const startsCold = {
+      setup: !loader.isLightDeviceSetupModuleLoaded(),
+      session: !loader.isLightDeviceSessionModuleLoaded(),
+    };
+    const firstSetupLoad = loader.loadLightDeviceSetupModule();
+    const secondSetupLoad = loader.loadLightDeviceSetupModule();
+    const setupPromiseShared = firstSetupLoad === secondSetupLoad;
+    const [add, custom] = await Promise.all([
+      loader.openAddDeviceDialog(),
+      loader.openCustomDeviceDialog(),
+      firstSetupLoad,
+      secondSetupLoad,
+    ]);
+    const session = await loader.openDeviceSessionDialog('device-7');
+    return {
+      startsCold,
+      setupPromiseShared,
+      add,
+      custom,
+      session,
+      setupLoaded: loader.isLightDeviceSetupModuleLoaded(),
+      sessionLoaded: loader.isLightDeviceSessionModuleLoaded(),
+      setupEvalCount: globalThis.__lightDeviceSetupEvalCount,
+      sessionEvalCount: globalThis.__lightDeviceSessionEvalCount,
+      setupDepKeys: globalThis.__lightDeviceSetupDepKeys,
+      sessionDepKeys: globalThis.__lightDeviceSessionDepKeys,
+      calls: globalThis.__lightDeviceModalCalls,
+    };
+  }, loaderUrl());
+
+  expect(setupRequests).toHaveLength(1);
+  expect(sessionRequests).toHaveLength(1);
+  expect(outcomes).toEqual({
+    startsCold: { setup: true, session: true },
+    setupPromiseShared: true,
+    add: 'add-opened',
+    custom: 'custom-opened',
+    session: 'session-opened:device-7',
+    setupLoaded: true,
+    sessionLoaded: true,
+    setupEvalCount: 1,
+    sessionEvalCount: 1,
+    setupDepKeys: ['addCustomDevice', 'addDeviceFromPreset', 'loadPresets'],
+    sessionDepKeys: ['getDevices', 'logDeviceSession'],
+    calls: [
+      ['setup', 'add'],
+      ['setup', 'custom'],
+      ['session', 'device-7'],
+    ],
+  });
+});
+
+test('failed Light device modal loads retry with fixed URLs', async ({ page }) => {
+  const setupRequests = [];
+  const sessionRequests = [];
+  await page.route('**/js/light-device-setup-modal.js*', route => {
+    const url = route.request().url();
+    setupRequests.push(url);
+    if (!url.includes('lazy-retry=1')) return route.abort('failed');
+    return route.fulfill({ contentType: 'text/javascript', body: syntheticSetupModule });
+  });
+  await page.route('**/js/light-device-session-modal.js*', route => {
+    const url = route.request().url();
+    sessionRequests.push(url);
+    if (!url.includes('lazy-retry=1')) return route.abort('failed');
+    return route.fulfill({ contentType: 'text/javascript', body: syntheticSessionModule });
+  });
+  await page.goto('/js/light-device-modal-loader.js', { waitUntil: 'load' });
+
+  const outcomes = await page.evaluate(async url => {
+    const loader = await import(url);
+    const setupFirst = await loader.openAddDeviceDialog();
+    const setupUnloaded = !loader.isLightDeviceSetupModuleLoaded();
+    const setupSecond = await loader.openAddDeviceDialog();
+    const sessionFirst = await loader.openDeviceSessionDialog('first');
+    const sessionUnloaded = !loader.isLightDeviceSessionModuleLoaded();
+    const sessionSecond = await loader.openDeviceSessionDialog('second');
+    return {
+      setupFirst,
+      setupUnloaded,
+      setupSecond,
+      setupLoaded: loader.isLightDeviceSetupModuleLoaded(),
+      sessionFirst,
+      sessionUnloaded,
+      sessionSecond,
+      sessionLoaded: loader.isLightDeviceSessionModuleLoaded(),
+    };
+  }, loaderUrl());
+
+  expect(outcomes).toEqual({
+    setupFirst: false,
+    setupUnloaded: true,
+    setupSecond: 'add-opened',
+    setupLoaded: true,
+    sessionFirst: false,
+    sessionUnloaded: true,
+    sessionSecond: 'session-opened:second',
+    sessionLoaded: true,
+  });
+  expect(setupRequests).toHaveLength(2);
+  expect(sessionRequests).toHaveLength(2);
+  expect(new URL(setupRequests[0]).search).toBe('');
+  expect(new URL(setupRequests[1]).search).toBe('?lazy-retry=1');
+  expect(new URL(sessionRequests[0]).search).toBe('');
+  expect(new URL(sessionRequests[1]).search).toBe('?lazy-retry=1');
+});

--- a/tests/test-a11y-phase3.js
+++ b/tests/test-a11y-phase3.js
@@ -333,13 +333,18 @@ console.log('=== Phase 3 A11y Tests ===\n');
   // modals (Log device session) require explicit Cancel/Save so accidental
   // taps don't lose typed values.
   const lightDevSrc = read('/js/light-devices.js');
+  const lightDevModalLoaderSrc = read('/js/light-device-modal-loader.js');
   const lightDevSetupSrc = read('/js/light-device-setup-modal.js');
   const lightDevSessionSrc = read('/js/light-device-session-modal.js');
   const lightDevCss = read('/css/light-devices.css');
-  assert('light-devices.js delegates session dialog rendering to extracted module',
-    lightDevSrc.includes("from './light-device-session-modal.js'"));
-  assert('light-devices.js delegates add/custom-device setup rendering to extracted module',
-    lightDevSrc.includes("from './light-device-setup-modal.js'"));
+  assert('light-devices.js lazily delegates session dialog rendering',
+    lightDevSrc.includes("from './light-device-modal-loader.js'")
+      && !lightDevSrc.includes("from './light-device-session-modal.js'")
+      && lightDevModalLoaderSrc.includes("import('./light-device-session-modal.js')"));
+  assert('light-devices.js lazily delegates add/custom-device setup rendering',
+    lightDevSrc.includes('configureLightDeviceModalLoader({')
+      && !lightDevSrc.includes("from './light-device-setup-modal.js'")
+      && lightDevModalLoaderSrc.includes("import('./light-device-setup-modal.js')"));
   assert('Add-device preset picker stays inside modal as button rows, not a native dropdown',
     lightDevSetupSrc.includes('light-device-preset-groups') &&
     lightDevSetupSrc.includes('light-device-preset-row') &&

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -163,6 +163,7 @@
     "js/light-conditions-now.js",
     "js/light-conditions-now-hooks.js",
     "js/light-device-ai-analysis.js",
+    "js/light-device-modal-loader.js",
     "js/light-device-session-engine.js",
     "js/light-device-session-modal.js",
     "js/light-device-setup-modal.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.390';
+self.APP_VERSION = '1.10.391';


### PR DESCRIPTION
## Summary
- route Light device setup and session dialogs through a retryable cold facade
- preserve dependency injection while independently loading each form modal on first use
- add real-module browser coverage for cold state, single-flight behavior, delegation, and retry URLs
- update the measured cold-load reference and app version

## Cold-load result
- 383 requests (`-1`)
- 1,480,294 transferred bytes (`-11,346`)
- 4,227,736 decoded bytes (`-36,324`)

Compared with merged main at `c5fbb1ec`.

## Validation
- `npm test` — 490 passed
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run architecture:check` — 477 modules, 0 cycles
- `npm run quality`
- `npm run vendor:check`
- targeted Chromium — 17 passed
- Firefox smoke — 3 passed
- combined Vitest + Playwright coverage — 67.13% (67.10% required)
- two unrelated parallel-run flakes rerun in isolation — 3 passed