### PR TITLE
Eliminate cycle domain strict-null debt

### DIFF
--- a/js/cycle-summary.js
+++ b/js/cycle-summary.js
@@ -25,6 +25,10 @@ const FLOW_ALIASES = {
   high: 'heavy',
 };
 
+/**
+ * @param {unknown} value
+ * @returns {value is Record<string, any>}
+ */
 function isPlainObject(value) {
   return !!value && typeof value === 'object' && !Array.isArray(value);
 }
@@ -210,6 +214,19 @@ export function normalizeCyclePeriod(period, {
   };
 }
 
+/**
+ * @param {{
+ *   startDate: string,
+ *   endDate?: string | null,
+ *   flow?: string,
+ *   symptoms?: string[],
+ *   notes?: string,
+ *   source?: string,
+ *   confidence?: string,
+ *   updatedAt?: string,
+ *   importId?: string | null,
+ * }} period
+ */
 export function createCyclePeriod({
   startDate,
   endDate,
@@ -235,6 +252,11 @@ export function createCyclePeriod({
   }, { defaultSource: source, defaultUpdatedAt: updatedAt });
 }
 
+/**
+ * @param {unknown} periods
+ * @param {Record<string, any>} [options]
+ * @returns {Array<Record<string, any>>}
+ */
 export function normalizeCyclePeriods(periods, options = {}) {
   if (!Array.isArray(periods)) return [];
   const byStart = new Map();
@@ -263,6 +285,53 @@ export function summarizeCyclePeriods(periods) {
     regularity: regularityFromIntervals(intervals),
     flow,
   };
+}
+
+export function calculateCycleStats(periods) {
+  /** @type {{ cycleLength: number | null, periodLength: number | null, regularity: 'regular' | 'irregular' | 'very_irregular' | null, flow: string | null }} */
+  const result = { cycleLength: null, periodLength: null, regularity: null, flow: null };
+  if (!periods || periods.length === 0) return result;
+  const sorted = periods.slice().sort((a, b) => a.startDate.localeCompare(b.startDate));
+
+  const periodLengths = sorted.filter(p => p.endDate).map(p => {
+    const start = new Date(p.startDate + 'T00:00:00');
+    const end = new Date(p.endDate + 'T00:00:00');
+    return Math.round((end.getTime() - start.getTime()) / DAY_MS) + 1;
+  });
+  if (periodLengths.length > 0) {
+    const avgPeriod = Math.round(periodLengths.reduce((a, b) => a + b, 0) / periodLengths.length);
+    result.periodLength = clamp(avgPeriod, 2, 10);
+  }
+
+  const recent = sorted.slice(-6).filter(p => p.flow);
+  if (recent.length > 0) {
+    const counts = {};
+    for (const p of recent) counts[p.flow] = (counts[p.flow] || 0) + 1;
+    result.flow = Object.entries(counts).sort((a, b) => b[1] - a[1])[0][0];
+  }
+
+  if (sorted.length >= 2) {
+    const cycleLengths = [];
+    for (let i = 1; i < sorted.length; i++) {
+      const prev = new Date(sorted[i - 1].startDate + 'T00:00:00');
+      const curr = new Date(sorted[i].startDate + 'T00:00:00');
+      cycleLengths.push(Math.round((curr.getTime() - prev.getTime()) / DAY_MS));
+    }
+    const avgCycle = Math.round(cycleLengths.reduce((a, b) => a + b, 0) / cycleLengths.length);
+    // Preserve long irregular and perimenopause cycles; the former 45-day
+    // ceiling shifted predicted draw windows by weeks.
+    result.cycleLength = clamp(avgCycle, 20, 90);
+    if (cycleLengths.length >= 2) {
+      const mean = cycleLengths.reduce((a, b) => a + b, 0) / cycleLengths.length;
+      const variance = cycleLengths.reduce((sum, value) => sum + (value - mean) ** 2, 0) / cycleLengths.length;
+      const deviation = Math.sqrt(variance);
+      if (deviation <= 2) result.regularity = 'regular';
+      else if (deviation <= 7) result.regularity = 'irregular';
+      else result.regularity = 'very_irregular';
+    }
+  }
+
+  return result;
 }
 
 export function buildCycleHistorySummary(periods) {
@@ -300,6 +369,10 @@ export function buildCycleHistorySummary(periods) {
   };
 }
 
+/**
+ * @param {unknown} periods
+ * @param {Record<string, any> | null} [previousCoverage]
+ */
 export function buildCycleCoverage(periods, previousCoverage = null) {
   const normalized = normalizeCyclePeriods(periods);
   const previousSources = isPlainObject(previousCoverage?.sources) ? previousCoverage.sources : {};
@@ -345,6 +418,7 @@ export function upgradeMenstrualCycleProfile(mc, {
   });
   const stats = summarizeCyclePeriods(periods);
   const cycleStatus = mc.cycleStatus || mc.status || 'regular';
+  /** @type {Record<string, any>} */
   const next = {
     ...mc,
     schemaVersion: 2,
@@ -384,7 +458,9 @@ export function stitchCyclePeriodsFromObservations(observations, {
     .filter(row => isPlainObject(row) && isISODate(row.date) && observationFlow(row))
     .slice()
     .sort((a, b) => a.date.localeCompare(b.date));
+  /** @type {Array<Record<string, any>>} */
   const periods = [];
+  /** @type {{ days: Array<Record<string, any>>, symptoms: any[] } | null} */
   let current = null;
   let prevDate = null;
   const closeCurrent = () => {

--- a/js/cycle.js
+++ b/js/cycle.js
@@ -6,7 +6,7 @@ import { escapeHTML, showNotification, showConfirmDialog, linearRegression } fro
 import { saveImportedData } from './data.js';
 import { openModalOverlay } from './modal-lifecycle.js';
 import { startCycleTour } from './tour.js';
-import { createCyclePeriod, recentCyclePeriods, upgradeMenstrualCycleProfile } from './cycle-summary.js';
+import { calculateCycleStats, createCyclePeriod, recentCyclePeriods, upgradeMenstrualCycleProfile } from './cycle-summary.js';
 import { clearCycleProfileData, renderCycleImportPickerControls, renderCycleImportSummarySection } from './cycle-import-loader.js';
 import { recordContextCardChangeRuntime } from './context-cards-runtime.js';
 import { closeCycleModalRuntime, configureCycleAnalysisBridge, isCycleStylesheetLoaded, loadCycleStylesheetForAction, navigateCycleViewRuntime } from './cycle-runtime.js';
@@ -88,6 +88,7 @@ function initCycleActionDelegates() {
   document.addEventListener('change', handleCycleChange);
 }
 initCycleActionDelegates();
+export { calculateCycleStats };
 /**
  * @param {string | null | undefined} id
  * @returns {HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement | null}
@@ -220,57 +221,6 @@ export function getBloodDrawPhases(mc, dates) {
     if (p) phases[d] = p;
   }
   return phases;
-}
-
-export function calculateCycleStats(periods) {
-  const result = { cycleLength: null, periodLength: null, regularity: null, flow: null };
-  if (!periods || periods.length === 0) return result;
-  const sorted = periods.slice().sort((a, b) => a.startDate.localeCompare(b.startDate));
-
-  // Average period length (1+ periods with valid endDate)
-  const periodLengths = sorted.filter(p => p.endDate).map(p => {
-    const start = new Date(p.startDate + 'T00:00:00');
-    const end = new Date(p.endDate + 'T00:00:00');
-    return Math.round((end.getTime() - start.getTime()) / 86400000) + 1;
-  });
-  if (periodLengths.length > 0) {
-    const avgPeriod = Math.round(periodLengths.reduce((a, b) => a + b, 0) / periodLengths.length);
-    result.periodLength = Math.max(2, Math.min(10, avgPeriod));
-  }
-
-  // Most common flow from recent entries (up to last 6)
-  const recent = sorted.slice(-6).filter(p => p.flow);
-  if (recent.length > 0) {
-    const counts = {};
-    for (const p of recent) counts[p.flow] = (counts[p.flow] || 0) + 1;
-    result.flow = Object.entries(counts).sort((a, b) => b[1] - a[1])[0][0];
-  }
-
-  // Cycle lengths between consecutive period starts (2+ periods)
-  if (sorted.length >= 2) {
-    const cycleLengths = [];
-    for (let i = 1; i < sorted.length; i++) {
-      const prev = new Date(sorted[i - 1].startDate + 'T00:00:00');
-      const curr = new Date(sorted[i].startDate + 'T00:00:00');
-      cycleLengths.push(Math.round((curr.getTime() - prev.getTime()) / 86400000));
-    }
-    const avgCycle = Math.round(cycleLengths.reduce((a, b) => a + b, 0) / cycleLengths.length);
-    // 90-day ceiling covers normal cycles, oligomenorrhea, and perimenopause.
-    // The old 45-day clamp silently truncated 60–90 day cycles, throwing off
-    // getNextBestDrawDate prediction by weeks for both irregular runs and
-    // regular-but-long perimenopause cycles.
-    result.cycleLength = Math.max(20, Math.min(90, avgCycle));
-    if (cycleLengths.length >= 2) {
-      const mean = cycleLengths.reduce((a, b) => a + b, 0) / cycleLengths.length;
-      const variance = cycleLengths.reduce((sum, v) => sum + (v - mean) ** 2, 0) / cycleLengths.length;
-      const stdev = Math.sqrt(variance);
-      if (stdev <= 2) result.regularity = 'regular';
-      else if (stdev <= 7) result.regularity = 'irregular';
-      else result.regularity = 'very_irregular';
-    }
-  }
-
-  return result;
 }
 
 export function detectPerimenopausePattern(mc, dob) {
@@ -407,6 +357,7 @@ export function openMenstrualCycleEditor() {
   }
   const modal = document.getElementById("detail-modal");
   const overlay = document.getElementById("modal-overlay");
+  if (!(modal instanceof HTMLElement)) return false;
   const mc = state.importedData.menstrualCycle || {};
   const periods = (mc.periods || []).slice().sort(function newestCyclePeriodFirst(a, b) { return b.startDate.localeCompare(a.startDate); });
   const stats = calculateCycleStats(mc.periods);
@@ -560,23 +511,31 @@ export function openMenstrualCycleEditor() {
   openModalOverlay(overlay);
 }
 export function saveMenstrualCycle() {
-  syncMenstrualCycleProfileFromForm();
+  const mc = syncMenstrualCycleProfileFromForm();
+  if (!mc) {
+    showNotification('Menstrual cycle profile could not be initialized', 'error');
+    return;
+  }
   // Auto-add pending period if form has data that hasn't been added yet
   const cycleStatus = getFieldValue('mc-cycle-status') || 'regular';
   const pendingStart = getFieldValue('mc-period-start');
   const pendingEnd = getFieldValue('mc-period-end');
   if (isActiveCycleStatus(cycleStatus) && pendingStart && pendingEnd && pendingEnd >= pendingStart) {
-    const periods = state.importedData.menstrualCycle?.periods || [];
+    const periods = mc.periods || [];
     const exists = periods.some(p => p.startDate === pendingStart);
     const overlaps = periods.some(p => pendingStart <= (p.endDate || p.startDate) && pendingEnd >= p.startDate);
     if (!exists && !overlaps) {
       const flow = getFieldValue('mc-period-flow') || 'moderate';
-      const symptomTags = document.querySelectorAll('#mc-period-symptoms .ctx-tag.active');
-      const symptoms = Array.from(symptomTags).filter(isHTMLElement).map(t => t.dataset.value);
+      const symptoms = getSelectedCycleSymptoms();
       const notes = getFieldValue('mc-period-notes').trim();
       const updatedAt = new Date().toISOString();
-      state.importedData.menstrualCycle.periods.push(createCyclePeriod({ startDate: pendingStart, endDate: pendingEnd, flow, symptoms, notes, updatedAt }));
-      state.importedData.menstrualCycle = upgradeMenstrualCycleProfile(state.importedData.menstrualCycle, { now: updatedAt });
+      const period = createCyclePeriod({ startDate: pendingStart, endDate: pendingEnd, flow, symptoms, notes, updatedAt });
+      if (!period) {
+        showNotification('Period dates are invalid', 'error');
+        return;
+      }
+      mc.periods.push(period);
+      state.importedData.menstrualCycle = upgradeMenstrualCycleProfile(mc, { now: updatedAt });
     }
   }
   recordContextCardChangeRuntime('menstrualCycle');
@@ -614,14 +573,19 @@ export function toggleCycleSymptomTag(btn) {
   btn.setAttribute('aria-pressed', active ? 'true' : 'false');
 }
 
+function getSelectedCycleSymptoms() {
+  const symptomTags = document.querySelectorAll('#mc-period-symptoms .ctx-tag.active');
+  return Array.from(symptomTags).filter(isHTMLElement).map(tag => tag.dataset.value || '').filter(Boolean);
+}
+
 export function syncMenstrualCycleProfileFromForm() {
   const mc = state.importedData.menstrualCycle || {};
   const cycleLengthAuto = document.getElementById('mc-cycle-length-auto');
   const periodLengthAuto = document.getElementById('mc-period-length-auto');
   const regularityAuto = document.getElementById('mc-regularity-auto');
   const flowAuto = document.getElementById('mc-flow-auto');
-  const parsedCycleLength = cycleLengthAuto instanceof HTMLElement ? parseInt(cycleLengthAuto.dataset.value) : (mc.cycleLength || 28);
-  const parsedPeriodLength = periodLengthAuto instanceof HTMLElement ? parseInt(periodLengthAuto.dataset.value) : (mc.periodLength || 5);
+  const parsedCycleLength = cycleLengthAuto instanceof HTMLElement ? parseInt(cycleLengthAuto.dataset.value || '', 10) : (mc.cycleLength || 28);
+  const parsedPeriodLength = periodLengthAuto instanceof HTMLElement ? parseInt(periodLengthAuto.dataset.value || '', 10) : (mc.periodLength || 5);
   const cycleLength = Number.isFinite(parsedCycleLength) ? parsedCycleLength : (mc.cycleLength || 28);
   const periodLength = Number.isFinite(parsedPeriodLength) ? parsedPeriodLength : (mc.periodLength || 5);
   const regularity = regularityAuto instanceof HTMLElement ? regularityAuto.dataset.value : (mc.regularity || 'regular');
@@ -632,38 +596,46 @@ export function syncMenstrualCycleProfileFromForm() {
   const base = state.importedData.menstrualCycle
     ? { ...state.importedData.menstrualCycle, cycleStatus, cycleLength, periodLength, regularity, flow, contraceptive, conditions }
     : { cycleStatus, cycleLength, periodLength, regularity, flow, contraceptive, conditions, periods: [] };
-  state.importedData.menstrualCycle = upgradeMenstrualCycleProfile(base);
+  const profile = upgradeMenstrualCycleProfile(base);
+  state.importedData.menstrualCycle = profile;
+  return profile;
 }
 
 export function addPeriodEntry() {
   const startDate = getFieldValue('mc-period-start');
   const endDate = getFieldValue('mc-period-end');
   const flow = getFieldValue('mc-period-flow');
-  const symptomTags = document.querySelectorAll('#mc-period-symptoms .ctx-tag.active');
-  const symptoms = Array.from(symptomTags).filter(isHTMLElement).map(t => t.dataset.value);
+  const symptoms = getSelectedCycleSymptoms();
   const notes = getFieldValue('mc-period-notes').trim();
   if (!startDate) { showNotification('Start date is required', 'error'); return; }
   if (!endDate) { showNotification('End date is required', 'error'); return; }
   if (endDate < startDate) { showNotification('End date must be on or after start date', 'error'); return; }
-  syncMenstrualCycleProfileFromForm();
-  const exists = state.importedData.menstrualCycle.periods.some(p => p.startDate === startDate);
+  const mc = syncMenstrualCycleProfileFromForm();
+  if (!mc) {
+    showNotification('Menstrual cycle profile could not be initialized', 'error');
+    return;
+  }
+  const exists = mc.periods.some(p => p.startDate === startDate);
   if (exists) { showNotification('A period entry with this start date already exists', 'error'); return; }
-  const overlaps = state.importedData.menstrualCycle.periods.some(p =>
+  const overlaps = mc.periods.some(p =>
     startDate <= (p.endDate || p.startDate) && endDate >= p.startDate
   );
   if (overlaps) { showNotification('This overlaps with an existing period entry', 'error'); return; }
   const updatedAt = new Date().toISOString();
-  state.importedData.menstrualCycle.periods.push(createCyclePeriod({ startDate, endDate, flow, symptoms, notes, updatedAt }));
-  state.importedData.menstrualCycle = upgradeMenstrualCycleProfile(state.importedData.menstrualCycle, { now: updatedAt });
+  const period = createCyclePeriod({ startDate, endDate, flow, symptoms, notes, updatedAt });
+  if (!period) { showNotification('Period dates are invalid', 'error'); return; }
+  mc.periods.push(period);
+  state.importedData.menstrualCycle = upgradeMenstrualCycleProfile(mc, { now: updatedAt });
   saveImportedData();
   openMenstrualCycleEditor();
 }
 
 export function deletePeriodEntry(startDate) {
   if (!state.importedData.menstrualCycle || !state.importedData.menstrualCycle.periods) return;
-  syncMenstrualCycleProfileFromForm();
-  state.importedData.menstrualCycle.periods = state.importedData.menstrualCycle.periods.filter(p => p.startDate !== startDate);
-  state.importedData.menstrualCycle = upgradeMenstrualCycleProfile(state.importedData.menstrualCycle);
+  const mc = syncMenstrualCycleProfileFromForm();
+  if (!mc) return;
+  mc.periods = mc.periods.filter(p => p.startDate !== startDate);
+  state.importedData.menstrualCycle = upgradeMenstrualCycleProfile(mc);
   saveImportedData();
   openMenstrualCycleEditor();
 }

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 482,
+  "totalDiagnostics": 457,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -39,8 +39,6 @@
     "js/cycle-import-file.js": 2,
     "js/cycle-import.js": 3,
     "js/cycle-store.js": 4,
-    "js/cycle-summary.js": 9,
-    "js/cycle.js": 16,
     "js/dashboard-lab-widget-renderers.js": 4,
     "js/dashboard-page-view.js": 7,
     "js/dashboard-view-composition.js": 2,

--- a/tests/playwright/cycle-browser-coverage.spec.js
+++ b/tests/playwright/cycle-browser-coverage.spec.js
@@ -298,6 +298,11 @@ test('cycle browser coverage exercises editor save clear and period guards', asy
         && toasts().some(text => text.includes('Menstrual cycle data cleared'));
       outcomes.clearConfirmDeletesRawCycleDatabase = (await cycleStore.getAllCycleObservationsRaw(state.currentProfile)).length === 0
         && (await cycleStore.getAllCycleImportMetaRaw(state.currentProfile)).length === 0;
+
+      const detachedModal = modal();
+      detachedModal?.remove();
+      outcomes.openEditorFailsClosedWithoutModal = detachedModal instanceof HTMLElement
+        && await cycle.openMenstrualCycleEditor() === false;
     } finally {
       state.importedData = saved.importedData;
       state.profileDob = saved.profileDob;

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -1038,8 +1038,9 @@ assert('Diagnoses editor binds suggestion closer once with delegates',
 console.log('12. Cycle Stats Guard');
 
 const cycleSrc = read('js/cycle.js');
-assert('Cycle stats filters periods with endDate', cycleSrc.includes('filter(p => p.endDate)'));
-assert('Period length guards empty array', cycleSrc.includes('if (periodLengths.length > 0)'));
+const cycleSummarySrc = read('js/cycle-summary.js');
+assert('Cycle stats filters periods with endDate', cycleSummarySrc.includes('filter(p => p.endDate)'));
+assert('Period length guards empty array', cycleSummarySrc.includes('if (periodLengths.length > 0)'));
 assert('Cycle renderer no longer uses supplement UI classes',
   !/supp-(timeline-header|add-btn|form-row|form-field|list)/.test(cycleSrc));
 assert('Cycle renderer avoids inline style attributes', !cycleSrc.includes('style='));

--- a/tests/test-correctness-phase2.js
+++ b/tests/test-correctness-phase2.js
@@ -366,12 +366,12 @@ assert('guard message references aborted connect',
 
 // ─── 7. Cycle perimenopause clamp ───
 console.log('\n7. Cycle clamp relax');
-const cycleSrc = read('js/cycle.js');
-assert('cycle.js no longer hard-clamps to 45 unconditionally',
-  !cycleSrc.includes('Math.max(20, Math.min(45, avgCycle))'),
+const cycleSummarySrc = read('js/cycle-summary.js');
+assert('cycle stats no longer hard-clamp to 45',
+  !cycleSummarySrc.includes('Math.max(20, Math.min(45, avgCycle))'),
   'old clamp truncated 60–90 day perimenopause cycles to 45');
-assert('cycle.js uses a 90-day ceiling',
-  cycleSrc.includes('Math.max(20, Math.min(90, avgCycle))'),
+assert('cycle stats use a 90-day ceiling',
+  cycleSummarySrc.includes('clamp(avgCycle, 20, 90)'),
   'regular-and-long perimenopause cycles need to land at their real average, not 45');
 
 // ─── 8. SSE trailing buffer flush + parse error filter ───

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.398';
+self.APP_VERSION = '1.10.399';


### PR DESCRIPTION
## What changed

- Add explicit cycle period, coverage, statistics, DOM, and profile-state contracts.
- Move the pure cycle statistics routine into `cycle-summary.js` while preserving the existing `cycle.js` export.
- Fail closed when the cycle editor shell or normalized profile/period cannot be created.
- Centralize selected symptom extraction and guard optional dataset values.
- Reduce `cycle.js` from 783 to 770 lines and keep the repository large-file budget unchanged.
- Reduce the strict-null baseline from 482 diagnostics across 142 files to 457 across 140 files.
- Bump the app version to 1.10.399.

## Impact

Cycle calculations and public module APIs remain unchanged. Editor save/add/delete paths now retain a concrete normalized profile instead of repeatedly dereferencing optional global state, and a missing modal shell returns safely instead of throwing.

## Validation

- `node tests/test-cycle-improvements.js` — 78 passed
- `npx vitest run tests/cycle-import-phase1.test.js` — 25 passed
- `PORT=8142 npx playwright test tests/playwright/cycle-browser-coverage.spec.js --workers=1` — 1 passed
- `node tests/test-audit.js` — 363 passed
- `node tests/verify-modules.js` — 141 passed
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run typecheck:strict-null`
- `npm run quality`
- `npm run architecture:check`
- `npm run production:check`
- `git diff --check`