### PR TITLE
Fix mobile chat viewport and thread navigation

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -9,8 +9,8 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 
 | Metric | Current |
 | --- | ---: |
-| Modules | 484 |
-| Internal import edges | 2192 |
+| Modules | 485 |
+| Internal import edges | 2193 |
 | Dynamic internal edges | 93 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -205,7 +205,7 @@ Native browser modules shipped with the static application.
 
 </details>
 
-<details><summary><code>chat</code> family — 39 modules</summary>
+<details><summary><code>chat</code> family — 40 modules</summary>
 
 - [`js/chat-actions.js`](js/chat-actions.js) → [`js/chat-history.js`](js/chat-history.js), [`js/chat-icons.js`](js/chat-icons.js), [`js/chat-message-action-attrs.js`](js/chat-message-action-attrs.js), [`js/chat-runtime.js`](js/chat-runtime.js), [`js/emf-runtime.js`](js/emf-runtime.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/chat-attestation.js`](js/chat-attestation.js) → [`js/utils.js`](js/utils.js)
@@ -230,10 +230,11 @@ Native browser modules shipped with the static application.
 - [`js/chat-loader.js`](js/chat-loader.js) → [`js/app-ai-interaction-modules.js`](js/app-ai-interaction-modules.js) *(dynamic)*
 - [`js/chat-marker-prompts.js`](js/chat-marker-prompts.js) → [`js/chat-history.js`](js/chat-history.js), [`js/chat-panel.js`](js/chat-panel.js), [`js/chat-runtime.js`](js/chat-runtime.js), [`js/chat-threads.js`](js/chat-threads.js), [`js/data.js`](js/data.js), [`js/marker-analysis.js`](js/marker-analysis.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/chat-message-action-attrs.js`](js/chat-message-action-attrs.js) → [`js/utils.js`](js/utils.js)
