### PR TITLE
Guard high-write local test suites

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# Repository agent instructions
+
+## Test scope and disk writes
+
+- Default to change-scoped verification. Run only the unit tests, Playwright
+  specs, and lightweight static gates relevant to the diff.
+- Do not interpret requests such as "make sure", "fully verify", or "100%" as
+  permission to run the complete local browser or coverage matrix.
+- GitHub Actions owns the exhaustive Chromium and combined-coverage run.
+- Before running a local command expected to produce more than 1 GB of disk
+  writes, obtain explicit user approval in the current conversation.
+- `./run-tests.sh` and `npm run test:playwright` are intentionally guarded
+  outside CI. Set `GETBASED_ALLOW_HIGH_WRITE_TESTS=1` only after that explicit
+  approval.
+- Prefer focused commands such as:
+  - `npm test -- tests/<relevant-test>.test.js`
+  - `npx playwright test tests/playwright/<relevant-spec>.spec.js`
+- When CI fails, inspect the failing job and reproduce only the failing or
+  directly related tests locally.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,16 +20,28 @@ Prerequisites: a modern browser (Chrome or Firefox), Node.js for the dev server,
 
 ## Tests
 
+Default to tests related to the files and behavior you changed:
+
 ```bash
-./run-tests.sh
-COVERAGE=1 ./run-tests.sh
+npm test -- tests/<relevant-test>.test.js
+npx playwright test tests/playwright/<relevant-spec>.spec.js
 npx playwright install firefox
 npm run test:firefox
 npm run performance:check
 ```
 
