### PR TITLE
Defer cycle backup helpers until backup

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -11,7 +11,7 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | --- | ---: |
 | Modules | 477 |
 | Internal import edges | 2126 |
-| Dynamic internal edges | 79 |
+| Dynamic internal edges | 80 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
 | Largest cyclic component | 0 |
@@ -121,7 +121,7 @@ Native browser modules shipped with the static application.
 
 - [`js/backup-cycle.js`](js/backup-cycle.js) → [`js/cycle-store.js`](js/cycle-store.js) *(dynamic)*
 - [`js/backup-serialization.js`](js/backup-serialization.js) → no in-scope imports
-- [`js/backup.js`](js/backup.js) → [`js/backup-cycle.js`](js/backup-cycle.js), [`js/backup-serialization.js`](js/backup-serialization.js), [`js/blob-storage.js`](js/blob-storage.js), [`js/profile-storage-key.js`](js/profile-storage-key.js), [`js/utils.js`](js/utils.js), [`js/wearables-store.js`](js/wearables-store.js) *(dynamic)*
+- [`js/backup.js`](js/backup.js) → [`js/backup-cycle.js`](js/backup-cycle.js) *(dynamic)*, [`js/backup-serialization.js`](js/backup-serialization.js), [`js/blob-storage.js`](js/blob-storage.js), [`js/profile-storage-key.js`](js/profile-storage-key.js), [`js/utils.js`](js/utils.js), [`js/wearables-store.js`](js/wearables-store.js) *(dynamic)*
 
 </details>
 

--- a/js/backup.js
+++ b/js/backup.js
@@ -4,9 +4,21 @@
 import { showNotification, showConfirmDialog, escapeAttr, escapeHTML } from './utils.js';
 import { profileStorageKey } from './profile-storage-key.js';
 import { getBlob, setBlob, shouldUseBlob } from './blob-storage.js';
-import { collectCycleBackup, restoreCycleBackup } from './backup-cycle.js';
 import { parseBackupSnapshot, serializeBackupSnapshot } from './backup-serialization.js';
 export { parseBackupSnapshot, serializeBackupSnapshot } from './backup-serialization.js';
+
+/** @type {Promise<typeof import('./backup-cycle.js')> | null} */
+let backupCycleModuleLoad = null;
+
+function loadBackupCycleModule() {
+  if (!backupCycleModuleLoad) {
+    backupCycleModuleLoad = import('./backup-cycle.js').catch(err => {
+      backupCycleModuleLoad = null;
+      throw err;
+    });
+  }
+  return backupCycleModuleLoad;
+}
 
 // Crypto imports this module for backup UI helpers, so inject the two crypto
 // operations backup needs instead of coupling the modules through globals.
@@ -321,6 +333,7 @@ export async function buildFullBackupSnapshot() {
   }
   const profileIds = (snap.profiles || []).map(p => p.profileId);
   snap.wearableIDB = await collectWearableIDB(profileIds);
+  const { collectCycleBackup } = await loadBackupCycleModule();
   const cycleBackup = await collectCycleBackup(profileIds);
   snap.cycleIDB = cycleBackup.observations;
   snap.cycleImportMeta = cycleBackup.importMeta;
