### PR TITLE
Eliminate PDF import strict-null debt

### DIFF
--- a/js/pdf-import.js
+++ b/js/pdf-import.js
@@ -161,17 +161,17 @@ export function showAINeededDialog(action = 'import') {
   </div>`;
   openModalOverlay(overlay, { initialFocus: '#ai-needed-or', focusDelay: 50 });
   const close = () => closeModalOverlay(overlay);
-  document.getElementById('ai-needed-or').onclick = () => { close(); pdfImportDeps.startOpenRouterOAuth(); };
-  document.getElementById('ai-needed-key').onclick = () => {
+  document.getElementById('ai-needed-or')?.addEventListener('click', () => { close(); pdfImportDeps.startOpenRouterOAuth(); });
+  document.getElementById('ai-needed-key')?.addEventListener('click', () => {
     close();
     getSettingsModuleFunction('openSettingsModal')?.('ai');
-  };
-  document.getElementById('ai-needed-demo').onclick = () => {
+  });
+  document.getElementById('ai-needed-demo')?.addEventListener('click', () => {
     close();
     const sex = state.profileSex === 'female' ? 'female' : 'male';
     void pdfImportDeps.loadDemoData(sex);
-  };
-  document.getElementById('ai-needed-cancel').onclick = close;
+  });
+  document.getElementById('ai-needed-cancel')?.addEventListener('click', close);
   overlay.onclick = (e) => { if (e.target === overlay) close(); };
 }
 
@@ -355,8 +355,8 @@ export async function isPdfByMagic(file) {
 
 export async function classifyImportFiles(files) {
   return classifyImportFileBuckets(files, {
-    isDNAFile: getDnaModuleFunction('isDNAFile'),
-    isDNAFileByContent: getDnaModuleFunction('isDNAFileByContent'),
+    isDNAFile: getDnaModuleFunction('isDNAFile') || undefined,
+    isDNAFileByContent: getDnaModuleFunction('isDNAFileByContent') || undefined,
     isCycleImportFile,
   });
 }
@@ -367,13 +367,13 @@ export async function classifyImportFiles(files) {
 export function setupDropZone() {
   const dropZone = document.getElementById("drop-zone");
   if (!dropZone) return;
-  dropZone.addEventListener("click", () => { if (isImportRunning()) return; document.getElementById('pdf-input').click(); });
+  dropZone.addEventListener("click", () => { if (isImportRunning()) return; document.getElementById('pdf-input')?.click(); });
   dropZone.addEventListener("dragover", e => { e.preventDefault(); if (!isImportRunning()) dropZone.classList.add("drag-over"); });
   dropZone.addEventListener("dragleave", e => { e.preventDefault(); dropZone.classList.remove("drag-over"); });
   dropZone.addEventListener("drop", async e => {
     e.preventDefault(); dropZone.classList.remove("drag-over");
     if (isImportRunning()) { showNotification("Import already in progress", "info"); return; }
-    const files = Array.from(e.dataTransfer.files);
+    const files = Array.from(e.dataTransfer?.files || []);
     if (files.length === 0) return;
     const { jsonFiles, pdfFiles, imageFiles, dnaFiles, textFiles, cycleFiles = [], unsupportedCount } = await classifyImportFiles(files);
     if (unsupportedCount > 0 && jsonFiles.length === 0 && pdfFiles.length === 0 && imageFiles.length === 0 && dnaFiles.length === 0 && textFiles.length === 0 && cycleFiles.length === 0) {
@@ -559,7 +559,7 @@ async function _showImageModeDialog() {
   });
 }
 
-export async function handlePDFFile(file, forceImageMode = false, preExtractedText = null) {
+export async function handlePDFFile(file, forceImageMode = false, preExtractedText = /** @type {string | null} */ (null)) {
   const _startProfileId = state.currentProfile;
   const benchmarkStarted = performance.now();
   const benchmarkId = startImportBenchmark({ fileName: file.name, fileSize: file.size, importMode: forceImageMode ? 'image' : 'text' });

--- a/js/pii.js
+++ b/js/pii.js
@@ -642,7 +642,8 @@ function wirePIIOverlayNudge(overlay) {
   });
 }
 
-export function reviewPIIBeforeSend(originalText, { obfuscatedText = '', streamFn = null } = {}) {
+/** @typedef {(onChunk: (chunk: string) => void, signal: AbortSignal, onThinking: (chunk: string) => void) => Promise<any>} PIIStreamFunction */
+export function reviewPIIBeforeSend(originalText, { obfuscatedText = '', streamFn = /** @type {PIIStreamFunction | null} */ (null) } = {}) {
   if (!isDataProtectionStylesheetLoaded()) {
     return loadDataProtectionStylesheetForAction().then(loaded => {
       if (loaded) return reviewPIIBeforeSend(originalText, { obfuscatedText, streamFn });
@@ -815,6 +816,7 @@ export function reviewPIIBeforeSend(originalText, { obfuscatedText = '', streamF
     // Streaming mode
     let abortController = null;
     if (isStreaming) {
+      const runStream = /** @type {PIIStreamFunction} */ (streamFn);
       if (!statusEl || !stopBtn) {
         closePIIOverlay(overlay);
         resolve('cancel');
@@ -877,7 +879,7 @@ export function reviewPIIBeforeSend(originalText, { obfuscatedText = '', streamF
           if (!rafPending) { rafPending = true; requestAnimationFrame(flushToTextarea); }
         };
 
-        streamFn(
+        runStream(
           (chunk) => {
             pendingText += chunk;
             if (!rafPending) { rafPending = true; requestAnimationFrame(flushToTextarea); }

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 398,
+  "totalDiagnostics": 385,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -49,7 +49,7 @@
     "js/dna-runtime.js": 1,
     "js/dna.js": 3,
     "js/emf-interpretation.js": 2,
-    "js/emf.js": 3,
+    "js/emf.js": 2,
     "js/export-report.js": 1,
     "js/export.js": 1,
     "js/focus-card.js": 4,
@@ -83,8 +83,7 @@
     "js/pdf-import-progress.js": 4,
     "js/pdf-import-review-runtime.js": 1,
     "js/pdf-import-review.js": 8,
-    "js/pdf-import.js": 11,
-    "js/pii.js": 2,
+    "js/pii.js": 1,
     "js/profile-context.js": 1,
     "js/profile-share.js": 3,
     "js/profile.js": 7,

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.403';
+self.APP_VERSION = '1.10.404';


### PR DESCRIPTION
## What changed

- Bind AI-needed dialog actions through null-safe listeners.
- Pass absent DNA classifiers as optional dependencies instead of nullable callbacks.
- Make drop-zone input and drag payload handling resilient to missing browser controls/data transfer.
- Give pre-extracted import text its existing nullable string contract.
- Give the shared PII privacy stream callback an explicit function contract, removing downstream PDF, EMF, and PII type debt.
- Ratchet the strict-null baseline from 398 diagnostics across 134 files to 385 across 133 files.
- Bump the app version to 1.10.404.

## Impact

PDF/text import, DNA classification, AI setup, privacy review, and EMF analysis behavior are unchanged. Incomplete DOM/drop events now fail safely instead of throwing.

## Validation

- `npm run typecheck:strict-null`
- `npm run typecheck:checkjs`
- `npm run typecheck`
- `node tests/test-unit-import.js` — 150 passed
- `node tests/test-image-utils.js` — 73 passed
- `node tests/test-emf.js` — 217 passed
- `node tests/test-pii.js` — 44 passed
- `node tests/test-modal-lifecycle-integrations.js` — 31 passed
- `PORT=8147 npx playwright test tests/playwright/pdf-import-browser-coverage.spec.js tests/playwright/pii-browser-coverage.spec.js --grep "PDF import progress and AI-needed|PDF import covers extraction errors|PII browser coverage exercises review modal" --workers=1` — 3 passed
- `npm run quality`
- `npm run architecture:check`
- `npm run production:check`
- `git diff --check`