### PR TITLE
Enforce intentional parameter contracts

### DIFF
--- a/js/adapters.js
+++ b/js/adapters.js
@@ -292,7 +292,7 @@ function _detectMetabolomix(fileName, pdfText) {
   return null;
 }
 
-function _normalizeMetabolomix(markers, fileName, pdfText, detectedProduct) {
+function _normalizeMetabolomix(markers, fileName, pdfText, _detectedProduct) {
   // Metabolomix+ FA add-on (pages 11-12): bloodspot fatty acids appear alongside OAT markers.
   // AI classifies the whole report as testType 'OAT', but FA markers need product-prefixing.
   // Detect FA markers and route them through FA normalization with 'metabolomix' prefix.
@@ -500,7 +500,7 @@ const ADAPTERS = [
     testTypes: ['biostarks'],
     markers: BIOSTARKS_MARKERS,
     detect(fileName, pdfText) { return _detectBiostarks(fileName, pdfText); },
-    normalize(markers, fileName, pdfText, detected) { _normalizeBiostarks(markers); },
+    normalize(markers, _fileName, _pdfText, _detected) { _normalizeBiostarks(markers); },
   },
   // Future adapters: DUTCH, HTMA, GI-MAP, HealthieOne, etc.
 ];

--- a/js/backup.js
+++ b/js/backup.js
@@ -447,7 +447,7 @@ export function openBackupDB() {
   if (_dbPromise) return _dbPromise;
   _dbPromise = new Promise((resolve, reject) => {
     const req = indexedDB.open(BACKUP_DB_NAME, 2);
-    req.onupgradeneeded = (e) => {
+    req.onupgradeneeded = () => {
       const db = req.result;
       if (!db.objectStoreNames.contains(BACKUP_STORE)) {
         db.createObjectStore(BACKUP_STORE, { keyPath: 'id', autoIncrement: true });

--- a/js/biology-score-render.js
+++ b/js/biology-score-render.js
@@ -347,7 +347,7 @@ export function renderDashboardBiologicalCoherenceWidget(ctx, computeBiologyScor
 /** Legacy summary widget — still exported for backward compatibility. The dashboard
  * now uses renderDashboardBiologyScoreWidget for individual score cards and
  * renderDashboardBiologicalCoherenceWidget for the coherence hero. */
-export function renderBiologyScoresWidget(ctx, options = {}, computeBiologyScores) {
+export function renderBiologyScoresWidget(ctx, computeBiologyScores) {
   if (!hasBiologyScoreContextReview(ctx?.data || {})) return renderBiologyScoreGate('dashboard');
   const scores = computeBiologyScores(ctx?.data || {});
   const usefulScores = scores.filter((score) => score.score != null || score.coverage > 0);

--- a/js/biology-scores.js
+++ b/js/biology-scores.js
@@ -343,8 +343,8 @@ export function renderDashboardBiologyScoreWidget(ctx, scoreId) {
   return renderDashboardBiologyScoreWidgetImpl(contextForScores(ctx), scoreId, computeBiologyScores);
 }
 
-export function renderBiologyScoresWidget(ctx, options = {}) {
-  return renderBiologyScoresWidgetImpl(contextForScores(ctx), options, computeBiologyScores);
+export function renderBiologyScoresWidget(ctx) {
+  return renderBiologyScoresWidgetImpl(contextForScores(ctx), computeBiologyScores);
 }
 
 export function renderBiologyScoresLens(ctx) {

--- a/js/category-page-view.js
+++ b/js/category-page-view.js
@@ -274,7 +274,7 @@ export function switchView(view, categoryKey, btn) {
   if (view === "table") {
     container.innerHTML = renderTableView(cat, safeLabels, categoryKey, data.dates);
   } else if (view === "heatmap") {
-    container.innerHTML = renderHeatmapView(cat, safeLabels, data.dates, categoryKey);
+    container.innerHTML = renderHeatmapView(cat, safeLabels, categoryKey);
   } else {
     if (cat.singleDate) {
       container.innerHTML = renderFattyAcidsView(cat, categoryKey);

--- a/js/category-view-renderers.js
+++ b/js/category-view-renderers.js
@@ -291,7 +291,7 @@ export function renderTableView(cat, dateLabels, categoryKey, dates) {
   return renderScrollableTableShell('data', 'data-table-wrapper', 'data-table', colgroup, headHtml, bodyHtml, minWidth);
 }
 
-export function renderHeatmapView(cat, dateLabels, dates, categoryKey) {
+export function renderHeatmapView(cat, dateLabels, categoryKey) {
   const labels = cat.singleDate ? [cat.singleDateLabel || "N/A"] : dateLabels;
   const markerEntries = Object.entries(cat.markers).filter(([, m]) =>
     m.values && m.values.some(v => v !== null)

--- a/js/changelog-impl.js
+++ b/js/changelog-impl.js
@@ -467,7 +467,7 @@ function renderChangelogItem(item) {
   // noopener/noreferrer so the opener can't be navigated.
   out = out.replace(
     /&lt;a href=&quot;(.+?)&quot;&gt;(.+?)&lt;\/a&gt;/g,
-    (match, escapedUrl, inner) => {
+    (_match, escapedUrl, inner) => {
       // The captured URL is HTML-escaped (& → &amp; etc.). Decode for the
       // protocol check, but emit the escaped form back into the href so
       // ampersand-bearing URLs (?foo=1&bar=2) round-trip correctly.

--- a/js/chat-empty-state.js
+++ b/js/chat-empty-state.js
@@ -529,7 +529,7 @@ function renderContextImportHandoffState(container, panel, { personality, name }
   return true;
 }
 
-function renderInitialNoDataState(container, panel, { personality, name }) {
+function renderInitialNoDataState(container, panel, { personality }) {
   setOnboardingActive(panel);
   const providerConnected = hasAIProvider();
   container.innerHTML = `<div class="chat-persona-label">${personality.icon} ${escapeHTML(personality.name)}</div>

--- a/js/chat-thread-search.js
+++ b/js/chat-thread-search.js
@@ -87,10 +87,10 @@ async function searchThreadContent(query) {
   // Re-check input hasn't changed
   const input = /** @type {HTMLInputElement | null} */ (document.getElementById('chat-thread-search'));
   if (!input || input.value.trim().toLowerCase() !== q) return;
-  showSearchResults(q, results);
+  showSearchResults(results);
 }
 
-function showSearchResults(query, results) {
+function showSearchResults(results) {
   const list = document.getElementById('chat-thread-list');
   if (!list) return;
   if (results.length === 0) {

--- a/js/context-card-dashboard-ai-impl.js
+++ b/js/context-card-dashboard-ai-impl.js
@@ -240,6 +240,7 @@ function hasSupplementsMedsData() {
 function renderContextSourceToggle({ key, toggleKey = key, kicker, title, description, status, checked, disabled = false, attrs = {}, child = false, affects = [] }) {
   const id = `context-source-${key}`;
   const titleId = `${id}-title`;
+  const descriptionId = `${id}-description`;
   const statusId = `${id}-status`;
   const extraAttrs = Object.entries(attrs)
     .filter(([, value]) => value !== undefined && value !== null)
@@ -252,11 +253,12 @@ function renderContextSourceToggle({ key, toggleKey = key, kicker, title, descri
     <div class="context-source-copy">
       <span class="context-source-kicker">${escapeHTML(kicker)}</span>
       <span class="context-source-title" id="${escapeAttr(titleId)}">${escapeHTML(title)}</span>
+      <span class="context-source-desc" id="${escapeAttr(descriptionId)}">${escapeHTML(description)}</span>
       ${affectsHtml}
       <span class="context-source-status" id="${escapeAttr(statusId)}">${escapeHTML(status)}</span>
     </div>
     <label class="toggle-switch" for="${escapeAttr(id)}">
-      <input type="checkbox" id="${escapeAttr(id)}" data-context-toggle="${escapeAttr(toggleKey)}" aria-labelledby="${escapeAttr(titleId)}" aria-describedby="${escapeAttr(statusId)}" ${checked ? 'checked' : ''} ${disabled ? 'disabled' : ''}>
+      <input type="checkbox" id="${escapeAttr(id)}" data-context-toggle="${escapeAttr(toggleKey)}" aria-labelledby="${escapeAttr(titleId)}" aria-describedby="${escapeAttr(descriptionId)} ${escapeAttr(statusId)}" ${checked ? 'checked' : ''} ${disabled ? 'disabled' : ''}>
       <span class="toggle-slider"></span>
     </label>
   </div>`;

--- a/js/dashboard-widget-controls.js
+++ b/js/dashboard-widget-controls.js
@@ -170,7 +170,7 @@ export function createDashboardWidgetControls(deps) {
     return options.sort((a, b) => String(a.category).localeCompare(String(b.category)) || String(a.name).localeCompare(String(b.name)));
   }
 
-  function getDashboardBiometricWidgetOptions(prefs = getDashboardWidgetPrefs()) {
+  function getDashboardBiometricWidgetOptions() {
     const selected = new Set(getDashboardBiometricSelection());
     const options = [];
     for (const metricId of getDashboardBiometricMetricOrder()) {
@@ -522,7 +522,7 @@ export function createDashboardWidgetControls(deps) {
     const prefs = getDashboardWidgetPrefs();
     const hidden = getAvailableDashboardFixedWidgets().filter(def => prefs.hidden.includes(def.id));
     const hiddenList = renderDashboardPickerFixedGroups(hidden);
-    const biometricOptions = getDashboardBiometricWidgetOptions(prefs);
+    const biometricOptions = getDashboardBiometricWidgetOptions();
     const biometricList = biometricOptions.length ? biometricOptions.map(renderDashboardBiometricWidgetOption).join('') : '';
     const markerOptions = getDashboardMarkerWidgetOptions(getActiveData(), prefs);
     const markerList = markerOptions.length ? markerOptions.map(renderDashboardMarkerWidgetOption).join('') : '';
@@ -557,7 +557,7 @@ export function createDashboardWidgetControls(deps) {
   function openDashboardBiometricPicker() {
     closeDashboardWidgetPicker();
     const prefs = getDashboardWidgetPrefs();
-    const biometricOptions = getDashboardBiometricWidgetOptions(prefs);
+    const biometricOptions = getDashboardBiometricWidgetOptions();
     const biometricList = biometricOptions.length ? biometricOptions.map(renderDashboardBiometricWidgetOption).join('') : '';
     openDashboardWidgetPickerOverlay(`<div class="modal-overlay" id="dashboard-widget-picker-overlay" data-dashboard-widget-overlay>
       <div class="modal dashboard-widget-picker dashboard-biometric-picker" role="dialog" aria-modal="true" aria-labelledby="dashboard-biometric-picker-title">

--- a/js/dna.js
+++ b/js/dna.js
@@ -824,7 +824,7 @@ export async function handleSnpReportFile(file) {
       _dnaImportRunning = false;
       return false;
     }
-    showDNAImportPreview(result, file.name);
+    showDNAImportPreview(result);
     return true;
   } catch (e) {
     logDnaDebugError('SNP report import error:', e);
@@ -853,7 +853,7 @@ export async function handleDNAFile(file) {
       _dnaImportRunning = false;
       return false;
     }
-    showDNAImportPreview(result, file.name);
+    showDNAImportPreview(result);
     return true;
   } catch (e) {
     logDnaDebugError('DNA import error:', e);
@@ -863,7 +863,7 @@ export async function handleDNAFile(file) {
   }
 }
 
-function showDNAImportPreview(result, fileName) {
+function showDNAImportPreview(result) {
   setPendingDnaImport(result);
 
   // Categorize matches by effect — skip raw APOE components when haplotype resolved

--- a/js/emf-interpretation.js
+++ b/js/emf-interpretation.js
@@ -17,7 +17,7 @@ import { openModalOverlay, removeModalOverlay, trapModalFocus } from './modal-li
 
 /**
  * @typedef {{ text?: string, model?: string, provider?: string, modelId?: string, inputTokens?: number, outputTokens?: number, date?: string }} EMFInterpretation
- * @typedef {HTMLElement & { _interpretText?: string, _onGenerate?: ((onSave: (((interp: EMFInterpretation) => void) | null)) => void), _onSave?: ((interp: EMFInterpretation) => void) | null, _mouseDownInside?: boolean, _delegatesInstalled?: boolean }} EMFInterpretationOverlay
+ * @typedef {HTMLElement & { _interpretText?: string, _onGenerate?: (() => void), _mouseDownInside?: boolean, _delegatesInstalled?: boolean }} EMFInterpretationOverlay
  * @typedef {{ collectActiveAssessmentState?: () => void, getAssessments?: () => any[] }} EMFInterpretationDeps
  */
 
@@ -135,7 +135,7 @@ function _handleEMFInterpretationClick(event) {
         btn.disabled = true;
         btn.textContent = 'Interpreting\u2026';
       }
-      overlay._onGenerate(overlay._onSave || null);
+      overlay._onGenerate();
       return;
     }
   }
@@ -151,7 +151,7 @@ function installEMFInterpretationDelegates(overlay) {
   overlay.addEventListener('click', _handleEMFInterpretationClick);
 }
 
-function openInterpretationModal(title, existingInterp, onGenerate, onSave, mitigationTags = []) {
+function openInterpretationModal(title, existingInterp, onGenerate, mitigationTags = []) {
   // Create overlay that sits on top of the EMF editor (z-index above modal-overlay)
   let overlay = /** @type {EMFInterpretationOverlay | null} */ (document.getElementById('emf-interp-overlay'));
   if (!overlay) {
@@ -192,7 +192,6 @@ function openInterpretationModal(title, existingInterp, onGenerate, onSave, miti
   // Store context for discuss button
   overlay._interpretText = hasExisting ? existingInterp.text : '';
   overlay._onGenerate = onGenerate;
-  overlay._onSave = onSave;
   overlay._mouseDownInside = false;
   installEMFInterpretationDelegates(overlay);
 
@@ -350,13 +349,13 @@ export function interpretEMFAssessment(assessmentId, deps = {}) {
   const data = serializeAssessment(a);
   const tags = _collectMitigationTags(a);
 
-  openInterpretationModal(title, a.interpretation, (onSave) => {
+  openInterpretationModal(title, a.interpretation, () => {
     const prompt = `Interpret this Baubiologie EMF assessment. Identify the most concerning readings, explain health implications (especially for sleeping areas), and recommend specific mitigations in priority order.\n\n${data}`;
     streamInterpretation(prompt, (interp) => {
       a.interpretation = interp;
       saveImportedData();
     });
-  }, null, tags);
+  }, tags);
 }
 
 export function interpretEMFComparison(deps = {}) {
@@ -374,11 +373,11 @@ export function interpretEMFComparison(deps = {}) {
   const seen = new Set();
   for (const t of tags) { if (!seen.has(t)) { seen.add(t); dedup.push(t); } }
 
-  openInterpretationModal(title, emf.comparisonInterpretation, (onSave) => {
+  openInterpretationModal(title, emf.comparisonInterpretation, () => {
     const prompt = `Compare these two Baubiologie EMF assessments (before and after). Evaluate what improved, what worsened, and what still needs attention. Prioritize remaining concerns and suggest next steps.\n\nBEFORE:\n${before}\nAFTER:\n${after}`;
     streamInterpretation(prompt, (interp) => {
       emf.comparisonInterpretation = interp;
       saveImportedData();
     });
-  }, null, dedup);
+  }, dedup);
 }

--- a/js/emf.js
+++ b/js/emf.js
@@ -547,6 +547,8 @@ export function toggleEMFAssessment(id) {
 }
 
 export function selectEMFRoom(assessmentId, roomIdx) {
+  // Ignore a stale delegated click after another assessment has become active.
+  if (_editingAssessmentId !== assessmentId) return;
   collectActiveAssessmentState();
   _activeRoomIdx = roomIdx;
   renderEMFEditor(document.getElementById('detail-modal'));

--- a/js/export-import.js
+++ b/js/export-import.js
@@ -70,7 +70,7 @@ export function importDataJSON(file) {
   return new Promise((resolve) => {
     const reader = new FileReader();
     reader.onerror = () => resolve();
-    reader.onload = async (e) => {
+    reader.onload = async () => {
       try {
         const json = JSON.parse(/** @type {string} */ (reader.result));
         // Guard: demo data should never be silently imported into a non-demo profile

--- a/js/export-report.js
+++ b/js/export-report.js
@@ -408,7 +408,7 @@ function filterReportCategories(data, categoryKeys) {
   return { ...data, categories };
 }
 
-function getReportNotes(data, options) {
+function getReportNotes(options) {
   const notes = (state.importedData.notes || []).slice().sort((a, b) => (a.date || '').localeCompare(b.date || ''));
   const cutoffStr = getReportCutoffDate(options.dateRange);
   if (!cutoffStr) return notes;
@@ -546,7 +546,7 @@ export function buildPreparedReportPayload(options = {}) {
   const profileName = profile.name;
   const sexLabel = state.profileSex === 'female' ? 'Female' : state.profileSex === 'male' ? 'Male' : 'Not specified';
   const flags = getAllFlaggedMarkers(data);
-  const notes = getReportNotes(data, reportOptions);
+  const notes = getReportNotes(reportOptions);
   const supps = state.importedData.supplements || [];
   const contextSections = buildReportContextSections(data);
 

--- a/js/image-utils.js
+++ b/js/image-utils.js
@@ -127,9 +127,9 @@ export function isValidImageType(type) {
  * Returns a single image content block in the format expected by the provider.
  * @param {string} base64 - raw base64 data (no prefix)
  * @param {string} mediaType - e.g. 'image/jpeg'
- * @param {string} provider - 'openrouter', 'venice', 'routstr', 'ppq', 'ollama'
+ * @param {string} _provider - retained for provider-compatible callers
  */
-export function formatImageBlock(base64, mediaType, provider) {
+export function formatImageBlock(base64, mediaType, _provider) {
   // All providers use OpenAI-compatible format
   return { type: 'image_url', image_url: { url: `data:${mediaType};base64,${base64}` } };
 }
@@ -141,10 +141,10 @@ export function formatImageBlock(base64, mediaType, provider) {
  * Builds a content array with image blocks + text block.
  * @param {Array} imageBlocks - from formatImageBlock()
  * @param {string} text
- * @param {string} provider
+ * @param {string} _provider - retained for provider-compatible callers
  * @returns {Array} content array for the messages API
  */
-export function buildVisionContent(imageBlocks, text, provider) {
+export function buildVisionContent(imageBlocks, text, _provider) {
   const content = [...imageBlocks];
   if (text) {
     content.push({ type: 'text', text });

--- a/js/lab-context.js
+++ b/js/lab-context.js
@@ -259,7 +259,7 @@ export {
 // ═══════════════════════════════════════════════
 // CHANGE SUMMARY HELPER
 // ═══════════════════════════════════════════════
-function summarizeChange(field, prev, curr) {
+function summarizeChange(prev, curr) {
   if (prev == null && curr == null) return null;
   if (prev == null) return 'added';
   if (curr == null) return 'cleared';
@@ -981,7 +981,7 @@ function _buildLabContextInner(/** @type {LabContextOptions} */ { skipGroupFilte
       const fieldEntries = byField[entry.field];
       const idx = fieldEntries.indexOf(entry);
       const prev = idx > 0 ? fieldEntries[idx - 1].snapshot : null;
-      const diff = summarizeChange(entry.field, prev, entry.snapshot);
+      const diff = summarizeChange(prev, entry.snapshot);
       if (diff) lines.push(`- ${fmtDate(entry.date)}: ${label} — ${diff}`);
     }
     if (lines.length > 0) {

--- a/js/light-channel-view.js
+++ b/js/light-channel-view.js
@@ -43,7 +43,7 @@ export function mergeTotals(a, b) {
 }
 
 // Mini 7-day sparkline rendered as inline SVG; sub-meaningful days get a faint stub.
-export function _channelSparkline(channelKey, totals = null) {
+export function _channelSparkline(channelKey) {
   const breakdown = lightChannelDeps.dailyChannelBreakdown;
   if (!breakdown) return '';
   const days = breakdown(channelKey, 7);
@@ -449,7 +449,7 @@ function _meaningfulDayCount(days, dailyTarget, threshold) {
 // exposure not banked. The "X of 7 days" framing matches the biology;
 // the cumulative real-unit (IU / J/cm²) when defensible is shown as
 // a sub-line for completeness.
-function _channelHero(channelKey, totalCurrent, totalPrev, days7, daysPrev7, weeklyTier = 0) {
+function _channelHero(channelKey, totalCurrent, days7, daysPrev7, weeklyTier = 0) {
   const meta = getChannelDisplay()[channelKey] || {};
   const target = meta.dailyTarget || 0;
   const threshold = _CHANNEL_DAY_THRESHOLD[channelKey] ?? 0.30;
@@ -564,7 +564,7 @@ function _renderChannelSourceMix(sun, dev) {
 // Channel-specific "next move" — a concrete recipe the user can act on
 // right now. Picks the best CTA based on channel + tier + available
 // devices + current sun conditions.
-function _channelNextMove(channelKey, t7, totalCurrent, devices, atm) {
+function _channelNextMove(channelKey, t7, devices, atm) {
   const matchingDevice = (devices || []).find(d => Array.isArray(d.channels) && d.channels.includes(channelKey));
   const dev = matchingDevice ? escapeHTML(`${matchingDevice.brand} ${matchingDevice.model}`) : '';
   const uvi = atm?.uvIndex ?? null;
@@ -667,7 +667,6 @@ function _renderChannelDetailPanel(channelKey) {
   // Previous-week total via 14-day breakdown (first 7 days = the
   // preceding week, last 7 days = current week). Lets the hero show
   // a real "vs last week" delta instead of a vague tier-vs-tier arrow.
-  let totalPrev = 0;
   let days7 = [];
   let daysPrev7 = [];
   try {
@@ -676,7 +675,6 @@ function _renderChannelDetailPanel(channelKey) {
       const days14 = breakdown(channelKey, 14);
       daysPrev7 = days14.slice(0, 7);
       days7 = days14.slice(7);
-      totalPrev = daysPrev7.reduce((s, d) => s + d.sun + d.device, 0);
     }
   } catch (e) {}
 
@@ -693,7 +691,7 @@ function _renderChannelDetailPanel(channelKey) {
       <button type="button" class="light-channel-detail-close" aria-label="Close ${escapeAttr(meta.label || channelKey)} detail" data-light-channel-action="toggle-detail" data-channel="${escapeAttr(channelKey)}">×</button>
     </header>
 
-    ${_channelHero(channelKey, totalCurrent, totalPrev, days7, daysPrev7, t7)}
+    ${_channelHero(channelKey, totalCurrent, days7, daysPrev7, t7)}
 
     <p class="light-channel-detail-body">${escapeHTML(meta.what || '')}</p>
 
@@ -703,7 +701,7 @@ function _renderChannelDetailPanel(channelKey) {
 
     ${_renderDailyBeatsBankingNote(channelKey)}
 
-    ${_channelNextMove(channelKey, t7, totalCurrent, devices, atm)}
+    ${_channelNextMove(channelKey, t7, devices, atm)}
 
     ${_renderChannelCitations(channelKey)}
   </div>`;

--- a/js/light-env-screen-ui.js
+++ b/js/light-env-screen-ui.js
@@ -10,7 +10,7 @@ const SCREEN_DEVICE_ICONS = {
   phone: '📱', laptop: '💻', monitor: '🖥', tablet: '📲', tv: '📺',
 };
 
-function screenSummary(s, status) {
+function screenSummary(s) {
   const parts = [];
   const hours = s.hoursPerDay;
   if (hours != null && hours > 0) parts.push(`${hours} hr/day`);
@@ -58,7 +58,7 @@ export function renderScreenCard(s, opts = {}) {
   const renderTodayToggle = opts.renderTodayToggle;
   const deviceIcon = SCREEN_DEVICE_ICONS[s.device] || '📱';
   const deviceLabel = (SCREEN_DEVICES.find(d => d.key === s.device)?.label) || 'Device';
-  const summary = screenSummary(s, status);
+  const summary = screenSummary(s);
 
   let html = `<div class="light-env-screen-card light-env-card-sev-${status.color}${activeToday ? '' : ' light-env-card-skipped'}${expanded ? ' expanded' : ''}" data-id="${escapeAttr(s.id)}">
     <div class="light-env-screen-card-head" role="button" tabindex="0" aria-expanded="${expanded ? 'true' : 'false'}" aria-label="${escapeAttr(deviceLabel + ' — ' + status.label + (summary ? ', ' + summary : '') + (expanded ? ', expanded' : ', collapsed'))}" ${lightEnvActionAttrs('toggle-screen-expanded', { id: s.id })}>

--- a/js/marker-detail-editing.js
+++ b/js/marker-detail-editing.js
@@ -312,7 +312,7 @@ export async function revertRefRange(id, type) {
   showNotification(result.message, 'info');
 }
 
-export function toggleMarkerNoteEditor(dotKey) {
+export function toggleMarkerNoteEditor() {
   const editor = document.getElementById('marker-note-editor');
   if (!editor) return;
   const isHidden = editor.style.display === 'none';

--- a/js/pii.js
+++ b/js/pii.js
@@ -447,7 +447,7 @@ export function obfuscatePDFText(pdfText) {
   ];
 
   for (const { pattern, gen } of labelReplacements) {
-    text = text.replace(pattern, (match, label, value, offset) => {
+    text = text.replace(pattern, (match, label, _value, offset) => {
       if (isProtectedLine(offset)) return match;
       replacements++;
       return label + gen();

--- a/js/recommendations-products.js
+++ b/js/recommendations-products.js
@@ -120,7 +120,7 @@ export function getLightDeviceProduct(catalog, slug) {
 // Campaign tag is "light-devices" so the partner-side UTM dashboard can
 // attribute device-card traffic separately from the EMF + supplement
 // surfaces.
-export function renderLightDeviceAffiliateRow(catalog, slug, opts = {}) {
+export function renderLightDeviceAffiliateRow(catalog, slug) {
   if (!isProductRecsEnabled() || !catalog || !slug) return '';
   const product = getLightDeviceProduct(catalog, slug);
   if (!product) return '';

--- a/js/settings-provider-bridge.js
+++ b/js/settings-provider-bridge.js
@@ -43,7 +43,7 @@ function loadProviderPanels() {
   return _providerPanelsLoad;
 }
 
-export function renderAIProviderPanelBridge(provider) {
+export function renderAIProviderPanelBridge() {
   loadProviderPanels().then(providerPanels => {
     const panel = document.getElementById('ai-provider-panel');
     if (panel) panel.innerHTML = providerPanels.renderAIProviderPanel(getAIProvider());

--- a/js/settings.js
+++ b/js/settings.js
@@ -857,7 +857,7 @@ export function openSettingsModal(tab) {
           <button class="ai-provider-btn${provider === 'custom' ? ' active' : ''}" data-provider="custom" data-settings-action="switch-ai-provider"><svg class="ai-provider-logo" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z"/></svg> Custom</button>
           <button class="ai-provider-btn${provider === 'ollama' ? ' active' : ''}" data-provider="ollama" data-settings-action="switch-ai-provider"><svg class="ai-provider-logo" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 15h-2v-6h2v6zm4 0h-2v-6h2v6zm-3-8c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1s1 .45 1 1v2c0 .55-.45 1-1 1z"/></svg> Local</button>
         </div>
-        <div id="ai-provider-panel">${renderAIProviderPanelBridge(provider)}</div>
+        <div id="ai-provider-panel">${renderAIProviderPanelBridge()}</div>
       </div>
 
       <div class="settings-group-title">Import Benchmarks</div>

--- a/js/startup-orchestrator.js
+++ b/js/startup-orchestrator.js
@@ -36,7 +36,7 @@ function handleStartupSequenceError(error) {
 
 function configureSyncComposition() {
   configureSyncLifecycleDeps({ enableSync, disableSync });
-  configureSyncModules({ enableSync, disableSync });
+  configureSyncModules({ enableSync });
 }
 
 export function startApp() {

--- a/js/sun-channel-metrics.js
+++ b/js/sun-channel-metrics.js
@@ -64,7 +64,7 @@ function getDeviceBodyFraction(session, fractionByKey) {
   return null;
 }
 
-export function formatChannelUnit(channelKey, channelAu, durationMin, fitzpatrick = 'III', uvi = null, zenith = null, rotatedSides = false, bodyFraction = null) {
+export function formatChannelUnit(channelKey, channelAu, durationMin, fitzpatrick = 'III', uvi = null, _zenith = null, rotatedSides = false, bodyFraction = null) {
   if (!Number.isFinite(channelAu) || channelAu <= 0) return '';
   if (durationMin > 0 && durationMin < TOO_SHORT_FOR_CHANNEL_VERDICT_MIN) {
     return 'session too short';

--- a/js/sun-context.js
+++ b/js/sun-context.js
@@ -207,7 +207,7 @@ function _trimToBudget(ctx, budget, aggressive = false) {
 
   // 4. Drop older audits past the most recent — keep one full audit
   // block, drop the rest. Same logic as step 1 but at the audit level.
-  ctx = ctx.replace(/(### Light audits[^\n]*\n(?:[^\n]*\n)*?  - [^\n]*\n(?:    · [^\n]*\n)*)([\s\S]*?)(?=\n[A-Z]|\n\[|\n###|$)/, (m, kept, rest) => {
+  ctx = ctx.replace(/(### Light audits[^\n]*\n(?:[^\n]*\n)*?  - [^\n]*\n(?:    · [^\n]*\n)*)([\s\S]*?)(?=\n[A-Z]|\n\[|\n###|$)/, (_match, kept, _rest) => {
     return kept;
   });
   if (ctx.length <= budget) return ctx;
@@ -710,7 +710,7 @@ function standardTierBlock(sessions) {
   const fmtIUCompact = (n) => n >= 10000 ? `${(n / 1000).toFixed(1).replace(/\.0$/, '')}k`
     : n >= 1000 ? `${(n / 1000).toFixed(1)}k` : `${Math.round(n)}`;
   const fmtJ = (n) => n >= 10 ? `${Math.round(n)}` : n >= 1 ? n.toFixed(1) : n.toFixed(2);
-  const _luxHFromAu = (k, weeklyAu) => {
+  const _luxHFromAu = (weeklyAu) => {
     // circadian channel-au needs duration to convert; bucket totals are
     // au-aggregates not lux-h. Approximation: use the always-tier helper
     // pattern but on a representative 1-hour basis. The AI cares about
@@ -738,7 +738,7 @@ function standardTierBlock(sessions) {
     if (k === 'vitamin_d') {
       formatted = b.map(v => v > 0 ? fmtIUCompact(v) : '0').join('→');
     } else if (k === 'circadian') {
-      formatted = b.map(v => v > 0 ? fmtIUCompact(_luxHFromAu(k, v)) : '0').join('→');
+      formatted = b.map(v => v > 0 ? fmtIUCompact(_luxHFromAu(v)) : '0').join('→');
     } else if (k === 'nir_solar' || k === 'pbm_red' || k === 'pbm_nir') {
       formatted = b.map(v => {
         if (v <= 0) return '0';

--- a/js/sun-defaults.js
+++ b/js/sun-defaults.js
@@ -475,7 +475,7 @@ function getSetupFilledCount() {
   return [skinFilled, homeFilled, eyewearFilled].filter(Boolean).length;
 }
 
-function renderSetupActions(filledCount = getSetupFilledCount()) {
+function renderSetupActions() {
   return `<div class="light-setup-actions" data-setup-actions="core">
     ${isOnboardingComplete()
       ? `<button class="import-btn import-btn-secondary" ${lightSetupActionAttrs('cancel-reopen')}>Cancel</button>
@@ -619,7 +619,7 @@ function renderSetupEditor({ includeActions = true } = {}) {
     </section>
     </section>
 
-    ${includeActions ? renderSetupActions(filledCount) : ''}
+    ${includeActions ? renderSetupActions() : ''}
   </div>`;
   return html;
 }

--- a/js/sun-spectrum.js
+++ b/js/sun-spectrum.js
@@ -243,7 +243,7 @@ function _heuristicPeakShares(peaks, deviceType) {
   }
   const bandCount = {};
   for (const b of bands) bandCount[b] = (bandCount[b] || 0) + 1;
-  const raw = bands.map((b, i) => (bandWeights[b] || 0) / (bandCount[b] || 1));
+  const raw = bands.map((b) => (bandWeights[b] || 0) / (bandCount[b] || 1));
   const sum = raw.reduce((a, b) => a + b, 0);
   return sum > 0 ? raw.map(w => w / sum) : peaks.map(() => 1 / peaks.length);
 }

--- a/js/sun-uvdata.js
+++ b/js/sun-uvdata.js
@@ -329,11 +329,11 @@ const PROVIDERS = {
   noaa: {
     name: 'noaa_nws',
     available: ({ lat, lon }) => isUSCoords(lat, lon),
-    fetch: async ({ lat, lon, isoTime }) => {
+    fetch: async ({ lat, lon }) => {
       // NOAA Air Resources Lab UV index endpoint
       const url = `https://www.cpc.ncep.noaa.gov/products/stratosphere/uv_index/json/uv_${Math.round(lat * 10)}_${Math.round(lon * 10)}.json`;
       const json = await fetchJson(url, {});
-      return shapeNoaaResponse(json, isoTime);
+      return shapeNoaaResponse(json);
     },
   },
   openMeteo: {
@@ -604,7 +604,7 @@ function shapeCamsResponse(json, isoTime, sourceLabel) {
   return shaped;
 }
 
-function shapeNoaaResponse(json, isoTime) {
+function shapeNoaaResponse(json) {
   if (!json) return null;
   // NOAA endpoint shape varies — extract UV index, fall through if not parseable
   const uvi = json.uv_index ?? json.UVI ?? null;

--- a/js/sync-configure.js
+++ b/js/sync-configure.js
@@ -46,8 +46,8 @@ import {
 /** @param {...any} args */
 function dbg(...args) { if (isDebugMode()) console.log('[sync]', ...args); }
 
-/** @param {{ enableSync?: (...args: any[]) => any, disableSync?: (...args: any[]) => any }} [deps] */
-export function configureSyncModules({ enableSync, disableSync } = {}) {
+/** @param {{ enableSync?: (...args: any[]) => any }} [deps] */
+export function configureSyncModules({ enableSync } = {}) {
   configureSyncPayload({ getProfiles });
   configureSyncStorageCleanup({ saveImportedData });
 

--- a/tests/playwright/category-view-renderers-browser-coverage.spec.js
+++ b/tests/playwright/category-view-renderers-browser-coverage.spec.js
@@ -178,7 +178,7 @@ test('category view renderers browser coverage exercises chart table heatmap and
         fixture.textContent.includes('No data yet for this category');
 
       state.markerRegistry = {};
-      fixture.innerHTML = renderers.renderHeatmapView(category, dateLabels, dates, 'lipids');
+      fixture.innerHTML = renderers.renderHeatmapView(category, dateLabels, 'lipids');
       const highHeatmapCell = fixture.querySelector('.heatmap-high');
       const missingHeatmapCell = fixture.querySelector('.heatmap-missing');
       outcomes.heatmapViewRegistersMarkersAndRendersStatusCells =
@@ -191,7 +191,7 @@ test('category view renderers browser coverage exercises chart table heatmap and
         && !fixture.innerHTML.includes('onclick=')
         && highHeatmapCell.getAttribute('aria-label')?.includes('ApoB <script> Mar 1: 130');
 
-      fixture.innerHTML = renderers.renderHeatmapView({ singleDate: false, markers: {} }, dateLabels, dates, 'empty');
+      fixture.innerHTML = renderers.renderHeatmapView({ singleDate: false, markers: {} }, dateLabels, 'empty');
       outcomes.heatmapViewEmptyStateExplainsNoData =
         fixture.textContent.includes('No data yet for this category');
 

--- a/tests/playwright/custom-api-settings.spec.js
+++ b/tests/playwright/custom-api-settings.spec.js
@@ -31,7 +31,7 @@ test('lazy provider render follows a provider switch made while loading', async 
     api.setAIProvider('openrouter');
     const panel = document.createElement('div');
     panel.id = 'ai-provider-panel';
-    panel.innerHTML = bridge.renderAIProviderPanelBridge('openrouter');
+    panel.innerHTML = bridge.renderAIProviderPanelBridge();
     document.body.appendChild(panel);
     api.setAIProvider('custom');
   });

--- a/tests/playwright/dashboard-knowledge-base.spec.js
+++ b/tests/playwright/dashboard-knowledge-base.spec.js
@@ -14,6 +14,8 @@ test('Context hub opens from Personalize AI alias and dismisses', async ({ page 
   await expect(overlay).toHaveClass(/show/);
   await expect(overlay.locator('.ai-picker-card')).toHaveCount(2);
   await expect(overlay.locator('.context-source-row')).toHaveCount(8);
+  await expect(overlay.locator('.context-source-desc')).toHaveCount(8);
+  await expect(overlay).toContainText('Health goals, medical history, diet, exercise, sleep, stress, environment, notes, biometrics, and cycle context.');
   await expect(overlay.locator('.context-grounding-panel + .context-source-panel')).toHaveCount(1);
   await expect(overlay).toContainText('Context');
   await expect(overlay).toContainText('Data sources');
@@ -43,6 +45,10 @@ test('Context hub opens from Personalize AI alias and dismisses', async ({ page 
   }));
   expect(toggleNames).toHaveLength(8);
   expect(toggleNames.every(Boolean)).toBe(true);
+  const describedByCounts = await overlay.locator('[data-context-toggle]').evaluateAll(inputs =>
+    inputs.map(input => (input.getAttribute('aria-describedby') || '').split(/\s+/).filter(Boolean).length)
+  );
+  expect(describedByCounts.every(count => count === 2)).toBe(true);
 
   await overlay.locator('.ai-picker-card[data-pick="lens"]').click();
   const editorOverlay = page.locator('#modal-overlay');

--- a/tests/playwright/environment-coverage-batch.spec.js
+++ b/tests/playwright/environment-coverage-batch.spec.js
@@ -273,6 +273,11 @@ test('EMF assessment editor covers room measurements tags compare delete and cha
         activeAssessment().rooms.length === 1
         && document.querySelector('.emf-room-tab.active')?.textContent.includes('Bedroom') === true;
 
+      emf.selectEMFRoom('stale-assessment-id', 99);
+      outcomes.staleRoomSelectionCannotChangeActiveAssessment =
+        document.querySelector('.emf-room-tab.active')?.textContent.includes('Bedroom') === true
+        && document.querySelector('[data-emf-room-idx="99"]') === null;
+
       activeAssessment().rooms[0].photos = [{
         name: 'meter.png',
         mediaType: 'image/svg+xml',

--- a/tests/playwright/startup-orchestrator-browser-coverage.spec.js
+++ b/tests/playwright/startup-orchestrator-browser-coverage.spec.js
@@ -81,8 +81,8 @@ async function openStartupOrchestratorPage(page) {
   await page.route('**/js/sync-configure.js*', route => route.fulfill({
     contentType: 'application/javascript',
     body: `
-      export function configureSyncModules({ enableSync, disableSync }) {
-        window.__startupCalls.push(['sync-modules', typeof enableSync, typeof disableSync]);
+      export function configureSyncModules({ enableSync }) {
+        window.__startupCalls.push(['sync-modules', typeof enableSync]);
       }
     `,
   }));

--- a/tests/playwright/sync-configure-reconcile-browser-coverage.spec.js
+++ b/tests/playwright/sync-configure-reconcile-browser-coverage.spec.js
@@ -52,7 +52,6 @@ test('sync configure browser coverage seeds local profiles through identity rest
 
       configure.configureSyncModules({
         enableSync: () => true,
-        disableSync: () => true,
       });
       actions.configureSyncActions({
         pushProfile: async (...args) => { pushes.push(args); },

--- a/tests/playwright/sync-lifecycle-browser-coverage.spec.js
+++ b/tests/playwright/sync-lifecycle-browser-coverage.spec.js
@@ -165,7 +165,6 @@ test('sync configure browser coverage wires module actions, UI, and relay quota 
     const originalSetTimeout = window.setTimeout;
     const notificationText = () => document.getElementById('notification-container')?.textContent || '';
     const enableAction = () => 'enabled';
-    const disableAction = () => 'disabled';
     const ownerId = `configure-owner-${Date.now()}`;
     const ownerWarnKey = `labcharts-${ownerId}-relay-quota-warned`;
     let thrownError = null;
@@ -177,7 +176,6 @@ test('sync configure browser coverage wires module actions, UI, and relay quota 
       document.getElementById('notification-container').innerHTML = '';
       configure.configureSyncModules({
         enableSync: enableAction,
-        disableSync: disableAction,
       });
 
       outcomes.configureKeepsLifecycleActionsModuleOnly =

--- a/tests/test-openrouter.js
+++ b/tests/test-openrouter.js
@@ -136,7 +136,7 @@ assert('provider button with data-provider="openrouter"', settingsSrc.includes('
 assert('OpenRouter provider button uses delegated settings action',
   /<button[^>]*data-provider="openrouter"[^>]*data-settings-action="switch-ai-provider"/.test(settingsSrc));
 assert('settings calls provider bridge APIs directly',
-  settingsSrc.includes('renderAIProviderPanelBridge(provider)') &&
+  settingsSrc.includes('renderAIProviderPanelBridge()') &&
     settingsSrc.includes('initSettingsProviderPanels()'));
 assert('settings provider bridge has eager provider switch', settingsBridgeSrc.includes('function switchAIProviderBridge(provider)'));
 assert('eager provider bridge persists selection synchronously', settingsBridgeSrc.includes('setAIProvider(provider);'));
@@ -359,7 +359,7 @@ assert('startup sync reconciliation pushes local AI setting drift',
   syncConfigureSrc.includes("from './sync-reconcile.js'")
     && !syncSrc.includes("from './sync-configure.js'")
     && startupOrchestratorSrc.includes("from './sync-configure.js'")
-    && startupOrchestratorSrc.includes('configureSyncModules({ enableSync, disableSync });')
+    && startupOrchestratorSrc.includes('configureSyncModules({ enableSync });')
     && syncReconcileSrc.includes('newer local AI settings')
     && syncReconcileSrc.includes('collectAISettings()'));
 const cssSrc = read('styles.css') + '\n' + read('css/settings.css');

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -124,6 +124,7 @@ const requiredCompilerSafetyOptions = {
   noFallthroughCasesInSwitch: true,
   noImplicitReturns: true,
   noImplicitThis: true,
+  noUnusedParameters: true,
   strictBindCallApply: true,
   strictFunctionTypes: true,
 };

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -223,7 +223,7 @@ await import('../js/settings.js');
       && syncConfigureSrc.includes('configureSyncDiagnostics({')
       && syncConfigureSrc.includes('configureSyncUI({')
       && syncConfigureSrc.includes('forceResendCurrentProfile,')
-      && startupOrchestratorSrc.includes('configureSyncModules({ enableSync, disableSync });'));
+      && startupOrchestratorSrc.includes('configureSyncModules({ enableSync });'));
   assert('service worker precaches sync-configure.js',
     serviceWorkerSrc.includes("'/js/sync-configure.js'"));
   assert('sync-init.js owns Evolu startup orchestration',

--- a/tests/test-table-heatmap-empty.js
+++ b/tests/test-table-heatmap-empty.js
@@ -72,13 +72,13 @@ const views = await import('../js/views.js');
   // ═══════════════════════════════════════
   console.log('%c 2. renderHeatmapView ', 'font-weight:bold;color:#f59e0b');
 
-  const heatHtml = views.renderHeatmapView(buildCat(), dateLabels, dates, 'testcat');
+  const heatHtml = views.renderHeatmapView(buildCat(), dateLabels, 'testcat');
   assert('Heatmap render includes the "Has Data" marker', heatHtml.includes('Has Data'));
   assert('Heatmap render includes the "Sparse Data" marker', heatHtml.includes('Sparse Data'));
   assert('Heatmap render OMITS the "No Data" marker', !heatHtml.includes('No Data'));
   assert('Heatmap render OMITS the "Another Empty" marker', !heatHtml.includes('Another Empty'));
 
-  const emptyHeat = views.renderHeatmapView(allEmptyCat, dateLabels, dates, 'empty');
+  const emptyHeat = views.renderHeatmapView(allEmptyCat, dateLabels, 'empty');
   assert('All-empty heatmap renders empty-state message',
     emptyHeat.includes('No data yet for this category'));
   assert("Heatmap empty-state doesn't render the <table>",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,
+    "noUnusedParameters": true,
     "strictBindCallApply": true,
     "strictFunctionTypes": true
   },


### PR DESCRIPTION
## Summary

- enable and pin TypeScript `noUnusedParameters` across the checked JavaScript graph
- resolve all 37 findings by removing obsolete internal arguments or explicitly naming required positional compatibility slots
- make the audit findings pay off with three behavior improvements: render and describe Context source explanations, reject stale EMF room-selection events, and simplify dead EMF interpretation callback state
- preserve intentional lazy provider behavior while removing its misleading unused argument
- update affected call sites and focused regression coverage

## Verification

- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
- `npm run production:check`
- focused Chromium slice: 24 passed
- `COVERAGE=1 ./run-tests.sh`
  - static verification: 141 passed
  - Vitest/Node: 509 passed
  - Chromium: 488 passed
  - responsive/theme: 520 passed
  - combined function coverage: 80.70% (floor 79.50%)