### PR TITLE
Load Light device presets only when needed

### DIFF
--- a/js/startup-maintenance.js
+++ b/js/startup-maintenance.js
@@ -68,6 +68,7 @@ function hydrateUserLightDevicesFromPresets() {
   // / Trinity device records have no `modes` array, so the session-log
   // dialog can't render the mode picker for them. Idempotent - re-runs
   // are no-ops once devices carry the fields.
+  if (!state.importedData?.lightDevices?.length) return;
   hydrateDevicesFromPresets().then(dirty => {
     if (dirty) logStartupMaintenanceRuntime('[light] hydrated user devices from preset library');
   }).catch(() => {});

--- a/scripts/cold-load-budget.json
+++ b/scripts/cold-load-budget.json
@@ -8,10 +8,10 @@
     "decodedBytes": 5099000
   },
   "reference": {
-    "requests": 372,
-    "transferBytes": 1425214,
-    "decodedBytes": 4026532
+    "requests": 371,
+    "transferBytes": 1421797,
+    "decodedBytes": 4013876
   },
-  "referenceCommit": "b7d95141",
+  "referenceCommit": "eec08a1e",
   "measuredAt": "2026-07-25"
 }

--- a/tests/playwright/cold-load-budget.spec.js
+++ b/tests/playwright/cold-load-budget.spec.js
@@ -175,6 +175,9 @@ test('cold mobile app load stays within committed resource budgets', async ({ pa
   expect(entries.some(entry => (
     new URL(entry.name).pathname === '/data/mito-compounds.json'
   ))).toBe(false);
+  expect(entries.some(entry => (
+    new URL(entry.name).pathname === '/data/light-device-presets.json'
+  ))).toBe(false);
   const deferredLightEnvironmentUiModules = new Set([
     '/js/light-env.js',
     '/js/light-env-actions.js',
@@ -254,4 +257,66 @@ test('cold mobile app load stays within committed resource budgets', async ({ pa
   console.log(`Cold-load budget: ${formatColdLoadSummary(metrics)}`);
   console.log(`Cold-load metrics: ${JSON.stringify(metrics)}`);
   expect(() => enforceColdLoadBudget(metrics, budget)).not.toThrow();
+});
+
+test('startup loads Light presets only when persisted devices need hydration', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('labcharts-legal-acceptance', JSON.stringify({
+      accepted: true,
+      termsVersion: '2026-06-22',
+      privacyVersion: '2026-06-22',
+      acceptedAt: '2026-07-23T00:00:00.000Z',
+      appVersion: 'light-device-hydration',
+      location: 'light-device-hydration',
+    }));
+    localStorage.setItem('labcharts-default-onboarded', 'profile-set');
+    localStorage.setItem('labcharts-default-emptyTour', 'completed');
+    localStorage.setItem('labcharts-default-tour', 'completed');
+    localStorage.setItem('labcharts-default-ai-reminder-dismissed', '1');
+    localStorage.setItem('labcharts-onboard-extras-done-default', '1');
+    localStorage.setItem('labcharts-onboard-provider-skipped-default', '1');
+    localStorage.setItem('labcharts-analytics-consent-seen', '1');
+  });
+
+  await page.goto('/app', { waitUntil: 'networkidle' });
+  await page.evaluate(async () => {
+    const [{ state }, { saveImportedData }] = await Promise.all([
+      import('/js/state.js'),
+      import('/js/data.js'),
+    ]);
+    state.importedData.lightDevices = [{
+      id: 'legacy-maxi-uvb',
+      presetId: 'mitochondriak-maxi-uvb',
+      brand: 'Mitochondriak',
+      model: 'Maxi UVB',
+      type: 'uvb',
+      peakWavelengths: [295, 380, 480, 630, 670, 760, 810, 830, 850],
+      channels: ['vitamin_d', 'pomc', 'no_cv', 'violet_eye', 'circadian', 'pbm_red', 'pbm_nir'],
+    }];
+    await saveImportedData({ immediate: true });
+  });
+
+  let presetRequests = 0;
+  page.on('request', request => {
+    if (new URL(request.url()).pathname === '/data/light-device-presets.json') {
+      presetRequests += 1;
+    }
+  });
+  await page.reload({ waitUntil: 'networkidle' });
+
+  await expect.poll(() => page.evaluate(async () => {
+    const { state } = await import('/js/state.js');
+    const device = state.importedData.lightDevices
+      .find(candidate => candidate.id === 'legacy-maxi-uvb');
+    return {
+      modes: device?.modes?.map(mode => mode.id) || [],
+      channelGroups: device?.channelGroups?.map(group => group.id) || [],
+      coupling: device?.coupling?.length || 0,
+    };
+  })).toEqual({
+    modes: ['all-on', 'red-nir-only'],
+    channelGroups: ['uv-blue', 'red-nir'],
+    coupling: 1,
+  });
+  expect(presetRequests).toBe(1);
 });

--- a/tests/playwright/startup-helpers-browser-coverage.spec.js
+++ b/tests/playwright/startup-helpers-browser-coverage.spec.js
@@ -249,6 +249,7 @@ test('startup maintenance starts services and runs non-blocking migrations', asy
       importedData: {
         biometrics: { weight: 70 },
         supplements: [{ name: 'Metformin' }],
+        lightDevices: [{ id: 'coverage-light-device', presetId: 'coverage-preset' }],
         wearableConnections: {
           manual: {
             connectedAt: '2026-07-01T00:00:00.000Z',
@@ -293,6 +294,12 @@ test('startup maintenance starts services and runs non-blocking migrations', asy
       const summarySynced = await waitUntil(() => window.__startupMaintenanceCalls
         .some(call => Array.isArray(call) && call[0] === 'syncWearableSummary')
         && window.__startupMaintenanceCalls.includes('initWearableScheduler'));
+      const trackedDeviceHydrationCount = window.__startupMaintenanceCalls
+        .filter(call => call === 'hydrateDevicesFromPresets').length;
+      window.__startupMaintenanceState.importedData.lightDevices = [];
+      maintenance.runPostProfileStartupMaintenance();
+      const emptyDeviceHydrationCount = window.__startupMaintenanceCalls
+        .filter(call => call === 'hydrateDevicesFromPresets').length;
 
       return {
         startupServicesInitializeWearableConfigAndScheduler:
@@ -305,8 +312,10 @@ test('startup maintenance starts services and runs non-blocking migrations', asy
           && window.__startupMaintenanceCalls.includes('rehydrateStaleSessions')
           && logs.some(line => line.includes('[sun] self-healed 2 session(s) under vmaintenance-test')),
         lightDeviceHydrationRunsAndLogsDirtyState:
-          window.__startupMaintenanceCalls.includes('hydrateDevicesFromPresets')
+          trackedDeviceHydrationCount === 1
           && logs.some(line => line.includes('[light] hydrated user devices from preset library')),
+        emptyProfilesSkipLightDevicePresetHydration:
+          emptyDeviceHydrationCount === trackedDeviceHydrationCount,
         trackedSupplementsPreloadWarningData:
           window.__startupMaintenanceCalls.includes('preloadMitoCompoundData'),
         legacyBiometricsMigrationRefreshesManualSummary:

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.396';
+self.APP_VERSION = '1.10.397';


### PR DESCRIPTION
## Summary

- skip Light device preset hydration when the active profile has no saved Light devices
- preserve startup hydration for legacy preset-backed devices and cover the real persisted-profile reload path
- ratchet the cold-load reference and bump the app version to `1.10.397`

## Why

The preset catalog was already fetched lazily, but startup always invoked its hydration path, so an empty returning-user profile still downloaded `data/light-device-presets.json`. Guarding that maintenance task removes the request without changing behavior for users who own saved Light devices.

## Impact

The empty-profile cold load drops from 372 to 371 requests, saving 3,417 compressed bytes and 12,656 decoded bytes. Profiles with legacy saved devices still fetch the catalog once and receive their missing modes, channel groups, and coupling metadata.

## Validation

- `PORT=8172 ./run-tests.sh` — full gate passed, including 477 Chromium tests and the 472-check responsive/theme matrix
- `npm run quality` — 11/11 guardrails passed
- targeted cold-load and startup-maintenance checks — 6/6 passed
- `git diff --check`