### PR TITLE
Stabilize browser coverage accounting

### DIFF
--- a/scripts/coverage-baseline.json
+++ b/scripts/coverage-baseline.json
@@ -1,7 +1,7 @@
 {
-  "minimumFunctionPct": 67.4,
-  "referenceFunctionPct": 67.61,
-  "referenceCommit": "3fcf9ae6",
+  "minimumFunctionPct": 79.5,
+  "referenceFunctionPct": 80.68,
+  "referenceCommit": "b634cb58",
   "measuredAt": "2026-07-26",
   "metric": "combined Vitest/Node and Playwright V8 function coverage"
 }

--- a/scripts/coverage-model-helpers.mjs
+++ b/scripts/coverage-model-helpers.mjs
@@ -1,0 +1,32 @@
+import crypto from 'node:crypto';
+
+export function sourceFingerprint(source) {
+  const text = typeof source === 'string' ? source : '';
+  return {
+    sourceLength: text.length,
+    sourceHash: text
+      ? crypto.createHash('sha256').update(text).digest('hex')
+      : null,
+  };
+}
+
+export function coverageEntryMatchesSource(entry, source) {
+  if (!entry?.sourceHash) return true;
+  const fingerprint = sourceFingerprint(source);
+  return entry.sourceLength === fingerprint.sourceLength
+    && entry.sourceHash === fingerprint.sourceHash;
+}
+
+export function coverageFunctionRange(fn) {
+  const range = fn?.ranges?.[0];
+  if (!range) return null;
+  const start = range.start ?? range.startOffset ?? 0;
+  const end = range.end ?? range.endOffset ?? 0;
+  return end > start ? { start, end } : null;
+}
+
+export function isTopLevelScriptFunction(fn, index, total) {
+  if (index !== 0 || fn?.functionName) return false;
+  const range = coverageFunctionRange(fn);
+  return Boolean(range && range.start === 0 && range.end >= total);
+}

--- a/scripts/playwright-coverage.mjs
+++ b/scripts/playwright-coverage.mjs
@@ -11,6 +11,11 @@ import { fileURLToPath } from 'url';
 import { chromium } from 'playwright';
 import { runBrowserScript } from '../tests/playwright/browser-script-runner.js';
 import { enforceFunctionCoverage, resolveCoverageMinimum } from './coverage-gate.mjs';
+import {
+  coverageEntryMatchesSource,
+  coverageFunctionRange,
+  isTopLevelScriptFunction,
+} from './coverage-model-helpers.mjs';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const PORT = process.env.PORT || '8000';
@@ -128,6 +133,11 @@ function sourceForFile(file) {
   return source;
 }
 
