### PR TITLE
Load supplement warning data only when needed

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -10,7 +10,7 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | Metric | Current |
 | --- | ---: |
 | Modules | 477 |
-| Internal import edges | 2126 |
+| Internal import edges | 2127 |
 | Dynamic internal edges | 80 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -709,7 +709,7 @@ Native browser modules shipped with the static application.
 
 - [`js/startup-foundation.js`](js/startup-foundation.js) → [`js/crypto.js`](js/crypto.js), [`js/sun-uvdata.js`](js/sun-uvdata.js)
 - [`js/startup-maintenance-runtime.js`](js/startup-maintenance-runtime.js) → [`js/sun-sessions-store.js`](js/sun-sessions-store.js)
-- [`js/startup-maintenance.js`](js/startup-maintenance.js) → [`js/light-devices.js`](js/light-devices.js), [`js/startup-maintenance-runtime.js`](js/startup-maintenance-runtime.js), [`js/state.js`](js/state.js), [`js/wearables-connect-loader.js`](js/wearables-connect-loader.js), [`js/wearables-manual.js`](js/wearables-manual.js), [`js/wearables-summary.js`](js/wearables-summary.js) *(dynamic)*
+- [`js/startup-maintenance.js`](js/startup-maintenance.js) → [`js/light-devices.js`](js/light-devices.js), [`js/startup-maintenance-runtime.js`](js/startup-maintenance-runtime.js), [`js/state.js`](js/state.js), [`js/supplement-warnings.js`](js/supplement-warnings.js), [`js/wearables-connect-loader.js`](js/wearables-connect-loader.js), [`js/wearables-manual.js`](js/wearables-manual.js), [`js/wearables-summary.js`](js/wearables-summary.js) *(dynamic)*
 - [`js/startup-oauth-callbacks.js`](js/startup-oauth-callbacks.js) → [`js/api.js`](js/api.js), [`js/utils.js`](js/utils.js), [`js/wearables-connect-loader.js`](js/wearables-connect-loader.js)
 - [`js/startup-orchestrator.js`](js/startup-orchestrator.js) → [`js/app-event-listeners.js`](js/app-event-listeners.js), [`js/import-loader.js`](js/import-loader.js), [`js/startup-foundation.js`](js/startup-foundation.js), [`js/startup-maintenance.js`](js/startup-maintenance.js), [`js/startup-oauth-callbacks.js`](js/startup-oauth-callbacks.js), [`js/startup-profile.js`](js/startup-profile.js), [`js/startup-ui.js`](js/startup-ui.js), [`js/sync-configure.js`](js/sync-configure.js), [`js/sync-lifecycle.js`](js/sync-lifecycle.js), [`js/sync.js`](js/sync.js), [`js/utils.js`](js/utils.js)
 - [`js/startup-profile.js`](js/startup-profile.js) → [`js/crypto.js`](js/crypto.js), [`js/data-merge.js`](js/data-merge.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js)

--- a/js/startup-maintenance.js
+++ b/js/startup-maintenance.js
@@ -5,6 +5,7 @@ import { state } from './state.js';
 import { migrateBiometricsToManual, hasManualData } from './wearables-manual.js';
 import { hydrateDevicesFromPresets } from './light-devices.js';
 import { loadWearablesConnectModule } from './wearables-connect-loader.js';
