### PR TITLE
Improve Biology Coherence theme contrast

### DIFF
--- a/css/dashboard-widgets.css
+++ b/css/dashboard-widgets.css
@@ -558,7 +558,7 @@
   height: 100%;
   border-radius: 50%;
   background:
-    radial-gradient(circle, var(--bg-card) 56%, transparent 58%),
+    radial-gradient(circle, var(--biology-coherence-center-bg, var(--bg-card)) 56%, transparent 58%),
     conic-gradient(
       var(--accent) calc(var(--bc-score) * 1%),
       color-mix(in srgb, var(--accent) 20%, var(--border)) 0
@@ -568,7 +568,7 @@
 .db-bio-coherence-excellent .db-bio-coherence-ring,
 .db-bio-coherence-good .db-bio-coherence-ring {
   background:
-    radial-gradient(circle, var(--bg-card) 56%, transparent 58%),
+    radial-gradient(circle, var(--biology-coherence-center-bg, var(--bg-card)) 56%, transparent 58%),
     conic-gradient(
       var(--green, #22c55e) calc(var(--bc-score) * 1%),
       color-mix(in srgb, var(--green, #22c55e) 20%, var(--border)) 0
@@ -577,7 +577,7 @@
 }
 .db-bio-coherence-strained .db-bio-coherence-ring {
   background:
-    radial-gradient(circle, var(--bg-card) 56%, transparent 58%),
+    radial-gradient(circle, var(--biology-coherence-center-bg, var(--bg-card)) 56%, transparent 58%),
     conic-gradient(
       var(--yellow, #f59e0b) calc(var(--bc-score) * 1%),
       color-mix(in srgb, var(--yellow, #f59e0b) 20%, var(--border)) 0
@@ -588,7 +588,7 @@
 .db-bio-coherence-concerning .db-bio-coherence-ring,
 .db-bio-coherence-severe .db-bio-coherence-ring {
   background:
-    radial-gradient(circle, var(--bg-card) 56%, transparent 58%),
+    radial-gradient(circle, var(--biology-coherence-center-bg, var(--bg-card)) 56%, transparent 58%),
     conic-gradient(
       var(--red, #ef4444) calc(var(--bc-score) * 1%),
       color-mix(in srgb, var(--red, #ef4444) 20%, var(--border)) 0

--- a/js/changelog-impl.js
+++ b/js/changelog-impl.js
@@ -11,6 +11,14 @@ const changelogDelegateRoots = new WeakSet();
 
 const CHANGELOG = [
   {
+    version: '1.10.397', date: '2026-07-27', title: 'Smoother mobile chat and clearer Biology Scores',
+    items: [
+      '<b>Chat is smoother on mobile.</b> The header and message box stay visible while typing, and choosing or starting a conversation takes you straight back to the chat.',
+      '<b>Biology Coherence is easier to read.</b> The score circle now has better contrast in the Glass / Liquid, Synth Sunrise, and Neuromancer themes.',
+      '<b>General fixes and improvements.</b> This update also includes codebase improvements, bug fixes, and small usability refinements.',
+    ]
+  },
+  {
     version: '1.10.320', date: '2026-07-21', title: 'Faster, clearer app updates',
     items: [
       '<b>App updates finish faster and show their progress.</b> The update banner now displays a themed progress bar, percentage, file count, and elapsed time while the complete offline app is refreshed.',

--- a/tests/playwright/biology-scores-dashboard-lens.spec.js
+++ b/tests/playwright/biology-scores-dashboard-lens.spec.js
@@ -1,5 +1,30 @@
 import { expect, test } from './coverage-fixture.js';
 
+const TRANSLUCENT_THEMES = ['glass', 'synth-sunrise', 'neuromancer'];
+
+function parseCssColor(value) {
+  const match = String(value || '').match(/rgba?\(([^)]+)\)/i);
+  if (!match) return null;
+  const parts = match[1].split(',').map(part => part.trim());
+  return {
+    r: Number(parts[0]),
+    g: Number(parts[1]),
+    b: Number(parts[2]),
+    a: parts[3] === undefined ? 1 : Number(parts[3]),
+  };
+}
+
+function luminance(channel) {
+  const value = channel / 255;
+  return value <= 0.03928 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+}
+
+function contrastRatio(foreground, background) {
+  const fg = 0.2126 * luminance(foreground.r) + 0.7152 * luminance(foreground.g) + 0.0722 * luminance(foreground.b);
+  const bg = 0.2126 * luminance(background.r) + 0.7152 * luminance(background.g) + 0.0722 * luminance(background.b);
+  return (Math.max(fg, bg) + 0.05) / (Math.min(fg, bg) + 0.05);
+}
+
 async function prepareDemoProfile(page) {
   await page.goto('/app', { waitUntil: 'load' });
   await page.waitForFunction(async () => {
@@ -60,6 +85,52 @@ test('dashboard renders Biological Coherence hero and domain rows', async ({ pag
   const firstRow = domainRows.first();
   await expect(firstRow).toHaveAttribute('data-biology-score-action', 'jump-to-domain');
   await expect(firstRow).toHaveAttribute('data-biology-score-id', /.+/);
+});
+
+test('translucent themes keep the dashboard coherence score center readable', async ({ page }) => {
+  await prepareDemoProfile(page);
+  await page.evaluate(async () => {
+    (await import('/js/views.js')).navigate('dashboard');
+    await new Promise(r => setTimeout(r, 300));
+  });
+
+  const hero = page.locator('[data-widget-id="biology-score-biologicalCoherence"]').first();
+  await expect(hero.locator('.db-bio-coherence-ring')).toBeVisible();
+
+  for (const theme of TRANSLUCENT_THEMES) {
+    await page.evaluate(async nextTheme => {
+      await (await import('/js/theme.js')).setTheme(nextTheme);
+      await new Promise(requestAnimationFrame);
+    }, theme);
+
+    const styles = await hero.evaluate(element => {
+      const ring = element.querySelector('.db-bio-coherence-ring');
+      const number = element.querySelector('.db-bio-coherence-number strong');
+      const rootStyle = getComputedStyle(document.documentElement);
+      const centerToken = rootStyle.getPropertyValue('--biology-coherence-center-bg').trim();
+      const probe = document.createElement('span');
+      probe.style.backgroundColor = centerToken;
+      document.body.appendChild(probe);
+      const centerColor = getComputedStyle(probe).backgroundColor;
+      probe.remove();
+      return {
+        centerColor,
+        numberColor: number ? getComputedStyle(number).color : '',
+        ringBackground: ring ? getComputedStyle(ring).backgroundImage : '',
+      };
+    });
+
+    const foreground = parseCssColor(styles.numberColor);
+    const center = parseCssColor(styles.centerColor);
+    expect(foreground, `${theme} score color ${styles.numberColor}`).toBeTruthy();
+    expect(center, `${theme} center color ${styles.centerColor}`).toBeTruthy();
+    expect(center.a, `${theme} center must be opaque`).toBe(1);
+    expect(styles.ringBackground, `${theme} ring must use ${styles.centerColor}`).toContain(styles.centerColor);
+    expect(
+      contrastRatio(foreground, center),
+      `${theme} score contrast (${styles.numberColor} on ${styles.centerColor})`,
+    ).toBeGreaterThanOrEqual(4.5);
+  }
 });
 
 test('dashboard coherence domain row navigates to Biology Scores lens and scrolls to score', async ({ page }) => {

--- a/tests/test-biology-scores.js
+++ b/tests/test-biology-scores.js
@@ -1088,7 +1088,16 @@ assert('removed mito-thyroid experiment is not kept in the service worker app sh
   !swSrc.includes('/js/biology-score-mitothyroid.js'),
   swSrc.slice(swSrc.indexOf('/js/biology-scores.js'), swSrc.indexOf('/js/profile-context.js')));
 const dashboardWidgetsCss = fs.readFileSync(path.join(ROOT, 'css/dashboard-widgets.css'), 'utf8');
+const extraThemesCss = fs.readFileSync(path.join(ROOT, 'themes-extra.css'), 'utf8');
 assert('collapsed scores needing data have explicit spacing between cards', dashboardWidgetsCss.includes('.biology-score-unavailable-group .biology-score-detail + .biology-score-detail') && dashboardWidgetsCss.includes('margin-top: 16px'));
+assert('translucent themes give the dashboard coherence score an opaque center',
+  (dashboardWidgetsCss.match(/var\(--biology-coherence-center-bg, var\(--bg-card\)\)/g) || []).length === 4
+  && extraThemesCss.includes('[data-theme="glass"]')
+  && extraThemesCss.includes('--biology-coherence-center-bg: #261e48')
+  && extraThemesCss.includes('[data-theme="synth-sunrise"]')
+  && extraThemesCss.includes('--biology-coherence-center-bg: #1c0e40')
+  && extraThemesCss.includes('[data-theme="neuromancer"]')
+  && extraThemesCss.includes('--biology-coherence-center-bg: #080b10'));
 const biologyScoreRenderSrc = fs.readFileSync(path.join(ROOT, 'js/biology-score-render.js'), 'utf8');
 const biologyScoreRailCss = dashboardWidgetsCss.slice(dashboardWidgetsCss.indexOf('.biology-score-rail-fill'), dashboardWidgetsCss.indexOf('.biology-score-pin'));
 const dashboardCoherenceToneCss = dashboardWidgetsCss.slice(dashboardWidgetsCss.indexOf('.db-bio-coherence-excellent .db-bio-coherence-ring'), dashboardWidgetsCss.indexOf('.db-bio-coherence-number'));

--- a/tests/test-changelog.js
+++ b/tests/test-changelog.js
@@ -127,6 +127,11 @@ assert('version.js sets APP_VERSION', versionMatch !== null, versionMatch ? `'${
 assert('APP_VERSION is semver', versionMatch && /^\d+\.\d+\.\d+/.test(versionMatch[1]), versionMatch ? versionMatch[1] : '');
 const latestChangelogVersion = changelogSrc.match(/version:\s*'([^']+)'/)?.[1] || '';
 assert('APP_VERSION is at least latest changelog entry', appVersion && latestChangelogVersion && semverGte(appVersion, latestChangelogVersion), `${appVersion} < ${latestChangelogVersion}`);
+assert('latest changelog gives a simple overview of mobile chat, Biology Coherence contrast, and general improvements',
+  /version:\s*'1\.10\.397'[\s\S]{0,500}Smoother mobile chat and clearer Biology Scores/.test(changelogSrc)
+    && /version:\s*'1\.10\.397'[\s\S]{0,1200}Chat is smoother on mobile/.test(changelogSrc)
+    && /version:\s*'1\.10\.397'[\s\S]{0,1200}Biology Coherence is easier to read/.test(changelogSrc)
+    && /version:\s*'1\.10\.397'[\s\S]{0,1200}General fixes and improvements/.test(changelogSrc));
 assert('latest changelog gives a simple high-level lab chart overview',
   /version:\s*'1\.10\.305'[\s\S]{0,500}Clearer lab trends at a glance/.test(changelogSrc)
     && /version:\s*'1\.10\.305'[\s\S]{0,1200}A consistent timeline across lab charts/.test(changelogSrc)

--- a/themes-extra.css
+++ b/themes-extra.css
@@ -64,6 +64,7 @@
   --bg-primary: #0a0817;
   --bg-secondary: rgba(28, 22, 56, 0.5);
   --bg-card: rgba(38, 30, 72, 0.35);
+  --biology-coherence-center-bg: #261e48;
   --sync-popover-bg: #181230;
   --bg-hover: rgba(50, 40, 92, 0.45);
   --border: rgba(255, 255, 255, 0.12);
@@ -155,6 +156,7 @@
   --bg-primary: #0d0524;
   --bg-secondary: #150830;
   --bg-card: rgba(28, 14, 64, 0.65);
+  --biology-coherence-center-bg: #1c0e40;
   --sync-popover-bg: #150830;
   --bg-hover: rgba(40, 22, 80, 0.75);
   --border: rgba(255, 43, 214, 0.35);
@@ -240,6 +242,7 @@
   --bg-primary: #050608;
   --bg-secondary: #0a0d12;
   --bg-card: rgba(8, 11, 16, 0.7);
+  --biology-coherence-center-bg: #080b10;
   --sync-popover-bg: #0a0d12;
   --bg-hover: rgba(14, 20, 28, 0.85);
   --border: rgba(0, 229, 255, 0.22);


### PR DESCRIPTION
## What changed
- Give the Biology Coherence score an opaque, theme-matched center in Glass / Liquid, Synth Sunrise, and Neuromancer.
- Preserve the existing rendering in all other themes.
- Add a concise v1.10.397 changelog entry covering this and the recent mobile-chat improvements.
- Add source-level and Chromium contrast regressions.

## Why
The affected themes intentionally use translucent card backgrounds. The score ring reused that token for its center, allowing the conic ring color to bleed through behind the score and reducing readability.

## User impact
The Biology Coherence score is clearer in the three affected themes, while other themes remain unchanged. The changelog now summarizes the recent UX improvements.

## Validation
- `node tests/test-biology-scores.js`
- Focused Playwright test (`--grep "translucent themes"`)
- `node tests/test-changelog.js`
- `npm run typecheck:checkjs`
- `npm run quality`
- `git diff --check`