### PR TITLE
Enable incremental compiler safety checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Run typecheck
         run: npm run typecheck
 
-      - name: Run checkJs pilot
+      - name: Run full-app checkJs
         run: npm run typecheck:checkjs
 
       - name: Verify architecture map and boundaries

--- a/js/mobile-dashboard.js
+++ b/js/mobile-dashboard.js
@@ -39,7 +39,7 @@ const MOBILE_DASHBOARD_ACTION_SELECTOR = `[${MOBILE_DASHBOARD_ACTION_ATTR}]`;
 /**
  * @typedef {{ data: any, filteredData: any, keyMarkers?: any[], trendAlerts?: any[], criticalFlags?: any[] }} MobileDashboardWidgetContext
  * @typedef {{ def: { id: string, [key: string]: any }, body?: string, [key: string]: any }} MobileDashboardWidgetEntry
- * @typedef {Record<string, any>} MobileDashboardWidgetPrefs
+ * @typedef {{ order: string[], hidden: string[], [key: string]: any }} MobileDashboardWidgetPrefs
  * @typedef {{
  *   buildDashboardWidgetContext: (data: any) => MobileDashboardWidgetContext,
  *   getDashboardWidgetPrefs: () => MobileDashboardWidgetPrefs,
@@ -60,7 +60,7 @@ const MOBILE_DASHBOARD_ACTION_SELECTOR = `[${MOBILE_DASHBOARD_ACTION_ATTR}]`;
 /** @type {MobileDashboardDeps} */
 const mobileDashboardDeps = {
   buildDashboardWidgetContext: (_data) => ({ data: getActiveData(), filteredData: getActiveData() }),
-  getDashboardWidgetPrefs: () => ({}),
+  getDashboardWidgetPrefs: () => ({ order: [], hidden: [] }),
   getVisibleDashboardWidgetEntries: (_ctx, _prefs) => [],
   renderDashboardControlButtons: (_options) => '',
   isDashboardOrganizeMode: () => false,

--- a/js/sync-payload-codec.js
+++ b/js/sync-payload-codec.js
@@ -40,7 +40,7 @@ export function _bytesToBase64(bytes) {
   let s = '';
   const CHUNK = 0x8000;
   for (let i = 0; i < bytes.length; i += CHUNK) {
-    s += String.fromCharCode.apply(null, bytes.subarray(i, i + CHUNK));
+    s += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
   }
   return btoa(s);
 }

--- a/tests/playwright/sync-delta-helper-browser-coverage.spec.js
+++ b/tests/playwright/sync-delta-helper-browser-coverage.spec.js
@@ -69,6 +69,20 @@ test('sync delta helper browser coverage exercises registry ids config and row c
     const plainDecoded = await rowCodec.decodeRowPayload({
       payload: JSON.stringify({ k: 'plain', v: { ok: true } }),
     });
+    const chunkBoundaryBytes = Uint8Array.from(
+      { length: 0x8000 + 3 },
+      (_, index) => index % 251,
+    );
+    const chunkBoundaryRoundTrip = syncPayload._base64ToBytes(
+      syncPayload._bytesToBase64(chunkBoundaryBytes),
+    );
+    outcomes.byteCodecRoundTripsAcrossItsArgumentChunkBoundary =
+      chunkBoundaryRoundTrip.length === chunkBoundaryBytes.length
+      && chunkBoundaryRoundTrip[0] === chunkBoundaryBytes[0]
+      && chunkBoundaryRoundTrip[0x7fff] === chunkBoundaryBytes[0x7fff]
+      && chunkBoundaryRoundTrip[0x8000] === chunkBoundaryBytes[0x8000]
+      && chunkBoundaryRoundTrip.at(-1) === chunkBoundaryBytes.at(-1);
+
     const gzipEnvelope = `GZ|v1|${syncPayload._bytesToBase64(
       await syncPayload._gzipString(JSON.stringify({ k: 'gzip', v: [1, 2, 3] }))
     )}`;

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -34,6 +34,7 @@ const moduleMap = fs.readFileSync(path.join(ROOT, 'MODULE_MAP.md'), 'utf8');
 const runTestsSrc = fs.readFileSync(path.join(ROOT, 'run-tests.sh'), 'utf8');
 const playwrightConfigSrc = fs.readFileSync(path.join(ROOT, 'playwright.config.js'), 'utf8');
 const testWorkflowSrc = fs.readFileSync(path.join(ROOT, '.github/workflows/test.yml'), 'utf8');
+const tsConfig = JSON.parse(fs.readFileSync(path.join(ROOT, 'tsconfig.json'), 'utf8'));
 const checkJsConfig = JSON.parse(fs.readFileSync(path.join(ROOT, 'tsconfig.checkjs.json'), 'utf8'));
 const appEventListenersSrc = fs.readFileSync(path.join(ROOT, 'js', 'app-event-listeners.js'), 'utf8');
 
@@ -117,6 +118,22 @@ assert('quality guardrail exits non-zero on failures',
 assert('full local test suite runs typecheck',
   runTestsSrc.includes('npm run typecheck || exit 1') &&
     runTestsSrc.includes('SKIP_TYPECHECK'));
+const requiredCompilerSafetyOptions = {
+  allowUnreachableCode: false,
+  allowUnusedLabels: false,
+  noFallthroughCasesInSwitch: true,
+  noImplicitThis: true,
+  strictBindCallApply: true,
+  strictFunctionTypes: true,
+};
+const missingCompilerSafetyOptions = Object.entries(requiredCompilerSafetyOptions)
+  .filter(([option, expected]) => tsConfig.compilerOptions?.[option] !== expected)
+  .map(([option]) => option);
+assert('TypeScript keeps incremental compiler safety checks enabled',
+  missingCompilerSafetyOptions.length === 0,
+  missingCompilerSafetyOptions.length
+    ? `missing or disabled: ${missingCompilerSafetyOptions.join(', ')}`
+    : '');
 assert('full local test suite runs static module verification',
   runTestsSrc.includes('node "$DIR/tests/verify-modules.js" || exit 1'));
 assert('full local test suite verifies architecture freshness and boundaries',
@@ -183,7 +200,7 @@ const highValueCheckJsModules = [
 ];
 const missingHighValueCheckJsModules = highValueCheckJsModules
   .filter(file => !checkJsConfig.include?.includes(file));
-assert('checkJs pilot includes high-coupling browser modules',
+assert('checkJs includes high-coupling browser modules',
   missingHighValueCheckJsModules.length === 0,
   missingHighValueCheckJsModules.length ? `missing: ${missingHighValueCheckJsModules.join(', ')}` : '');
 const domainUiCheckJsModules = [
@@ -206,7 +223,7 @@ const domainUiCheckJsModules = [
 ];
 const missingDomainUiCheckJsModules = domainUiCheckJsModules
   .filter(file => !checkJsConfig.include?.includes(file));
-assert('checkJs pilot includes domain and UI modules',
+assert('checkJs includes domain and UI modules',
   missingDomainUiCheckJsModules.length === 0,
   missingDomainUiCheckJsModules.length ? `missing: ${missingDomainUiCheckJsModules.join(', ')}` : '');
 const broadSurfaceCheckJsModules = [
@@ -236,7 +253,7 @@ const broadSurfaceCheckJsModules = [
 ];
 const missingBroadSurfaceCheckJsModules = broadSurfaceCheckJsModules
   .filter(file => !checkJsConfig.include?.includes(file));
-assert('checkJs pilot includes broad UI surface modules',
+assert('checkJs includes broad UI surface modules',
   missingBroadSurfaceCheckJsModules.length === 0,
   missingBroadSurfaceCheckJsModules.length ? `missing: ${missingBroadSurfaceCheckJsModules.join(', ')}` : '');
 const healthDomainCheckJsModules = [
@@ -271,7 +288,7 @@ const healthDomainCheckJsModules = [
 ];
 const missingHealthDomainCheckJsModules = healthDomainCheckJsModules
   .filter(file => !checkJsConfig.include?.includes(file));
-assert('checkJs pilot includes health domain modules',
+assert('checkJs includes health domain modules',
   missingHealthDomainCheckJsModules.length === 0,
   missingHealthDomainCheckJsModules.length ? `missing: ${missingHealthDomainCheckJsModules.join(', ')}` : '');
 const uiWorkflowCheckJsModules = [
@@ -307,7 +324,7 @@ const uiWorkflowCheckJsModules = [
 ];
 const missingUiWorkflowCheckJsModules = uiWorkflowCheckJsModules
   .filter(file => !checkJsConfig.include?.includes(file));
-assert('checkJs pilot includes UI workflow modules',
+assert('checkJs includes UI workflow modules',
   missingUiWorkflowCheckJsModules.length === 0,
   missingUiWorkflowCheckJsModules.length ? `missing: ${missingUiWorkflowCheckJsModules.join(', ')}` : '');
 const lightWorkflowCheckJsModules = [
@@ -346,7 +363,7 @@ const lightWorkflowCheckJsModules = [
 ];
 const missingLightWorkflowCheckJsModules = lightWorkflowCheckJsModules
   .filter(file => !checkJsConfig.include?.includes(file));
-assert('checkJs pilot includes light workflow modules',
+assert('checkJs includes light workflow modules',
   missingLightWorkflowCheckJsModules.length === 0,
   missingLightWorkflowCheckJsModules.length ? `missing: ${missingLightWorkflowCheckJsModules.join(', ')}` : '');
 const wearablesWorkflowCheckJsModules = [
@@ -375,7 +392,7 @@ const wearablesWorkflowCheckJsModules = [
 ];
 const missingWearablesWorkflowCheckJsModules = wearablesWorkflowCheckJsModules
   .filter(file => !checkJsConfig.include?.includes(file));
-assert('checkJs pilot includes wearables workflow modules',
+assert('checkJs includes wearables workflow modules',
   missingWearablesWorkflowCheckJsModules.length === 0,
   missingWearablesWorkflowCheckJsModules.length ? `missing: ${missingWearablesWorkflowCheckJsModules.join(', ')}` : '');
 const chatWorkflowCheckJsModules = [
@@ -414,7 +431,7 @@ const chatWorkflowCheckJsModules = [
 ];
 const missingChatWorkflowCheckJsModules = chatWorkflowCheckJsModules
   .filter(file => !checkJsConfig.include?.includes(file));
-assert('checkJs pilot includes chat workflow modules',
+assert('checkJs includes chat workflow modules',
   missingChatWorkflowCheckJsModules.length === 0,
   missingChatWorkflowCheckJsModules.length ? `missing: ${missingChatWorkflowCheckJsModules.join(', ')}` : '');
 const startupAppShellCheckJsModules = [
@@ -449,7 +466,7 @@ const startupAppShellCheckJsModules = [
 ];
 const missingStartupAppShellCheckJsModules = startupAppShellCheckJsModules
   .filter(file => !checkJsConfig.include?.includes(file));
-assert('checkJs pilot includes startup and app-shell modules',
+assert('checkJs includes startup and app-shell modules',
   missingStartupAppShellCheckJsModules.length === 0,
   missingStartupAppShellCheckJsModules.length ? `missing: ${missingStartupAppShellCheckJsModules.join(', ')}` : '');
 const pdfReportCheckJsModules = [
@@ -468,7 +485,7 @@ const pdfReportCheckJsModules = [
 ];
 const missingPdfReportCheckJsModules = pdfReportCheckJsModules
   .filter(file => !checkJsConfig.include?.includes(file));
-assert('checkJs pilot includes PDF import and report modules',
+assert('checkJs includes PDF import and report modules',
   missingPdfReportCheckJsModules.length === 0,
   missingPdfReportCheckJsModules.length ? `missing: ${missingPdfReportCheckJsModules.join(', ')}` : '');
 const appJsModules = fs.readdirSync(path.join(ROOT, 'js'))
@@ -477,7 +494,7 @@ const appJsModules = fs.readdirSync(path.join(ROOT, 'js'))
   .sort();
 const missingAppCheckJsModules = appJsModules
   .filter(file => !checkJsConfig.include?.includes(file));
-assert('checkJs pilot includes every app JS module',
+assert('checkJs includes every app JS module',
   missingAppCheckJsModules.length === 0,
   missingAppCheckJsModules.length ? `missing: ${missingAppCheckJsModules.join(', ')}` : '');
 

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -1,5 +1,5 @@
 {
-  "description": "Pilot checkJs config for selected JavaScript modules and their local dependency graph.",
+  "description": "Full-app checkJs config for JavaScript modules and their local dependency graph.",
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "checkJs": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,13 @@
     "moduleResolution": "Node16",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
-    "strict": false
+    "strict": false,
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitThis": true,
+    "strictBindCallApply": true,
+    "strictFunctionTypes": true
   },
   "include": [
     "types/globals.d.ts",


### PR DESCRIPTION
## Summary

- enable six incremental TypeScript safety checks across both existing typecheck modes: unreachable code, unused labels, switch fallthrough, implicit `this`, bind/call/apply signatures, and function variance
- make mobile dashboard fallback preferences satisfy the real widget contract
- use typed-array-safe argument spreading in the sync base64 encoder
- pin the compiler options in the dependency-free quality guardrail test and rename the now-full-app checkJs CI step
- add a browser regression that round-trips 32,771 bytes across the encoder's 32,768-byte chunk boundary

## Why

The refreshed quality audit found that checkJs now covers all 478 app modules, despite still being labelled a pilot. Enabling all of `strict` at once currently exposes 10,669 errors. This focused slice captures six high-signal compiler guarantees with only two source fixes, keeping the change reviewable and enforceable.

## Validation

- `npm run typecheck`
- `npm run typecheck:checkjs`
- `COVERAGE=1 SKIP_TYPECHECK=1 ./run-tests.sh`
  - 141 verification checks
  - 509 Vitest tests
  - 488 Chromium Playwright tests
  - 520 responsive assertions
  - 80.69% combined function coverage; 79.50% ratchet passes by 1.19pt
- focused mobile dashboard + sync browser contracts: 4 passed
- `npm run quality`
- `npm run production:check`
- `git diff --check`