### PR TITLE
Restore CI coverage headroom and clear PostCSS advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1846,9 +1846,9 @@
       "license": "CC0-1.0"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -1981,9 +1981,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -2001,7 +2001,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/scripts/coverage-baseline.json
+++ b/scripts/coverage-baseline.json
@@ -1,7 +1,7 @@
 {
-  "minimumFunctionPct": 67.1,
-  "referenceFunctionPct": 67.27,
-  "referenceCommit": "73c4c56a",
-  "measuredAt": "2026-07-21",
+  "minimumFunctionPct": 67.4,
+  "referenceFunctionPct": 67.61,
+  "referenceCommit": "3fcf9ae6",
+  "measuredAt": "2026-07-26",
   "metric": "combined Vitest/Node and Playwright V8 function coverage"
 }

--- a/tests/app-event-listeners-runtime.test.js
+++ b/tests/app-event-listeners-runtime.test.js
@@ -1,0 +1,248 @@
+// @vitest-environment jsdom
+
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+const shell = vi.hoisted(() => ({
+  buildSidebar: vi.fn(),
+  endTour: vi.fn(),
+  refreshCallback: null,
+  registerRefreshCallback: vi.fn(callback => {
+    shell.refreshCallback = callback;
+  }),
+  state: { currentView: 'reports' },
+}));
+
+vi.mock('../js/state.js', () => ({ state: shell.state }));
+vi.mock('../js/data.js', () => ({ registerRefreshCallback: shell.registerRefreshCallback }));
+vi.mock('../js/nav.js', () => ({ buildSidebar: shell.buildSidebar }));
+vi.mock('../js/tour.js', () => ({ endTour: shell.endTour }));
+
+const appEvents = await import('../js/app-event-listeners.js');
+
+function appendOverlay(id, body = '<div class="modal" role="dialog"></div>') {
+  const overlay = document.createElement('div');
+  overlay.id = id;
+  overlay.className = 'modal-overlay show';
+  overlay.innerHTML = body;
+  document.body.appendChild(overlay);
+  return overlay;
+}
+
+function press(key, options = {}) {
+  const event = new KeyboardEvent('keydown', {
+    key,
+    bubbles: true,
+    cancelable: true,
+    ...options,
+  });
+  document.dispatchEvent(event);
+  return event;
+}
+
+describe('app event listener runtime', () => {
+  const actions = {
+    closeChangelog: vi.fn(),
+    closeChatPanel: vi.fn(),
+    closeClientList: vi.fn(),
+    closeEMFInterpretation: vi.fn(),
+    closeFeedbackModal: vi.fn(),
+    closeImportModal: vi.fn(),
+    closeLightEnvironmentAssessment: vi.fn(),
+    closeMobileSidebar: vi.fn(),
+    closeModal: vi.fn(),
+    closeReportBuilder: vi.fn(),
+    closeRestoreMnemonicDialog: vi.fn(),
+    closeSettingsModal: vi.fn(),
+    closeSummaryModal: vi.fn(),
+    closeSyncSetup: vi.fn(),
+    closeTweaksPanel: vi.fn(),
+    navigate: vi.fn(),
+    toggleChatPanel: vi.fn(),
+    updateChatNudge: vi.fn(),
+  };
+
+  beforeAll(() => {
+    document.body.innerHTML = '';
+    appEvents.configureAppEventListeners(actions);
+    appEvents.installGlobalEventListeners();
+  });
+
+  it('routes backdrops, keyboard actions, modal safety, and refresh through the composed shell', async () => {
+    const scrollable = document.createElement('div');
+    scrollable.className = 'modal';
+    Object.defineProperties(scrollable, {
+      clientHeight: { configurable: true, value: 100 },
+      scrollHeight: { configurable: true, value: 300 },
+      scrollTop: { configurable: true, writable: true, value: 100 },
+    });
+    const wheelOverlay = appendOverlay('wheel-overlay', '');
+    wheelOverlay.appendChild(scrollable);
+    const middleWheel = new WheelEvent('wheel', { deltaY: 1, bubbles: true, cancelable: true });
+    scrollable.dispatchEvent(middleWheel);
+    expect(middleWheel.defaultPrevented).toBe(false);
+    scrollable.scrollTop = 200;
+    const edgeWheel = new WheelEvent('wheel', { deltaY: 1, bubbles: true, cancelable: true });
+    scrollable.dispatchEvent(edgeWheel);
+    expect(edgeWheel.defaultPrevented).toBe(true);
+    wheelOverlay.remove();
+
+    const modalOverlay = appendOverlay('modal-overlay');
+    const modal = modalOverlay.querySelector('.modal');
+    modal.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    modalOverlay.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(actions.closeModal).not.toHaveBeenCalled();
+    modalOverlay.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(actions.closeModal).toHaveBeenCalledOnce();
+    modalOverlay.remove();
+
+    const backdropRoutes = [
+      ['light-env-assessment-overlay', 'closeLightEnvironmentAssessment'],
+      ['changelog-modal-overlay', 'closeChangelog'],
+      ['report-builder-overlay', 'closeReportBuilder'],
+      ['settings-modal-overlay', 'closeSettingsModal'],
+    ];
+    for (const [id, action] of backdropRoutes) {
+      const overlay = appendOverlay(id);
+      overlay.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      expect(actions[action]).toHaveBeenCalled();
+      overlay.remove();
+    }
+
+    for (const id of ['import-modal-overlay', 'feedback-modal-overlay']) {
+      const overlay = appendOverlay(id);
+      const child = overlay.firstElementChild;
+      overlay.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      expect(child.classList.contains('modal-nudge')).toBe(true);
+      child.dispatchEvent(new Event('animationend'));
+      expect(child.classList.contains('modal-nudge')).toBe(false);
+      overlay.remove();
+    }
+
+    const clientOverlay = appendOverlay('client-list-overlay', '<div class="modal cl-form"></div>');
+    clientOverlay.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(clientOverlay.firstElementChild.classList.contains('modal-nudge')).toBe(true);
+    clientOverlay.querySelector('.cl-form').remove();
+    clientOverlay.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(actions.closeClientList).toHaveBeenCalled();
+    clientOverlay.remove();
+
+    document.body.insertAdjacentHTML('beforeend', `
+      <div id="corr-options" class="show"><span id="inside-correlation"></span></div>
+      <input id="corr-search">
+      <button id="outside-correlation"></button>
+    `);
+    document.getElementById('inside-correlation').click();
+    expect(document.getElementById('corr-options').classList.contains('show')).toBe(true);
+    document.getElementById('outside-correlation').click();
+    expect(document.getElementById('corr-options').classList.contains('show')).toBe(false);
+
+    const roleButton = document.createElement('div');
+    roleButton.setAttribute('role', 'button');
+    roleButton.tabIndex = 0;
+    const roleClick = vi.fn();
+    roleButton.addEventListener('click', roleClick);
+    document.body.appendChild(roleButton);
+    roleButton.dispatchEvent(new KeyboardEvent('keydown', {
+      key: ' ',
+      bubbles: true,
+      cancelable: true,
+    }));
+    expect(roleClick).toHaveBeenCalledOnce();
+
+    const passphrase = appendOverlay('passphrase-overlay');
+    passphrase.style.display = 'flex';
+    press('Escape');
+    expect(actions.closeModal).toHaveBeenCalledTimes(1);
+    passphrase.remove();
+
+    const tour = appendOverlay('tour-overlay');
+    press('Escape');
+    expect(shell.endTour).toHaveBeenCalledOnce();
+    tour.remove();
+
+    const escapeRoutes = [
+      ['sidebar-nav', 'mobile-open', 'closeMobileSidebar'],
+      ['emf-interp-overlay', 'show', 'closeEMFInterpretation'],
+      ['summary-modal-overlay', 'show', 'closeSummaryModal'],
+      ['chat-panel', 'open', 'closeChatPanel'],
+      ['changelog-modal-overlay', 'show', 'closeChangelog'],
+      ['report-builder-overlay', 'show', 'closeReportBuilder'],
+      ['client-list-overlay', 'show', 'closeClientList'],
+      ['feedback-modal-overlay', 'show', 'closeFeedbackModal'],
+      ['settings-modal-overlay', 'show', 'closeSettingsModal'],
+      ['tweaks-panel-overlay', 'show', 'closeTweaksPanel'],
+      ['light-env-assessment-overlay', 'show', 'closeLightEnvironmentAssessment'],
+      ['modal-overlay', 'show', 'closeModal'],
+    ];
+    for (const [id, className, action] of escapeRoutes) {
+      const overlay = appendOverlay(id);
+      overlay.className = className;
+      press('Escape');
+      expect(actions[action]).toHaveBeenCalled();
+      overlay.remove();
+    }
+
+    const importOverlay = appendOverlay(
+      'import-modal-overlay',
+      '<div class="modal" id="import-modal"></div>',
+    );
+    press('Escape');
+    expect(actions.closeImportModal).toHaveBeenCalledOnce();
+    importOverlay.remove();
+
+    const confirmOverlay = appendOverlay('confirm-dialog-overlay');
+    press('Escape');
+    expect(confirmOverlay.classList.contains('show')).toBe(false);
+    confirmOverlay.remove();
+
+    const anonymousOverlay = document.createElement('div');
+    anonymousOverlay.className = 'modal-overlay show';
+    document.body.appendChild(anonymousOverlay);
+    press('Escape');
+    expect(anonymousOverlay.isConnected).toBe(false);
+
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    actions.closeRestoreMnemonicDialog.mockImplementationOnce(() => {
+      throw new Error('restore close failed');
+    });
+    const restoreOverlay = appendOverlay('sync-restore-overlay');
+    press('Escape');
+    restoreOverlay.remove();
+    actions.closeSyncSetup.mockImplementationOnce(() => Promise.reject(new Error('setup close failed')));
+    const setupOverlay = appendOverlay('sync-setup-overlay');
+    press('Escape');
+    setupOverlay.remove();
+    await vi.waitFor(() => expect(consoleError).toHaveBeenCalledTimes(2));
+    consoleError.mockRestore();
+
+    const focusOverlay = appendOverlay(
+      'modal-overlay',
+      '<div class="modal" role="dialog"><button id="first-focus">First</button><button id="last-focus">Last</button></div>',
+    );
+    const first = document.getElementById('first-focus');
+    const last = document.getElementById('last-focus');
+    last.focus();
+    expect(press('Tab').defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(first);
+    expect(press('Tab', { shiftKey: true }).defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(last);
+    focusOverlay.remove();
+
+    press('c');
+    expect(actions.toggleChatPanel).toHaveBeenCalledOnce();
+    const search = document.createElement('input');
+    search.id = 'sidebar-search';
+    search.select = vi.fn();
+    document.body.appendChild(search);
+    press('/');
+    expect(document.activeElement).toBe(search);
+    expect(search.select).toHaveBeenCalledOnce();
+
+    appEvents.registerAppRefreshCallback();
+    expect(shell.registerRefreshCallback).toHaveBeenCalledOnce();
+    shell.refreshCallback();
+    expect(shell.buildSidebar).toHaveBeenCalledOnce();
+    expect(actions.navigate).toHaveBeenCalledWith('reports');
+    expect(actions.updateChatNudge).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/export-import-runtime.test.js
+++ b/tests/export-import-runtime.test.js
@@ -1,0 +1,301 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const runtime = vi.hoisted(() => ({
+  clearDemoLoadingProfile: vi.fn(),
+  encryptedGetItem: vi.fn(),
+  encryptedSetItem: vi.fn(),
+  getEncryptionEnabled: vi.fn(() => false),
+  getProfiles: vi.fn(() => [{ id: 'profile-1', name: 'Primary' }]),
+  refreshImportRuntimeShell: vi.fn(async () => {}),
+  saveImportedData: vi.fn(),
+  setSelectedNodeUrl: vi.fn(),
+  showNotification: vi.fn(),
+  state: { currentProfile: 'profile-1', importedData: {} },
+}));
+
+vi.mock('../js/state.js', () => ({ state: runtime.state }));
+vi.mock('../js/utils.js', () => ({
+  isDebugMode: () => false,
+  showNotification: runtime.showNotification,
+}));
+vi.mock('../js/data.js', () => ({ saveImportedData: runtime.saveImportedData }));
+vi.mock('../js/profile.js', () => ({
+  createProfile: vi.fn(),
+  getProfiles: runtime.getProfiles,
+  loadProfile: vi.fn(async () => {}),
+  migrateProfileData: vi.fn(),
+  profileStorageKey: (id, kind) => `${id}:${kind}`,
+  updateProfileMeta: vi.fn(),
+}));
+vi.mock('../js/crypto.js', () => ({
+  encryptedGetItem: runtime.encryptedGetItem,
+  encryptedSetItem: runtime.encryptedSetItem,
+  getEncryptionEnabled: runtime.getEncryptionEnabled,
+}));
+vi.mock('../js/data-merge.js', () => ({
+  appendImportedArrayItem(data, field, item) {
+    if (!Array.isArray(data[field])) data[field] = [];
+    data[field].push(item);
+  },
+  clearTombstone: vi.fn(),
+  ensureImportedArray(data, field) {
+    if (!Array.isArray(data[field])) data[field] = [];
+    return data[field];
+  },
+  replaceImportedArrayItem(data, field, index, item) {
+    data[field][index] = item;
+  },
+  sortImportedArray(data, field, compare) {
+    data[field].sort(compare);
+  },
+  trimImportedArray(data, field, limit) {
+    data[field] = data[field].slice(-limit);
+  },
+}));
+vi.mock('../js/lab-entry-mutations.js', () => ({
+  findOrCreateLabEntry(data, date) {
+    let entry = data.entries.find(item => item.date === date);
+    if (!entry) {
+      entry = { date, markers: {} };
+      data.entries.push(entry);
+    }
+    return entry;
+  },
+}));
+vi.mock('../js/lab-entry.js', () => ({
+  setLabEntryMarker(entry, key, value) {
+    entry.markers[key] = value;
+  },
+}));
+vi.mock('../js/export-runtime.js', () => ({
+  clearDemoLoadingProfile: runtime.clearDemoLoadingProfile,
+  isDemoLoadingProfile: () => false,
+  refreshImportRuntimeShell: runtime.refreshImportRuntimeShell,
+}));
+vi.mock('../js/nostr-discovery.js', () => ({ setSelectedNodeUrl: runtime.setSelectedNodeUrl }));
+
+const { importDataJSON } = await import('../js/export-import.js');
+
+describe('JSON restore runtime', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    runtime.state.currentProfile = 'profile-1';
+    runtime.state.importedData = {
+      entries: [{ date: '2026-01-10', markers: { glucose: 90 } }],
+      healthGoals: [{ text: 'Sleep better', severity: 'medium' }],
+      menstrualCycle: {
+        cycleLength: 28,
+        periods: [{ startDate: '2025-12-01' }],
+      },
+      emfAssessment: { assessments: [{ id: 'emf-existing' }] },
+      biometrics: {
+        weight: [{ date: '2026-01-01', value: 70 }],
+        pulse: [],
+        bp: [],
+      },
+      sunSessions: [{ id: 'sun-existing' }],
+      deviceSessions: [],
+      lightDevices: [],
+      lightAudits: [],
+      lightMeasurements: [],
+      lightEnvironment: {
+        rooms: [{ id: 'room-existing' }],
+        screens: [],
+      },
+      lightDailyVerdicts: { '2026-01-01': { status: 'existing' } },
+      changeHistory: [{ field: 'diet', date: '2026-01-01', value: 'old' }],
+      chatSummaries: [{ threadId: 'thread-existing', summary: 'old' }],
+      supplements: [{ name: 'Magnesium', startDate: '2026-01-01' }],
+      notes: [{ date: '2026-01-01', text: 'Existing note' }],
+      importSnapshots: [{ id: 'snap-existing', importedAt: 10 }],
+    };
+  });
+
+  it('merges a rich backup without duplicating same-date or stable-id data', async () => {
+    localStorage.setItem('labcharts-profile-1-chat-threads', JSON.stringify([
+      { id: 'thread-existing', title: 'Existing' },
+    ]));
+    const backup = {
+      entries: [
+        {
+          date: '2026-01-10',
+          file: 'panel-a.pdf',
+          sourceFiles: ['panel-a.pdf'],
+          markers: { insulin: 5 },
+          markerSources: { insulin: { file: 'panel-a.pdf' } },
+        },
+        {
+          date: '2026-01-10',
+          sourceFile: 'panel-b.pdf',
+          sourceFiles: ['panel-b.pdf'],
+          markers: { triglycerides: 80 },
+        },
+        { markers: { ignored: 1 } },
+      ],
+      diagnoses: 'Seasonal allergies',
+      diet: { type: 'whole-food', restrictions: [] },
+      exercise: 'Strength three times weekly',
+      sleepCircadian: {
+        duration: 8,
+        issues: ['blue light blockers', 'restless sleep'],
+        note: 'Migrated combined field',
+      },
+      healthGoals: [
+        { text: 'Sleep better', severity: 'medium' },
+        { text: 'Improve recovery', severity: 'high' },
+      ],
+      customMarkers: { 'custom.one': { label: 'One' } },
+      refOverrides: { glucose: { min: 70, max: 99 } },
+      categoryLabels: { metabolic: 'Metabolic' },
+      categoryIcons: { metabolic: '⚡' },
+      markerLabels: { glucose: 'Glucose' },
+      menstrualCycle: {
+        cycleLength: 30,
+        periods: [
+          { startDate: '2025-12-01' },
+          { startDate: '2026-01-01' },
+        ],
+      },
+      emfAssessment: {
+        assessments: [
+          { id: 'emf-existing' },
+          { id: 'emf-new' },
+        ],
+      },
+      genetics: { snps: { rs1: 'AA' } },
+      biometrics: {
+        weight: [
+          { date: '2026-01-01', value: 70 },
+          { date: '2026-01-10', value: 69 },
+        ],
+        pulse: [{ date: '2026-01-10', value: 55 }],
+        bp: [{ date: '2026-01-10', systolic: 110, diastolic: 70 }],
+      },
+      markerNotes: { glucose: 'fasted' },
+      markerValueNotes: { 'glucose:2026-01-10': 'morning' },
+      manualValues: { 'glucose:2026-01-10': true },
+      sunSessions: [
+        { id: 'sun-existing' },
+        { id: 'sun-new' },
+        null,
+      ],
+      deviceSessions: [{ id: 'device-new' }],
+      lightDevices: [{ id: 'light-device-new' }],
+      lightAudits: [{ id: 'audit-new' }],
+      lightMeasurements: [{ id: 'measurement-new' }],
+      lightEnvironment: {
+        rooms: [
+          { id: 'room-existing' },
+          { id: 'room-new' },
+        ],
+        screens: [{ id: 'screen-new' }],
+        burdenAI: { status: 'complete' },
+      },
+      sunDefaults: { skinType: 2 },
+      sunCorrelations: { enabled: true },
+      lifelightProfile: { chronotype: 'early' },
+      lightDailyVerdicts: {
+        '2026-01-01': { status: 'replacement-ignored' },
+        '2026-01-02': { status: 'new' },
+      },
+      channelMixAI: { status: 'complete' },
+      biologyScoreContextAI: { status: 'complete' },
+      contextSourceSettings: { labs: true },
+      changeHistory: [
+        { field: 'diet', date: '2026-01-01', value: 'updated' },
+        { field: 'exercise', date: '2026-01-02', value: 'new' },
+      ],
+      wearableSummary: {
+        sources: { garmin: { connected: true } },
+      },
+      wearableCardOrder: ['sleep', 'recovery'],
+      wearablePrimaryOverride: {
+        sleep: 'garmin',
+        recovery: 'missing-source',
+      },
+      chatSummaries: [
+        { threadId: 'thread-existing', summary: 'updated' },
+        { threadId: 'thread-new', summary: 'new' },
+      ],
+      supplements: [
+        { name: 'Magnesium', startDate: '2026-01-01' },
+        {
+          name: 'Vitamin D',
+          dosage: '2000 IU',
+          startDate: '2026-01-02',
+          sourceUrl: 'https://example.com/product',
+        },
+      ],
+      notes: [
+        { date: '2026-01-01', text: 'Existing note' },
+        { date: '2026-01-02', text: 'New note' },
+      ],
+      importSnapshots: [
+        { id: 'snap-existing', importedAt: 20, fileName: 'newer.pdf' },
+        { id: 'snap-new', importedAt: 15, fileName: 'new.pdf' },
+      ],
+      chat: {
+        threads: [
+          { id: 'thread-existing', title: 'Existing' },
+          { id: 'thread-new', title: 'New' },
+        ],
+        messages: {
+          'thread-new': [{ role: 'user', content: 'Hello' }],
+        },
+        personality: 'coach',
+        customPersonalities: [{ id: 'custom-coach' }],
+      },
+    };
+
+    const file = new File(
+      [JSON.stringify(backup)],
+      'getbased-backup.json',
+      { type: 'application/json' },
+    );
+    await importDataJSON(file);
+
+    const imported = runtime.state.importedData;
+    expect(imported.entries).toHaveLength(1);
+    expect(imported.entries[0].markers).toEqual({
+      glucose: 90,
+      insulin: 5,
+      triglycerides: 80,
+    });
+    expect(imported.entries[0].sourceFiles).toEqual(['panel-a.pdf', 'panel-b.pdf']);
+    expect(imported.sleepRest.issues).toEqual(['restless sleep']);
+    expect(imported.lightCircadian.practices).toEqual(['blue light blockers']);
+    expect(imported.healthGoals).toHaveLength(2);
+    expect(imported.menstrualCycle.periods).toHaveLength(2);
+    expect(imported.emfAssessment.assessments).toHaveLength(2);
+    expect(imported.biometrics.weight).toHaveLength(2);
+    expect(imported.sunSessions).toEqual([
+      { id: 'sun-existing' },
+      { id: 'sun-new' },
+    ]);
+    expect(imported.lightEnvironment.rooms).toHaveLength(2);
+    expect(imported.lightDailyVerdicts['2026-01-01']).toEqual({ status: 'existing' });
+    expect(imported.lightDailyVerdicts['2026-01-02']).toEqual({ status: 'new' });
+    expect(imported.changeHistory).toEqual([
+      { field: 'diet', date: '2026-01-01', value: 'updated' },
+      { field: 'exercise', date: '2026-01-02', value: 'new' },
+    ]);
+    expect(imported.wearablePrimaryOverride).toEqual({ sleep: 'garmin' });
+    expect(imported.chatSummaries).toHaveLength(2);
+    expect(imported.supplements).toHaveLength(2);
+    expect(imported.notes).toHaveLength(2);
+    expect(imported.importSnapshots.map(snapshot => snapshot.id)).toEqual([
+      'snap-existing',
+      'snap-new',
+    ]);
+    expect(JSON.parse(localStorage.getItem('labcharts-profile-1-chat-threads'))).toHaveLength(2);
+    expect(runtime.saveImportedData).toHaveBeenCalledOnce();
+    expect(runtime.refreshImportRuntimeShell).toHaveBeenCalledWith({ chat: true });
+    expect(runtime.showNotification).toHaveBeenLastCalledWith(
+      'Imported 2 date entries',
+      'success',
+    );
+  });
+});

--- a/tests/settings-import-benchmark-controller-runtime.test.js
+++ b/tests/settings-import-benchmark-controller-runtime.test.js
@@ -1,0 +1,222 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const benchmarkRuntime = vi.hoisted(() => ({
+  deleteImportBenchmarks: vi.fn(),
+  getSnapshots: vi.fn(),
+  runReference: vi.fn(),
+  showConfirmDialog: vi.fn(async () => true),
+  showNotification: vi.fn(),
+  snapshots: [],
+  updateSelection: vi.fn(),
+}));
+
+function benchmarkBody() {
+  return `
+    <button data-import-benchmarks-action="close">Close</button>
+    <button data-import-benchmarks-action="run-reference">Run</button>
+    <button data-import-benchmarks-action="select-latest">Latest</button>
+    <button data-import-benchmarks-action="clear-selection">Clear</button>
+    <button data-import-benchmarks-action="delete-selected">Delete selected</button>
+    <button data-import-benchmark-review="candidate">Review</button>
+    <button data-import-benchmark-differences-close>Close review</button>
+    <button data-import-benchmark-delete="candidate">Delete candidate</button>
+    <input type="checkbox" data-import-benchmark-select="candidate">
+    <input type="checkbox" data-import-benchmark-select="incompatible">
+    <div data-import-benchmark-difference-review hidden></div>
+    <div data-import-reference-progress hidden></div>
+    <div class="import-reference-progress-track" aria-valuenow="0">
+      <div data-import-reference-progress-fill></div>
+    </div>
+    <div data-import-reference-progress-copy></div>
+  `;
+}
+
+vi.mock('../js/import-benchmarks.js', () => ({
+  deleteImportBenchmarks: benchmarkRuntime.deleteImportBenchmarks,
+}));
+vi.mock('../js/import-reference-benchmark.js', () => ({
+  IMPORT_REFERENCE_FIXTURE: { id: 'fixture-1' },
+  runBundledImportReferenceBenchmark: benchmarkRuntime.runReference,
+}));
+vi.mock('../js/modal-lifecycle.js', () => ({
+  openAppendedModalOverlay(overlay) {
+    document.body.appendChild(overlay);
+    overlay.classList.add('show');
+  },
+  removeModalOverlay(overlay) {
+    overlay.remove();
+  },
+}));
+vi.mock('../js/settings-data.js', () => ({
+  getImportBenchmarkSnapshots: benchmarkRuntime.getSnapshots,
+  importBenchmarkModelIdentity: snapshot => snapshot.model || '',
+  importBenchmarkStorageId: snapshot => snapshot.id,
+  importBenchmarksUseSameInput: (baseline, candidate) => baseline?.input === candidate?.input,
+  isImportBenchmarkComparable: snapshot => snapshot.comparable !== false,
+  latestCompatibleModelTests: snapshots => snapshots.filter(snapshot => !snapshot.benchmarkLocked).slice(-2),
+  referenceDifferenceLabel: count => count === 1 ? 'difference' : 'differences',
+  renderImportBenchmarksBody: () => benchmarkBody(),
+  renderReferenceDiscrepancyDetails: snapshot => `<strong>${snapshot.fileName}</strong>`,
+  updateImportBenchmarkSelection: benchmarkRuntime.updateSelection,
+}));
+vi.mock('../js/utils.js', () => ({
+  isDebugMode: () => false,
+  showConfirmDialog: benchmarkRuntime.showConfirmDialog,
+  showNotification: benchmarkRuntime.showNotification,
+}));
+
+const {
+  closeImportBenchmarksModal,
+  openImportBenchmarksModal,
+  renderImportBenchmarksEntrySection,
+} = await import('../js/settings-import-benchmark-controller.js');
+
+function click(selector) {
+  const element = document.querySelector(selector);
+  expect(element).not.toBeNull();
+  element.click();
+  return element;
+}
+
+describe('model import benchmark controller runtime', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.body.innerHTML = '';
+    benchmarkRuntime.snapshots = [
+      {
+        id: 'gold',
+        benchmarkLocked: true,
+        benchmarkKind: 'reference',
+        referenceFixtureId: 'fixture-1',
+        comparable: true,
+        input: 'fixture-input',
+        model: 'gold-model',
+        fileName: 'Gold standard',
+      },
+      {
+        id: 'latest',
+        benchmarkLocked: false,
+        benchmarkKind: 'reference',
+        referenceFixtureId: 'fixture-1',
+        comparable: true,
+        input: 'fixture-input',
+        model: 'model-a',
+        fileName: 'Latest model',
+      },
+      {
+        id: 'candidate',
+        benchmarkLocked: false,
+        benchmarkKind: 'upload',
+        comparable: true,
+        input: 'fixture-input',
+        model: 'model-b',
+        fileName: 'Candidate model',
+      },
+      {
+        id: 'incompatible',
+        benchmarkLocked: false,
+        benchmarkKind: 'upload',
+        comparable: true,
+        input: 'another-report',
+        model: 'model-c',
+        fileName: 'Different report',
+      },
+    ];
+    benchmarkRuntime.getSnapshots.mockImplementation(() => benchmarkRuntime.snapshots);
+    benchmarkRuntime.deleteImportBenchmarks.mockImplementation(async ids => {
+      benchmarkRuntime.snapshots = benchmarkRuntime.snapshots.filter(snapshot => !ids.includes(snapshot.id));
+      return ids.length;
+    });
+    benchmarkRuntime.runReference.mockImplementation(async ({ onProgress }) => {
+      onProgress(45, 'Model is reading report');
+      onProgress(95, 'Checking exact markers');
+      const completed = {
+        benchmarkId: 'completed',
+        manifest: { id: 'fixture-1' },
+        score: {
+          referenceExactMarkerCount: 9,
+          referenceExpectedMarkerCount: 10,
+          referenceExactMatch: false,
+          referenceF1Percent: 96,
+          referenceDiscrepancyCount: 1,
+        },
+      };
+      benchmarkRuntime.snapshots.push({
+        id: completed.benchmarkId,
+        benchmarkLocked: false,
+        benchmarkKind: 'reference',
+        referenceFixtureId: 'fixture-1',
+        comparable: true,
+        input: 'fixture-input',
+        model: 'model-d',
+        fileName: 'Completed model',
+      });
+      return completed;
+    });
+    globalThis.requestAnimationFrame = callback => {
+      callback(0);
+      return 1;
+    };
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  it('runs, compares, selects, refreshes, and deletes model benchmarks through one modal lifecycle', async () => {
+    expect(openImportBenchmarksModal()).toBe(true);
+    const overlay = document.getElementById('import-benchmarks-overlay');
+    expect(overlay).not.toBeNull();
+    expect(benchmarkRuntime.updateSelection).toHaveBeenCalled();
+
+    click('[data-import-benchmark-review="candidate"]');
+    const reviewPanel = document.querySelector('[data-import-benchmark-difference-review]');
+    expect(reviewPanel.hidden).toBe(false);
+    expect(reviewPanel.textContent).toContain('Candidate model');
+    expect(document.querySelector('[data-import-benchmark-review="candidate"]').getAttribute('aria-expanded')).toBe('true');
+    click('[data-import-benchmark-differences-close]');
+    expect(reviewPanel.hidden).toBe(true);
+
+    const incompatible = document.querySelector('[data-import-benchmark-select="incompatible"]');
+    incompatible.checked = true;
+    incompatible.click();
+    incompatible.checked = true;
+    incompatible.dispatchEvent(new Event('click', { bubbles: true }));
+    expect(incompatible.checked).toBe(false);
+    expect(benchmarkRuntime.showNotification).toHaveBeenCalledWith(
+      'Choose model tests that used the same report.',
+      'info',
+    );
+
+    const candidate = document.querySelector('[data-import-benchmark-select="candidate"]');
+    candidate.checked = true;
+    candidate.dispatchEvent(new Event('click', { bubbles: true }));
+    expect(benchmarkRuntime.updateSelection).toHaveBeenCalled();
+
+    click('[data-import-benchmarks-action="run-reference"]');
+    await vi.waitFor(() => expect(benchmarkRuntime.runReference).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(benchmarkRuntime.showNotification).toHaveBeenCalledWith(
+      'Model test scored 9/10 exact markers with 96% F1. 1 difference saved for review.',
+      'info',
+    ));
+
+    click('[data-import-benchmarks-action="select-latest"]');
+    click('[data-import-benchmarks-action="clear-selection"]');
+
+    click('[data-import-benchmark-delete="candidate"]');
+    await vi.waitFor(() => expect(benchmarkRuntime.deleteImportBenchmarks).toHaveBeenCalledWith(['candidate']));
+    expect(benchmarkRuntime.showConfirmDialog).toHaveBeenCalledWith(
+      'Delete this model test for "Candidate model"? Your imported health data will not be changed.',
+    );
+    expect(benchmarkRuntime.showNotification).toHaveBeenCalledWith(
+      '1 model test deleted.',
+      'success',
+    );
+
+    const entry = renderImportBenchmarksEntrySection();
+    expect(entry).toContain('3 saved tests');
+    expect(entry).toContain('across 3 model setups');
+
+    expect(closeImportBenchmarksModal()).toBe(true);
+    expect(document.getElementById('import-benchmarks-overlay')).toBeNull();
+  });
+});

--- a/tests/sync-recovery-runtime.test.js
+++ b/tests/sync-recovery-runtime.test.js
@@ -1,0 +1,203 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const syncRuntime = vi.hoisted(() => ({
+  closeModalOverlay: vi.fn(),
+  confirmAction: vi.fn(async () => true),
+  currentSyncEnabled: vi.fn(() => false),
+  enableSync: vi.fn(async () => {}),
+  ensureBip39: vi.fn(),
+  ensureQRCode: vi.fn(),
+  openModalOverlay: vi.fn(overlay => overlay.classList.add('show')),
+  restoreMnemonic: vi.fn(async () => true),
+  showNotification: vi.fn(),
+}));
+
+vi.mock('../js/utils.js', () => ({
+  escapeHTML: value => String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;'),
+  showNotification: syncRuntime.showNotification,
+}));
+vi.mock('../js/sync-identity.js', () => ({
+  ensureBip39: syncRuntime.ensureBip39,
+  ensureQRCode: syncRuntime.ensureQRCode,
+}));
+vi.mock('../js/modal-lifecycle.js', () => ({
+  closeModalOverlay: syncRuntime.closeModalOverlay,
+  openModalOverlay: syncRuntime.openModalOverlay,
+}));
+vi.mock('../js/sync-diagnose-actions-context.js', () => ({
+  currentSyncEnabled: syncRuntime.currentSyncEnabled,
+  enableSyncForDiagnose: syncRuntime.enableSync,
+  restoreMnemonicForDiagnose: syncRuntime.restoreMnemonic,
+}));
+vi.mock('../js/sync-diagnose-runtime.js', () => ({
+  confirmSyncDiagnoseActionRuntime: syncRuntime.confirmAction,
+}));
+
+const { confirmRotateIdentity } = await import('../js/sync-diagnose-identity-actions.js');
+const { _evoluDiagnosticsText } = await import('../js/sync-diagnostics-text.js');
+
+function click(selector) {
+  const element = document.querySelector(selector);
+  expect(element).not.toBeNull();
+  element.click();
+  return element;
+}
+
+describe('sync recovery runtime', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.body.innerHTML = '';
+    syncRuntime.confirmAction.mockResolvedValue(true);
+    syncRuntime.currentSyncEnabled.mockReturnValue(false);
+    syncRuntime.restoreMnemonic.mockResolvedValue(true);
+    document.execCommand = vi.fn(() => true);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: vi.fn(async () => { throw new Error('clipboard denied'); }) },
+    });
+  });
+
+  it('rotates identity only after confirmation, saved-word acknowledgement, and a successful local restore', async () => {
+    syncRuntime.ensureBip39.mockRejectedValueOnce(new Error('loader failed'));
+    await confirmRotateIdentity(null);
+    expect(syncRuntime.showNotification).toHaveBeenCalledWith(
+      'BIP-39 library not loaded — cannot rotate identity',
+      'error',
+    );
+
+    const mnemonic = Array.from({ length: 24 }, (_, index) => `word${index + 1}`).join(' ');
+    syncRuntime.ensureBip39.mockResolvedValue({
+      generateMnemonic: vi.fn(async () => mnemonic),
+    });
+    syncRuntime.ensureQRCode.mockResolvedValue(() => ({
+      addData: vi.fn(),
+      createSvgTag: vi.fn(() => '<svg aria-label="mnemonic QR"></svg>'),
+      make: vi.fn(),
+    }));
+
+    const existing = document.createElement('div');
+    existing.className = 'modal-overlay show';
+    const trigger = document.createElement('button');
+    existing.appendChild(trigger);
+    document.body.appendChild(existing);
+
+    await confirmRotateIdentity(trigger);
+
+    expect(existing.isConnected).toBe(false);
+    expect(syncRuntime.closeModalOverlay).toHaveBeenCalledWith(existing);
+    expect(document.querySelectorAll('#rotate-words span')).toHaveLength(48);
+    const apply = document.querySelector('#rotate-apply-btn');
+    expect(apply.disabled).toBe(true);
+
+    click('#rotate-copy-btn');
+    await vi.waitFor(() => {
+      expect(document.execCommand).toHaveBeenCalledWith('copy');
+      expect(document.querySelector('#rotate-copy-btn').textContent).toBe('✓ Copied');
+    });
+
+    const saved = document.querySelector('#rotate-saved-check');
+    saved.checked = true;
+    saved.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(apply.disabled).toBe(false);
+
+    apply.click();
+    await vi.waitFor(() => expect(syncRuntime.restoreMnemonic).toHaveBeenCalledWith(
+      mnemonic,
+      { seedLocal: true },
+    ));
+
+    expect(syncRuntime.enableSync).toHaveBeenCalledWith({ skipPush: true });
+    expect(syncRuntime.showNotification).toHaveBeenCalledWith(
+      'Sync identity rotated. Enter the new mnemonic on your other devices to keep them syncing.',
+      'success',
+    );
+    expect(document.querySelector('#rotate-apply-btn')).toBeNull();
+  });
+
+  it('formats a complete, support-ready diagnostics snapshot without dropping blockers or telemetry', () => {
+    const text = _evoluDiagnosticsText({
+      syncEnabled: true,
+      relay: 'wss://relay.example',
+      ownerId: 'owner-1',
+      mnemonicPrefix: 'alpha beta',
+      activeProfileId: 'profile-1',
+      activeImported: { sunSessions: 2, lightDevices: 1 },
+      rows: [{
+        profileId: 'profile-1',
+        isDeleted: false,
+        syncedAtMs: 12345,
+        sun: 2,
+        dev: 1,
+        bytes: 420,
+        format: 'delta',
+        profileIdSource: 'row',
+      }],
+      rowsError: 'one stale row could not be read',
+      deltaTelemetry: {
+        summary: {
+          ratio: 0.03,
+          count: 2,
+          totalBlobBytes: 1000,
+          totalDeltaBytes: 30,
+          totalOps: 4,
+        },
+        pushes: [{
+          at: '2026-01-10T12:00:00.000Z',
+          blobBytes: 1000,
+          totalDeltaBytes: 30,
+          totalOps: 4,
+          perArray: {
+            sunSessions: { ins: 1, upd: 1, tom: 0 },
+            empty: { ins: 0, upd: 0, tom: 0 },
+          },
+        }],
+        pull: {
+          mergedAt: '2026-01-10T12:01:00.000Z',
+          perArray: {
+            sunSessions: { live: 2, tombstones: 0 },
+            notes: { live: 1, tombstones: 1 },
+          },
+        },
+      },
+      cutoverReadiness: {
+        ready: false,
+        blockerCount: 1,
+        surfaceCount: 3,
+        surfaces: {
+          sunSessions: {
+            status: 'ok',
+            shape: 'array',
+            localCount: 2,
+            rowCount: 2,
+          },
+          notes: {
+            status: 'missing-rows',
+            shape: 'array',
+            localCount: 1,
+            rowCount: 0,
+          },
+          settings: {
+            status: 'ok',
+            shape: 'object',
+            localCount: 1,
+            rowCount: 1,
+          },
+        },
+      },
+    });
+
+    expect(text).toContain('Sync enabled: yes');
+    expect(text).toContain('profile-1');
+    expect(text).toContain('sunSessions(1/1/0)');
+    expect(text).not.toContain('empty(0/0/0)');
+    expect(text).toContain('notes                live=1 tombstones=1');
+    expect(text).toContain('BLOCKED — 1 surface(s) missing rows');
+    expect(text).toContain('notes                shape=array local=1 rows=0');
+    expect(text).toContain('✓ ok (2): sunSessions, settings');
+  });
+});


