### PR TITLE
Enforce explicit return contracts

### DIFF
--- a/js/api-transport.js
+++ b/js/api-transport.js
@@ -134,4 +134,5 @@ export async function fetchWithRetry(
     if (options.signal?.aborted) return res;
     await new Promise(r => setTimeout(r, delay));
   }
+  throw new Error('request retry loop exhausted unexpectedly');
 }

--- a/js/chat-actions.js
+++ b/js/chat-actions.js
@@ -75,30 +75,30 @@ function runChatMessageAction(actionEl, event) {
     regenerateLastMessage();
   } else if (action === 'copy-message') {
     const index = readMessageIndex(actionEl);
-    if (index == null) return;
+    if (index == null) return false;
     copyMessage(index);
   } else if (action === 'toggle-context-details') {
     const index = readMessageIndex(actionEl);
-    if (index == null) return;
+    if (index == null) return false;
     toggleContextDetails(index);
   } else if (action === 'remove-image-attachment') {
     const index = readMessageIndex(actionEl);
-    if (index == null) return;
+    if (index == null) return false;
     chatMessageActionDeps.removeImageAttachment(index);
   } else if (action === 'open-image-lightbox') {
     const src = actionEl instanceof HTMLImageElement ? actionEl.src : actionEl.dataset.chatMessageSrc;
-    if (!src) return;
+    if (!src) return false;
     chatMessageActionDeps.openImageLightbox(src);
   } else if (action === 'open-emf-assessment') {
     void chatMessageActionDeps.openEMFAssessmentEditor();
   } else if (action === 'jump-search-result') {
     const index = readMessageIndex(actionEl);
     const threadId = actionEl.dataset.chatMessageThreadId || '';
-    if (!threadId || index == null) return;
+    if (!threadId || index == null) return false;
     void chatMessageActionDeps.jumpToSearchResult(threadId, index, actionEl.dataset.chatMessagePrefix || '');
   } else if (action === 'view-summary') {
     const id = actionEl.dataset.chatMessageSummaryId || '';
-    if (!id) return;
+    if (!id) return false;
     chatMessageActionDeps.viewSavedSummary(id);
   } else if (action === 'close-summary') {
     chatMessageActionDeps.closeSummaryModal();
@@ -110,7 +110,7 @@ function runChatMessageAction(actionEl, event) {
     chatMessageActionDeps.printSummary();
   } else if (action === 'delete-summary') {
     const id = actionEl.dataset.chatMessageSummaryId || '';
-    if (!id) return;
+    if (!id) return false;
     void chatMessageActionDeps.deleteSavedSummary(id);
   } else if (action === 'start-discussion-from-picker') {
     void chatMessageActionDeps.startDiscussionFromPicker();

--- a/js/crypto.js
+++ b/js/crypto.js
@@ -337,7 +337,7 @@ export async function _setTestSessionKey(passphrase) {
   if (!appWindow.__WEARABLES_TEST) {
     throw new Error('_setTestSessionKey is test-only — enable the runtime __WEARABLES_TEST flag first');
   }
-  if (passphrase === null) { _sessionKey = null; return; }
+  if (passphrase === null) { _sessionKey = null; return null; }
   const salt = crypto.getRandomValues(new Uint8Array(16));
   _sessionKey = await deriveKey(passphrase, salt);
   return salt;

--- a/js/dna-mtdna.js
+++ b/js/dna-mtdna.js
@@ -140,28 +140,31 @@ export function detectMtDNAMismatch(genetics) {
 let _mtdnaImportRunning = false;
 
 export async function handleMtDNAFile(file) {
-  if (_mtdnaImportRunning) { showNotification('mtDNA import already in progress', 'info'); return; }
+  if (_mtdnaImportRunning) { showNotification('mtDNA import already in progress', 'info'); return false; }
   if (!await loadGeneticsStylesheetForAction()) return false;
   _mtdnaImportRunning = true;
   try {
     const text = await file.text();
     const mutations = parseMtDNAMutations(text);
-    if (mutations.length === 0) { showNotification('No mtDNA mutations found in this file', 'error'); _mtdnaImportRunning = false; return; }
+    if (mutations.length === 0) { showNotification('No mtDNA mutations found in this file', 'error'); _mtdnaImportRunning = false; return false; }
 
     const hapTable = await loadHaplogroupTable();
     const resolved = resolveHaplogroup(mutations, hapTable);
-    if (!resolved) { showNotification('Could not determine haplogroup - try a more complete mtDNA export', 'error'); _mtdnaImportRunning = false; return; }
+    if (!resolved) { showNotification('Could not determine haplogroup - try a more complete mtDNA export', 'error'); _mtdnaImportRunning = false; return false; }
 
     const coupling = classifyCoupling(resolved.haplogroup, hapTable);
     const hgData = hapTable.haplogroups[resolved.haplogroup];
     const source = file.name.toLowerCase().includes('23andme') || file.name.toLowerCase().includes('genome') ? 'mtDNA (23andMe)' : 'mtDNA CSV';
     setPendingMtDnaImport({ mutations, resolved, coupling, hgData, source });
     _showMtDNAPreview(resolved, coupling, mutations, file.name);
+    _mtdnaImportRunning = false;
+    return true;
   } catch (e) {
     logDnaDebugError('mtDNA import error:', e);
     showNotification(e.message || 'Failed to parse mtDNA file', 'error');
+    _mtdnaImportRunning = false;
+    return false;
   }
-  _mtdnaImportRunning = false;
 }
 
 function _showMtDNAPreview(resolved, coupling, mutations, fileName) {

--- a/js/dna.js
+++ b/js/dna.js
@@ -744,6 +744,7 @@ export async function openManualSnpModal() {
   }
   overlay.innerHTML = `<div class="modal dna-preview-modal dna-manual-modal" role="dialog" aria-label="Add SNPs manually">${html}</div>`;
   openDnaModalOverlay(overlay, '#manual-snp-bulk');
+  return true;
 }
 
 export function parseManualSnpRows(singleRsid, singleGenotype, bulkText) {
@@ -803,7 +804,7 @@ export async function importSnpReport() {
 }
 
 export async function handleSnpReportFile(file) {
-  if (_dnaImportRunning) { showNotification('DNA import already in progress', 'info'); return; }
+  if (_dnaImportRunning) { showNotification('DNA import already in progress', 'info'); return false; }
   if (!await loadGeneticsStylesheetForAction()) return false;
   _dnaImportRunning = true;
   try {
@@ -821,13 +822,15 @@ export async function handleSnpReportFile(file) {
     if (Object.keys(result.matches).length === 0) {
       showNotification('No catalog SNP results found in this report. Add the SNP manually.', 'error');
       _dnaImportRunning = false;
-      return;
+      return false;
     }
     showDNAImportPreview(result, file.name);
+    return true;
   } catch (e) {
     logDnaDebugError('SNP report import error:', e);
     showNotification(e.message || 'Failed to read SNP report', 'error');
     _dnaImportRunning = false;
+    return false;
   }
 }
 
@@ -838,8 +841,8 @@ export async function handleSnpReportFile(file) {
 let _dnaImportRunning = false;
 
 export async function handleDNAFile(file) {
-  if (_dnaImportRunning) { showNotification('DNA import already in progress', 'info'); return; }
-  if (isDnaLabImportRunning()) { showNotification('Lab import in progress — wait for it to finish', 'info'); return; }
+  if (_dnaImportRunning) { showNotification('DNA import already in progress', 'info'); return false; }
+  if (isDnaLabImportRunning()) { showNotification('Lab import in progress — wait for it to finish', 'info'); return false; }
   if (!await loadGeneticsStylesheetForAction()) return false;
   _dnaImportRunning = true;
   try {
@@ -848,13 +851,15 @@ export async function handleDNAFile(file) {
     if (Object.keys(result.matches).length === 0) {
       showNotification('No health-relevant SNPs found in this file. Is it a DNA raw data export?', 'error');
       _dnaImportRunning = false;
-      return;
+      return false;
     }
     showDNAImportPreview(result, file.name);
+    return true;
   } catch (e) {
     logDnaDebugError('DNA import error:', e);
     showNotification(e.message || 'Failed to parse DNA file', 'error');
     _dnaImportRunning = false;
+    return false;
   }
 }
 

--- a/js/marker-detail-modal-impl.js
+++ b/js/marker-detail-modal-impl.js
@@ -258,19 +258,19 @@ function renderDetailModal(id, opts = {}) {
   // id is interpolated into delegated data-action attributes throughout the
   // modal body. Reject anything outside the strict allowlist so a poisoned
   // customMarker key cannot break attribute context or state lookups.
-  if (!safeMarkerId(id)) return;
+  if (!safeMarkerId(id)) return false;
   const data = getActiveData();
   const idx = id.indexOf('_');
   const catKey = id.slice(0, idx), mKey = id.slice(idx + 1);
   let marker = data.categories[catKey]?.markers[mKey];
   if (marker) state.markerRegistry[id] = marker;
-  if (!marker) return;
+  if (!marker) return false;
   // Remember which marker is open so toggleAltUnits can re-render in place.
   state._activeDetailMarkerId = id;
   rememberModalTrigger();
   const modal = setDetailModalShell('marker-detail-modal');
   const overlay = document.getElementById("modal-overlay");
-  if (!modal) return;
+  if (!modal) return false;
   modal.dataset.syncRefreshKind = 'marker';
   modal.dataset.syncRefreshItemId = id;
   const dates = marker.singlePoint ? [marker.singleDateLabel || "N/A"] : data.dateLabels;

--- a/js/sync-pull.js
+++ b/js/sync-pull.js
@@ -140,7 +140,7 @@ export function clearSyncPullTimers() {
 export function forcePull() {
   if (!currentEvolu() || !currentProfileQuery()) {
     console.warn('[sync] Cannot force pull — Evolu not initialized');
-    return;
+    return undefined;
   }
   _pulling = false;
   dbg('Force pull triggered');

--- a/js/theme.js
+++ b/js/theme.js
@@ -354,6 +354,7 @@ export function setTheme(theme) {
         return false;
       });
   }
+  return true;
 }
 
 function refreshThemeDependents() {

--- a/tests/playwright/crypto-browser-coverage.spec.js
+++ b/tests/playwright/crypto-browser-coverage.spec.js
@@ -98,7 +98,8 @@ test('crypto storage wrappers cover encryption cache blob and enable disable flo
         && wrongKeyValue === null
         && cryptoStore.getCachedKey('labcharts-api-key') === rawApiKey;
 
-      await cryptoStore._setTestSessionKey(null);
+      const clearedSessionKey = await cryptoStore._setTestSessionKey(null);
+      outcomes.sessionKeyClearReturnsNull = clearedSessionKey === null;
       localStorage.removeItem('labcharts-encryption-enabled');
       localStorage.removeItem('labcharts-encryption-salt');
       localStorage.removeItem('labcharts-api-key');

--- a/tests/playwright/dna-browser-coverage.spec.js
+++ b/tests/playwright/dna-browser-coverage.spec.js
@@ -222,17 +222,20 @@ rs999999\t1\t100\tAG
 `;
 
     importRunning = true;
-    await dna.handleDNAFile(textFile(validContent, 'busy.txt'));
-    check('busy import blocks preview', !document.getElementById('dna-modal-overlay')?.classList.contains('show'));
+    const busyImport = await dna.handleDNAFile(textFile(validContent, 'busy.txt'));
+    check('busy import reports failure and blocks preview',
+      busyImport === false && !document.getElementById('dna-modal-overlay')?.classList.contains('show'));
     importRunning = false;
 
-    await dna.handleDNAFile(textFile(noMatchContent, 'nomatch.txt'));
-    check('no-match file does not open preview', !document.getElementById('dna-modal-overlay')?.classList.contains('show'));
+    const noMatchImport = await dna.handleDNAFile(textFile(noMatchContent, 'nomatch.txt'));
+    check('no-match file reports failure and does not open preview',
+      noMatchImport === false && !document.getElementById('dna-modal-overlay')?.classList.contains('show'));
 
-    await dna.handleDNAFile(textFile(validContent, 'ancestry-ui.txt'));
+    const validImport = await dna.handleDNAFile(textFile(validContent, 'ancestry-ui.txt'));
     await wait();
     let overlay = document.getElementById('dna-modal-overlay');
-    check('valid file opens DNA preview', overlay?.classList.contains('show') === true);
+    check('valid file reports success and opens DNA preview',
+      validImport === true && overlay?.classList.contains('show') === true);
     check('preview stores pending import', window._pendingDNAImport?.coverage?.found > 0);
     check('DNA preview uses delegated actions', !overlay?.querySelector('[onclick], [onkeydown]'));
     overlay?.querySelector('.dna-preview-collapsible')?.click();
@@ -361,14 +364,16 @@ test('DNA mtDNA browser coverage exercises haplogroup parsing, preview, import, 
     const invalidBand = dna.detectMtDNAMismatch({ mtdna: { haplogroup: 'J', coupling: { matchedLatBands: [3, 4] } } });
     check('detectMtDNAMismatch covers mismatch, match, invalid band', mismatch?.mismatch === true && matched?.mismatch === false && invalidBand === null);
 
-    await dna.handleMtDNAFile(textFile('not mtdna', 'empty-mtdna.txt'));
-    check('empty mtDNA file does not open preview', !document.getElementById('dna-modal-overlay')?.classList.contains('show'));
+    const emptyMtDnaImport = await dna.handleMtDNAFile(textFile('not mtdna', 'empty-mtdna.txt'));
+    check('empty mtDNA file reports failure and does not open preview',
+      emptyMtDnaImport === false && !document.getElementById('dna-modal-overlay')?.classList.contains('show'));
 
     dnaRuntime.configureDnaRuntimeDeps({ getLatitudeFromLocation: () => '<25\u00B0 latitude (tropical)' });
-    await dna.handleMtDNAFile(textFile(jText, 'genome-mtdna.txt'));
+    const validMtDnaImport = await dna.handleMtDNAFile(textFile(jText, 'genome-mtdna.txt'));
     await wait();
     let overlay = document.getElementById('dna-modal-overlay');
-    check('handleMtDNAFile opens preview', overlay?.classList.contains('show') === true && window._pendingMtDNA?.resolved?.haplogroup === 'J');
+    check('handleMtDNAFile reports success and opens preview',
+      validMtDnaImport === true && overlay?.classList.contains('show') === true && window._pendingMtDNA?.resolved?.haplogroup === 'J');
     check('mtDNA preview includes mismatch', overlay?.textContent.includes('Environment mismatch'));
     check('mtDNA preview uses delegated actions', !overlay?.querySelector('[onclick], [onkeydown]'));
     overlay?.querySelector('[data-dna-action="close-mtdna-preview"]')?.click();

--- a/tests/playwright/extra-themes-stylesheet-browser-coverage.spec.js
+++ b/tests/playwright/extra-themes-stylesheet-browser-coverage.spec.js
@@ -16,11 +16,16 @@ test('default and light startup stay cold without optional theme presentation', 
   await expect(page.locator('link[data-extra-themes-stylesheet]')).toHaveCount(0);
   expect(stylesheetRequests).toBe(0);
 
-  const sunsetAccent = await page.evaluate(async () => {
-    (await import('/js/theme.js')).setSunsetMode(true);
-    return getComputedStyle(document.documentElement).getPropertyValue('--accent').trim();
+  const defaultThemeOutcome = await page.evaluate(async () => {
+    const theme = await import('/js/theme.js');
+    const applied = theme.setTheme('dark');
+    theme.setSunsetMode(true);
+    return {
+      applied,
+      accent: getComputedStyle(document.documentElement).getPropertyValue('--accent').trim(),
+    };
   });
-  expect(sunsetAccent).toBe('#ffb000');
+  expect(defaultThemeOutcome).toEqual({ applied: true, accent: '#ffb000' });
   expect(stylesheetRequests).toBe(0);
 });
 

--- a/tests/playwright/marker-detail-browser-coverage.spec.js
+++ b/tests/playwright/marker-detail-browser-coverage.spec.js
@@ -1104,6 +1104,8 @@ test('marker detail modal covers default deps descriptions alt units and bio age
         document.querySelectorAll('link[data-marker-detail-stylesheet]').length === 1
         && !!detail
         && getComputedStyle(detail).paddingTop === '0px';
+      outcomes.missingMarkerReturnsFalse =
+        await modal.showDetailModal('proteins_missing') === false;
       outcomes.detailModalRendersAltUnitsQuickPinAndRecommendations =
         detailText.includes('Albumin renamed')
         && detailText.includes('g/dl')

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -122,6 +122,7 @@ const requiredCompilerSafetyOptions = {
   allowUnreachableCode: false,
   allowUnusedLabels: false,
   noFallthroughCasesInSwitch: true,
+  noImplicitReturns: true,
   noImplicitThis: true,
   strictBindCallApply: true,
   strictFunctionTypes: true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
     "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
     "noImplicitThis": true,
     "strictBindCallApply": true,
     "strictFunctionTypes": true


### PR DESCRIPTION
## Summary

- enable and pin TypeScript `noImplicitReturns` across the full-app checkJs surface
- replace all 26 implicit mixed-return findings with intentional return contracts across retry, chat, crypto, DNA import, marker modal, sync, and theme paths
- add browser assertions for DNA success/failure, session-key clearing, default theme application, and missing-marker handling

## Validation

- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
- `npm run production:check`
- `npm run architecture:check`
- focused browser suite: 23 passed
- full `COVERAGE=1 ./run-tests.sh`: 141 verification, 509 Vitest, 488 Chromium, 520 responsive checks
- global function coverage: 80.69% (79.50% floor, +1.19pt)