+function matchesRepositorySource(entry) {
+  const file = canonicalFile(entry.url);
+  return coverageEntryMatchesSource(entry, sourceForFile(file));
+}
+
 function lineOffsets(source) {
   const offsets = [0];
   for (let i = 0; i < source.length; i += 1) {
@@ -192,7 +202,7 @@ function addBrowserEntriesToModel(model, entries) {
   const canonical = new Map();
 
   for (const entry of entries) {
-    if (!isAppSource(entry.url)) continue;
+    if (!isAppSource(entry.url) || !matchesRepositorySource(entry)) continue;
     const file = canonicalFile(entry.url);
     const total = entrySource(entry).length || sourceForFile(file).length;
     if (!total) continue;
@@ -209,26 +219,37 @@ function addBrowserEntriesToModel(model, entries) {
   for (const [file, entry] of canonical) {
     const metrics = getFileMetrics(model, file, entrySource(entry).length || sourceForFile(file).length, 'playwright');
     coverageFunctions(entry)
-      .filter(fn => fn.functionName)
       .forEach((fn, index) => {
+        const range = coverageFunctionRange(fn);
+        if (!range || isTopLevelScriptFunction(fn, index, metrics.total)) return;
         const called = (fn.ranges || []).some(fnRange => (fnRange.count || 0) > 0);
-        addFunction(metrics, `${fn.functionName}:${index}`, fn.functionName, called);
+        addFunction(
+          metrics,
+          `${range.start}:${range.end}`,
+          fn.functionName || `(anonymous_${index - 1})`,
+          called,
+        );
       });
   }
 
   for (const entry of entries) {
-    if (!isAppSource(entry.url)) continue;
+    if (!isAppSource(entry.url) || !matchesRepositorySource(entry)) continue;
     const file = canonicalFile(entry.url);
     if (entry === canonical.get(file)) continue;
     const metrics = model.get(file);
     if (!metrics) continue;
 
-    for (const fn of coverageFunctions(entry)) {
-      const called = fn.functionName && (fn.ranges || []).some(fnRange => (fnRange.count || 0) > 0);
+    for (const [index, fn] of coverageFunctions(entry).entries()) {
+      const range = coverageFunctionRange(fn);
+      if (!range || isTopLevelScriptFunction(fn, index, metrics.total)) continue;
+      const called = (fn.ranges || []).some(fnRange => (fnRange.count || 0) > 0);
       if (!called) continue;
-      const target = [...metrics.functions.values()]
-        .find(candidate => candidate.name === fn.functionName && !candidate.called);
-      if (target) target.called = true;
+      addFunction(
+        metrics,
+        `${range.start}:${range.end}`,
+        fn.functionName || `(anonymous_${index - 1})`,
+        true,
+      );
     }
   }
 }
@@ -258,7 +279,7 @@ function readVitestCoverageModel() {
     for (const [id, fn] of Object.entries(fileCoverage.fnMap || {})) {
       if (!fn.name) continue;
       const range = locToRange(source, fn.loc, offsets) || locToRange(source, fn.decl, offsets) || { start: 0, end: 0 };
-      addFunction(metrics, `${fn.name}:${range.start}:${range.end}`, fn.name, (fileCoverage.f?.[id] || 0) > 0);
+      addFunction(metrics, `${range.start}:${range.end}`, fn.name, (fileCoverage.f?.[id] || 0) > 0);
     }
   }
 

--- a/tests/coverage-gate.test.js
+++ b/tests/coverage-gate.test.js
@@ -1,11 +1,22 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { describe, expect, it } from 'vitest';
 
 import {
   enforceFunctionCoverage,
   resolveCoverageMinimum,
 } from '../scripts/coverage-gate.mjs';
+import {
+  coverageEntryMatchesSource,
+  coverageFunctionRange,
+  isTopLevelScriptFunction,
+  sourceFingerprint,
+} from '../scripts/coverage-model-helpers.mjs';
 
 const BASELINE = { minimumFunctionPct: 67.1 };
+const TESTS_DIR = path.dirname(fileURLToPath(import.meta.url));
 
 describe('coverage ratchet', () => {
   it('uses the committed minimum by default', () => {
@@ -49,5 +60,57 @@ describe('coverage ratchet', () => {
     const gate = resolveCoverageMinimum({ baseline: BASELINE });
     expect(() => enforceFunctionCoverage(67.09, gate))
       .toThrow('function coverage 67.09% is below 67.10%');
+  });
+
+  it('collects every browser-coverage suite through the coverage fixture', () => {
+    const playwrightDir = path.join(TESTS_DIR, 'playwright');
+    const uncoveredSuites = fs.readdirSync(playwrightDir)
+      .filter(name => name.endsWith('-browser-coverage.spec.js'))
+      .filter(name => {
+        const source = fs.readFileSync(path.join(playwrightDir, name), 'utf8');
+        return !/from ['"]\.\/coverage-fixture\.js['"]/.test(source);
+      });
+
+    expect(uncoveredSuites).toEqual([]);
+  });
+});
+
+describe('browser coverage model', () => {
+  it('accepts captured coverage only when it fingerprints the repository source', () => {
+    const source = 'export function realSource() { return true; }\n';
+    const fingerprint = sourceFingerprint(source);
+
+    expect(coverageEntryMatchesSource(fingerprint, source)).toBe(true);
+    expect(coverageEntryMatchesSource(fingerprint, source.replace('true', 'false'))).toBe(false);
+    expect(coverageEntryMatchesSource({ ...fingerprint, sourceLength: source.length + 1 }, source))
+      .toBe(false);
+  });
+
+  it('accepts legacy shards without a fingerprint', () => {
+    expect(coverageEntryMatchesSource({}, 'export const legacy = true;\n')).toBe(true);
+  });
+
+  it('normalizes V8 ranges into stable function identities', () => {
+    expect(coverageFunctionRange({
+      ranges: [{ startOffset: 17, endOffset: 42, count: 1 }],
+    })).toEqual({ start: 17, end: 42 });
+    expect(coverageFunctionRange({
+      ranges: [{ start: 17, end: 42, count: 1 }],
+    })).toEqual({ start: 17, end: 42 });
+    expect(coverageFunctionRange({ ranges: [] })).toBeNull();
+  });
+
+  it('excludes only the anonymous whole-script V8 function', () => {
+    const topLevel = {
+      functionName: '',
+      ranges: [{ startOffset: 0, endOffset: 100, count: 1 }],
+    };
+    const anonymousCallback = {
+      functionName: '',
+      ranges: [{ startOffset: 10, endOffset: 30, count: 1 }],
+    };
+
+    expect(isTopLevelScriptFunction(topLevel, 0, 100)).toBe(true);
+    expect(isTopLevelScriptFunction(anonymousCallback, 1, 100)).toBe(false);
   });
 });

--- a/tests/playwright/changelog-loader-browser-coverage.spec.js
+++ b/tests/playwright/changelog-loader-browser-coverage.spec.js
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './coverage-fixture.js';
 
 const facadeUrl = () => `/js/changelog.js?loaderCoverage=${Date.now()}-${Math.random().toString(36).slice(2)}`;
 const syntheticChangelog = `

--- a/tests/playwright/chat-loader-browser-coverage.spec.js
+++ b/tests/playwright/chat-loader-browser-coverage.spec.js
@@ -1,0 +1,193 @@
+import { expect, test } from './coverage-fixture.js';
+
+const chatLoaderUrl = () =>
+  `/js/chat-loader.js?facadeCoverage=${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+const syntheticChatModule = `
+  const record = (name, args = []) => {
+    window.__chatFacadeCalls ||= [];
+    window.__chatFacadeCalls.push([name, ...args]);
+    return { name, args };
+  };
+  export function configureAppChatHooks(deps) {
+    window.__chatFacadeConfigKeys = Object.keys(deps).sort();
+  }
+  export function openChatPanel(...args) { return record('openChatPanel', args); }
+  export function toggleChatPanel(...args) { return record('toggleChatPanel', args); }
+  export function createNewThread(...args) { return record('createNewThread', args); }
+  export function clearChatHistory(...args) { return record('clearChatHistory', args); }
+  export function filterThreadList(...args) { return record('filterThreadList', args); }
+  export function sendChatMessage(...args) { return record('sendChatMessage', args); }
+  export function setChatPersonality(...args) { return record('setChatPersonality', args); }
+  export function setChatWebSearchEnabled(...args) { return record('setChatWebSearchEnabled', args); }
+  export function startDiscussion(...args) { return record('startDiscussion', args); }
+  export function summarizeThread(...args) { return record('summarizeThread', args); }
+  export function toggleChatFullscreen(...args) { return record('toggleChatFullscreen', args); }
+  export function toggleHDMode(...args) { return record('toggleHDMode', args); }
+  export function togglePersonalityBar(...args) { return record('togglePersonalityBar', args); }
+  export function toggleThreadRail(...args) { return record('toggleThreadRail', args); }
+  export function useChatPrompt(...args) { return record('useChatPrompt', args); }
+  export function askAIAboutCorrelations(...args) { return record('askAIAboutCorrelations', args); }
+  export function askAIAboutMarker(...args) { return record('askAIAboutMarker', args); }
+  export function closeChatPanel(...args) { return record('closeChatPanel', args); }
+  export function closeSummaryModal(...args) { return record('closeSummaryModal', args); }
+  export function isChatStreaming(...args) { record('isChatStreaming', args); return true; }
+  export function ensureActiveThread(...args) { return record('ensureActiveThread', args); }
+  export function loadChatHistory(...args) { return record('loadChatHistory', args); }
+  export function loadChatThreads(...args) { return record('loadChatThreads', args); }
+  export function renderThreadList(...args) { return record('renderThreadList', args); }
+  export function updateChatContextStatus(...args) { return record('updateChatContextStatus', args); }
+  export function updateChatHeaderModel(...args) { return record('updateChatHeaderModel', args); }
+  export function onContextCardSaved(...args) { return record('onContextCardSaved', args); }
+`;
+
+test.beforeEach(async ({ page }) => {
+  await page.route('**/chat-loader-facade-coverage', route => route.fulfill({
+    contentType: 'text/html',
+    body: '<!doctype html><html><body><div id="fixture"></div></body></html>',
+  }));
+  await page.goto('/chat-loader-facade-coverage');
+});
+
+test('Chat lazy facade preserves every public action before and after first load', async ({ page }) => {
+  let implementationRequests = 0;
+  await page.route('**/js/app-ai-interaction-modules.js*', route => {
+    implementationRequests += 1;
+    return route.fulfill({
+      contentType: 'text/javascript',
+      body: syntheticChatModule,
+    });
+  });
+
+  const outcomes = await page.evaluate(async url => {
+    const loader = await import(url);
+    const coldFallbacks = [
+      loader.closeChatPanel(),
+      loader.closeSummaryModal(),
+      loader.isChatStreaming(),
+      loader.ensureActiveThreadIfLoaded(),
+      loader.loadChatHistoryIfLoaded(),
+      loader.loadChatThreadsIfLoaded(),
+      loader.renderThreadListIfLoaded(),
+      loader.onContextCardSavedIfLoaded(),
+      loader.updateChatContextStatusIfLoaded(),
+      loader.updateChatHeaderModelIfLoaded(),
+    ];
+
+    loader.configureChatLoader({
+      marker: 'configured',
+      prepareLightSunContext: () => Promise.reject(new Error('optional Light context unavailable')),
+      prepareHealthDataContext: () => ({ ready: true }),
+    });
+    const [first, second] = await Promise.all([
+      loader.loadChatModule(),
+      loader.loadChatModule(),
+    ]);
+
+    const lazyResults = await Promise.all([
+      loader.openChatPanel('open'),
+      loader.toggleChatPanel('toggle'),
+      loader.createNewThread('thread'),
+      loader.clearChatHistory('history'),
+      loader.filterThreadList('filter'),
+      loader.sendChatMessage('send'),
+      loader.setChatPersonality('analyst'),
+      loader.setChatWebSearchEnabled(true),
+      loader.startDiscussion('discussion'),
+      loader.summarizeThread('summary'),
+      loader.toggleChatFullscreen('fullscreen'),
+      loader.toggleHDMode('hd'),
+      loader.togglePersonalityBar('personality'),
+      loader.toggleThreadRail('rail'),
+      loader.useChatPrompt('prompt'),
+      loader.askAIAboutCorrelations('correlations'),
+      loader.askAIAboutMarker('marker'),
+    ]);
+
+    const loadedResults = [
+      loader.closeChatPanel('close'),
+      loader.closeSummaryModal('close-summary'),
+      loader.isChatStreaming('streaming'),
+      loader.ensureActiveThreadIfLoaded('ensure'),
+      loader.loadChatHistoryIfLoaded('load-history'),
+      loader.loadChatThreadsIfLoaded('load-threads'),
+      loader.renderThreadListIfLoaded('render-threads'),
+      loader.updateChatContextStatusIfLoaded('context-status'),
+      loader.updateChatHeaderModelIfLoaded('header-model'),
+      loader.onContextCardSavedIfLoaded('context-saved'),
+    ];
+
+    let enterPrevented = false;
+    const ignoredKey = loader.handleChatKeydown({ key: 'Escape' });
+    const ignoredShiftEnter = loader.handleChatKeydown({ key: 'Enter', shiftKey: true });
+    const handledEnter = await loader.handleChatKeydown({
+      key: 'Enter',
+      shiftKey: false,
+      preventDefault() { enterPrevented = true; },
+    });
+
+    return {
+      startsCold: coldFallbacks.every(value => value === false),
+      sharedModule: first === second,
+      loaded: loader.isChatModuleLoaded(),
+      configKeys: window.__chatFacadeConfigKeys,
+      lazyResultNames: lazyResults.map(result => result.name),
+      loadedResultNames: loadedResults.map(result => (
+        typeof result === 'boolean' ? 'isChatStreaming' : result.name
+      )),
+      ignoredKey,
+      ignoredShiftEnter,
+      handledEnterName: handledEnter.name,
+      enterPrevented,
+      calls: window.__chatFacadeCalls,
+    };
+  }, chatLoaderUrl());
+
+  expect(implementationRequests).toBe(1);
+  expect(outcomes).toMatchObject({
+    startsCold: true,
+    sharedModule: true,
+    loaded: true,
+    configKeys: [
+      'marker',
+      'prepareHealthDataContext',
+      'prepareLightSunContext',
+    ],
+    lazyResultNames: [
+      'openChatPanel',
+      'toggleChatPanel',
+      'createNewThread',
+      'clearChatHistory',
+      'filterThreadList',
+      'sendChatMessage',
+      'setChatPersonality',
+      'setChatWebSearchEnabled',
+      'startDiscussion',
+      'summarizeThread',
+      'toggleChatFullscreen',
+      'toggleHDMode',
+      'togglePersonalityBar',
+      'toggleThreadRail',
+      'useChatPrompt',
+      'askAIAboutCorrelations',
+      'askAIAboutMarker',
+    ],
+    loadedResultNames: [
+      'closeChatPanel',
+      'closeSummaryModal',
+      'isChatStreaming',
+      'ensureActiveThread',
+      'loadChatHistory',
+      'loadChatThreads',
+      'renderThreadList',
+      'updateChatContextStatus',
+      'updateChatHeaderModel',
+      'onContextCardSaved',
+    ],
+    ignoredKey: false,
+    ignoredShiftEnter: false,
+    handledEnterName: 'sendChatMessage',
+    enterPrevented: true,
+  });
+  expect(outcomes.calls.map(call => call[0])).toContain('sendChatMessage');
+});

--- a/tests/playwright/context-card-dashboard-ai-loader-browser-coverage.spec.js
+++ b/tests/playwright/context-card-dashboard-ai-loader-browser-coverage.spec.js
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './coverage-fixture.js';
 
 const facadeUrl = () => `/js/context-card-dashboard-ai.js?loaderCoverage=${Date.now()}-${Math.random().toString(36).slice(2)}`;
 const syntheticDashboardAI = `

--- a/tests/playwright/context-card-lifestyle-editors-loader-browser-coverage.spec.js
+++ b/tests/playwright/context-card-lifestyle-editors-loader-browser-coverage.spec.js
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './coverage-fixture.js';
 
 const facadeUrl = () => `/js/context-card-lifestyle-editors.js?loaderCoverage=${Date.now()}-${Math.random().toString(36).slice(2)}`;
 const syntheticLifestyleEditors = `

--- a/tests/playwright/context-card-medical-history-editor-loader-browser-coverage.spec.js
+++ b/tests/playwright/context-card-medical-history-editor-loader-browser-coverage.spec.js
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './coverage-fixture.js';
 
 const facadeUrl = () => `/js/context-card-medical-history-editor.js?loaderCoverage=${Date.now()}-${Math.random().toString(36).slice(2)}`;
 const syntheticMedicalHistoryEditor = `

--- a/tests/playwright/coverage-fixture.js
+++ b/tests/playwright/coverage-fixture.js
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { expect, test as base } from '@playwright/test';
+import { sourceFingerprint } from '../../scripts/coverage-model-helpers.mjs';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 const coverageDir = process.env.PLAYWRIGHT_COVERAGE_DIR ||
@@ -63,10 +64,12 @@ function coverageFile(testInfo, label) {
 }
 
 function shrinkEntry(entry) {
+  const source = entry.source || entry.text || '';
   return {
     url: entry.url,
     ranges: entry.ranges,
     functions: entry.functions,
+    ...sourceFingerprint(source),
     rawScriptCoverage: entry.rawScriptCoverage
       ? { functions: entry.rawScriptCoverage.functions }
       : undefined,
@@ -233,8 +236,9 @@ export async function stopPageCoverage(page, testInfo, label = 'page') {
 }
 
 export const test = base.extend({
-  page: async ({ page }, use, testInfo) => {
-    await seedCurrentLegalAcceptance(page);
+  seedLegalAcceptance: [true, { option: true }],
+  page: async ({ page, seedLegalAcceptance }, use, testInfo) => {
+    if (seedLegalAcceptance) await seedCurrentLegalAcceptance(page);
 
     if (!isCoverageEnabled()) {
       await use(page);

--- a/tests/playwright/export-facade-loader-browser-coverage.spec.js
+++ b/tests/playwright/export-facade-loader-browser-coverage.spec.js
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './coverage-fixture.js';
 
 function syntheticExportFacade() {
   return `

--- a/tests/playwright/export-import-loader-browser-coverage.spec.js
+++ b/tests/playwright/export-import-loader-browser-coverage.spec.js
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './coverage-fixture.js';
 
 const exportUrl = () => `/js/export.js?importLoaderCoverage=${Date.now()}-${Math.random().toString(36).slice(2)}`;
 const syntheticImportModule = `

--- a/tests/playwright/legal-consent-startup.spec.js
+++ b/tests/playwright/legal-consent-startup.spec.js
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './coverage-fixture.js';
 
 const CURRENT_ACCEPTANCE = {
   accepted: true,
@@ -9,7 +9,10 @@ const CURRENT_ACCEPTANCE = {
   location: 'playwright',
 };
 
-test.use({ viewport: { width: 412, height: 844 } });
+test.use({
+  viewport: { width: 412, height: 844 },
+  seedLegalAcceptance: false,
+});
 
 async function holdMainModule(page) {
   let release;

--- a/tests/playwright/light-tool-camera-loader-browser-coverage.spec.js
+++ b/tests/playwright/light-tool-camera-loader-browser-coverage.spec.js
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './coverage-fixture.js';
 
 const lightToolsUrl = () => `/js/light-tools.js?cameraLoaderCoverage=${Date.now()}-${Math.random().toString(36).slice(2)}`;
 

--- a/tests/playwright/marker-detail-browser-coverage.spec.js
+++ b/tests/playwright/marker-detail-browser-coverage.spec.js
@@ -4,6 +4,42 @@ function moduleUrl(path) {
   return `${path}?markerDetailCoverage=${Date.now()}-${Math.random().toString(36).slice(2)}`;
 }
 
+function markerDetailFacadeStubBody() {
+  const actions = [
+    'fetchCustomMarkerDescription',
+    'showDetailModal',
+    'editRefRange',
+    'saveRefRange',
+    'revertRefRange',
+    'openManualEntryForm',
+    'saveManualEntry',
+    'saveAndAddAnotherManualEntry',
+    'openCreateMarkerModal',
+    'pickNewCatIcon',
+    'saveCustomMarker',
+    'deleteMarkerValue',
+    'deleteCustomMarker',
+    'editMarkerValue',
+    'revertMarkerValue',
+    'editValueNote',
+    'deleteValueNote',
+    'toggleMarkerNoteEditor',
+    'saveMarkerNote',
+    'deleteMarkerNote',
+  ];
+  return `
+    const record = (name, args) => {
+      window.__markerDetailFacadeCalls ||= [];
+      window.__markerDetailFacadeCalls.push([name, ...args]);
+      return name;
+    };
+    export function configureMarkerDetailModal(deps) {
+      window.__markerDetailFacadeConfigKeys = Object.keys(deps).sort();
+    }
+    ${actions.map(name => `export function ${name}(...args) { return record('${name}', args); }`).join('\n')}
+  `;
+}
+
 async function openMarkerDetailLoaderPage(page, path) {
   await page.route(`**${path}`, route => route.fulfill({
     status: 200,
@@ -44,6 +80,74 @@ test('marker detail implementation loads on demand and single-flights', async ({
     loadedAfterAction: true,
   });
   expect(implementationRequests).toBe(1);
+});
+
+test('marker detail lazy facade forwards its complete editing contract', async ({ page }) => {
+  await page.route('**/js/marker-detail-modal-impl.js*', route => route.fulfill({
+    status: 200,
+    contentType: 'application/javascript',
+    body: markerDetailFacadeStubBody(),
+  }));
+  await openMarkerDetailLoaderPage(page, '/marker-detail-facade-contract-coverage');
+
+  const outcomes = await page.evaluate(async ({ modalUrl }) => {
+    const modal = await import(modalUrl);
+    modal.configureMarkerDetailModal({ marker: 'configured' });
+    await modal.loadMarkerDetailModule();
+    const results = [
+      modal.fetchCustomMarkerDescription('marker'),
+      modal.showDetailModal('proteins_albumin', { source: 'contract' }),
+      modal.editRefRange('marker'),
+      modal.saveRefRange('marker'),
+      modal.revertRefRange('marker'),
+      modal.openManualEntryForm('marker'),
+      modal.saveManualEntry('marker'),
+      modal.saveAndAddAnotherManualEntry('marker'),
+      modal.openCreateMarkerModal(),
+      modal.pickNewCatIcon('icon'),
+      modal.saveCustomMarker('marker'),
+      modal.deleteMarkerValue('marker'),
+      modal.deleteCustomMarker('marker'),
+      modal.editMarkerValue('marker'),
+      modal.revertMarkerValue('marker'),
+      modal.editValueNote('marker'),
+      modal.deleteValueNote('marker'),
+      modal.toggleMarkerNoteEditor('marker'),
+      modal.saveMarkerNote('marker'),
+      modal.deleteMarkerNote('marker'),
+    ];
+    return {
+      configKeys: window.__markerDetailFacadeConfigKeys,
+      results,
+      calls: window.__markerDetailFacadeCalls,
+    };
+  }, { modalUrl: moduleUrl('/js/marker-detail-modal.js') });
+
+  const expectedActions = [
+    'fetchCustomMarkerDescription',
+    'showDetailModal',
+    'editRefRange',
+    'saveRefRange',
+    'revertRefRange',
+    'openManualEntryForm',
+    'saveManualEntry',
+    'saveAndAddAnotherManualEntry',
+    'openCreateMarkerModal',
+    'pickNewCatIcon',
+    'saveCustomMarker',
+    'deleteMarkerValue',
+    'deleteCustomMarker',
+    'editMarkerValue',
+    'revertMarkerValue',
+    'editValueNote',
+    'deleteValueNote',
+    'toggleMarkerNoteEditor',
+    'saveMarkerNote',
+    'deleteMarkerNote',
+  ];
+  expect(outcomes.configKeys).toEqual(['marker']);
+  expect(outcomes.results).toEqual(expectedActions);
+  expect(outcomes.calls.map(call => call[0])).toEqual(expectedActions);
 });
 
 test('marker detail implementation removes a failure and retries once', async ({ page }) => {

--- a/tests/playwright/report-builder-loader-browser-coverage.spec.js
+++ b/tests/playwright/report-builder-loader-browser-coverage.spec.js
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './coverage-fixture.js';
 
 const exportUrl = () => `/js/export.js?reportBuilderLoaderCoverage=${Date.now()}-${Math.random().toString(36).slice(2)}`;
 const syntheticReportBuilder = `


### PR DESCRIPTION
## Summary

- fingerprint captured browser sources so route-fulfilled synthetic modules cannot corrupt repository coverage
- merge Vitest and Playwright functions by stable source ranges, including anonymous callbacks, instead of display name/index
- ensure every `*-browser-coverage.spec.js` suite uses the coverage fixture and preserve explicit fresh-visitor legal-consent coverage
- add complete lazy-facade contracts for Chat and marker-detail actions
- raise the combined function-coverage floor from 67.40% to 79.50%

## Why

Post-merge main CI for #1389 exposed a flaky coverage gate: identical passing tests reported 67.41% on the PR and 67.25% on main against a 67.40% floor. The reporter was omitting anonymous browser functions, assigning function identities by unstable names/indexes, and could mistake synthetic route responses for repository source.

Fresh full runs with the repaired model measured 80.70% and 80.68% (0.02pt spread). The 79.50% ratchet keeps 1.18pt headroom while raising the enforceable floor by 12.10pt.

## Validation

- `COVERAGE=1 SKIP_TYPECHECK=1 ./run-tests.sh`
  - 141 verification checks
  - 509 Vitest tests
  - 488 Chromium Playwright tests
  - 520 responsive assertions
  - 80.68% combined function coverage; 79.50% ratchet passes by 1.18pt
- repeated aggregation of identical shards: 80.70% both times
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
- `npm run production:check`
- `git diff --check`