### PR DESCRIPTION
## What changed

- upgrades the transitive development-only PostCSS dependency from 8.5.15 to 8.5.23, including its compatible Nano ID update
- adds behavioral runtime coverage for JSON backup restore, app-wide modal/keyboard routing, sync identity recovery and diagnostics, and import model benchmark lifecycle
- raises the combined function-coverage floor from 67.1% to 67.4% after measuring 67.61%

## Why

The full coverage run had drifted to 67.07%, just below the committed 67.1% gate, and the lockfile still selected a PostCSS version affected by GHSA-r28c-9q8g-f849. The added tests cover consequential recovery and interaction paths rather than lowering the gate.

## Impact

CI regains 0.21 points of measured headroom above a stricter floor, backup/sync/modal/model-test regressions get direct behavioral protection, and `npm audit` returns zero known vulnerabilities across production and development dependencies.

## Validation

- clean `npm ci`
- `npm audit --json`: 0 vulnerabilities
- `npm run quality`: 11/11 guardrails
- `npm run test:firefox`: 3/3
- `PORT=8138 COVERAGE=1 ./run-tests.sh`
  - typecheck + checkJs passed
  - architecture, vendor, supply-chain, and module checks passed
  - Vitest: 499 passed
  - Chromium: 477 passed
  - responsive matrix: 472 assertions passed
  - combined function coverage: 67.61% (7,621 / 11,272) against 67.40% floor
  - cold load: 371 requests, 1,421,797 transferred bytes, 4,013,876 decoded bytes