### PR TITLE
Eliminate provider wallet strict-null debt

### DIFF
--- a/js/provider-wallet-panels.js
+++ b/js/provider-wallet-panels.js
@@ -29,10 +29,10 @@ export { configureRoutstrWalletRuntime, walletRuntime };
 export { buildRoutstrNodeActions, routstrWalletActionButtons };
 
 const walletCallbacks = {
-  renderAIProviderPanel: null,
-  renderRoutstrModelDropdown: null,
-  initSettingsModelFetch: null,
-  returnToChatIfOnboarding: null
+  renderAIProviderPanel: /** @type {((provider: string) => string) | null} */ (null),
+  renderRoutstrModelDropdown: /** @type {((models: any[]) => void) | null} */ (null),
+  initSettingsModelFetch: /** @type {(() => void) | null} */ (null),
+  returnToChatIfOnboarding: /** @type {(() => void) | null} */ (null)
 };
 
 export function configureRoutstrWalletPanels(callbacks = {}) {
@@ -248,7 +248,11 @@ export async function doRoutstrWalletReceiveCashu() {
   await _receiveRoutstrWalletCashu(token, input, statusEl);
 }
 
-async function _receiveRoutstrWalletCashu(token, input = null, statusEl = null) {
+async function _receiveRoutstrWalletCashu(
+  token,
+  input = /** @type {HTMLInputElement | HTMLTextAreaElement | null} */ (null),
+  statusEl = /** @type {HTMLElement | null} */ (null)
+) {
   statusEl = statusEl || document.getElementById('routstr-wfund-status');
   input = input || _getWalletInput('routstr-wcashu-input');
   if (statusEl) statusEl.innerHTML = '<div style="margin-top:4px;font-size:11px;color:var(--text-muted)">Depositing to wallet\u2026</div>';
@@ -319,7 +323,7 @@ export async function doRoutstrMintChange() {
     await walletRuntime.cashuSetMintUrl(url);
     const label = document.getElementById('routstr-mint-label');
     if (label) label.textContent = url.replace(/^https?:\/\//, '');
-    document.getElementById('routstr-mint-edit').style.display = 'none';
+    const mintEdit = document.getElementById('routstr-mint-edit'); if (mintEdit) mintEdit.style.display = 'none';
     _refreshRoutstrWalletBalance();
     showNotification('Mint changed to ' + url.replace(/^https?:\/\//, ''), 'success');
   } catch (e) {
@@ -646,7 +650,8 @@ export function showRoutstrWithdrawLightning() {
   input?.addEventListener('input', () => {
     const val = input.value.trim();
     const needsAmount = val.includes('@') && !val.match(/^ln(bc|tb|bcrt)/);
-    document.getElementById('routstr-withdraw-ln-amount').style.display = needsAmount ? 'block' : 'none';
+    const amount = document.getElementById('routstr-withdraw-ln-amount');
+    if (amount) amount.style.display = needsAmount ? 'block' : 'none';
   });
 }
 

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 443,
+  "totalDiagnostics": 431,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -91,7 +91,6 @@
     "js/provider-local-ai-controls.js": 11,
     "js/provider-panel-renderers.js": 1,
     "js/provider-panels.js": 2,
-    "js/provider-wallet-panels.js": 12,
     "js/recommendations-products.js": 2,
     "js/recommendations-runtime.js": 2,
     "js/schema.js": 2,

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.400';
+self.APP_VERSION = '1.10.401';


### PR DESCRIPTION
## What changed

- Give the injected Routstr wallet UI callbacks explicit nullable function contracts.
- Type the optional Cashu receive controls so supplied DOM elements are handled correctly.
- Guard the mint editor and Lightning-address amount controls before updating their styles.
- Remove all 12 strict-null diagnostics from `js/provider-wallet-panels.js` and ratchet the repository baseline from 443 diagnostics across 139 files to 431 across 138 files.
- Keep the module at 798 physical lines, below the large-file guardrail, and bump the app version to 1.10.401.

## Impact

This is a type-safety and resilience improvement. Wallet balances, deposits, withdrawals, seed handling, callback behavior, and network flows are unchanged. Unexpectedly missing optional controls now fail safely instead of throwing.

## Validation

- `npm run typecheck:strict-null`
- `npm run typecheck:checkjs`
- `npm run typecheck`
- `node tests/test-cashu-wallet.js` — 254 passed
- `node tests/test-provider-wallet-delegated-actions.js` — 35 passed
- `PORT=8144 npx playwright test tests/playwright/cashu-wallet-browser-coverage.spec.js tests/playwright/routstr-wallet-dom.spec.js --grep "routstr wallet panels|Routstr wallet DOM" --workers=1` — 2 passed
- `npm run quality`
- `npm run architecture:check`
- `npm run production:check`
- `git diff --check`