### PR TITLE
Fix cold mobile startup performance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Verify architecture map and boundaries
         run: npm run architecture:check
 
+      - name: Verify production bundle and performance budgets
+        run: npm run production:check
+
       - name: Run quality guardrails
         run: npm run quality
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ npm run quality
 npm test
 npm run test:firefox
 npm run performance:check
+npm run production:check
 ./run-tests.sh
 COVERAGE=1 ./run-tests.sh
 ```
@@ -137,11 +138,13 @@ COVERAGE=1 ./run-tests.sh
 `COVERAGE=1 ./run-tests.sh` also combines Vitest and Playwright V8 function coverage and enforces the committed ratchet in `scripts/coverage-baseline.json`; CI runs this mode on every change.
 `npm run test:firefox` runs the focused Firefox critical-flow suite; install its browser binary once with `npx playwright install firefox`.
 `npm run performance:check` runs the focused cold mobile-load check and enforces the committed request-count, compressed-transfer, and decoded-byte ceilings.
+`npm run production:check` builds the deploy artifact in a temporary directory and enforces the production startup and lazy-chunk budgets without changing the worktree.
 `npm run sbom` writes a combined CycloneDX inventory for npm and vendored browser components to `artifacts/getbased.cdx.json`.
 
 ## Tech stack
 
-- Native browser ES modules; no app bundler for runtime source.
+- Native browser ES modules in source; the Vercel build uses Rolldown to collapse
+  the static startup graph while preserving feature-level lazy chunks.
 - Plain HTML/CSS/JS with split modules under `js/` and feature CSS under `css/`.
 - Chart.js for charts.
 - pdf.js for PDF text extraction.

--- a/index.html
+++ b/index.html
@@ -272,7 +272,37 @@
   <div class="layout">
     <div class="sidebar-backdrop" id="sidebar-backdrop" data-shell-action="close-mobile-sidebar"></div>
     <nav class="sidebar" id="sidebar-nav"></nav>
-    <main class="main" id="main-content"></main>
+    <main class="main" id="main-content">
+      <div class="welcome-hero welcome-hero-noai" data-prerendered-welcome>
+        <h2>Welcome to getbased</h2>
+        <p class="welcome-hero-subtitle">Health intelligence that's actually yours — five lenses on your biology, one private dashboard.</p>
+        <div class="welcome-primary-panel welcome-chat-panel">
+          <span class="welcome-primary-kicker">Start here</span>
+          <strong>Start with guided chat</strong>
+          <p>Chat starts with the basics, then guides AI setup only when it is needed for import or recommendations.</p>
+          <div class="welcome-primary-actions">
+            <button type="button" class="welcome-action-btn welcome-action-primary" data-dashboard-welcome-action="open-chat">Start guided chat</button>
+            <button type="button" class="welcome-action-btn welcome-direct-import-btn" data-dashboard-welcome-action="direct-import">Import file</button>
+          </div>
+        </div>
+        <div class="drop-zone drop-zone-hidden" id="drop-zone"></div>
+        <div class="welcome-demo-section">
+          <span class="welcome-section-label">Preview with demo data</span>
+          <div class="demo-cards">
+            <button type="button" class="demo-card" data-dashboard-welcome-action="load-demo" data-dashboard-welcome-demo="female">
+              <span class="demo-card-avatar">👩</span>
+              <span class="demo-card-name">Sarah, 34</span>
+              <span class="demo-card-desc">Iron + Oura: overtraining clues</span>
+            </button>
+            <button type="button" class="demo-card" data-dashboard-welcome-action="load-demo" data-dashboard-welcome-demo="male">
+              <span class="demo-card-avatar">👨</span>
+              <span class="demo-card-name">Alex, 38</span>
+              <span class="demo-card-desc">Metabolic + Withings body comp</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </main>
   </div>
 
   <footer class="app-footer">
@@ -427,7 +457,9 @@
 
   <script src="version.js" defer></script>
   <script type="module" src="js/service-worker-update.js"></script>
+  <!-- PRODUCTION_MAIN_SCRIPT_START -->
   <script type="module" src="js/main.js"></script>
+  <!-- PRODUCTION_MAIN_SCRIPT_END -->
   <script>
     // Cookieless Umami analytics — opt-out via Settings → Privacy. Skips on
     // file:// (offline export), .onion (Tor), local dev hosts (so the

--- a/js/dashboard-page-view.js
+++ b/js/dashboard-page-view.js
@@ -201,6 +201,7 @@ export function createDashboardPageView(deps) {
     try { ensureActiveDeviceTicker(); } catch (e) {}
     if (!data) data = getActiveData();
     const main = document.getElementById("main-content");
+    if (main.hasAttribute('aria-busy')) main.removeAttribute('aria-busy');
     const wasMobileDashboardActive = document.body.classList.contains('mobile-dashboard-active');
     document.body.classList.remove('mobile-dashboard-active');
     const wearableMetrics = state.importedData?.wearableSummary?.metrics || {};
@@ -219,6 +220,7 @@ export function createDashboardPageView(deps) {
     //    is set in loadDemoData() and cleared on import success/failure.
     if (!hasData && getDashboardPageRuntimeValue('_demoLoadingProfileId') === state.currentProfile) {
       document.body.classList.add('empty-dashboard-active');
+      main.setAttribute('aria-busy', 'true');
       main.innerHTML = `<div class="welcome-hero" aria-busy="true" role="status" aria-live="polite">
         <h2>Loading demo data…</h2>
         <p class="welcome-hero-subtitle">Setting up the demo profile — this takes a few seconds the first time.</p>
