### PR TITLE
Eliminate crypto UI strict-null debt

### DIFF
--- a/js/crypto.js
+++ b/js/crypto.js
@@ -478,7 +478,7 @@ function renderPassphraseForm(overlay, onSuccess) {
   if (!input || !btn || !errorEl || !forgotBtn) return;
   overlay.style.display = 'flex';
 
-  async function attemptUnlock() {
+  const attemptUnlock = async () => {
     const passphrase = input.value;
     if (!passphrase) { errorEl.textContent = 'Please enter your passphrase'; return; }
     btn.disabled = true;
@@ -517,7 +517,7 @@ function renderPassphraseForm(overlay, onSuccess) {
       btn.textContent = 'Unlock';
       input.focus();
     }
-  }
+  };
 
   btn.addEventListener('click', attemptUnlock);
   input.addEventListener('keydown', (e) => {
@@ -634,7 +634,7 @@ export function showEnableEncryptionModal() {
   const barColors = ['var(--red)', 'var(--orange)', 'var(--yellow)', 'var(--green)'];
   let migrationStarted = false;
 
-  function updateStrengthMeter() {
+  const updateStrengthMeter = () => {
     const p = input1.value;
     const score = getPassphraseStrength(p);
     strengthBars.forEach((bar, i) => {
@@ -643,7 +643,7 @@ export function showEnableEncryptionModal() {
     // Update checklist
     const checks = [p.length >= 8, /[a-z]/.test(p), /[A-Z]/.test(p), /[!@#$%^&*()\-_=+\[\]{};:'",.<>?/\\|`~]/.test(p)];
     ruleItems.forEach((li, i) => li.classList.toggle('met', checks[i]));
-  }
+  };
   input1.addEventListener('input', updateStrengthMeter);
 
   cancelBtn.addEventListener('click', () => {
@@ -678,10 +678,8 @@ export function showEnableEncryptionModal() {
       overlay.style.display = 'none';
       overlay.innerHTML = '';
       showNotification('Encryption enabled \u2014 keep your passphrase safe', 'success');
-      // Refresh settings UI
-      if (document.getElementById('encryption-section')) {
-        document.getElementById('encryption-section').innerHTML = renderEncryptionSection();
-      }
+      const section = document.getElementById('encryption-section');
+      if (section) section.innerHTML = renderEncryptionSection();
     } catch (err) {
       errorEl.textContent = 'Encryption failed: ' + getErrorMessage(err);
       btn.disabled = false;
@@ -719,12 +717,14 @@ export function maybeShowEncryptionNudge() {
         </div>
       </div>`;
     overlay.style.display = 'flex';
-    document.getElementById('encryption-nudge-dismiss').addEventListener('click', () => {
+    const dismissBtn = document.getElementById('encryption-nudge-dismiss'), enableBtn = document.getElementById('encryption-nudge-enable');
+    if (!dismissBtn || !enableBtn) return;
+    dismissBtn.addEventListener('click', () => {
       localStorage.setItem('labcharts-encryption-nudge-dismissed', 'true');
       overlay.style.display = 'none';
       overlay.innerHTML = '';
     });
-    document.getElementById('encryption-nudge-enable').addEventListener('click', () => {
+    enableBtn.addEventListener('click', () => {
       overlay.style.display = 'none';
       overlay.innerHTML = '';
       showEnableEncryptionModal();
@@ -794,12 +794,15 @@ export function maybeShowBackupNudge() {
         </div>
       </div>`;
     el.style.display = 'flex';
-    document.getElementById('backup-nudge-snooze').addEventListener('click', () => {
+    const snoozeBtn = document.getElementById('backup-nudge-snooze'),
+      downloadBtn = document.getElementById('backup-nudge-download');
+    if (!snoozeBtn || !downloadBtn) return;
+    snoozeBtn.addEventListener('click', () => {
       localStorage.setItem('labcharts-backup-nudge-snoozed-until', String(Date.now() + THIRTY_DAYS));
       el.style.display = 'none';
       el.innerHTML = '';
     });
-    document.getElementById('backup-nudge-download').addEventListener('click', () => {
+    downloadBtn.addEventListener('click', () => {
       el.style.display = 'none';
       el.innerHTML = '';
       exportEncryptedBackup();
@@ -934,9 +937,8 @@ export async function disableEncryption() {
       _sessionKey = null;
       clearKeyCache();
       showNotification('Encryption disabled', 'info');
-      if (document.getElementById('encryption-section')) {
-        document.getElementById('encryption-section').innerHTML = renderEncryptionSection();
-      }
+      const section = document.getElementById('encryption-section');
+      if (section) section.innerHTML = renderEncryptionSection();
     } catch (err) {
       showNotification('Failed to disable encryption: ' + getErrorMessage(err), 'error');
     }

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 501,
+  "totalDiagnostics": 482,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -35,7 +35,6 @@
     "js/compare-correlations.js": 7,
     "js/context-card-lifestyle-editors-impl.js": 2,
     "js/context-source-registry.js": 1,
-    "js/crypto.js": 19,
     "js/cycle-import-adapters.js": 1,
     "js/cycle-import-file.js": 2,
     "js/cycle-import.js": 3,

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.397';
+self.APP_VERSION = '1.10.398';


### PR DESCRIPTION
## What changed

- Preserve non-null modal control contracts across unlock and strength-meter callbacks.
- Guard encryption and backup nudge controls before binding events.
- Safely refresh the optional Security settings section.
- Reduce the strict-null baseline from 501 diagnostics across 143 files to 482 across 142 files.
- Bump the app version to 1.10.398.

## Why

`crypto.js` was the largest remaining strict-null hotspot, with 19 diagnostics concentrated around dynamically rendered passphrase, encryption, and backup controls. The runtime behavior already depended on those controls, but the contracts were not expressed safely across callbacks.

## Impact

No encryption algorithms, key handling, storage formats, or user-visible workflows changed. Missing dynamic controls now fail closed instead of throwing, and the ratchet prevents this debt from returning.

## Validation

- `node tests/test-crypto.js` — 298 passed
- `PORT=8141 npx playwright test tests/playwright/crypto-browser-coverage.spec.js --workers=1` — 3 passed
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run typecheck:strict-null`
- `npm run quality`
- `npm run architecture:check`
- `npm run production:check`
- `git diff --check`