@@ -400,7 +413,8 @@ export function importEncryptedBackup(file) {
 
         Promise.all([
           restoreWearableIDB(backup.wearableIDB),
-          restoreCycleBackup(backup.cycleIDB, backup.cycleImportMeta),
+          loadBackupCycleModule()
+            .then(({ restoreCycleBackup }) => restoreCycleBackup(backup.cycleIDB, backup.cycleImportMeta)),
         ]).finally(() => {
           showNotification('Backup restored \u2014 reloading...', 'success');
           setTimeout(() => location.reload(), 1000);
@@ -548,7 +562,8 @@ export async function restoreAutoBackup(id) {
     // along with everything else.
     Promise.all([
       restoreWearableIDB(backup.wearableIDB),
-      restoreCycleBackup(backup.cycleIDB, backup.cycleImportMeta),
+      loadBackupCycleModule()
+        .then(({ restoreCycleBackup }) => restoreCycleBackup(backup.cycleIDB, backup.cycleImportMeta)),
     ]).finally(() => {
       showNotification('Backup restored \u2014 reloading...', 'success');
       setTimeout(() => location.reload(), 1000);

--- a/scripts/cold-load-budget.json
+++ b/scripts/cold-load-budget.json
@@ -8,10 +8,10 @@
     "decodedBytes": 5099000
   },
   "reference": {
-    "requests": 374,
-    "transferBytes": 1434032,
-    "decodedBytes": 4078260
+    "requests": 373,
+    "transferBytes": 1433294,
+    "decodedBytes": 4077035
   },
-  "referenceCommit": "b4b86ece",
+  "referenceCommit": "2e9f912e",
   "measuredAt": "2026-07-25"
 }

--- a/tests/playwright/backup-browser-coverage.spec.js
+++ b/tests/playwright/backup-browser-coverage.spec.js
@@ -5,7 +5,15 @@ function moduleUrl(path) {
 }
 
 test('backup browser coverage exercises export import auto backup and folder states', async ({ page }) => {
-  await page.goto('/app', { waitUntil: 'load' });
+  let backupCycleRequests = 0;
+  page.on('request', request => {
+    if (new URL(request.url()).pathname === '/js/backup-cycle.js') {
+      backupCycleRequests += 1;
+    }
+  });
+
+  await page.goto('/app', { waitUntil: 'networkidle' });
+  expect(backupCycleRequests).toBe(0);
 
   const results = await page.evaluate(async ({ backupUrl }) => {
     const [backup, blobStorage] = await Promise.all([
@@ -306,6 +314,7 @@ test('backup browser coverage exercises export import auto backup and folder sta
   for (const [name, passed] of Object.entries(results)) {
     expect(passed, name).toBe(true);
   }
+  expect(backupCycleRequests).toBe(1);
 });
 
 test('backup browser coverage exercises IDB errors and folder reauthorization', async ({ page }) => {

--- a/tests/playwright/cold-load-budget.spec.js
+++ b/tests/playwright/cold-load-budget.spec.js
@@ -169,6 +169,9 @@ test('cold mobile app load stays within committed resource budgets', async ({ pa
   expect(entries.some(entry => (
     new URL(entry.name).pathname === '/js/light-today-ai.js'
   ))).toBe(false);
+  expect(entries.some(entry => (
+    new URL(entry.name).pathname === '/js/backup-cycle.js'
+  ))).toBe(false);
   const deferredLightEnvironmentUiModules = new Set([
     '/js/light-env.js',
     '/js/light-env-actions.js',

--- a/tests/playwright/wearables-settings-browser-coverage.spec.js
+++ b/tests/playwright/wearables-settings-browser-coverage.spec.js
@@ -94,9 +94,10 @@ test('wearables settings browser coverage exercises import and connection action
         && calls.some(call => call[0] === 'navigate' && call[1] === 'dashboard'));
 
       actions.handleWearableConnect('apple_health');
-      await delay(20);
-      check('connect handler reports non-oauth adapter error',
+      const connectFailureShown = await waitFor(() =>
         document.body.textContent.includes('Connect failed: Adapter apple_health is not OAuth2'));
+      check('connect handler reports non-oauth adapter error',
+        connectFailureShown);
 
       const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <HealthData>

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.394';
+self.APP_VERSION = '1.10.395';


### PR DESCRIPTION
## Summary
- replace the eager `backup-cycle.js` import with a cached, retryable dynamic import
- load cycle backup support only when creating or restoring a full backup
- assert the helper stays cold at startup and loads exactly once on demand
- stabilize an unrelated wearable-settings coverage assertion exposed by the full parallel browser run
- regenerate the architecture map and bump the app version to 1.10.395

## Cold-load result
Returning-user mobile `/app` load, browser cache and service workers disabled:

- requests: 374 → 373 (-1)
- transfer: 1,434,032 → 1,433,294 bytes (-738)
- decoded: 4,078,260 → 4,077,035 bytes (-1,225)

## Validation
- `npm test` — 490 passed
- `npm run test:playwright` — 476 passed
- `npm run test:firefox` — 3 passed
- focused backup browser coverage — 2 passed
- exact cold-load baseline reproduced
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
- `npm run architecture:check`
- `npm run vendor:check`
- `git diff --check`