### PR TITLE
Eliminate provider local-AI strict-null debt

### DIFF
--- a/js/provider-local-ai-controls.js
+++ b/js/provider-local-ai-controls.js
@@ -421,7 +421,7 @@ export async function testOllamaConnection() {
   const urlInput = /** @type {HTMLInputElement | null} */ (document.getElementById('local-ai-url-input'));
   const dot = document.getElementById('local-ai-dot');
   const text = document.getElementById('local-ai-status-text');
-  if (!urlInput || !text) return;
+  if (!urlInput || !dot || !text) return;
   const urlCheck = normalizeLocalAiBaseUrl(urlInput.value);
   const config = getOllamaConfig();
   const apiKeyInput = /** @type {HTMLInputElement | null} */ (document.getElementById('local-ai-apikey-input'));
@@ -488,7 +488,7 @@ export async function testPIIOllamaConnection() {
   const text = document.getElementById('pii-local-status-text');
   const piiDropdown = document.getElementById('pii-model-dropdown');
   const piiSelect = /** @type {HTMLSelectElement | null} */ (document.getElementById('pii-model-select'));
-  if (!urlInput || !text) return;
+  if (!urlInput || !dot || !text) return;
   const urlCheck = normalizeLocalAiBaseUrl(urlInput.value);
   const apiKeyInput = /** @type {HTMLInputElement | null} */ (document.getElementById('pii-local-apikey-input'));
   const apiKey = apiKeyInput ? apiKeyInput.value.trim() : getOllamaPIIApiKey();

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 409,
+  "totalDiagnostics": 398,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -88,7 +88,6 @@
     "js/profile-context.js": 1,
     "js/profile-share.js": 3,
     "js/profile.js": 7,
-    "js/provider-local-ai-controls.js": 11,
     "js/provider-panel-renderers.js": 1,
     "js/provider-panels.js": 2,
     "js/recommendations-products.js": 2,

--- a/tests/test-hardware.js
+++ b/tests/test-hardware.js
@@ -264,6 +264,19 @@ console.log('=== Hardware & Model Advisor Tests ===\n');
       piiText.textContent);
     assert('Malformed PII Local AI URL does not fetch', fetchCalls === 0, `fetch calls: ${fetchCalls}`);
 
+    elements = {
+      'local-ai-url-input': { value: 'http://localhost:11434' },
+      'local-ai-status-text': mainText,
+    };
+    await localAiControls.testOllamaConnection();
+    assert('Main Local AI connection fails closed when its status dot is missing', fetchCalls === 0);
+    elements = {
+      'pii-local-url-input': { value: 'http://localhost:11434' },
+      'pii-local-status-text': piiText,
+    };
+    await localAiControls.testPIIOllamaConnection();
+    assert('PII Local AI connection fails closed when its status dot is missing', fetchCalls === 0);
+
     fetchCalls = 0;
     globalThis.fetch = async () => {
       fetchCalls++;

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.402';
+self.APP_VERSION = '1.10.403';


### PR DESCRIPTION
## What changed

- Treat each local-AI connection status dot as part of the required settings-template contract.
- Return safely before URL validation or network work when either the main or PII connection UI is incomplete.
- Add focused regression coverage proving missing status dots do not fetch or throw.
- Remove all 11 strict-null diagnostics from `js/provider-local-ai-controls.js` and ratchet the repository baseline from 409 diagnostics across 135 files to 398 across 134 files.
- Bump the app version to 1.10.403.

## Impact

Normal Ollama/LM Studio connection, model advisor, privacy, and hardware flows are unchanged. An unexpectedly incomplete settings template now fails closed instead of throwing.

## Validation

- `npm run typecheck:strict-null`
- `npm run typecheck:checkjs`
- `npm run typecheck`
- `node tests/test-hardware.js` — 65 passed
- `PORT=8146 npx playwright test tests/playwright/settings-provider-browser-coverage.spec.js --grep "local AI settings controls cover connection" --workers=1` — 1 passed
- `npm run quality`
- `npm run architecture:check`
- `npm run production:check`
- `git diff --check`