@@ -234,6 +236,7 @@ export function createDashboardPageView(deps) {
       const aiPaused = isAIPaused();
       const importReady = aiReady && !aiPaused;
       const heroClass = importReady ? 'welcome-hero welcome-hero-ready' : 'welcome-hero welcome-hero-noai';
+      const aiConnectionReminder = renderAIConnectionReminder();
       const primaryTitle = aiPaused ? 'Resume guided chat' : 'Start with guided chat';
       const primaryCopy = aiPaused
         ? 'Chat will walk you through re-enabling AI before you add files, connect sources, or ask for recommendations.'
@@ -254,7 +257,7 @@ export function createDashboardPageView(deps) {
           </div>
         </div>
         <div class="drop-zone drop-zone-hidden" id="drop-zone"></div>`;
-      const html = `${renderAIConnectionReminder()}<div class="${escapeHTML(heroClass)}">
+      const html = `${aiConnectionReminder}<div class="${escapeHTML(heroClass)}">
         <h2>Welcome to getbased</h2>
         <p class="welcome-hero-subtitle">Health intelligence that's actually yours — five lenses on your biology, one private dashboard.</p>
         ${primaryPanel}
@@ -274,7 +277,17 @@ export function createDashboardPageView(deps) {
           </div>
         </div>
       </div>`;
-      main.innerHTML = html;
+      const startupWelcome = main.querySelector('[data-prerendered-welcome]');
+      const canHydrateStartupWelcome = startupWelcome
+        && !aiReady
+        && !aiPaused
+        && !aiConnectionReminder;
+      // Preserve the already-painted DOM in the default state so the welcome
+      // copy remains the page's early LCP candidate. Delegated actions are
+      // live after startup without changing the rendered subtree.
+      if (!canHydrateStartupWelcome) {
+        main.innerHTML = html;
+      }
       setupDropZone();
       // First visit starts the empty-state tour from the welcome screen.
       // Delay one tick so header/profile controls are rendered before targets

--- a/js/service-worker-update.js
+++ b/js/service-worker-update.js
@@ -503,9 +503,38 @@ export async function registerServiceWorkerUpdates({
   }
 }
 
+export function scheduleServiceWorkerRegistration({
+  win = getDefaultServiceWorkerWindow(),
+  serviceWorkerContainer = getDefaultServiceWorkerContainer(),
+  cacheStorage = getDefaultCacheStorage(),
+  register = registerServiceWorkerUpdates,
+} = {}) {
+  if (!win || !serviceWorkerContainer) return false;
+  let registrationStarted = false;
+
+  const registerWhenIdle = () => {
+    if (registrationStarted) return;
+    registrationStarted = true;
+    const startRegistration = () => {
+      register({ win, serviceWorkerContainer, cacheStorage }).catch(() => {});
+    };
+    if (typeof win.requestIdleCallback === 'function') {
+      win.requestIdleCallback(startRegistration, { timeout: 2000 });
+    } else if (typeof win.setTimeout === 'function') {
+      win.setTimeout(startRegistration, 0);
+    } else {
+      startRegistration();
+    }
+  };
+
+  if (win.document?.readyState === 'complete') registerWhenIdle();
+  else win.addEventListener?.('load', registerWhenIdle, { once: true });
+  return true;
+}
+
 // Skip SW registration on dev hosts by default. WebKit's HTTP cache layer can
 // otherwise keep serving stale module bytes in Tauri/webkit2gtk dev windows.
 // Use ?dev-sw=1 for explicit local offline smoke testing.
 if (getDefaultServiceWorkerWindow() && getDefaultServiceWorkerContainer()) {
-  registerServiceWorkerUpdates();
+  scheduleServiceWorkerRegistration();
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "architecture:check": "node scripts/architecture-map.mjs --check",
     "dev-server": "node dev-server.js",
     "performance:check": "playwright test tests/playwright/cold-load-budget.spec.js --workers=1",
+    "production:build": "node scripts/build-production.mjs",
+    "production:check": "node scripts/build-production.mjs --check",
     "quality": "node scripts/quality-guardrails.mjs",
     "sbom": "node scripts/supply-chain.mjs --sbom artifacts/getbased.cdx.json",
     "supply-chain:check": "node scripts/supply-chain.mjs --check",

--- a/scripts/build-production.mjs
+++ b/scripts/build-production.mjs
@@ -1,0 +1,253 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build, RUNTIME_MODULE_ID } from 'rolldown';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const MAIN_ENTRY = path.join(ROOT, 'js', 'main.js');
+const RETRY_QUERY = '?lazy-retry=1';
+const GENERATED_BUNDLE_RE = /^bundle-[A-Za-z0-9_-]+\.js$/;
+const INDEX_SCRIPT_START = '  <!-- PRODUCTION_MAIN_SCRIPT_START -->';
+const INDEX_SCRIPT_END = '  <!-- PRODUCTION_MAIN_SCRIPT_END -->';
+const SW_BUNDLES_START = '  // PRODUCTION_BUNDLE_ASSETS_START';
+const SW_BUNDLES_END = '  // PRODUCTION_BUNDLE_ASSETS_END';
+const PRODUCTION_RAW_JS_ASSETS = new Set([
+  '/js/service-worker-update.js',
+  '/js/lens-local-worker.js',
+  '/js/lens-local-utils.js',
+  '/js/lens-local-store.js',
+]);
+
+function stripRetryQuery(id) {
+  return id.endsWith(RETRY_QUERY) ? id.slice(0, -RETRY_QUERY.length) : id;
+}
+
+function retryImportPlugin() {
+  return {
+    name: 'getbased-lazy-retry-imports',
+    resolveId(source, importer) {
+      if (source.endsWith(RETRY_QUERY)) {
+        if (!importer) return null;
+        const cleanSource = source.slice(0, -RETRY_QUERY.length);
+        const importerPath = stripRetryQuery(importer);
+        const resolved = path.isAbsolute(cleanSource)
+          ? cleanSource
+          : path.resolve(path.dirname(importerPath), cleanSource);
+        return `${resolved}${RETRY_QUERY}`;
+      }
+
+      if (importer?.endsWith(RETRY_QUERY) && source.startsWith('.')) {
+        return path.resolve(path.dirname(stripRetryQuery(importer)), source);
+      }
+
+      return null;
+    },
+    async load(id) {
+      if (!id.endsWith(RETRY_QUERY)) return null;
+      return fs.readFile(stripRetryQuery(id), 'utf8');
+    },
+  };
+}
+
+function initialGraphPlugin(initialModules) {
+  const staticImports = new Map();
+
+  return {
+    name: 'getbased-initial-module-graph',
+    moduleParsed(info) {
+      staticImports.set(info.id, [...info.importedIds]);
+    },
+    buildEnd() {
+      const visit = (id) => {
+        if (initialModules.has(id)) return;
+        initialModules.add(id);
+        for (const importedId of staticImports.get(id) || []) visit(importedId);
+      };
+      visit(MAIN_ENTRY);
+      initialModules.add(RUNTIME_MODULE_ID);
+    },
+  };
+}
+
+function replaceMarkedSection(source, startMarker, endMarker, replacementLines) {
+  const start = source.indexOf(startMarker);
+  const end = source.indexOf(endMarker);
+  if (start < 0 || end < 0 || end < start) {
+    throw new Error(`Missing or invalid build markers: ${startMarker} … ${endMarker}`);
+  }
+  const before = source.slice(0, start + startMarker.length);
+  const after = source.slice(end);
+  return `${before}\n${replacementLines.join('\n')}\n${after}`;
+}
+
+function pruneSourceModuleAppShell(source) {
+  return source.replace(
+    /^  '(\/js\/[^']+\.js)',\n/gm,
+    (line, url) => (PRODUCTION_RAW_JS_ASSETS.has(url) ? line : ''),
+  );
+}
+
+async function validateBundlerLock() {
+  const lock = JSON.parse(await fs.readFile(path.join(ROOT, 'package-lock.json'), 'utf8'));
+  const bundler = lock.packages?.['node_modules/rolldown'];
+  if (bundler?.version !== '1.0.3' || !bundler?.integrity) {
+    throw new Error('rolldown must be directly locked to 1.0.3 with integrity metadata');
+  }
+}
+
+async function removeOldBundles(outputDirectory) {
+  const entries = await fs.readdir(outputDirectory, { withFileTypes: true }).catch(() => []);
+  await Promise.all(entries
+    .filter(entry => entry.isFile() && GENERATED_BUNDLE_RE.test(entry.name))
+    .map(entry => fs.unlink(path.join(outputDirectory, entry.name))));
+}
+
+function collectStaticStartupFiles(entryChunk, chunkByName) {
+  const startupFiles = new Set();
+  const visit = (fileName) => {
+    if (startupFiles.has(fileName)) return;
+    startupFiles.add(fileName);
+    const chunk = chunkByName.get(fileName);
+    for (const imported of chunk?.imports || []) visit(imported);
+  };
+  visit(entryChunk.fileName);
+  return startupFiles;
+}
+
+async function enforceBuildBudget(summary) {
+  const budget = JSON.parse(
+    await fs.readFile(path.join(ROOT, 'scripts', 'production-build-budget.json'), 'utf8'),
+  );
+  const failures = [];
+  for (const [metric, maximum] of Object.entries(budget.maximums || {})) {
+    const actual = summary[metric];
+    if (!Number.isFinite(actual)) failures.push(`${metric} was not measured`);
+    else if (actual > maximum) failures.push(`${metric} ${actual} exceeds ${maximum}`);
+  }
+  if (failures.length) throw new Error(`Production build budget failed: ${failures.join('; ')}`);
+}
+
+export async function buildProduction({ outputRoot = ROOT } = {}) {
+  await validateBundlerLock();
+
+  const outputDirectory = path.join(outputRoot, 'js');
+  await fs.mkdir(outputDirectory, { recursive: true });
+  await removeOldBundles(outputDirectory);
+
+  const initialModules = new Set();
+  const result = await build({
+    input: MAIN_ENTRY,
+    platform: 'browser',
+    plugins: [
+      retryImportPlugin(),
+      initialGraphPlugin(initialModules),
+    ],
+    output: {
+      dir: outputDirectory,
+      format: 'es',
+      minify: true,
+      sourcemap: false,
+      entryFileNames: 'bundle-main-[hash].js',
+      chunkFileNames: 'bundle-[name]-[hash].js',
+      assetFileNames: 'bundle-[name]-[hash][extname]',
+      manualChunks(id) {
+        return initialModules.has(id) ? 'startup' : undefined;
+      },
+    },
+  });
+
+  const chunks = result.output.filter(item => item.type === 'chunk');
+  const assets = result.output.filter(item => item.type === 'asset');
+  const entryChunk = chunks.find(chunk => chunk.isEntry);
+  if (!entryChunk) throw new Error('Production build did not emit an entry chunk');
+  if (assets.length) {
+    throw new Error(`Production build emitted ${assets.length} unexpected non-JavaScript asset(s)`);
+  }
+  if (!chunks.every(chunk => GENERATED_BUNDLE_RE.test(chunk.fileName))) {
+    throw new Error('Production build emitted a file outside the bundle-*.js namespace');
+  }
+
+  const chunkByName = new Map(chunks.map(chunk => [chunk.fileName, chunk]));
+  const startupFiles = collectStaticStartupFiles(entryChunk, chunkByName);
+  const startupDecodedBytes = [...startupFiles].reduce(
+    (total, fileName) => total + Buffer.byteLength(chunkByName.get(fileName)?.code || ''),
+    0,
+  );
+  const outputDecodedBytes = chunks.reduce(
+    (total, chunk) => total + Buffer.byteLength(chunk.code),
+    0,
+  );
+  const summary = {
+    entryFile: entryChunk.fileName,
+    startupJavaScriptFiles: startupFiles.size,
+    startupDecodedBytes,
+    outputJavaScriptFiles: chunks.length,
+    outputDecodedBytes,
+    lazyJavaScriptFiles: chunks.length - startupFiles.size,
+  };
+  await enforceBuildBudget(summary);
+
+  const [indexSource, serviceWorkerSource] = await Promise.all([
+    fs.readFile(path.join(ROOT, 'index.html'), 'utf8'),
+    fs.readFile(path.join(ROOT, 'service-worker.js'), 'utf8'),
+  ]);
+  const builtIndex = replaceMarkedSection(
+    indexSource,
+    INDEX_SCRIPT_START,
+    INDEX_SCRIPT_END,
+    [
+      ...[...startupFiles]
+        .filter(fileName => fileName !== entryChunk.fileName)
+        .sort()
+        .map(fileName => `  <link rel="modulepreload" href="js/${fileName}">`),
+      `  <script type="module" src="js/${entryChunk.fileName}"></script>`,
+    ],
+  );
+  const bundleAssetLines = chunks
+    .map(chunk => `  '/js/${chunk.fileName}',`)
+    .sort();
+  const builtServiceWorker = replaceMarkedSection(
+    pruneSourceModuleAppShell(serviceWorkerSource),
+    SW_BUNDLES_START,
+    SW_BUNDLES_END,
+    bundleAssetLines,
+  );
+  await Promise.all([
+    fs.writeFile(path.join(outputRoot, 'index.html'), builtIndex),
+    fs.writeFile(path.join(outputRoot, 'service-worker.js'), builtServiceWorker),
+  ]);
+
+  return summary;
+}
+
+function formatBytes(bytes) {
+  return `${(bytes / 1024).toFixed(1)} KiB`;
+}
+
+async function runCli() {
+  const checkOnly = process.argv.includes('--check');
+  const outputRoot = checkOnly
+    ? await fs.mkdtemp(path.join(os.tmpdir(), 'getbased-production-build-'))
+    : ROOT;
+  try {
+    const summary = await buildProduction({ outputRoot });
+    console.log(
+      `Production startup: ${summary.startupJavaScriptFiles} JS files, `
+      + `${formatBytes(summary.startupDecodedBytes)} decoded`,
+    );
+    console.log(
+      `Lazy output: ${summary.lazyJavaScriptFiles} JS files; `
+      + `${formatBytes(summary.outputDecodedBytes)} total decoded`,
+    );
+    console.log(`Entry: js/${summary.entryFile}`);
+  } finally {
+    if (checkOnly) await fs.rm(outputRoot, { recursive: true, force: true });
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  await runCli();
+}

--- a/scripts/production-build-budget.json
+++ b/scripts/production-build-budget.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": 1,
+  "maximums": {
+    "startupJavaScriptFiles": 2,
+    "startupDecodedBytes": 1100000,
+    "outputJavaScriptFiles": 140,
+    "outputDecodedBytes": 4500000
+  },
+  "reference": {
+    "startupJavaScriptFiles": 2,
+    "startupDecodedBytes": 1015500,
+    "outputJavaScriptFiles": 127,
+    "outputDecodedBytes": 4043101
+  },
+  "referenceCommit": "f064079d",
+  "measuredAt": "2026-07-26"
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -69,6 +69,8 @@ const APP_SHELL = [
   '/themes-extra.css',
   '/js/service-worker-update.js',
   '/js/main.js',
+  // PRODUCTION_BUNDLE_ASSETS_START
+  // PRODUCTION_BUNDLE_ASSETS_END
   '/js/shell-actions.js',
   '/js/app-feature-modules.js',
   '/js/app-foundation-modules.js',

--- a/tests/production-build.test.js
+++ b/tests/production-build.test.js
@@ -1,0 +1,62 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { buildProduction } from '../scripts/build-production.mjs';
+
+let outputRoot;
+let summary;
+
+beforeAll(async () => {
+  outputRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'getbased-production-build-test-'));
+  summary = await buildProduction({ outputRoot });
+}, 20_000);
+
+afterAll(async () => {
+  if (outputRoot) await fs.rm(outputRoot, { recursive: true, force: true });
+});
+
+describe('production startup build', () => {
+  it('collapses the static startup graph into one bundle plus its tiny runtime', () => {
+    expect(summary.startupJavaScriptFiles).toBe(2);
+    expect(summary.startupDecodedBytes).toBeLessThanOrEqual(1_100_000);
+    expect(summary.outputJavaScriptFiles).toBeLessThanOrEqual(140);
+    expect(summary.outputDecodedBytes).toBeLessThanOrEqual(4_500_000);
+    expect(summary.lazyJavaScriptFiles).toBeGreaterThan(100);
+  });
+
+  it('points production HTML at the hashed entry while preserving the early welcome paint', async () => {
+    const index = await fs.readFile(path.join(outputRoot, 'index.html'), 'utf8');
+    expect(index).toContain(`<script type="module" src="js/${summary.entryFile}"></script>`);
+    expect(index).toContain('<link rel="modulepreload" href="js/bundle-rolldown-runtime-');
+    expect(index).not.toContain('<script type="module" src="js/main.js"></script>');
+    expect(index).toContain('data-prerendered-welcome');
+    expect(index).toContain('data-dashboard-welcome-action="open-chat"');
+    expect(index).toContain('Chat starts with the basics');
+  });
+
+  it('pre-caches every generated lazy chunk for installed offline use', async () => {
+    const serviceWorker = await fs.readFile(path.join(outputRoot, 'service-worker.js'), 'utf8');
+    const generatedFiles = (await fs.readdir(path.join(outputRoot, 'js')))
+      .filter(fileName => /^bundle-.*\.js$/.test(fileName));
+
+    expect(generatedFiles).toHaveLength(summary.outputJavaScriptFiles);
+    for (const fileName of generatedFiles) {
+      expect(serviceWorker).toContain(`'/js/${fileName}',`);
+    }
+    expect(serviceWorker).not.toContain("'/js/main.js',");
+    expect(serviceWorker).not.toContain("'/js/views.js',");
+    expect(serviceWorker).toContain("'/js/service-worker-update.js',");
+    expect(serviceWorker).toContain("'/js/lens-local-worker.js',");
+    expect(serviceWorker).toContain("'/js/lens-local-utils.js',");
+    expect(serviceWorker).toContain("'/js/lens-local-store.js',");
+  });
+
+  it('keeps the cold Latin body font from repainting the mobile LCP text', async () => {
+    const fonts = await fs.readFile('vendor/fonts/fonts.css', 'utf8');
+    expect(fonts).toMatch(
+      /font-weight: 400;\s+font-display: optional;\s+src: url\('\.\/inter-400-7\.woff2'\)/,
+    );
+  });
+});

