### PR TITLE
Stabilize app-shell graph verification

### DIFF
--- a/tests/service-worker-app-shell.test.js
+++ b/tests/service-worker-app-shell.test.js
@@ -27,7 +27,7 @@ function resolveLocalAsset(importerUrl, specifier) {
 
 function moduleSpecifiers(source, fileName = 'module.js') {
   const specifiers = new Set();
-  const sourceFile = ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.JS);
+  const sourceFile = ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest, false, ts.ScriptKind.JS);
 
   function addStringLiteral(node) {
     if (node && ts.isStringLiteralLike(node)) specifiers.add(node.text);
@@ -144,7 +144,7 @@ describe('service worker app-shell completeness', () => {
     expect(entries).toEqual(['/js/service-worker-update.js', '/js/main.js']);
     expect(missingFiles).toEqual([]);
     expect(uncached).toEqual([]);
-  });
+  }, 30_000);
 
   it('pre-caches local files referenced by cached stylesheets', () => {
     const entries = appShellEntries();


### PR DESCRIPTION
## Summary

- avoid constructing unused parent links while parsing the 484-module app-shell graph
- give the intentionally repository-wide graph assertion an explicit 30-second timeout instead of Vitest's generic 5-second unit-test ceiling

## Why

The HVT9 PR was green, but its first merged-main run failed only because this graph test took 9.2 seconds on a contended runner. All 516 other tests passed and the graph produced no assertion failure; local execution completes in under a second. The test's workload is repository-scale, so its timeout should reflect that scope.

Failed merged-main run: https://github.com/elkimek/get-based/actions/runs/30213296474

## Verification

- `npm test -- --coverage` — 59/59 files, 517/517 tests
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run typecheck:strict-null` — 578 diagnostics / 146 files within ratchet
- `npm run quality` — 11/11 guardrails