+import { preloadMitoCompoundData } from './supplement-warnings.js';
 import {
   getStartupSunEngineVersionRuntime,
   hasSunSessionRehydrateRuntime,
@@ -13,10 +14,17 @@ import {
 } from './startup-maintenance-runtime.js';
 
 export function runPostProfileStartupMaintenance() {
+  preloadTrackedSupplementWarnings();
   startConnectedWearableServices().catch(() => {});
   scheduleSunSessionRehydrate();
   hydrateUserLightDevicesFromPresets();
   migrateLegacyBiometrics();
+}
+
+function preloadTrackedSupplementWarnings() {
+  if (state.importedData?.supplements?.length) {
+    void preloadMitoCompoundData();
+  }
 }
 
 function hasConnectedOAuthWearable() {

--- a/js/supplement-warnings.js
+++ b/js/supplement-warnings.js
@@ -7,24 +7,33 @@
 // MitoTox or any third-party database.
 
 // ── Lazy-loaded compound data ──
+/** @type {Array<any> | null} */
 let _mitoData = null;
-let _mitoLoading = false;
+/** @type {Promise<Array<any> | null> | null} */
+let _mitoDataLoad = null;
 
-async function _loadMitoData() {
-  if (_mitoData) return _mitoData;
-  if (_mitoLoading) return null;
-  _mitoLoading = true;
-  try {
-    const res = await fetch('data/mito-compounds.json');
-    if (!res.ok) return null;
-    _mitoData = await res.json();
-    return _mitoData;
-  } catch { return null; }
-  finally { _mitoLoading = false; }
+export function hasMitoCompoundData() {
+  return Array.isArray(_mitoData);
 }
 
-// Preload on import (fire-and-forget, silent fail if file missing)
-_loadMitoData();
+export function preloadMitoCompoundData() {
+  if (_mitoData) return Promise.resolve(_mitoData);
+  if (!_mitoDataLoad) {
+    _mitoDataLoad = fetch('data/mito-compounds.json')
+      .then(async res => {
+        if (!res.ok) return null;
+        const data = await res.json();
+        if (!Array.isArray(data)) return null;
+        _mitoData = data;
+        return _mitoData;
+      })
+      .catch(() => null)
+      .finally(() => {
+        _mitoDataLoad = null;
+      });
+  }
+  return _mitoDataLoad;
+}
 
 /**
  * Look up a compound in the mito database by name.
@@ -83,7 +92,10 @@ function _isHarmfulEffect(e) {
  */
 export function scanSupplementsForWarnings(supplements) {
   if (!supplements || supplements.length === 0) return [];
-  if (!_mitoData) return [];
+  if (!_mitoData) {
+    void preloadMitoCompoundData();
+    return [];
+  }
   const warnings = [];
   const seen = new Set();
 

--- a/js/supplements.js
+++ b/js/supplements.js
@@ -14,7 +14,12 @@ import { callClaudeAPI, getAIProvider, hasAIProvider, supportsVision } from './a
 import { resizeImage, isValidImageType, formatImageBlock, buildVisionContent } from './image-utils.js';
 import { openModalOverlay } from './modal-lifecycle.js';
 import { initSupplementActionDelegates, suppActionAttrs } from './supplement-action-delegates.js';
-import { scanSupplementsForWarnings, humanizeEffect } from './supplement-warnings.js';
+import {
+  hasMitoCompoundData,
+  humanizeEffect,
+  preloadMitoCompoundData,
+  scanSupplementsForWarnings,
+} from './supplement-warnings.js';
 import { getUtilsRuntimeHostname } from './utils-runtime.js';
 import { closeSupplementsModalRuntime, navigateSupplementsViewRuntime } from './supplements-runtime.js';
 import {
@@ -46,6 +51,25 @@ function closeSupplementModal() {
 
 function navigateSupplementView(category) {
   navigateSupplementsViewRuntime(category);
+}
+
+/** @type {Promise<void> | null} */
+let supplementWarningRefreshLoad = null;
+
+/**
+ * @param {Array<any>} supplements
+ */
+function scheduleSupplementWarningRefresh(supplements) {
+  if (!supplements.length || hasMitoCompoundData() || supplementWarningRefreshLoad) return;
+  supplementWarningRefreshLoad = preloadMitoCompoundData()
+    .then(data => {
+      if (!data) return;
+      const section = document.querySelector('.supp-timeline-section');
+      if (section) section.outerHTML = renderSupplementsSection();
+    })
+    .finally(() => {
+      supplementWarningRefreshLoad = null;
+    });
 }
 
 /**
@@ -128,6 +152,7 @@ if (typeof window !== 'undefined') {
 
 export function renderSupplementsSection() {
   const supps = state.importedData.supplements || [];
+  scheduleSupplementWarningRefresh(supps);
   let html = `<div class="supp-timeline-section">
     <div class="supp-timeline-header">
       <span class="context-section-title">Supplements & Medications</span>

--- a/scripts/cold-load-budget.json
+++ b/scripts/cold-load-budget.json
@@ -8,10 +8,10 @@
     "decodedBytes": 5099000
   },
   "reference": {
-    "requests": 373,
-    "transferBytes": 1433294,
-    "decodedBytes": 4077035
+    "requests": 372,
+    "transferBytes": 1425214,
+    "decodedBytes": 4026532
   },
-  "referenceCommit": "2e9f912e",
+  "referenceCommit": "b7d95141",
   "measuredAt": "2026-07-25"
 }

--- a/tests/playwright/cold-load-budget.spec.js
+++ b/tests/playwright/cold-load-budget.spec.js
@@ -172,6 +172,9 @@ test('cold mobile app load stays within committed resource budgets', async ({ pa
   expect(entries.some(entry => (
     new URL(entry.name).pathname === '/js/backup-cycle.js'
   ))).toBe(false);
+  expect(entries.some(entry => (
+    new URL(entry.name).pathname === '/data/mito-compounds.json'
+  ))).toBe(false);
   const deferredLightEnvironmentUiModules = new Set([
     '/js/light-env.js',
     '/js/light-env-actions.js',

--- a/tests/playwright/startup-helpers-browser-coverage.spec.js
+++ b/tests/playwright/startup-helpers-browser-coverage.spec.js
@@ -226,6 +226,12 @@ test('startup maintenance starts services and runs non-blocking migrations', asy
         return true;
       }
     `,
+    '**/js/supplement-warnings.js*': `
+      export async function preloadMitoCompoundData() {
+        window.__startupMaintenanceCalls.push('preloadMitoCompoundData');
+        return [];
+      }
+    `,
     '**/js/wearables-summary.js*': `
       export async function syncWearableSummary(profileId, sources) {
         window.__startupMaintenanceCalls.push(['syncWearableSummary', profileId, sources]);
@@ -242,6 +248,7 @@ test('startup maintenance starts services and runs non-blocking migrations', asy
       currentProfile: 'startup-maintenance-profile',
       importedData: {
         biometrics: { weight: 70 },
+        supplements: [{ name: 'Metformin' }],
         wearableConnections: {
           manual: {
             connectedAt: '2026-07-01T00:00:00.000Z',
@@ -300,6 +307,8 @@ test('startup maintenance starts services and runs non-blocking migrations', asy
         lightDeviceHydrationRunsAndLogsDirtyState:
           window.__startupMaintenanceCalls.includes('hydrateDevicesFromPresets')
           && logs.some(line => line.includes('[light] hydrated user devices from preset library')),
+        trackedSupplementsPreloadWarningData:
+          window.__startupMaintenanceCalls.includes('preloadMitoCompoundData'),
         legacyBiometricsMigrationRefreshesManualSummary:
           summarySynced
           && window.__startupMaintenanceCalls.some(call => Array.isArray(call)

--- a/tests/playwright/supplement-warnings-browser-coverage.spec.js
+++ b/tests/playwright/supplement-warnings-browser-coverage.spec.js
@@ -34,26 +34,53 @@ test('supplement warning browser coverage exercises lookup scan urls and effect 
     const savedFetch = window.fetch;
 
     try {
-      window.fetch = async () => new Response('[]', { status: 503 });
+      let notOkFetchCalls = 0;
+      window.fetch = async () => {
+        notOkFetchCalls += 1;
+        return new Response('[]', { status: 503 });
+      };
       const notOk = await import(notOkUrl);
-      await wait(0);
+      outcomes.notOkImportStaysCold = notOkFetchCalls === 0;
+      await notOk.preloadMitoCompoundData();
       outcomes.notOkDataLoadLeavesLookupEmpty = notOk.lookupMitoCompound('metformin') === null;
       outcomes.notOkDataLoadLeavesScanEmpty =
         notOk.scanSupplementsForWarnings([{ name: 'Metformin' }]).length === 0;
+      outcomes.notOkDataLoadAttemptedOnDemand = notOkFetchCalls >= 1
+        && notOk.hasMitoCompoundData() === false;
 
-      window.fetch = async () => { throw new Error('offline'); };
+      let throwingFetchCalls = 0;
+      window.fetch = async () => {
+        throwingFetchCalls += 1;
+        throw new Error('offline');
+      };
       const thrown = await import(throwUrl);
-      await wait(0);
+      outcomes.throwingImportStaysCold = throwingFetchCalls === 0;
+      await thrown.preloadMitoCompoundData();
       outcomes.throwingDataLoadLeavesLookupEmpty = thrown.lookupMitoCompound('metformin') === null;
       outcomes.throwingDataLoadLeavesScanEmpty =
         thrown.scanSupplementsForWarnings([{ name: 'Metformin' }]).length === 0;
+      outcomes.throwingDataLoadAttemptedOnDemand = throwingFetchCalls >= 1
+        && thrown.hasMitoCompoundData() === false;
 
-      window.fetch = savedFetch;
+      let successFetchCalls = 0;
+      window.fetch = (...args) => {
+        successFetchCalls += 1;
+        return savedFetch(...args);
+      };
       const warnings = await import(successUrl);
+      outcomes.successImportStaysCold = successFetchCalls === 0
+        && warnings.hasMitoCompoundData() === false;
+      const firstColdScan = warnings.scanSupplementsForWarnings([{ name: 'Metformin' }]);
+      const joinedLoad = warnings.preloadMitoCompoundData();
+      outcomes.firstScanStartsSingleFlightLoad = firstColdScan.length === 0
+        && joinedLoad === warnings.preloadMitoCompoundData()
+        && successFetchCalls === 1;
+      await joinedLoad;
       await waitUntil(
         () => warnings.lookupMitoCompound('metformin') !== null,
         'mitochondrial compound data',
       );
+      outcomes.successfulLoadMarksDataReady = warnings.hasMitoCompoundData() === true;
 
       const metformin = warnings.lookupMitoCompound(' METFORMIN ');
       const tylenol = warnings.lookupMitoCompound('daily tylenol tablets');

--- a/tests/playwright/supplements-browser-coverage.spec.js
+++ b/tests/playwright/supplements-browser-coverage.spec.js
@@ -109,6 +109,16 @@ test('supplements browser coverage handles editor ingredients imports sync and A
             usage: { prompt_tokens: 12, completion_tokens: 18 },
           });
         }
+        if (urlText === 'data/mito-compounds.json') {
+          return jsonResponse([{
+            name: 'Magnesium',
+            k: ['magnesium glycinate'],
+            cat: 'supplement',
+            effects: [{ f: 'Complex I', a: 'inhibits', t: 'coverage fixture' }],
+            pmid: 12345678,
+            more: 'magnesium+mitochondria',
+          }]);
+        }
         throw new Error(`Unexpected fetch ${urlText}`);
       };
 
@@ -136,6 +146,18 @@ test('supplements browser coverage handles editor ingredients imports sync and A
         changeHistory: [],
       };
       data.invalidateActiveDataCache();
+
+      const supplementSectionHost = document.createElement('div');
+      supplementSectionHost.id = 'supplement-warning-refresh-fixture';
+      supplementSectionHost.innerHTML = supplements.renderSupplementsSection();
+      document.body.appendChild(supplementSectionHost);
+      await waitUntil(
+        () => !!supplementSectionHost.querySelector('.supp-mitotox'),
+        'deferred mitochondrial warning refresh',
+      );
+      outcomes.supplementWarningsLoadOnDemandAndRefreshTheSection =
+        fetchCalls.filter(call => call.url === 'data/mito-compounds.json').length === 1
+        && supplementSectionHost.textContent.includes('may inhibit Complex I');
 
       supplements.openSupplementsEditor();
       await waitUntil(() => document.getElementById('modal-overlay')?.classList.contains('show'), 'supplement editor open');
@@ -245,6 +267,7 @@ test('supplements browser coverage handles editor ingredients imports sync and A
       document.getElementById('modal-overlay')?.classList.remove('show');
       document.querySelectorAll('.notification-toast').forEach(el => el.remove());
       document.getElementById('supplements-ai-context-fixture')?.remove();
+      document.getElementById('supplement-warning-refresh-fixture')?.remove();
       state.importedData = saved.importedData;
       state.currentProfile = saved.currentProfile;
       state.currentView = saved.currentView;

--- a/tests/playwright/supplements-browser-coverage.spec.js
+++ b/tests/playwright/supplements-browser-coverage.spec.js
@@ -161,6 +161,12 @@ test('supplements browser coverage handles editor ingredients imports sync and A
 
       supplements.openSupplementsEditor();
       await waitUntil(() => document.getElementById('modal-overlay')?.classList.contains('show'), 'supplement editor open');
+      document.querySelector('[data-supp-action="close-modal"]')?.click();
+      await waitUntil(() => !document.getElementById('modal-overlay')?.classList.contains('show'), 'supplement editor close');
+      outcomes.closeButtonDelegatesToSupplementModalRuntime =
+        !document.getElementById('modal-overlay')?.classList.contains('show');
+      supplements.openSupplementsEditor();
+      await waitUntil(() => document.getElementById('modal-overlay')?.classList.contains('show'), 'supplement editor reopen');
       supplements.toggleSuppAccordion(0);
       await waitUntil(() => !!document.querySelector('.supp-list-expanded'), 'supplement row expanded');
       const expanded = document.querySelector('.supp-list-expanded');

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.395';
+self.APP_VERSION = '1.10.396';


### PR DESCRIPTION
## Summary
- stop fetching the mitochondrial compound database merely because supplement warning helpers are imported
- preload it after profile hydration only when the active profile actually tracks supplements
- preserve first-use behavior with a cached, retryable, single-flight loader and refresh the supplement warning section after demand loading completes
- cover cold imports, failure/retry behavior, concurrent loads, tracked-profile startup, and the cold resource boundary
- regenerate the architecture map and bump the app version to 1.10.396

## Cold-load result
Returning-user mobile `/app` load with browser cache and service workers disabled:

- requests: 373 → 372 (-1)
- transfer: 1,433,294 → 1,425,214 bytes (-8,080)
- decoded: 4,077,035 → 4,026,532 bytes (-50,503)

## Validation
- `npm test` — 490 passed
- `npm run test:playwright` — 476 passed
- `npm run test:firefox` — 3 passed
- focused supplement/startup browser coverage — 5 passed
- exact cold-load baseline reproduced
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
- `npm run architecture:check`
- `npm run vendor:check`
- `git diff --check`