### PR TITLE
Defer PDF marker mapping until import

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -10,7 +10,7 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | Metric | Current |
 | --- | ---: |
 | Modules | 477 |
-| Internal import edges | 2128 |
+| Internal import edges | 2127 |
 | Dynamic internal edges | 79 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -606,7 +606,7 @@ Native browser modules shipped with the static application.
 
 - [`js/profile-context.js`](js/profile-context.js) → [`js/context-source-registry.js`](js/context-source-registry.js), [`js/state.js`](js/state.js)
 - [`js/profile-fatty-acid-migrations.js`](js/profile-fatty-acid-migrations.js) → [`js/adapters.js`](js/adapters.js)
-- [`js/profile-marker-migrations.js`](js/profile-marker-migrations.js) → [`js/adapters.js`](js/adapters.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/pdf-import-marker-mapping.js`](js/pdf-import-marker-mapping.js), [`js/profile-fatty-acid-migrations.js`](js/profile-fatty-acid-migrations.js), [`js/schema.js`](js/schema.js)
+- [`js/profile-marker-migrations.js`](js/profile-marker-migrations.js) → [`js/adapters.js`](js/adapters.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/profile-fatty-acid-migrations.js`](js/profile-fatty-acid-migrations.js), [`js/schema.js`](js/schema.js)
 - [`js/profile-runtime.js`](js/profile-runtime.js) → [`js/chat-discussion.js`](js/chat-discussion.js) *(dynamic)*, [`js/chat-history.js`](js/chat-history.js) *(dynamic)*, [`js/chat-personalities.js`](js/chat-personalities.js) *(dynamic)*, [`js/chat-threads.js`](js/chat-threads.js) *(dynamic)*, [`js/data.js`](js/data.js) *(dynamic)*, [`js/lab-context.js`](js/lab-context.js) *(dynamic)*, [`js/nav.js`](js/nav.js) *(dynamic)*, [`js/state.js`](js/state.js), [`js/views.js`](js/views.js) *(dynamic)*, [`js/wearables-connect.js`](js/wearables-connect.js) *(dynamic)*, [`js/wearables-manual.js`](js/wearables-manual.js) *(dynamic)*, [`js/wearables-summary.js`](js/wearables-summary.js) *(dynamic)*
 - [`js/profile-share-loader.js`](js/profile-share-loader.js) → [`js/profile-share.js`](js/profile-share.js) *(dynamic)*, [`js/utils-runtime.js`](js/utils-runtime.js), [`js/utils.js`](js/utils.js)
 - [`js/profile-share.js`](js/profile-share.js) → [`js/export.js`](js/export.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils-runtime.js`](js/utils-runtime.js), [`js/utils.js`](js/utils.js)

--- a/js/pdf-import-marker-mapping.js
+++ b/js/pdf-import-marker-mapping.js
@@ -2,41 +2,23 @@
 // pdf-import-marker-mapping.js — marker key safety, reference lookup, and unit normalization for imports
 
 import { state } from './state.js';
-import { MARKER_SCHEMA, UNIT_CONVERSIONS } from './schema.js';
+import {
+  MARKER_SCHEMA,
+  normalizeClinicalUnit as normalizeUnitStr,
+  normalizeToSI,
+  UNIT_CONVERSIONS,
+} from './schema.js';
 import { SPECIALTY_MARKER_DEFS } from './adapters.js';
 import { SECONDARY_UNIT_CONVERSIONS } from './secondary-unit-conversions.js';
+
+export { normalizeToSI };
 
 // ═══════════════════════════════════════════════
 // UNIT NORMALIZATION — convert US-unit values to SI before storage
 // ═══════════════════════════════════════════════
-function normalizeUnitStr(s) {
-  return s.normalize('NFKC').toLowerCase().replace(/\s/g, '').replace(/[\u00b5\u03bc]/g, 'u').replace(/^mcg/, 'ug').replace(/^iu\//, 'u/').replace(/^ug\/l$/, 'ng/ml');
-}
-
 function isPercentImportUnit(unit) {
   const norm = normalizeUnitStr(String(unit || ''));
   return norm === '%' || norm === 'pct' || norm === 'percent' || norm === 'percentage';
-}
-
-function isFractionStoredPercentMarker(key) {
-  const [catKey, markerKey] = String(key || '').split('.');
-  const marker = MARKER_SCHEMA[catKey]?.markers?.[markerKey];
-  const conv = UNIT_CONVERSIONS[key];
-  return !!marker
-    && (marker.unit || '') === ''
-    && marker.refMax != null
-    && marker.refMax <= 1
-    && conv?.type === 'multiply'
-    && conv.factor === 100
-    && isPercentImportUnit(conv.usUnit);
-}
-
-function normalizeFractionStoredPercentValue(key, value, unit, context = null) {
-  if (!isFractionStoredPercentMarker(key) || !isPercentImportUnit(unit)) return null;
-  const [catKey, markerKey] = String(key || '').split('.');
-  const [schemaRefMax, reportRefMax] = [Number(MARKER_SCHEMA[catKey]?.markers?.[markerKey]?.refMax), Number(context?.refMax)];
-  const siValue = value > 1 || (reportRefMax > 1 && reportRefMax > schemaRefMax && !(Number.isFinite(schemaRefMax) && value <= schemaRefMax)) ? value / 100 : value;
-  return parseFloat(siValue.toPrecision(6));
 }
 
 export const GENERIC_IMPORT_UNITS = [
@@ -677,65 +659,6 @@ export function reconcileImportMarkerMappings(markers, options = {}) {
     }
   }
   return markers;
-}
-
-export function normalizeToSI(key, value, unit, context = null) {
-  if (value == null || isNaN(value)) return null;
-
-  // Hematocrit: schema stores as % (40–50) but some labs report as fraction l/l (0.40–0.50)
-  if (key === 'hematology.hematocrit' && value < 1.5) {
-    return parseFloat((value * 100).toFixed(1));
-  }
-
-  // When a unit string is present, systematically evaluate all conversion registries
-  if (unit) {
-    const aiUnit = normalizeUnitStr(unit);
-    const fractionPercentValue = normalizeFractionStoredPercentValue(key, value, aiUnit, context);
-    if (fractionPercentValue != null) return fractionPercentValue;
-
-    // 1. Evaluate primary US conversions
-    const primaryConv = UNIT_CONVERSIONS[key];
-    if (primaryConv && primaryConv.type === 'multiply') {
-      if (aiUnit === normalizeUnitStr(primaryConv.usUnit)) {
-        return parseFloat((value / primaryConv.factor).toPrecision(6));
-      }
-    } else if (primaryConv && primaryConv.type === 'hba1c' && aiUnit === '%') {
-      return parseFloat(((value - 2.15) * 10.929).toFixed(1));
-    }
-
-    // 2. Evaluate systematic secondary conversions (European, trace mineral, and specialized units)
-    const secondaryList = SECONDARY_UNIT_CONVERSIONS[key];
-    if (secondaryList) {
-      for (const sec of secondaryList) {
-        if (sec.type === 'multiply' && aiUnit === normalizeUnitStr(sec.unit)) {
-          return parseFloat((value / sec.factor).toPrecision(6));
-        } else if (sec.type === 'hba1c' && aiUnit === normalizeUnitStr(sec.unit)) {
-          return parseFloat(((value - 2.15) * 10.929).toFixed(1));
-        }
-      }
-    }
-
-    // 3. Exact SI passthrough match
-    const [catKey, markerKey] = key.split('.');
-    const siUnit = MARKER_SCHEMA[catKey]?.markers?.[markerKey]?.unit;
-    if (siUnit && aiUnit === normalizeUnitStr(siUnit)) return value;
-    // A unit was provided but matched nothing — return as-is rather than guessing
-    return value;
-  }
-
-  // Fallback heuristic for unit-less data (only triggers when no unit string was provided)
-  const fallbackConv = UNIT_CONVERSIONS[key];
-  if (fallbackConv && fallbackConv.type === 'multiply' && fallbackConv.factor > 1) {
-    const [catKey, markerKey] = key.split('.');
-    const markerDef = MARKER_SCHEMA[catKey]?.markers?.[markerKey];
-    if (markerDef && markerDef.refMax != null) {
-      if (value > markerDef.refMax * fallbackConv.factor * 0.3) {
-        return parseFloat((value / fallbackConv.factor).toPrecision(6));
-      }
-    }
-  }
-
-  return value;
 }
 
 /**

--- a/js/profile-marker-migrations.js
+++ b/js/profile-marker-migrations.js
@@ -1,10 +1,9 @@
 // @ts-check
 // profile-marker-migrations.js - Marker alias, unit-suffix, and specialty import repairs.
 
-import { MARKER_SCHEMA } from './schema.js';
+import { MARKER_SCHEMA, normalizeToSI } from './schema.js';
 import { SPECIALTY_MARKER_DEFS } from './adapters.js';
 import { renameLabEntryMarker } from './lab-entry.js';
-import { normalizeToSI } from './pdf-import-marker-mapping.js';
 import {
   ensureProductFattyAcidCustomMarker,
   repairSnapshotBackedProductFattyAcidMetadata,

--- a/js/schema.js
+++ b/js/schema.js
@@ -360,6 +360,85 @@ export const UNIT_CONVERSIONS = {
 
 export { SECONDARY_UNIT_CONVERSIONS };
 
+/** Normalize clinical unit spellings for import and migration comparisons. @param {unknown} unit */
+export function normalizeClinicalUnit(unit) {
+  return String(unit || '')
+    .normalize('NFKC').toLowerCase().replace(/\s/g, '')
+    .replace(/[\u00b5\u03bc]/g, 'u')
+    .replace(/^mcg/, 'ug').replace(/^iu\//, 'u/')
+    .replace(/^ug\/l$/, 'ng/ml');
+}
+
+function isPercentClinicalUnit(unit) {
+  const normalized = normalizeClinicalUnit(unit);
+  return ['%', 'pct', 'percent', 'percentage'].includes(normalized);
+}
+
+function isFractionStoredPercentMarker(key) {
+  const [catKey, markerKey] = String(key || '').split('.');
+  const marker = MARKER_SCHEMA[catKey]?.markers?.[markerKey];
+  const conversion = UNIT_CONVERSIONS[key];
+  return !!marker && (marker.unit || '') === '' && marker.refMax != null && marker.refMax <= 1
+    && conversion?.type === 'multiply'
+    && conversion.factor === 100 && isPercentClinicalUnit(conversion.usUnit);
+}
+
+function normalizeFractionStoredPercentValue(key, value, unit, context = null) {
+  if (!isFractionStoredPercentMarker(key) || !isPercentClinicalUnit(unit)) return null;
+  const [catKey, markerKey] = String(key || '').split('.');
+  const schemaRefMax = Number(MARKER_SCHEMA[catKey]?.markers?.[markerKey]?.refMax);
+  const reportRefMax = Number(context?.refMax);
+  const hasWholePercentRange = reportRefMax > 1 && reportRefMax > schemaRefMax
+    && !(Number.isFinite(schemaRefMax) && value <= schemaRefMax);
+  const siValue = value > 1 || hasWholePercentRange ? value / 100 : value;
+  return parseFloat(siValue.toPrecision(6));
+}
+
+/**
+ * Convert an imported or legacy marker value to the schema's canonical SI unit.
+ * @param {string} key
+ * @param {any} value
+ * @param {unknown} unit
+ * @param {Record<string, any> | null} [context]
+ */
+export function normalizeToSI(key, value, unit, context = null) {
+  if (value == null || isNaN(value)) return null;
+  // Hematocrit: schema stores as % (40–50) but some labs report as fraction l/l (0.40–0.50).
+  if (key === 'hematology.hematocrit' && value < 1.5) return parseFloat((value * 100).toFixed(1));
+  if (unit) {
+    const normalizedUnit = normalizeClinicalUnit(unit);
+    const fractionPercentValue = normalizeFractionStoredPercentValue(key, value, normalizedUnit, context);
+    if (fractionPercentValue != null) return fractionPercentValue;
+    const primaryConversion = UNIT_CONVERSIONS[key];
+    if (
+      primaryConversion?.type === 'multiply'
+      && normalizedUnit === normalizeClinicalUnit(primaryConversion.usUnit)
+    ) {
+      return parseFloat((value / primaryConversion.factor).toPrecision(6));
+    }
+    if (primaryConversion?.type === 'hba1c' && normalizedUnit === '%') {
+      return parseFloat(((value - 2.15) * 10.929).toFixed(1));
+    }
+    for (const conversion of SECONDARY_UNIT_CONVERSIONS[key] || []) {
+      if (normalizedUnit !== normalizeClinicalUnit(conversion.unit)) continue;
+      if (conversion.type === 'multiply') {
+        return parseFloat((value / conversion.factor).toPrecision(6));
+      }
+      if (conversion.type === 'hba1c') return parseFloat(((value - 2.15) * 10.929).toFixed(1));
+    }
+    return value;
+  }
+  const fallbackConversion = UNIT_CONVERSIONS[key];
+  if (fallbackConversion?.type === 'multiply' && fallbackConversion.factor > 1) {
+    const [catKey, markerKey] = key.split('.');
+    const marker = MARKER_SCHEMA[catKey]?.markers?.[markerKey];
+    if (marker?.refMax != null && value > marker.refMax * fallbackConversion.factor * 0.3) {
+      return parseFloat((value / fallbackConversion.factor).toPrecision(6));
+    }
+  }
+  return value;
+}
+
 // Returns the converted {value, unit} in the *other* unit system for dual-display,
 // or null when no conversion exists. `displayValue` is what the user currently sees
 // (state.unitSystem-dependent); `isUSMode` is the current display mode flag.

--- a/scripts/cold-load-budget.json
+++ b/scripts/cold-load-budget.json
@@ -8,10 +8,10 @@
     "decodedBytes": 5099000
   },
   "reference": {
-    "requests": 380,
-    "transferBytes": 1462481,
-    "decodedBytes": 4166968
+    "requests": 379,
+    "transferBytes": 1455543,
+    "decodedBytes": 4136757
   },
-  "referenceCommit": "b26c338b",
+  "referenceCommit": "c7713a01",
   "measuredAt": "2026-07-25"
 }

--- a/tests/playwright/cold-load-budget.spec.js
+++ b/tests/playwright/cold-load-budget.spec.js
@@ -163,6 +163,9 @@ test('cold mobile app load stays within committed resource budgets', async ({ pa
   expect(entries.some(entry => (
     deferredCycleImportModules.has(new URL(entry.name).pathname)
   ))).toBe(false);
+  expect(entries.some(entry => (
+    new URL(entry.name).pathname === '/js/pdf-import-marker-mapping.js'
+  ))).toBe(false);
   const deferredLightEnvironmentUiModules = new Set([
     '/js/light-env.js',
     '/js/light-env-actions.js',

--- a/tests/playwright/import-loader-browser-coverage.spec.js
+++ b/tests/playwright/import-loader-browser-coverage.spec.js
@@ -24,6 +24,37 @@ function pdfImportStubBody(counterName, marker) {
   `;
 }
 
