### PR TITLE
Eliminate top strict-null hotspots

### DIFF
--- a/js/context-card-dashboard-ai-impl.js
+++ b/js/context-card-dashboard-ai-impl.js
@@ -95,10 +95,30 @@ function hasGenomeSummaryData() {
   return !!(genetics.apoe || genetics.mtdna);
 }
 
+/**
+ * @typedef {{
+ *   name: string,
+ *   count: number,
+ *   products: string[],
+ *   sections: string[],
+ * }} LabSourceGroup
+ */
+
+/**
+ * @typedef {{
+ *   coreMarkers: number,
+ *   totalMarkers: number,
+ *   groups: LabSourceGroup[],
+ * }} LabSourceStats
+ */
+
+/** @returns {LabSourceStats} */
 function getLabSourceStats() {
+  /** @type {LabSourceStats} */
   const stats = { coreMarkers: 0, totalMarkers: 0, groups: [] };
   try {
     const data = getActiveData();
+    /** @type {Map<string, { name: string, count: number, products: Set<string>, sections: Set<string> }>} */
     const groups = new Map();
     const imported = /** @type {any} */ (state.importedData || {});
     const snapshotsById = new Map((imported.importSnapshots || []).filter(s => s?.id).map(s => [s.id, s]));
@@ -161,12 +181,14 @@ function getImportSnapshotProductLabel(snapshot, dotKey) {
   return testType;
 }
 
+/** @param {LabSourceGroup} group */
 function getLabGroupTitle(group) {
   const products = group.products || [];
   if (products.length === 1 && products[0] !== group.name) return `${products[0]} · ${group.name}`;
   return group.name;
 }
 
+/** @param {LabSourceGroup} group */
 function getLabGroupDescription(group) {
   const markerCount = `${group.count} marker${group.count !== 1 ? 's' : ''}`;
   const products = group.products || [];
@@ -237,6 +259,21 @@ function hasSupplementsMedsData() {
   return hasMeaningfulContextValue(imported.supplements);
 }
 
+/**
+ * @param {{
+ *   key: string,
+ *   toggleKey?: string,
+ *   kicker: string,
+ *   title: string,
+ *   description: string,
+ *   status: string,
+ *   checked: boolean,
+ *   disabled?: boolean,
+ *   attrs?: Record<string, unknown>,
+ *   child?: boolean,
+ *   affects?: string[],
+ * }} options
+ */
 function renderContextSourceToggle({ key, toggleKey = key, kicker, title, description, status, checked, disabled = false, attrs = {}, child = false, affects = [] }) {
   const id = `context-source-${key}`;
   const titleId = `${id}-title`;
@@ -279,8 +316,11 @@ function renderContextSummaryChip(label) {
 }
 
 function renderContextSourceSummary({ insightOn, hasInsight, supplementsOn, hasSupplements, labStats, labOn, genomeSummaryOn, genomePriorityOn, genomeOn, hasGenomeSummary, hasGenome, lightOn, bodyOn }) {
+  /** @type {string[]} */
   const included = [];
+  /** @type {string[]} */
   const excluded = [];
+  /** @type {string[]} */
   const inactive = [];
   if (hasInsight) {
     if (insightOn) included.push('Insight Cards');

--- a/js/light-tool-camera-modals.js
+++ b/js/light-tool-camera-modals.js
@@ -5,6 +5,7 @@ import { escapeHTML, queryRequired, showNotification } from './utils.js';
 import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
 import {
   aimingGuideHTML,
+  getRequired2DContext,
   lockCameraForMeasurement,
   cameraLockStatusLine,
   computeRowBanding,
@@ -93,8 +94,7 @@ function luxZone(lux) {
   return LUX_ZONES[LUX_ZONES.length - 1];
 }
 
-let _luxState = { running: false, sensor: null, stream: null, video: null, calibration: 1.0 };
-
+let _luxState = /** @type {{ running: boolean, sensor: { stop: () => void } | null, stream: MediaStream | null, video: HTMLVideoElement | null, calibration: number }} */ ({ running: false, sensor: null, stream: null, video: null, calibration: 1.0 });
 
 export async function openLuxMeter(opts = {}, deps = {}) {
   const saveMeasurement = getSaveMeasurement(deps);
@@ -199,7 +199,7 @@ export async function openLuxMeter(opts = {}, deps = {}) {
       _luxState.video = video;
       const canvas = document.createElement('canvas');
       canvas.width = 64; canvas.height = 48;
-      const ctx = canvas.getContext('2d', { willReadFrequently: true });
+      const ctx = getRequired2DContext(canvas);
       const tick = () => {
         if (!_luxState.running || closed) return;
         try {
@@ -315,7 +315,7 @@ export async function openLuxMeter(opts = {}, deps = {}) {
         showNotification('Camera not reading yet — wait a moment, then try again.', 'error');
         return;
       }
-      const refLux = parseFloat(calRefInput?.value);
+      const refLux = parseFloat(calRefInput?.value || '');
       if (!Number.isFinite(refLux) || refLux <= 0) {
         showNotification('Enter a positive lux value from your reference.', 'error');
         return;
@@ -363,7 +363,7 @@ export async function openLuxMeter(opts = {}, deps = {}) {
 
 // ─── Tool 2: Flicker Detector ──────────────────────────────────────────
 
-let _flickerState = { running: false, stream: null };
+let _flickerState = /** @type {{ running: boolean, stream: MediaStream | null }} */ ({ running: false, stream: null });
 
 export async function openFlickerDetector(opts = {}, deps = {}) {
   const saveMeasurement = getSaveMeasurement(deps);
@@ -440,7 +440,7 @@ export async function openFlickerDetector(opts = {}, deps = {}) {
     // Use 64x48 capture so we have enough rows to see banding cleanly.
     const canvas = document.createElement('canvas');
     canvas.width = 64; canvas.height = 48;
-    const ctx = canvas.getContext('2d', { willReadFrequently: true });
+    const ctx = getRequired2DContext(canvas);
     const frameSamples = [];
     const bandingSamples = [];
     const startTime = performance.now();
@@ -524,7 +524,7 @@ export async function openFlickerDetector(opts = {}, deps = {}) {
 
 // ─── Tool 6: Sleep Darkness Meter ─────────────────────────────────────
 
-let _darkState = { running: false, stream: null };
+let _darkState = /** @type {{ running: boolean, stream: MediaStream | null }} */ ({ running: false, stream: null });
 
 export async function openDarknessMeter(opts = {}, deps = {}) {
   const saveMeasurement = getSaveMeasurement(deps);
@@ -589,7 +589,7 @@ export async function openDarknessMeter(opts = {}, deps = {}) {
       const lock = await lockCameraForMeasurement(stream, { longExposure: true });
       const canvas = document.createElement('canvas');
       canvas.width = 32; canvas.height = 24;
-      const ctx = canvas.getContext('2d', { willReadFrequently: true });
+      const ctx = getRequired2DContext(canvas);
       const lumas = [];      // mean per sample
       const peaks = [];      // single-pixel max per sample
       const t0 = performance.now();
@@ -692,7 +692,7 @@ export async function openDarknessMeter(opts = {}, deps = {}) {
 
 // ─── Tool 3: CCT Meter ────────────────────────────────────────────────
 
-let _cctState = { running: false, stream: null };
+let _cctState = /** @type {{ running: boolean, stream: MediaStream | null }} */ ({ running: false, stream: null });
 
 export async function openCCTMeter(opts = {}, deps = {}) {
   const saveMeasurement = getSaveMeasurement(deps);
@@ -765,7 +765,7 @@ export async function openCCTMeter(opts = {}, deps = {}) {
     // PWM-dimmed lights whose CCT shifts during the PWM cycle.
     const canvas = document.createElement('canvas');
     canvas.width = 64; canvas.height = 48;
-    const ctx = canvas.getContext('2d', { willReadFrequently: true });
+    const ctx = getRequired2DContext(canvas);
     const bandingPeaks = [];
     const tick = () => {
       if (!_cctState.running) return;
@@ -853,7 +853,7 @@ function solarCoherence(k) {
 
 // ─── Tool 4: Spectrum Classifier (simplified) ────────────────────────
 
-let _specState = { running: false, stream: null };
+let _specState = /** @type {{ running: boolean, stream: MediaStream | null }} */ ({ running: false, stream: null });
 
 export async function openSpectrumClassifier(opts = {}, deps = {}) {
   const saveMeasurement = getSaveMeasurement(deps);
@@ -920,7 +920,7 @@ export async function openSpectrumClassifier(opts = {}, deps = {}) {
     // frame-luma variance (which can't see anything above fps/2).
     const canvas = document.createElement('canvas');
     canvas.width = 64; canvas.height = 48;
-    const ctx = canvas.getContext('2d', { willReadFrequently: true });
+    const ctx = getRequired2DContext(canvas);
     const bandingPeaks = [];   // recent banding ratios — peak across last second wins
     const tick = () => {
       if (!_specState.running) return;
@@ -1107,7 +1107,7 @@ export async function openGlassTransmission(opts = {}, deps = {}) {
       _lastGlassLock = lock;
       const canvas = document.createElement('canvas');
       canvas.width = 32; canvas.height = 24;
-      const ctx = canvas.getContext('2d', { willReadFrequently: true });
+      const ctx = getRequired2DContext(canvas);
       // Sample over 1s
       const samples = [];
       for (let i = 0; i < 8; i++) {

--- a/js/light-tool-camera.js
+++ b/js/light-tool-camera.js
@@ -3,6 +3,13 @@
 
 import { escapeAttr, escapeHTML } from './utils.js';
 
+/** @param {HTMLCanvasElement} canvas */
+export function getRequired2DContext(canvas) {
+  const context = canvas.getContext('2d', { willReadFrequently: true });
+  if (!context) throw new Error('Camera measurement requires a 2D canvas context');
+  return context;
+}
+
 // Per-tool "where to aim the camera" guide. Spelt out because the
 // difference between "what hits you" tools (lux, sleep darkness, eye-
 // level audit) and "what the source emits" tools (flicker, CCT,

--- a/js/wearables-apple-health-runtime.js
+++ b/js/wearables-apple-health-runtime.js
@@ -31,6 +31,11 @@ export function getAppleHealthJSZip() {
   return getRuntimeWindow()?.JSZip || null;
 }
 
+/**
+ * @param {Blob} blob
+ * @param {string} fileName
+ * @param {((event: any) => void) | null} [onProgress]
+ */
 export async function parseAppleHealthCycleRuntime(blob, fileName, onProgress = null) {
   if (!appleHealthRuntimeDeps.parseCycleBlob) return null;
   return appleHealthRuntimeDeps.parseCycleBlob(blob, fileName, onProgress);

--- a/js/wearables-apple-health.js
+++ b/js/wearables-apple-health.js
@@ -268,6 +268,36 @@ export function parseAppleHealthXml(xmlText) {
   return _aggregateByDayByMetric(byDayByMetric);
 }
 
+/**
+ * @typedef {{
+ *   source: 'apple_health',
+ *   date: string,
+ *   hrv_rmssd: number | null,
+ *   hrv_sdnn: number | null,
+ *   rhr: number | null,
+ *   hrv_day: number | null,
+ *   hr_day: number | null,
+ *   sleep_score: number | null,
+ *   readiness_score: number | null,
+ *   activity_score: number | null,
+ *   steps: number | null,
+ *   strain: number | null,
+ *   stress_high_min: number | null,
+ *   resilience_level: number | null,
+ *   cardio_age: number | null,
+ *   weight: number | null,
+ *   bp_systolic: number | null,
+ *   bp_diastolic: number | null,
+ *   body_fat_pct: number | null,
+ *   lean_mass_kg: number | null,
+ *   fat_mass_kg: number | null,
+ *   spo2_avg: number | null,
+ *   body_temp_delta: number | null,
+ *   glucose_avg: number | null,
+ *   vo2max: number | null,
+ * }} AppleHealthDailyRow
+ */
+
 function _aggregateByDayByMetric(byDayByMetric) {
   // Aggregate per day → canonical L1 row.
   //   hrv_sdnn   mean of night-window (22:00–06:00 local) samples — deep
@@ -289,6 +319,12 @@ function _aggregateByDayByMetric(byDayByMetric) {
   const isNight = (h) => (typeof h === 'number') && (h < 6 || h >= 22);
   const isDay   = (h) => (typeof h === 'number') && (h >= 6 && h < 22);
   const mean = (arr) => arr.length ? arr.reduce((a, b) => a + b, 0) / arr.length : null;
+  /** @param {number[]} values */
+  const roundedMean = (values) => {
+    const average = mean(values);
+    if (average == null) throw new Error('Cannot average an empty Apple Health sample set');
+    return Math.round(average * 100) / 100;
+  };
   const sumByMaxSource = (samples) => {
     if (!Array.isArray(samples) || samples.length === 0) return null;
     const totals = new Map();
@@ -303,8 +339,10 @@ function _aggregateByDayByMetric(byDayByMetric) {
     return best;
   };
 
+  /** @type {AppleHealthDailyRow[]} */
   const rows = [];
   for (const [day, bucket] of byDayByMetric) {
+    /** @type {AppleHealthDailyRow} */
     const row = {
       source: 'apple_health', date: day,
       hrv_rmssd: null, hrv_sdnn: null, rhr: null,
@@ -331,7 +369,7 @@ function _aggregateByDayByMetric(byDayByMetric) {
       const dayMean   = mean(dayW);
       if (night.length === 0 && dayW.length === 0) {
         // No hour info — keep legacy "mean of all samples → hrv_sdnn" behaviour.
-        row.hrv_sdnn = Math.round(mean(all) * 100) / 100;
+        row.hrv_sdnn = roundedMean(all);
       } else {
         row.hrv_sdnn = nightMean != null ? Math.round(nightMean * 100) / 100 : null;
         row.hrv_day  = dayMean   != null ? Math.round(dayMean   * 100) / 100 : null;
@@ -353,7 +391,7 @@ function _aggregateByDayByMetric(byDayByMetric) {
     if (Array.isArray(bucket.hr_day) && bucket.hr_day.length) {
       const dayW = bucket.hr_day.filter(s => isDay(s.h)).map(s => s.v);
       if (dayW.length > 0) {
-        row.hr_day = Math.round(mean(dayW) * 100) / 100;
+        row.hr_day = roundedMean(dayW);
       }
     }
 
@@ -362,32 +400,32 @@ function _aggregateByDayByMetric(byDayByMetric) {
       row.steps = Math.round(stepsBest * 100) / 100;
     }
     if (Array.isArray(bucket.spo2_avg) && bucket.spo2_avg.length) {
-      row.spo2_avg = Math.round(mean(bucket.spo2_avg.map(s => s.v)) * 100) / 100;
+      row.spo2_avg = roundedMean(bucket.spo2_avg.map(s => s.v));
     }
     if (Array.isArray(bucket.body_temp_delta) && bucket.body_temp_delta.length) {
-      row.body_temp_delta = Math.round(mean(bucket.body_temp_delta.map(s => s.v)) * 100) / 100;
+      row.body_temp_delta = roundedMean(bucket.body_temp_delta.map(s => s.v));
     }
     // VO2max — Apple Watch writes one measurement per outdoor walk/run, so
     // a given day may carry 0, 1, or multiple samples. Mean smooths out
     // back-to-back walks on the same day; the gaps between days are
     // expected and handled by the chart's span-gaps.
     if (Array.isArray(bucket.vo2max) && bucket.vo2max.length) {
-      row.vo2max = Math.round(mean(bucket.vo2max.map(s => s.v)) * 100) / 100;
+      row.vo2max = roundedMean(bucket.vo2max.map(s => s.v));
     }
     if (Array.isArray(bucket.weight) && bucket.weight.length) {
-      row.weight = Math.round(mean(bucket.weight.map(s => s.v)) * 100) / 100;
+      row.weight = roundedMean(bucket.weight.map(s => s.v));
     }
     if (Array.isArray(bucket.body_fat_pct) && bucket.body_fat_pct.length) {
-      row.body_fat_pct = Math.round(mean(bucket.body_fat_pct.map(s => s.v)) * 100) / 100;
+      row.body_fat_pct = roundedMean(bucket.body_fat_pct.map(s => s.v));
     }
     if (Array.isArray(bucket.lean_mass_kg) && bucket.lean_mass_kg.length) {
-      row.lean_mass_kg = Math.round(mean(bucket.lean_mass_kg.map(s => s.v)) * 100) / 100;
+      row.lean_mass_kg = roundedMean(bucket.lean_mass_kg.map(s => s.v));
     }
     if (Array.isArray(bucket.bp_systolic) && bucket.bp_systolic.length) {
-      row.bp_systolic = Math.round(mean(bucket.bp_systolic.map(s => s.v)) * 100) / 100;
+      row.bp_systolic = roundedMean(bucket.bp_systolic.map(s => s.v));
     }
     if (Array.isArray(bucket.bp_diastolic) && bucket.bp_diastolic.length) {
-      row.bp_diastolic = Math.round(mean(bucket.bp_diastolic.map(s => s.v)) * 100) / 100;
+      row.bp_diastolic = roundedMean(bucket.bp_diastolic.map(s => s.v));
     }
     if (row.weight != null && row.body_fat_pct != null) {
       row.fat_mass_kg = Math.round(row.weight * row.body_fat_pct) / 100;

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 578,
+  "totalDiagnostics": 501,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -33,7 +33,6 @@
     "js/client-list-impl.js": 7,
     "js/client-list-runtime.js": 1,
     "js/compare-correlations.js": 7,
-    "js/context-card-dashboard-ai-impl.js": 26,
     "js/context-card-lifestyle-editors-impl.js": 2,
     "js/context-source-registry.js": 1,
     "js/crypto.js": 19,
@@ -73,7 +72,6 @@
     "js/light-env-audits.js": 2,
     "js/light-page-view.js": 2,
     "js/light-today-ai.js": 4,
-    "js/light-tool-camera-modals.js": 25,
     "js/light-tool-camera.js": 5,
     "js/light-tools.js": 6,
     "js/local-ai-lifecycle.js": 2,
@@ -138,7 +136,6 @@
     "js/touch-tooltip.js": 6,
     "js/tour.js": 3,
     "js/utils.js": 4,
-    "js/wearables-apple-health.js": 26,
     "js/wearables-bp-detail-chart.js": 8,
     "js/wearables-connect-runtime.js": 2,
     "js/wearables-connect.js": 2,


### PR DESCRIPTION
## What
- add explicit contracts for Dashboard AI lab-source groups, context toggles, and summary lists
- type Apple Health cycle callbacks and canonical daily rows; enforce non-empty averaging at the aggregation boundary
- type camera/sensor state and centralize required 2D-canvas acquisition for every camera-backed Light tool
- ratchet strict-null debt from 578 diagnostics across 146 files to 501 across 143 files

## Why
These were the three largest remaining strict-null hotspots. Clearing them removes 77 diagnostics (13.3% of all remaining debt) while strengthening real browser/device boundaries instead of suppressing errors.

## Verification
- `COVERAGE=1 ./run-tests.sh`
  - 141/141 module verifiers
  - 59/59 Vitest files, 517/517 tests
  - 488/488 Chromium tests
  - 520/520 responsive checks
  - 80.75% global function coverage (79.50% floor)
- focused Playwright: Apple Health + Dashboard AI loader + camera success/edge paths: 5/5
- all three TypeScript checks pass; strict-null ratchet: 501 diagnostics / 143 files
- architecture: 484 modules, 0 cycles
- quality guardrails: 11/11; largest-file cap remains 1168/1168

## Scope
One commit, six files, based on `6fab5558`; remote comparison is ahead by one and behind by zero.