-`./run-tests.sh` auto-starts a server, runs Vitest, the origin guard, and the full Chromium Playwright suite. The Firefox command runs a focused cross-browser check of startup, demo data, navigation, settings, JSON round trips, and offline app-shell readiness. Exit code 0 = all pass. If you add a feature or fix a bug, add assertions to the relevant test file. See the [Testing developer doc](https://docs.getbased.health/developers/testing) for how the harness works.
-`COVERAGE=1 ./run-tests.sh` additionally enforces the combined function-coverage minimum in `scripts/coverage-baseline.json`. Raise that committed minimum when coverage improves; `COVERAGE_MIN` may temporarily demand a stricter local threshold but cannot weaken the repository baseline.
+GitHub Actions owns the exhaustive Chromium and combined-coverage matrix. This
+avoids repeatedly creating large temporary browser profiles and V8 coverage
+snapshots on developer drives. If an exceptional local full run is necessary,
+acknowledge its high write volume explicitly:
+
+```bash
+GETBASED_ALLOW_HIGH_WRITE_TESTS=1 ./run-tests.sh
+GETBASED_ALLOW_HIGH_WRITE_TESTS=1 COVERAGE=1 ./run-tests.sh
+```
+
+`./run-tests.sh` auto-starts a server, runs Vitest, the origin guard, and the full Chromium Playwright suite. `COVERAGE=1` additionally enforces the combined function-coverage minimum in `scripts/coverage-baseline.json`. The commands are blocked outside CI without the explicit environment opt-in above. The Firefox command runs a focused cross-browser check of startup, demo data, navigation, settings, JSON round trips, and offline app-shell readiness. Exit code 0 = all pass. If you add a feature or fix a bug, add assertions to the relevant test file. See the [Testing developer doc](https://docs.getbased.health/developers/testing) for how the harness works.
+Raise the committed coverage minimum when coverage improves; `COVERAGE_MIN` may temporarily demand a stricter threshold but cannot weaken the repository baseline.
 `npm run performance:check` measures the cold mobile app path and enforces the committed request-count, compressed-transfer, and decoded-byte ceilings in `scripts/cold-load-budget.json`.
 
 If you add, remove, rename, or rewire a runtime module, regenerate and inspect the file map:
@@ -44,7 +56,8 @@ npm run architecture:check
 ## Pull request guidelines
 
 - Keep PRs focused. One thing at a time is easier to review.
-- Run `./run-tests.sh` before opening a PR.
+- Run change-scoped tests and relevant lightweight gates before opening a PR;
+  let GitHub Actions run the exhaustive browser and coverage matrix.
 - If you touch any app file (JS, CSS, HTML, manifest), bump the version in `version.js` — this busts the service worker cache for existing users.
 - Commit the regenerated [`MODULE_MAP.md`](MODULE_MAP.md) when runtime modules or imports change.
 - Update [`ARCHITECTURE.md`](ARCHITECTURE.md) when responsibilities, entry points, major data flows, or allowed dependency directions change.

--- a/README.md
+++ b/README.md
@@ -126,15 +126,15 @@ npm run vendor:check
 npm run supply-chain:check
 npm run sbom
 npm run quality
-npm test
+npm test -- tests/<relevant-test>.test.js
+npx playwright test tests/playwright/<relevant-spec>.spec.js
 npm run test:firefox
 npm run performance:check
 npm run production:check
-./run-tests.sh
-COVERAGE=1 ./run-tests.sh
 ```
 
-`./run-tests.sh` runs both type checkers, verifies the architecture map, vendored browser assets and their supply-chain inventory, and the static module graph, starts an isolated local server, runs the Node/Vitest tests, checks the dev-server origin guard, and runs Playwright browser assertions.
+Default to tests related to the current change. GitHub Actions runs the exhaustive browser and combined-coverage matrix so local development does not repeatedly create high volumes of temporary Chromium and V8 coverage data.
+`./run-tests.sh` runs both type checkers, verifies the architecture map, vendored browser assets and their supply-chain inventory, and the static module graph, starts an isolated local server, runs the Node/Vitest tests, checks the dev-server origin guard, and runs every Playwright browser assertion. It is blocked outside CI unless the high-write run is explicitly acknowledged with `GETBASED_ALLOW_HIGH_WRITE_TESTS=1`.
 `COVERAGE=1 ./run-tests.sh` also combines Vitest and Playwright V8 function coverage and enforces the committed ratchet in `scripts/coverage-baseline.json`; CI runs this mode on every change.
 `npm run test:firefox` runs the focused Firefox critical-flow suite; install its browser binary once with `npx playwright install firefox`.
 `npm run performance:check` runs the focused cold mobile-load check and enforces the committed request-count, compressed-transfer, and decoded-byte ceilings.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "supply-chain:snapshot": "node scripts/supply-chain.mjs --snapshot",
     "test": "vitest run",
     "test:firefox": "playwright test --config=playwright.firefox.config.js",
-    "test:playwright": "playwright test",
+    "test:playwright": "node scripts/local-full-suite-guard.mjs && playwright test",
     "typecheck": "tsc -p tsconfig.json",
     "typecheck:checkjs": "tsc -p tsconfig.checkjs.json",
     "typecheck:strict-null": "node scripts/strict-null-ratchet.mjs",

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -5,6 +5,8 @@
 set -e
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
+node "$DIR/scripts/local-full-suite-guard.mjs" || exit 2
+
 PORT=${PORT:-8000}
 REUSE_TEST_SERVER=${REUSE_TEST_SERVER:-0}
 COVERAGE_ENABLED=0

--- a/scripts/local-full-suite-guard.mjs
+++ b/scripts/local-full-suite-guard.mjs
@@ -1,0 +1,41 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const OPT_IN_VARIABLE = 'GETBASED_ALLOW_HIGH_WRITE_TESTS';
+
+function isEnabled(value) {
+  return ['1', 'true', 'yes', 'on'].includes(String(value || '').trim().toLowerCase());
+}
+
+export function fullLocalSuiteDecision(env = {}) {
+  if (isEnabled(env.CI)) {
+    return { allowed: true, source: 'CI' };
+  }
+  if (isEnabled(env[OPT_IN_VARIABLE])) {
+    return { allowed: true, source: OPT_IN_VARIABLE };
+  }
+  return {
+    allowed: false,
+    source: null,
+    message: [
+      'Local full browser suite blocked to protect disk-write endurance.',
+      'Run only the unit or Playwright specs relevant to the current diff.',
+      'GitHub Actions runs the exhaustive browser and coverage matrix.',
+      `After explicit approval for a high-write local run, set ${OPT_IN_VARIABLE}=1.`,
+    ].join('\n'),
+  };
+}
+
+export function runFullLocalSuiteGuard(env = {}, writeError = message => console.error(message)) {
+  const decision = fullLocalSuiteDecision(env);
+  if (decision.allowed) return 0;
+  writeError(decision.message);
+  return 2;
+}
+
+function runCli() {
+  process.exitCode = runFullLocalSuiteGuard(process.env);
+}
+
+const entryPath = process.argv[1] ? path.resolve(process.argv[1]) : '';
+if (entryPath === fileURLToPath(import.meta.url)) runCli();

--- a/tests/local-full-suite-guard.test.js
+++ b/tests/local-full-suite-guard.test.js
@@ -1,0 +1,81 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  fullLocalSuiteDecision,
+  runFullLocalSuiteGuard,
+} from '../scripts/local-full-suite-guard.mjs';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+describe('local full-suite disk-write guard', () => {
+  it('blocks the exhaustive suite by default outside CI', () => {
+    const decision = fullLocalSuiteDecision({});
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.message).toContain('disk-write endurance');
+    expect(decision.message).toContain('GETBASED_ALLOW_HIGH_WRITE_TESTS=1');
+  });
+
+  it.each(['1', 'true', 'YES', 'on'])('allows explicit local opt-in value %s', value => {
+    expect(fullLocalSuiteDecision({
+      GETBASED_ALLOW_HIGH_WRITE_TESTS: value,
+    })).toEqual({
+      allowed: true,
+      source: 'GETBASED_ALLOW_HIGH_WRITE_TESTS',
+    });
+  });
+
+  it.each(['1', 'true', 'YES', 'on'])('allows the exhaustive suite in CI with value %s', value => {
+    expect(fullLocalSuiteDecision({ CI: value })).toEqual({
+      allowed: true,
+      source: 'CI',
+    });
+  });
+
+  it('does not treat false-like environment values as approval', () => {
+    expect(fullLocalSuiteDecision({
+      CI: 'false',
+      GETBASED_ALLOW_HIGH_WRITE_TESTS: '0',
+    }).allowed).toBe(false);
+  });
+
+  it('returns the blocking exit code and explanation without opt-in', () => {
+    let message = '';
+    const exitCode = runFullLocalSuiteGuard({
+      CI: 'false',
+      GETBASED_ALLOW_HIGH_WRITE_TESTS: '0',
+    }, value => {
+      message = value;
+    });
+
+    expect(exitCode).toBe(2);
+    expect(message).toContain('Local full browser suite blocked');
+  });
+
+  it('returns success without an error message in CI', () => {
+    let message = '';
+    const exitCode = runFullLocalSuiteGuard({
+      CI: 'true',
+      GETBASED_ALLOW_HIGH_WRITE_TESTS: '0',
+    }, value => {
+      message = value;
+    });
+
+    expect(exitCode).toBe(0);
+    expect(message).toBe('');
+  });
+
+  it('wires the guard into both exhaustive local entry points', () => {
+    const runTests = fs.readFileSync(path.join(ROOT, 'run-tests.sh'), 'utf8');
+    const packageJson = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
+
+    expect(runTests.indexOf('scripts/local-full-suite-guard.mjs'))
+      .toBeLessThan(runTests.indexOf('npm run typecheck'));
+    expect(packageJson.scripts['test:playwright'])
+      .toMatch(/^node scripts\/local-full-suite-guard\.mjs && /);
+  });
+});


### PR DESCRIPTION
## What
- make change-scoped tests the default in repository agent and contributor guidance
- add a CI-aware guard to `./run-tests.sh` and `npm run test:playwright`
- require `GETBASED_ALLOW_HIGH_WRITE_TESTS=1` for an explicitly approved exhaustive local run
- cover default blocking, CI bypass, explicit opt-in, false-like values, and entry-point wiring

## Why
The previous contributor workflow recommended the complete local browser and coverage matrix before every PR. Repeating that matrix creates substantial transient Chromium profile, cache, IndexedDB, service-worker, and V8 coverage writes. The guidance and tooling had no protection against accidental high-write reruns.

## Impact
Targeted Vitest and Playwright specs remain available normally. Exhaustive local browser commands now stop before launching browsers unless the dedicated opt-in is set. GitHub Actions remains unchanged because CI bypasses the local guard.

## Verification
- `npm test -- tests/local-full-suite-guard.test.js` — 13/13 passed
- `node --check scripts/local-full-suite-guard.mjs`
- `bash -n run-tests.sh`
- `git diff --check`
- confirmed `./run-tests.sh` and `npm run test:playwright` both exit before browser startup without opt-in

No full browser or coverage suite was run locally.