### PR TITLE
Unify mobile chat FAB

### DIFF
--- a/css/app-shell.css
+++ b/css/app-shell.css
@@ -770,10 +770,13 @@ body.analytics-consent-visible .version-update-banner { bottom: 78px; }
   body.empty-dashboard-active.mobile-tabs-active #chat-fab {
     display: none;
   }
+  body.analytics-consent-visible.mobile-dashboard-active #chat-fab,
   body.analytics-consent-visible.mobile-tabs-active #chat-fab,
+  body.version-update-visible.mobile-dashboard-active #chat-fab,
   body.version-update-visible.mobile-tabs-active #chat-fab {
     bottom: calc(186px + env(safe-area-inset-bottom));
   }
+  body.analytics-consent-visible.version-update-visible.mobile-dashboard-active #chat-fab,
   body.analytics-consent-visible.version-update-visible.mobile-tabs-active #chat-fab {
     bottom: calc(250px + env(safe-area-inset-bottom));
   }

--- a/css/chat-redesign-open.css
+++ b/css/chat-redesign-open.css
@@ -296,8 +296,7 @@ body.chat-open .analytics-consent-banner {
   .chat-msg { font-size: 14px; padding: 12px 14px; }
 }
 @media (max-width: 768px) {
-  body.chat-open .m-tabbar,
-  body.chat-open .m-chat-fab {
+  body.chat-open .m-tabbar {
     display: none;
   }
   body.chat-open .main { padding-right: 0; }

--- a/css/mobile-dashboard.css
+++ b/css/mobile-dashboard.css
@@ -53,7 +53,6 @@
     overscroll-behavior-x: none;
   }
   body.mobile-dashboard-active .app-footer { display: none; }
-  body.mobile-dashboard-active #chat-fab { display: none; }
   .m-shell {
     position: relative;
     display: block;
@@ -80,11 +79,9 @@
     padding: 20px 14px calc(128px + env(safe-area-inset-bottom));
     overflow-x: clip;
   }
-  .m-chat-fab,
   .m-tab {
     -webkit-tap-highlight-color: transparent;
   }
-  .m-chat-fab svg,
   .m-tab-icon svg {
     display: block;
     width: 18px;
@@ -156,8 +153,7 @@
   .m-stat-card:focus-visible,
   .m-insight:focus-visible,
   .m-marker-row:focus-visible,
-  .m-tab:focus-visible,
-  .m-chat-fab:focus-visible {
+  .m-tab:focus-visible {
     outline: 2px solid var(--accent);
     outline-offset: 2px;
   }
@@ -488,24 +484,6 @@
   .m-dashboard-widgets .dashboard-widget-description {
     white-space: normal;
   }
-  .m-chat-fab {
-    position: fixed;
-    right: 16px;
-    bottom: calc(154px + env(safe-area-inset-bottom) + var(--mobile-visual-bottom-offset, 0px));
-    z-index: 220;
-    width: 52px;
-    height: 52px;
-    border-radius: 18px;
-    border: 1px solid color-mix(in srgb, var(--accent) 52%, var(--border));
-    background: var(--accent);
-    color: var(--on-accent);
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 22px;
-    box-shadow: var(--shadow-lg);
-    cursor: pointer;
-  }
   .m-tabbar {
     position: fixed;
     left: 50%;
@@ -580,7 +558,9 @@
   .m-tab.active .m-tab-icon {
     color: var(--accent);
   }
+  body.mobile-dashboard-active #chat-fab,
   body.mobile-tabs-active #chat-fab {
+    right: 24px;
     bottom: calc(92px + env(safe-area-inset-bottom) + var(--mobile-visual-bottom-offset, 0px));
   }
   [data-theme="cyberterm"] .dashboard-greeting h1::before,
@@ -594,7 +574,6 @@
   [data-theme="cyberterm"] .m-insight,
   [data-theme="cyberterm"] .m-marker-row,
   [data-theme="cyberterm"] .m-wear-tile,
-  [data-theme="cyberterm"] .m-chat-fab,
   [data-theme="cyberterm"] .m-tabbar {
     border-radius: 0;
   }
@@ -604,7 +583,6 @@
   [data-theme="cyberterm"] .m-wear-tile {
     box-shadow: 2px 2px 0 var(--border);
   }
-  [data-theme="cyberterm"] .m-chat-fab,
   [data-theme="cyberterm"] .m-tabbar {
     box-shadow: 2px 2px 0 var(--border);
   }
@@ -626,7 +604,6 @@
     background-size: 18px 18px;
     opacity: 0.45;
   }
-  [data-theme="neuromancer"] .m-chat-fab,
   [data-theme="neuromancer"] .m-tabbar {
     box-shadow:
       0 0 22px -12px rgba(0, 229, 255, 0.62),

--- a/js/dashboard-view-composition.js
+++ b/js/dashboard-view-composition.js
@@ -242,7 +242,6 @@ export function createDashboardViewComposition({
     setupDropZone,
     loadCommitHash,
     navigate,
-    openChatPanel,
     toggleMobileSidebar,
     loadContextCardTips,
     loadCatalog,

--- a/js/mobile-dashboard.js
+++ b/js/mobile-dashboard.js
@@ -50,7 +50,6 @@ const MOBILE_DASHBOARD_ACTION_SELECTOR = `[${MOBILE_DASHBOARD_ACTION_ATTR}]`;
  *   setupDropZone: () => void,
  *   loadCommitHash: () => void,
  *   navigate: (route: string) => void,
- *   openChatPanel: () => void,
  *   toggleMobileSidebar: () => void,
  *   loadContextCardTips: () => any,
  *   loadCatalog: () => Promise<any>,
@@ -69,7 +68,6 @@ const mobileDashboardDeps = {
   setupDropZone: () => {},
   loadCommitHash: () => {},
   navigate: () => {},
-  openChatPanel: () => {},
   toggleMobileSidebar: () => {},
   loadContextCardTips: () => {},
   loadCatalog: async () => null,
@@ -112,8 +110,6 @@ function handleMobileDashboardActionClick(event) {
     const route = actionEl.dataset.mobileDashboardRoute || tab;
     mobileDashboardSetTab(tab);
     mobileDashboardDeps.navigate(route);
-  } else if (action === 'open-chat') {
-    mobileDashboardDeps.openChatPanel();
   } else if (action === 'open-search') {
     openMobileDashboardSearch();
   } else {
@@ -515,7 +511,6 @@ export function renderMobileDashboard(data, { resetScroll = false } = {}) {
         ${mobileWidgetStack}
       </div>
     </div>
-    <button type="button" class="m-chat-fab" ${mobileDashboardActionAttrs('open-chat')} aria-label="Ask AI">${renderMobileIcon('chat')}</button>
     ${renderMobileBottomTabs('dashboard')}`;
 
   if (resetScroll) scrollMobileDashboardToTop();

--- a/js/tour.js
+++ b/js/tour.js
@@ -23,7 +23,7 @@ const TOUR_STEPS = [
   { target: '.dashboard-sticky-actions', title: 'Customize Widgets', text: 'Use Customize and Add widget to choose the sections that matter for this profile.', position: 'bottom' },
   { target: '.tweaks-btn', title: 'Display Tweaks', text: 'Adjust theme, accent color, density, and motion effects without leaving the current screen.', position: 'bottom' },
   { target: '.settings-btn', title: 'Settings & Connections', text: 'Configure demographics, privacy, AI providers, wearables, sync, and data controls here.', position: 'bottom' },
-  { target: '#chat-fab, .m-chat-fab, #chat-panel.open', title: 'Ask AI', text: 'Use chat for guided interpretation, import setup, and follow-up questions. It uses the current profile context when an AI provider is connected.', position: 'left' },
+  { target: '#chat-fab, #chat-panel.open', title: 'Ask AI', text: 'Use chat for guided interpretation, import setup, and follow-up questions. It uses the current profile context when an AI provider is connected.', position: 'left' },
 ];
 
 const CYCLE_TOUR_STEPS = [

--- a/tests/playwright/mobile-dashboard-browser-coverage.spec.js
+++ b/tests/playwright/mobile-dashboard-browser-coverage.spec.js
@@ -92,7 +92,6 @@ test('mobile dashboard browser coverage exercises defaults breakpoint search and
       mobileDashboard.configureMobileDashboardView({
         navigate: route => calls.push(['navigate', route]),
         toggleMobileSidebar: () => calls.push(['toggleMobileSidebar']),
-        openChatPanel: () => calls.push(['openChatPanel']),
         loadContextCardTips: () => calls.push(['loadContextCardTips']),
         loadCatalog: async () => {
           calls.push(['loadCatalog']);
@@ -162,11 +161,6 @@ test('mobile dashboard browser coverage exercises defaults breakpoint search and
         && !document.querySelector('.m-tab[data-tab="light"]')?.hasAttribute('onclick')
         && !firstRenderHtml.includes('onclick=');
 
-      document.querySelector('.m-chat-fab')?.click();
-      outcomes.mobileChatFabUsesDelegatedAction = calls.some(call => call[0] === 'openChatPanel')
-        && document.querySelector('.m-chat-fab')?.getAttribute('data-mobile-dashboard-action') === 'open-chat'
-        && !document.querySelector('.m-chat-fab')?.hasAttribute('onclick');
-
       mobileDashboard.openMobileDashboardSearch();
       await wait(100);
       outcomes.openMobileDashboardSearchTogglesSidebarAndFocusesSearch = calls.some(call => call[0] === 'toggleMobileSidebar')
@@ -194,7 +188,6 @@ test('mobile dashboard browser coverage exercises defaults breakpoint search and
       mobileDashboard.configureMobileDashboardView({
         navigate: () => {},
         toggleMobileSidebar: () => {},
-        openChatPanel: () => {},
         loadContextCardTips: () => {},
         loadCatalog: async () => null,
         cacheCatalog: () => {},

--- a/tests/playwright/theme-responsive-e2e.spec.js
+++ b/tests/playwright/theme-responsive-e2e.spec.js
@@ -396,8 +396,8 @@ async function evaluateBaseChecks(page, theme, viewport) {
     if (viewport.mobile) {
       const shell = document.querySelector('.m-shell');
       const tabbar = document.querySelector('.m-tabbar');
-      const fab = document.querySelector('.m-chat-fab');
-      const desktopChatFab = document.getElementById('chat-fab');
+      const fab = document.getElementById('chat-fab');
+      const fabRect = fab?.getBoundingClientRect();
       const headerImportBtn = document.querySelector('.header-import-btn');
       ok('mobile dashboard shell is active', document.body.classList.contains('mobile-dashboard-active'));
       ok('mobile chrome root mirrors dashboard state', document.documentElement.classList.contains('mobile-dashboard-active'));
@@ -407,8 +407,14 @@ async function evaluateBaseChecks(page, theme, viewport) {
       ok('mobile header import button is visible',
         visible(headerImportBtn) && inViewport(headerImportBtn, 2));
       ok('mobile dashboard tabbar is outside clipped shell', tabbar && !tabbar.closest('.m-shell'));
-      ok('mobile chat FAB is visible and above tabbar', visible(fab) && tabbar && rect(fab).bottom < rect(tabbar).top);
-      ok('desktop chat FAB hidden inside mobile shell', !visible(desktopChatFab));
+      ok('mobile dashboard uses the shared chat FAB',
+        visible(fab) && !document.querySelector('.m-chat-fab'));
+      ok('mobile chat FAB has a usable square target and sits above tabbar',
+        !!fabRect && tabbar &&
+        fabRect.width >= 48 &&
+        Math.abs(fabRect.width - fabRect.height) <= 1 &&
+        fabRect.bottom < rect(tabbar).top,
+        fabRect ? `size=${fabRect.width.toFixed(1)}x${fabRect.height.toFixed(1)}` : 'missing');
       ok('donate button hidden on mobile', !visible(document.querySelector('.donate-btn')));
       const mobileWidgets = bySelector('.m-dashboard-widgets .dashboard-widget[data-widget-id]').filter(visible);
       ok('mobile renders the shared dashboard widget stack', mobileWidgets.length >= 5, `widgets=${mobileWidgets.length}`);
@@ -921,6 +927,19 @@ async function checkMobileInteractions(page, theme, viewportName, assert) {
     JSON.stringify(result));
   await delay(100);
 
+  const homeFabGeometry = await page.evaluate(() => {
+    const fab = document.getElementById('chat-fab');
+    if (!fab) return null;
+    const style = getComputedStyle(fab);
+    return {
+      width: style.width,
+      height: style.height,
+      right: style.right,
+      bottom: style.bottom,
+      borderRadius: style.borderRadius,
+    };
+  });
+
   for (const tab of ['labs', 'body', 'light', 'insight']) {
     await page.evaluate(async () => (await import('/js/views.js')).navigate('dashboard'));
     await delay(180);
@@ -934,7 +953,7 @@ async function checkMobileInteractions(page, theme, viewportName, assert) {
         { timeout: 2500 }
       ).catch(() => {});
     }
-    result = await page.evaluate(async ({ tab, theme }) => {
+    result = await page.evaluate(async ({ tab, theme, homeFabGeometry }) => {
       const { state } = await import('/js/state.js');
       const active = document.querySelector(`#mobile-bottom-tabs .m-tab[data-tab="${tab}"], .m-tabbar .m-tab[data-tab="${tab}"]`);
       const conditionsGrid = document.querySelector('.lens-page-widgets[data-lens-route="light"] .conditions-now-grid') || document.querySelector('.conditions-now-grid');
@@ -957,7 +976,7 @@ async function checkMobileInteractions(page, theme, viewportName, assert) {
       const tabbar = document.querySelector('.m-tabbar');
       const tabbarStyle = tabbar ? getComputedStyle(tabbar) : null;
       const tabbarRect = tabbar?.getBoundingClientRect();
-      const fab = document.querySelector('.m-chat-fab');
+      const fab = document.getElementById('chat-fab');
       const fabStyle = fab ? getComputedStyle(fab) : null;
       const fabRect = fab?.getBoundingClientRect();
       const lightWidgetRoute = document.querySelector('.lens-page-widgets[data-lens-route="light"]');
@@ -965,6 +984,13 @@ async function checkMobileInteractions(page, theme, viewportName, assert) {
       const tabbarPaint = shadowReach(tabbarStyle?.boxShadow);
       const fabPaint = shadowReach(fabStyle?.boxShadow);
       const terminalTheme = theme === 'cyberterm' || theme === 'neuromancer';
+      const fabGeometry = fabStyle ? {
+        width: fabStyle.width,
+        height: fabStyle.height,
+        right: fabStyle.right,
+        bottom: fabStyle.bottom,
+        borderRadius: fabStyle.borderRadius,
+      } : null;
       window.scrollTo(0, Math.min(620, document.scrollingElement.scrollHeight));
       const header = document.querySelector('.header');
       const headerStyle = header ? getComputedStyle(header) : null;
@@ -987,6 +1013,9 @@ async function checkMobileInteractions(page, theme, viewportName, assert) {
         hasBottomTabs: !!document.querySelector('#mobile-bottom-tabs, .m-shell .m-tabbar'),
         currentView: state?.currentView,
         visibleMain: document.getElementById('main-content')?.textContent?.trim().length > 40,
+        fabMatchesHome: !!fabGeometry && JSON.stringify(fabGeometry) === JSON.stringify(homeFabGeometry),
+        fabGeometry,
+        homeFabGeometry,
         rootTabsActive: document.documentElement.classList.contains('mobile-tabs-active'),
         headerSticky:
           headerStyle?.position === 'sticky' &&
@@ -1037,7 +1066,7 @@ async function checkMobileInteractions(page, theme, viewportName, assert) {
           getComputedStyle(sessionWidget.querySelector('.light-session-device .light-session-kind')).whiteSpace !== 'nowrap',
         supportColumns,
       };
-    }, { tab, theme });
+    }, { tab, theme, homeFabGeometry });
     assert(testName(theme, viewportName, `tab ${tab} navigates and stays active`),
       result.active && result.hasBottomTabs && result.visibleMain,
       JSON.stringify(result));
@@ -1046,6 +1075,9 @@ async function checkMobileInteractions(page, theme, viewportName, assert) {
         result.tabbarFixed && result.tabbarContained && result.tabbarStable &&
         result.horizontalOverflow <= 1 && result.bottomChromePaintContained,
       JSON.stringify(result));
+    assert(testName(theme, viewportName, `tab ${tab} keeps the Home chat FAB geometry`),
+      result.fabMatchesHome,
+      JSON.stringify({ home: result.homeFabGeometry, tab: result.fabGeometry }));
     assert(testName(theme, viewportName, `tab ${tab} keeps top header sticky`),
       result.headerSticky,
       JSON.stringify(result));

--- a/tests/test-mobile.js
+++ b/tests/test-mobile.js
@@ -66,6 +66,9 @@ ${await fetchWithRetry('css/chat-redesign-open.css')}`;
     css.includes('body.mobile-dashboard-active .header') &&
     css.includes('display: flex') &&
     !mobileDashboardSrc.includes('class="m-topbar"'));
+  assert('mobile dashboard home uses the shared chat FAB',
+    css.includes('body.mobile-dashboard-active #chat-fab') &&
+    !mobileDashboardSrc.includes('m-chat-fab'));
   assert('mobile dashboard no longer ships dead private topbar styles',
     !css.includes('.m-topbar-actions') &&
     !css.includes('.m-avatar-btn') &&

--- a/tests/test-tour.js
+++ b/tests/test-tour.js
@@ -98,7 +98,7 @@ assert('Step 5: Dashboard overview', tourSrc.includes("target: '.dashboard-greet
 assert('Step 6: Widget customization', tourSrc.includes("target: '.dashboard-sticky-actions', title: 'Customize Widgets'"));
 assert('Step 7: Display tweaks', tourSrc.includes("target: '.tweaks-btn', title: 'Display Tweaks'"));
 assert('Step 8: Settings', tourSrc.includes("target: '.settings-btn', title: 'Settings & Connections'"));
-assert('Step 9: Chat targets', tourSrc.includes("target: '#chat-fab, .m-chat-fab, #chat-panel.open', title: 'Ask AI'"));
+assert('Step 9: Chat targets', tourSrc.includes("target: '#chat-fab, #chat-panel.open', title: 'Ask AI'"));
 
 const tourStepsStart = tourSrc.indexOf('const TOUR_STEPS');
 const cycleStepsStart = tourSrc.indexOf('const CYCLE_TOUR_STEPS');


### PR DESCRIPTION
## What changed

- Removed the Home-only `.m-chat-fab` launcher and its separate action/styling path.
- Reused the global `#chat-fab` on Home, with the same bottom offset and right gutter used on other mobile routes.
- Kept consent/update-banner offsets working on the Home shell.
- Simplified tour and chat-open selectors after removing the duplicate launcher.
- Added responsive regression coverage that compares Home FAB geometry with Labs, Body, Light, and Insight across every shipped theme at 393px and 320px widths.

## Why

The mobile Home dashboard rendered a second FAB with different dimensions, shape, and positioning (`52px`, rounded square, `154px` bottom offset). Other pages used the global launcher (`#chat-fab`) at the shared mobile navigation offset. This made Home’s chat bubble look different and sit visibly higher.

Home now uses the same DOM element, styling, click behavior, and positioning as every other mobile route.

## Validation

- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm test` — 57 files / 504 tests passed
- targeted Playwright mobile dashboard coverage passed
- theme/responsive Playwright matrix — 520 assertions passed across 6 themes, desktop, 393px, 320px, and 799/800px boundary checks
- `npm run quality` — 11/11 guardrails passed
- `npm run architecture:check` — 482 modules, 0 cycles
- `npm run production:check`
- `npm run vendor:check`