--- a/tests/service-worker-update.test.js
+++ b/tests/service-worker-update.test.js
@@ -37,6 +37,40 @@ describe('service worker update prompt', () => {
     expect(shouldRegisterServiceWorker({ hostname: 'tauri.localhost', search: '' })).toBe(true);
   });
 
+  it('waits for page load and browser idle time before registration', async () => {
+    const { scheduleServiceWorkerRegistration } = serviceWorkerUpdate;
+    let onLoad = null;
+    let onIdle = null;
+    const register = vi.fn(async () => null);
+    const win = {
+      document: { readyState: 'loading' },
+      addEventListener: vi.fn((type, listener) => {
+        if (type === 'load') onLoad = listener;
+      }),
+      requestIdleCallback: vi.fn((callback) => {
+        onIdle = callback;
+        return 1;
+      }),
+    };
+    const serviceWorkerContainer = {};
+
+    expect(scheduleServiceWorkerRegistration({
+      win,
+      serviceWorkerContainer,
+      cacheStorage: null,
+      register,
+    })).toBe(true);
+    expect(register).not.toHaveBeenCalled();
+    expect(win.addEventListener).toHaveBeenCalledWith('load', expect.any(Function), { once: true });
+
+    onLoad();
+    expect(register).not.toHaveBeenCalled();
+    expect(win.requestIdleCallback).toHaveBeenCalledWith(expect.any(Function), { timeout: 2000 });
+
+    onIdle();
+    expect(register).toHaveBeenCalledWith({ win, serviceWorkerContainer, cacheStorage: null });
+  });
+
   it('turns a secondary-tab controllerchange into a reload prompt', async () => {
     const { registerServiceWorkerUpdates } = serviceWorkerUpdate;
     let onControllerChange = null;

--- a/vendor/fonts/fonts.css
+++ b/vendor/fonts/fonts.css
@@ -56,7 +56,7 @@
   font-family: 'Inter';
   font-style: normal;
   font-weight: 400;
-  font-display: swap;
+  font-display: optional;
   src: url('./inter-400-7.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/vercel.json
+++ b/vercel.json
@@ -5,9 +5,16 @@
       "**": false
     }
   },
-  "buildCommand": "node scripts/fetch-catalog.mjs",
+  "buildCommand": "node scripts/fetch-catalog.mjs && node scripts/build-production.mjs",
   "outputDirectory": ".",
   "routes": [
+    {
+      "src": "^/js/bundle-.*\\.js$",
+      "headers": {
+        "Cache-Control": "public, max-age=31536000, immutable"
+      },
+      "continue": true
+    },
     {
       "src": "/(.*)",
       "headers": {


### PR DESCRIPTION
## What changed

- bundle the production startup graph with Rolldown while preserving feature-level dynamic chunks and retry URLs
- prerender and hydrate the default welcome state in place so the largest visible content does not wait for JavaScript
- prevent the cold Latin body-font swap from repainting the LCP text
- defer service-worker registration until load/idle, precache generated chunks, and remove redundant raw app modules from the production cache
- serve hashed production chunks as immutable and enforce startup/output budgets in CI

## Root cause

The application shipped native ES modules directly in production. A fresh constrained mobile load requested hundreds of startup modules, and the welcome LCP element was created only after that network graph completed. A later Inter font swap repainted the same text and moved LCP even further out.

## Impact

Three fresh-profile mobile Lighthouse 13.4.1 runs with DevTools throttling produced a median performance score of **95** and median LCP of **2.43 s**, versus the measured production baseline of **74** and **7.42 s**. Median TBT is **5.3 ms**, CLS **0.00018**, and the built startup uses 30 requests / about 604 KB transferred in the local production preview.

The generated PWA was also installed and tested offline: a cache-only cold reload opened both Chat and Light successfully, with all 127 generated chunks cached and no raw `js/main.js` entry.

## Validation

- `./run-tests.sh` — green; 482 Playwright tests passed, including the 472-case theme/responsive matrix
- both TypeScript checks, architecture, vendor, supply-chain, legacy verification, and Vitest suites passed inside the full gate
- `npm run production:check`
- `npm run quality`
- production artifact mobile smoke: startup, Chat, Light, and Labs; zero page/console/request errors
- 3 fresh-profile mobile Lighthouse runs: 95 / 95 / 95, LCP 2.427 / 2.423 / 2.430 s
- generated-service-worker offline cold reload plus Chat and Light smoke