+test('PDF marker mapping stays cold until the real import implementation loads', async ({ page }) => {
+  let markerMappingRequests = 0;
+  page.on('request', request => {
+    if (new URL(request.url()).pathname === '/js/pdf-import-marker-mapping.js') {
+      markerMappingRequests += 1;
+    }
+  });
+  await openBlankPage(page, '/import-marker-mapping-demand-coverage');
+
+  const outcomes = await page.evaluate(async ({ loaderUrl }) => {
+    const loader = await import(loaderUrl);
+    const mappingStayedColdAfterLoaderImport = performance.getEntriesByType('resource')
+      .every(entry => new URL(entry.name).pathname !== '/js/pdf-import-marker-mapping.js');
+    const pdfImport = await loader.loadPdfImport();
+    return {
+      mappingStayedColdAfterLoaderImport,
+      realImportApiLoaded:
+        typeof pdfImport.buildMarkerReference === 'function'
+        && typeof pdfImport.reconcileImportMarkerMappings === 'function',
+    };
+  }, {
+    loaderUrl: moduleUrl('/js/import-loader.js'),
+  });
+
+  expect(outcomes).toEqual({
+    mappingStayedColdAfterLoaderImport: true,
+    realImportApiLoaded: true,
+  });
+  expect(markerMappingRequests).toBe(1);
+});
+
 test('import loader browser coverage caches the successful pdf import module', async ({ page }) => {
   let pdfImportRequests = 0;
   await page.route('**/js/pdf-import.js', route => {

--- a/tests/test-normalize-units.js
+++ b/tests/test-normalize-units.js
@@ -22,7 +22,6 @@ console.log('=== Unit Normalization Pipeline Tests ===\n');
 
 const src = read('js/pdf-import.js');
 const fileUtilsSrc = read('js/pdf-import-file-utils.js');
-const mappingSrc = read('js/pdf-import-marker-mapping.js');
 const schemaSrc = read('js/schema.js');
 const { UNIT_CONVERSIONS, MARKER_SCHEMA } = await import('../js/schema.js');
 const { assessTextQuality } = await import('../js/pdf-import.js');
@@ -139,13 +138,14 @@ const { normalizeToSI: normalizeImportedValueToSI } = await import('../js/pdf-im
   // ═══════════════════════════════════════
   console.log('%c 6. normalizeUnitStr — source verification ', 'font-weight:bold;color:#f59e0b');
 
-  assert('normalizeUnitStr defined in source', mappingSrc.includes('function normalizeUnitStr(s)'));
-  assert('normalizes Unicode compatibility forms in source', mappingSrc.includes("normalize('NFKC')"));
-  assert('handles U+00B5 in source', mappingSrc.includes('\\u00b5'));
-  assert('handles U+03BC in source', mappingSrc.includes('\\u03bc'));
-  assert('mcg replacement in source', mappingSrc.includes("replace(/^mcg/, 'ug')"));
-  assert('iu/ replacement in source', mappingSrc.includes("replace(/^iu\\//, 'u/')"));
-  assert('ug/l → ng/ml alias in source', mappingSrc.includes("replace(/^ug\\/l$/, 'ng/ml')"));
+  assert('normalizeClinicalUnit defined in schema source',
+    schemaSrc.includes('function normalizeClinicalUnit(unit)'));
+  assert('normalizes Unicode compatibility forms in source', schemaSrc.includes("normalize('NFKC')"));
+  assert('handles U+00B5 in source', schemaSrc.includes('\\u00b5'));
+  assert('handles U+03BC in source', schemaSrc.includes('\\u03bc'));
+  assert('mcg replacement in source', schemaSrc.includes("replace(/^mcg/, 'ug')"));
+  assert('iu/ replacement in source', schemaSrc.includes("replace(/^iu\\//, 'u/')"));
+  assert('ug/l → ng/ml alias in source', schemaSrc.includes("replace(/^ug\\/l$/, 'ng/ml')"));
 
   // ═══════════════════════════════════════
   // 7. normalizeToSI — glucose (mg/dL → mmol/L)

--- a/tests/test-unit-import.js
+++ b/tests/test-unit-import.js
@@ -26,6 +26,7 @@ const aiUtilsSrc = read('js/pdf-import-ai-utils.js');
 const exportSrc = read('js/export.js');
 const exportImportSrc = read('js/export-import.js');
 const mappingSrc = read('js/pdf-import-marker-mapping.js');
+const schemaSrc = read('js/schema.js');
 const normalizationSrc = read('js/pdf-import-marker-normalization.js');
 const persistenceSrc = read('js/pdf-import-persistence.js');
 const settingsDataSrc = read('js/settings-data.js');
@@ -41,9 +42,12 @@ const importCssSrc = read('css/import.css');
   // ═══════════════════════════════════════
   console.log('%c 1. normalizeToSI function ', 'font-weight:bold;color:#f59e0b');
 
-  assert('normalizeToSI defined', mappingSrc.includes('function normalizeToSI('));
-  assert('normalizeToSI checks UNIT_CONVERSIONS', mappingSrc.includes('UNIT_CONVERSIONS[key]'));
-  assert('normalizeUnitStr handles µ variants', mappingSrc.includes('normalizeUnitStr') && mappingSrc.includes('\\u03bc'));
+  assert('normalizeToSI is schema-owned and re-exported by the import mapper',
+    schemaSrc.includes('function normalizeToSI(')
+      && /export\s*\{\s*normalizeToSI\s*\}/.test(mappingSrc));
+  assert('normalizeToSI checks UNIT_CONVERSIONS', schemaSrc.includes('UNIT_CONVERSIONS[key]'));
+  assert('clinical unit normalization handles µ variants',
+    schemaSrc.includes('normalizeClinicalUnit') && schemaSrc.includes('\\u03bc'));
 
   // ═══════════════════════════════════════
   // 2. UNIT_CONVERSIONS is imported
@@ -202,8 +206,8 @@ const importCssSrc = read('css/import.css');
   // ═══════════════════════════════════════
   console.log('%c 4. Conversion logic ', 'font-weight:bold;color:#f59e0b');
 
-  assert('divides by factor for multiply type', /value \/ \w+\.factor/.test(mappingSrc));
-  assert('handles hba1c inverse', mappingSrc.includes('(value - 2.15) * 10.929'));
+  assert('divides by factor for multiply type', /value \/ \w+\.factor/.test(schemaSrc));
+  assert('handles hba1c inverse', schemaSrc.includes('(value - 2.15) * 10.929'));
 
   // ═══════════════════════════════════════
   // 5. Functional test via module import

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.392';
+self.APP_VERSION = '1.10.393';


### PR DESCRIPTION
## Summary
- move clinical-unit normalization into the already-eager schema module and preserve the PDF mapper re-export
- let profile marker migrations use schema normalization directly, so PDF marker mapping stays cold until the import feature loads
- add demand-loading coverage and pin the new measured cold-load baseline

## Cold-load impact
- requests: 380 → 379 (-1)
- transfer: 1,462,481 → 1,455,543 bytes (-6,938)
- decoded: 4,166,968 → 4,136,757 bytes (-30,211)

## Validation
- 490/490 unit tests
- typecheck and check-JS typecheck
- architecture, quality, and vendor checks
- focused normalization/import tests
- exact cold-load budget test
- Chromium: 475/476 in the parallel full run; the one unrelated Wearables contention failure passed immediately in isolation
- Firefox smoke: 3/3