+- [`js/chat-mobile-viewport.js`](js/chat-mobile-viewport.js) → no in-scope imports
 - [`js/chat-nudge.js`](js/chat-nudge.js) → [`js/api.js`](js/api.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js)
 - [`js/chat-onboarding-host-bindings.js`](js/chat-onboarding-host-bindings.js) → [`js/chat-onboarding.js`](js/chat-onboarding.js)
 - [`js/chat-onboarding.js`](js/chat-onboarding.js) → [`js/api.js`](js/api.js), [`js/constants.js`](js/constants.js), [`js/data-merge.js`](js/data-merge.js), [`js/data.js`](js/data.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
-- [`js/chat-panel.js`](js/chat-panel.js) → [`js/api.js`](js/api.js), [`js/chat-history.js`](js/chat-history.js), [`js/chat-nudge.js`](js/chat-nudge.js), [`js/chat-personalities.js`](js/chat-personalities.js), [`js/chat-summaries.js`](js/chat-summaries.js), [`js/chat-threads.js`](js/chat-threads.js), [`js/lens.js`](js/lens.js), [`js/utils.js`](js/utils.js)
+- [`js/chat-panel.js`](js/chat-panel.js) → [`js/api.js`](js/api.js), [`js/chat-history.js`](js/chat-history.js), [`js/chat-mobile-viewport.js`](js/chat-mobile-viewport.js), [`js/chat-nudge.js`](js/chat-nudge.js), [`js/chat-personalities.js`](js/chat-personalities.js), [`js/chat-summaries.js`](js/chat-summaries.js), [`js/chat-threads.js`](js/chat-threads.js), [`js/lens.js`](js/lens.js), [`js/utils.js`](js/utils.js)
 - [`js/chat-personalities.js`](js/chat-personalities.js) → [`js/api.js`](js/api.js), [`js/chat-attestation.js`](js/chat-attestation.js), [`js/chat-icons.js`](js/chat-icons.js), [`js/chat-runtime.js`](js/chat-runtime.js), [`js/chat-threads.js`](js/chat-threads.js), [`js/constants.js`](js/constants.js), [`js/context-source-registry.js`](js/context-source-registry.js), [`js/lens.js`](js/lens.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/chat-prompt-context.js`](js/chat-prompt-context.js) → no in-scope imports
 - [`js/chat-render-runtime.js`](js/chat-render-runtime.js) → [`js/recommendations-runtime.js`](js/recommendations-runtime.js)

--- a/css/chat-mobile.css
+++ b/css/chat-mobile.css
@@ -5,6 +5,20 @@
 
 /* ═══ Chat thread rail: back button on mobile overlay ═══ */
 @media (max-width: 768px) {
+  /*
+   * Mobile keyboards resize and, on iOS, can also pan the visual viewport
+   * without changing the layout viewport used by position: fixed. Keep both
+   * the header and composer inside the actually visible portion.
+   */
+  .chat-panel.open {
+    top: var(--chat-visual-viewport-top, 0px);
+    bottom: var(--chat-visual-viewport-bottom, 0px);
+  }
+  .chat-panel-conversation {
+    min-height: 0;
+    overflow: hidden;
+  }
+  .chat-messages { min-height: 0; }
   .chat-thread-rail.open .chat-thread-rail-header { padding-top: 10px; }
 }
 

--- a/js/chat-mobile-viewport.js
+++ b/js/chat-mobile-viewport.js
@@ -1,0 +1,136 @@
+// @ts-check
+// Keep the mobile chat chrome inside the visual viewport when the software
+// keyboard resizes or pans it independently of the layout viewport.
+
+const MOBILE_CHAT_QUERY = '(max-width: 768px)';
+const VIEWPORT_TOP_PROPERTY = '--chat-visual-viewport-top';
+const VIEWPORT_BOTTOM_PROPERTY = '--chat-visual-viewport-bottom';
+const PASSIVE_LISTENER_OPTIONS = { passive: true };
+
+/** @type {HTMLElement | null} */
+let activePanel = null;
+/** @type {Window | null} */
+let activeRuntime = null;
+/** @type {VisualViewport | null} */
+let activeVisualViewport = null;
+
+function getRuntimeWindow() {
+  return typeof window !== 'undefined' ? window : null;
+}
+
+function finitePositiveNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : null;
+}
+
+function finiteNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function isMobileChatViewport(runtime) {
+  if (typeof runtime.matchMedia === 'function') {
+    return runtime.matchMedia(MOBILE_CHAT_QUERY).matches;
+  }
+  const width = finitePositiveNumber(runtime.innerWidth);
+  return width != null && width <= 768;
+}
+
+function clearMobileChatViewportInsets(panel) {
+  panel.style.removeProperty(VIEWPORT_TOP_PROPERTY);
+  panel.style.removeProperty(VIEWPORT_BOTTOM_PROPERTY);
+}
+
+/**
+ * Return the portions of the layout viewport hidden above and below the
+ * visual viewport. Android keyboards generally change only the bottom inset;
+ * iOS may also pan the visual viewport, producing a non-zero top inset.
+ *
+ * @param {Window | null} [runtime]
+ * @returns {{ top: number, bottom: number } | null}
+ */
+export function getMobileChatViewportInsets(runtime = getRuntimeWindow()) {
+  const visualViewport = runtime?.visualViewport;
+  if (!runtime || !visualViewport) return null;
+
+  const root = typeof document !== 'undefined' ? document.documentElement : null;
+  const layoutHeight = finitePositiveNumber(runtime.innerHeight)
+    || finitePositiveNumber(root?.clientHeight);
+  const viewportTop = finiteNumber(visualViewport.offsetTop);
+  const viewportHeight = finitePositiveNumber(visualViewport.height);
+  if (layoutHeight == null || viewportTop == null || viewportHeight == null) return null;
+
+  const top = Math.max(0, Math.ceil(viewportTop));
+  const bottom = Math.max(0, Math.ceil(layoutHeight - top - viewportHeight));
+  return { top, bottom };
+}
+
+/**
+ * @param {HTMLElement | null} [panel]
+ */
+export function syncMobileChatViewport(panel = activePanel) {
+  const runtime = getRuntimeWindow();
+  if (!panel) return false;
+  const insets = runtime && isMobileChatViewport(runtime)
+    ? getMobileChatViewportInsets(runtime)
+    : null;
+
+  if (!panel.classList.contains('open') || !insets) {
+    clearMobileChatViewportInsets(panel);
+    return false;
+  }
+
+  panel.style.setProperty(VIEWPORT_TOP_PROPERTY, `${insets.top}px`);
+  panel.style.setProperty(VIEWPORT_BOTTOM_PROPERTY, `${insets.bottom}px`);
+  return true;
+}
+
+function handleMobileChatViewportChange() {
+  syncMobileChatViewport();
+}
+
+/**
+ * @param {HTMLElement | null} panel
+ */
+export function startMobileChatViewportSync(panel) {
+  stopMobileChatViewportSync();
+  if (!panel) return false;
+
+  activePanel = panel;
+  activeRuntime = getRuntimeWindow();
+  activeVisualViewport = activeRuntime?.visualViewport || null;
+
+  activeRuntime?.addEventListener(
+    'resize',
+    handleMobileChatViewportChange,
+    PASSIVE_LISTENER_OPTIONS,
+  );
+  activeVisualViewport?.addEventListener(
+    'resize',
+    handleMobileChatViewportChange,
+    PASSIVE_LISTENER_OPTIONS,
+  );
+  activeVisualViewport?.addEventListener(
+    'scroll',
+    handleMobileChatViewportChange,
+    PASSIVE_LISTENER_OPTIONS,
+  );
+  return syncMobileChatViewport(panel);
+}
+
+export function stopMobileChatViewportSync() {
+  activeRuntime?.removeEventListener(
+    'resize',
+    handleMobileChatViewportChange,
+  );
+  activeVisualViewport?.removeEventListener(
+    'resize',
+    handleMobileChatViewportChange,
+  );
+  activeVisualViewport?.removeEventListener(
+    'scroll',
+    handleMobileChatViewportChange,
+  );
+  if (activePanel) clearMobileChatViewportInsets(activePanel);
+  activePanel = null;
+  activeRuntime = null;
+  activeVisualViewport = null;
+}

--- a/js/chat-panel.js
+++ b/js/chat-panel.js
@@ -12,6 +12,10 @@ import {
 import { renderSavedSummaries } from './chat-summaries.js';
 import { updateLensIndicator } from './lens.js';
 import { dismissCurrentChatNudge } from './chat-nudge.js';
+import {
+  startMobileChatViewportSync,
+  stopMobileChatViewportSync,
+} from './chat-mobile-viewport.js';
 import { showNotification } from './utils.js';
 
 export { setChatNudge, updateChatNudge } from './chat-nudge.js';
@@ -215,6 +219,7 @@ export async function openChatPanel(prefillMessage) {
   if (!panel || !backdrop) return false;
   if (!(await loadChatPresentationStylesheetsForAction())) return false;
   panel.classList.add('open');
+  startMobileChatViewportSync(panel);
   // Restore the user's last fullscreen preference. Persisted in
   // localStorage so reopening chat keeps the mode they chose last.
   // Use toggle(force) so previous-session state is fully overwritten —
@@ -279,6 +284,7 @@ export function updateChatInputState() {
 }
 
 export function closeChatPanel() {
+  stopMobileChatViewportSync();
   document.getElementById('chat-panel')?.classList.remove('open');
   document.getElementById('chat-backdrop')?.classList.remove('open');
   // body.style.overflow no longer set on open (so nothing to restore)

--- a/js/chat-threads.js
+++ b/js/chat-threads.js
@@ -22,6 +22,7 @@ export { filterThreadList, invalidateThreadContentCache, jumpToSearchResult };
 const MAX_THREADS = 50;
 const THREAD_ICON_EDIT = '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>';
 const THREAD_ICON_DELETE = '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18"/><path d="M8 6V4h8v2"/><path d="M19 6l-1 14H6L5 6"/><path d="M10 11v5"/><path d="M14 11v5"/></svg>';
+const MOBILE_THREAD_RAIL_QUERY = '(max-width: 768px)';
 const CHAT_DELETED_PROTO_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 let chatThreadDelegatesInstalled = false;
 let blockedThreadIndexKey = null;
@@ -241,12 +242,14 @@ export function createNewThread({ sync = true } = {}) {
   chatThreadDeps.updateChatHeaderTitle();
   chatThreadDeps.updatePersonalityBar();
   renderThreadList();
+  closeThreadRailAfterMobileSelection();
   // Focus input
   const input = /** @type {HTMLTextAreaElement | null} */ (document.getElementById('chat-input'));
   if (input) input.focus();
 }
 
 export async function switchToThread(threadId) {
+  closeThreadRailAfterMobileSelection();
   if (threadId === state.currentThreadId) return;
   // Save current thread messages
   await chatThreadDeps.saveChatHistory();
@@ -349,6 +352,19 @@ export function pruneOldThreads() {
 // ═══════════════════════════════════════════════
 // THREAD RAIL UI
 // ═══════════════════════════════════════════════
+function closeThreadRailAfterMobileSelection() {
+  const isMobile = typeof matchMedia === 'function'
+    ? matchMedia(MOBILE_THREAD_RAIL_QUERY).matches
+    : typeof innerWidth === 'number' && innerWidth <= 768;
+  if (!isMobile) return false;
+
+  const rail = document.getElementById('chat-thread-rail');
+  if (!rail?.classList.contains('open')) return false;
+  rail.classList.remove('open');
+  localStorage.setItem(`labcharts-${state.currentProfile}-chatRailOpen`, 'false');
+  return true;
+}
+
 /** @param {Event} event */
 function closestThreadAction(event) {
   const target = event.target;

--- a/service-worker.js
+++ b/service-worker.js
@@ -220,6 +220,7 @@ const APP_SHELL = [
   '/js/chat-attestation.js',
   '/js/chat-actions.js',
   '/js/chat-nudge.js',
+  '/js/chat-mobile-viewport.js',
   '/js/chat-panel.js',
   '/js/chat-discussion.js',
   '/js/chat-discussion-callbacks.js',

--- a/tests/chat-mobile-viewport.test.js
+++ b/tests/chat-mobile-viewport.test.js
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  getMobileChatViewportInsets,
+  startMobileChatViewportSync,
+  stopMobileChatViewportSync,
+  syncMobileChatViewport,
+} from '../js/chat-mobile-viewport.js';
+
+const runtimeProperties = ['innerHeight', 'innerWidth', 'matchMedia', 'visualViewport'];
+const savedDescriptors = new Map(
+  runtimeProperties.map(property => [property, Object.getOwnPropertyDescriptor(window, property)]),
+);
+
+function setRuntimeProperty(property, value) {
+  Object.defineProperty(window, property, {
+    configurable: true,
+    writable: true,
+    value,
+  });
+}
+
+function restoreRuntimeProperties() {
+  for (const property of runtimeProperties) {
+    const descriptor = savedDescriptors.get(property);
+    if (descriptor) Object.defineProperty(window, property, descriptor);
+    else delete window[property];
+  }
+}
+
+function installViewport({ height, offsetTop, mobile = true }) {
+  const visualViewport = new EventTarget();
+  Object.assign(visualViewport, { height, offsetTop });
+  setRuntimeProperty('innerHeight', 844);
+  setRuntimeProperty('innerWidth', 390);
+  setRuntimeProperty('matchMedia', () => ({ matches: mobile }));
+  setRuntimeProperty('visualViewport', visualViewport);
+  return visualViewport;
+}
+
+function renderOpenPanel() {
+  document.body.innerHTML = '<aside id="chat-panel" class="chat-panel open"></aside>';
+  return document.getElementById('chat-panel');
+}
+
+describe('mobile chat visual viewport', () => {
+  beforeEach(() => {
+    stopMobileChatViewportSync();
+  });
+
+  afterEach(() => {
+    stopMobileChatViewportSync();
+    restoreRuntimeProperties();
+    document.body.innerHTML = '';
+  });
+
+  it('keeps the panel between iOS-style top and keyboard bottom insets', () => {
+    const visualViewport = installViewport({ height: 500, offsetTop: 96 });
+    const panel = renderOpenPanel();
+
+    expect(getMobileChatViewportInsets()).toEqual({ top: 96, bottom: 248 });
+    expect(startMobileChatViewportSync(panel)).toBe(true);
+    expect(panel.style.getPropertyValue('--chat-visual-viewport-top')).toBe('96px');
+    expect(panel.style.getPropertyValue('--chat-visual-viewport-bottom')).toBe('248px');
+
+    visualViewport.offsetTop = 0;
+    visualViewport.height = 532;
+    visualViewport.dispatchEvent(new Event('resize'));
+
+    expect(panel.style.getPropertyValue('--chat-visual-viewport-top')).toBe('0px');
+    expect(panel.style.getPropertyValue('--chat-visual-viewport-bottom')).toBe('312px');
+  });
+
+  it('clears viewport overrides when the panel closes or leaves mobile layout', () => {
+    installViewport({ height: 500, offsetTop: 0 });
+    const panel = renderOpenPanel();
+
+    startMobileChatViewportSync(panel);
+    panel.classList.remove('open');
+    expect(syncMobileChatViewport(panel)).toBe(false);
+    expect(panel.style.getPropertyValue('--chat-visual-viewport-top')).toBe('');
+    expect(panel.style.getPropertyValue('--chat-visual-viewport-bottom')).toBe('');
+
+    panel.classList.add('open');
+    setRuntimeProperty('matchMedia', () => ({ matches: false }));
+    expect(syncMobileChatViewport(panel)).toBe(false);
+    expect(panel.style.getPropertyValue('--chat-visual-viewport-top')).toBe('');
+    expect(panel.style.getPropertyValue('--chat-visual-viewport-bottom')).toBe('');
+  });
+
+  it('ignores incomplete visual viewport geometry', () => {
+    installViewport({ height: 500, offsetTop: 0 });
+    setRuntimeProperty('visualViewport', { offsetTop: 20 });
+
+    expect(getMobileChatViewportInsets()).toBeNull();
+  });
+});

--- a/tests/playwright/chat-mobile-viewport.spec.js
+++ b/tests/playwright/chat-mobile-viewport.spec.js
@@ -1,0 +1,57 @@
+import { expect, test } from '@playwright/test';
+
+test('mobile chat keeps its header and composer inside the keyboard viewport', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.addInitScript(() => {
+    localStorage.setItem('labcharts-ai-provider', 'ollama');
+    localStorage.setItem('labcharts-legal-acceptance', JSON.stringify({
+      accepted: true,
+      termsVersion: '2026-06-22',
+      privacyVersion: '2026-06-22',
+      acceptedAt: '2026-07-27T00:00:00.000Z',
+      appVersion: 'mobile-chat-test',
+      location: 'mobile-chat-test',
+    }));
+  });
+  await page.goto('/app', { waitUntil: 'load' });
+  await page.evaluate(async () => {
+    await (await import('/js/chat-panel.js')).openChatPanel();
+    const panel = document.getElementById('chat-panel');
+    panel?.style.setProperty('--chat-visual-viewport-top', '96px');
+    panel?.style.setProperty('--chat-visual-viewport-bottom', '248px');
+  });
+
+  await expect(page.locator('#chat-input')).toBeFocused();
+  const keyboardLayout = await page.evaluate(() => {
+    const panel = document.getElementById('chat-panel');
+    const header = document.querySelector('.chat-header');
+    const messages = document.querySelector('.chat-messages');
+    const composer = document.querySelector('.chat-input-area');
+    const rect = element => element?.getBoundingClientRect();
+    return {
+      panel: rect(panel),
+      header: rect(header),
+      messages: rect(messages),
+      composer: rect(composer),
+    };
+  });
+
+  expect(keyboardLayout.panel?.top).toBe(96);
+  expect(keyboardLayout.panel?.bottom).toBe(596);
+  expect(keyboardLayout.panel?.height).toBe(500);
+  expect(keyboardLayout.header?.top).toBeGreaterThanOrEqual(keyboardLayout.panel.top);
+  expect(keyboardLayout.composer?.bottom).toBeLessThanOrEqual(keyboardLayout.panel.bottom);
+  expect(keyboardLayout.messages?.top).toBeGreaterThanOrEqual(keyboardLayout.header.bottom);
+  expect(keyboardLayout.messages?.bottom).toBeLessThanOrEqual(keyboardLayout.composer.top);
+
+  await page.evaluate(() => {
+    const panel = document.getElementById('chat-panel');
+    panel?.style.setProperty('--chat-visual-viewport-top', '0px');
+    panel?.style.setProperty('--chat-visual-viewport-bottom', '0px');
+  });
+  const restoredLayout = await page.locator('#chat-panel').boundingBox();
+  expect(restoredLayout?.y).toBe(0);
+  expect(restoredLayout?.height).toBe(844);
+  await expect(page.locator('.chat-header')).toBeVisible();
+  await expect(page.locator('.chat-input-area')).toBeVisible();
+});

--- a/tests/playwright/chat-threads-dom.spec.js
+++ b/tests/playwright/chat-threads-dom.spec.js
@@ -100,8 +100,13 @@ test('chat thread rail and delegated thread actions work in the live DOM', async
         showPromptDialog: async () => 'Renamed Thread',
       });
       state.currentThreadId = 't_b';
+      rail?.classList.add('open');
+      localStorage.setItem(railKey, 'true');
       threadItem?.click();
       outcomes.threadItemClickSwitchesThread = await waitFor(() => state.currentThreadId === 't_a');
+      outcomes.desktopThreadSelectionKeepsSplitRailOpen =
+        rail?.classList.contains('open') === true
+        && localStorage.getItem(railKey) === 'true';
 
       document.querySelector('.chat-thread-item[data-thread-id="t_a"] .chat-thread-item-action')?.click();
       outcomes.renameButtonRenamesThread = await waitFor(() =>
@@ -151,6 +156,86 @@ test('chat thread rail and delegated thread actions work in the live DOM', async
       else localStorage.setItem(railKey, originalRailState);
       if (originalThreads.length > 0) chatThreads.saveChatThreadIndex();
       else localStorage.removeItem(chatThreads.getChatThreadsKey());
+      chatThreads.renderThreadList();
+    }
+
+    return outcomes;
+  });
+
+  for (const [name, passed] of Object.entries(results)) {
+    expect(passed, name).toBe(true);
+  }
+});
+
+test('mobile thread selection and creation return directly to the chat', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/app', { waitUntil: 'load' });
+
+  const results = await page.evaluate(async () => {
+    const chatThreads = await import('/js/chat-threads.js');
+    const { state } = await import('/js/state.js');
+    const rail = document.getElementById('chat-thread-rail');
+    const railKey = `labcharts-${state.currentProfile}-chatRailOpen`;
+    const originalThreads = state.chatThreads;
+    const originalThreadId = state.currentThreadId;
+    const originalRailState = localStorage.getItem(railKey);
+    const outcomes = {};
+    const waitFor = async (fn, timeoutMs = 500) => {
+      const start = Date.now();
+      while (Date.now() - start < timeoutMs) {
+        if (fn()) return true;
+        await new Promise(resolve => setTimeout(resolve, 20));
+      }
+      return false;
+    };
+    const previousDeps = chatThreads.configureChatThreadDeps({
+      saveChatHistory: async () => {},
+      loadChatHistory: async () => {},
+      cleanupDiscussionState: () => {},
+      restoreDiscussionContinuePrompt: () => {},
+      renderChatMessages: () => {},
+      renderSavedSummaries: () => {},
+      updateChatHeaderTitle: () => {},
+      updatePersonalityBar: () => {},
+      getActivePersonality: () => ({ name: 'Default', icon: '' }),
+    });
+
+    try {
+      const now = new Date().toISOString();
+      state.chatThreads = [
+        { id: 'mobile-a', name: 'First conversation', createdAt: now, updatedAt: now, messageCount: 2, personality: 'default' },
+        { id: 'mobile-b', name: 'Second conversation', createdAt: now, updatedAt: now, messageCount: 1, personality: 'default' },
+      ];
+      state.currentThreadId = 'mobile-b';
+      chatThreads.renderThreadList();
+      rail?.classList.add('open');
+      localStorage.setItem(railKey, 'true');
+
+      document.querySelector('.chat-thread-item[data-thread-id="mobile-a"]')?.click();
+      outcomes.selectingThreadClosesMobileRail =
+        await waitFor(() => state.currentThreadId === 'mobile-a')
+        && rail?.classList.contains('open') === false
+        && localStorage.getItem(railKey) === 'false';
+
+      rail?.classList.add('open');
+      localStorage.setItem(railKey, 'true');
+      document.querySelector('.chat-thread-item[data-thread-id="mobile-a"]')?.click();
+      outcomes.selectingActiveThreadAlsoClosesMobileRail =
+        rail?.classList.contains('open') === false
+        && localStorage.getItem(railKey) === 'false';
+
+      rail?.classList.add('open');
+      localStorage.setItem(railKey, 'true');
+      chatThreads.createNewThread({ sync: false });
+      outcomes.creatingThreadClosesMobileRail =
+        rail?.classList.contains('open') === false
+        && localStorage.getItem(railKey) === 'false';
+    } finally {
+      chatThreads.configureChatThreadDeps(previousDeps);
+      state.chatThreads = originalThreads;
+      state.currentThreadId = originalThreadId;
+      if (originalRailState == null) localStorage.removeItem(railKey);
+      else localStorage.setItem(railKey, originalRailState);
       chatThreads.renderThreadList();
     }
 

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -79,6 +79,7 @@
     "js/chat-nudge.js",
     "js/chat-onboarding-host-bindings.js",
     "js/chat-onboarding.js",
+    "js/chat-mobile-viewport.js",
     "js/chat-panel.js",
     "js/chat-personalities.js",
     "js/chat-prompt-context.js",


### PR DESCRIPTION
## What changed

- keep the mobile chat header and composer inside the visual viewport while the software keyboard opens, resizes, or pans the page
- clean up visual-viewport listeners when the chat closes
- return directly to the chat after selecting an active or inactive conversation on mobile
- return directly to the composer after creating a conversation on mobile
- preserve the existing desktop split-rail behavior and keep rename/delete actions in the conversation list
- add focused unit and Chromium regression coverage

## Why

Mobile browsers can move the visual viewport independently of the fixed layout viewport when the software keyboard opens. The chat panel remained anchored to the layout viewport, which could hide either its header or composer. Separately, the mobile conversation rail is a full-screen overlay but thread selection did not dismiss it, requiring an extra tap on the back control.

## User impact

The header and input now remain visible while typing on mobile, and choosing or creating a conversation takes the user straight back to the chat. Desktop behavior is unchanged.

## Validation

- `npm test -- tests/chat-mobile-viewport.test.js`
- `node tests/test-chat-threads.js`
- `npx playwright test tests/playwright/chat-mobile-viewport.spec.js --workers=1`
- focused mobile and desktop cases in `tests/playwright/chat-threads-dom.spec.js`
- `npm run typecheck:checkjs`
- `npm run quality`
- `npm run architecture:check`
- `git diff --check`