### PR TITLE
Eliminate Ollama provider strict-null debt

### DIFF
--- a/js/local-ai-provider-ollama.js
+++ b/js/local-ai-provider-ollama.js
@@ -227,7 +227,8 @@ export async function inferWithOllamaNativeProvider({ config, model, opts, plan,
   };
   if (opts.jsonMode) body.format = opts.jsonSchema || 'json';
   if (opts.jsonMode || opts.reasoningEffort === 'none') body.think = false;
-  let response;
+  /** @type {Response | null} */
+  let response = null;
   let structuredOutputFallback = false;
   let reasoningControlFallback = false;
   for (let attempt = 0; attempt < 3; attempt++) {
@@ -246,6 +247,7 @@ export async function inferWithOllamaNativeProvider({ config, model, opts, plan,
     }
     break;
   }
+  if (!response) throw new Error('Ollama request ended without a response.');
   if (!response.ok) {
     let detail = '';
     try {
@@ -268,6 +270,7 @@ export async function inferWithOllamaNativeProvider({ config, model, opts, plan,
     return normalizedOllamaResult(text, data, requestDiagnostics);
   }
 
+  if (!response.body) throw new Error('Ollama returned a streaming response without a readable body.');
   const reader = response.body.getReader();
   const decoder = new TextDecoder();
   let buffer = '';
@@ -298,7 +301,7 @@ export async function inferWithOllamaNativeProvider({ config, model, opts, plan,
       throw new Error(`Ollama stream exceeded ${maxBuffer} bytes without a newline - aborting.`);
     }
     const lines = buffer.split('\n');
-    buffer = lines.pop();
+    buffer = lines.pop() ?? '';
     for (const line of lines) handleNdjsonLine(line, true);
   }
   if (buffer.trim()) handleNdjsonLine(buffer, false);

--- a/js/local-ai-provider-shared.js
+++ b/js/local-ai-provider-shared.js
@@ -27,6 +27,10 @@ export function redactApiSecretText(value, secrets = []) {
     .replace(/\bcashu[A-Za-z0-9._~+/=-]{8,}/gi, '[redacted]');
 }
 
+/**
+ * @param {string} kind
+ * @param {Record<string, any>} [detail]
+ */
 export function localAiDiscoveryError(kind, detail = {}) {
   return { kind, ...detail };
 }
@@ -37,6 +41,10 @@ export function localAiFetchFailure(error) {
   return localAiDiscoveryError(name === 'TimeoutError' || name === 'AbortError' ? 'timeout' : 'network', { message });
 }
 
+/**
+ * @param {string} [provider]
+ * @param {Record<string, any> | null} [error]
+ */
 export function unavailableLocalAiResult(provider = 'unknown', error = null) {
   return {
     available: false,

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 385,
+  "totalDiagnostics": 370,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -72,10 +72,7 @@
     "js/light-tool-camera.js": 5,
     "js/light-tools.js": 6,
     "js/local-ai-lifecycle.js": 2,
-    "js/local-ai-provider-lmstudio.js": 3,
-    "js/local-ai-provider-ollama.js": 10,
-    "js/local-ai-provider-openai-compatible.js": 2,
-    "js/local-ai-provider-registry.js": 1,
+    "js/local-ai-provider-lmstudio.js": 1,
     "js/marker-detail-modal-impl.js": 10,
     "js/nav.js": 1,
     "js/pdf-import-marker-mapping.js": 2,

--- a/tests/api-provider-contracts.test.js
+++ b/tests/api-provider-contracts.test.js
@@ -846,6 +846,22 @@ describe('AI provider request contracts', () => {
     expect(ollamaStreamError.message).not.toContain(secret);
   });
 
+  it('reports an Ollama streaming response without a readable body', async () => {
+    globalThis.fetch = vi.fn(async () => new Response(null, { status: 200 }));
+
+    await expect(inferWithOllamaNativeProvider({
+      config: { url: 'http://ollama.test', apiKey: '' },
+      model: 'local-model',
+      opts: {
+        messages: [{ role: 'user', content: 'hello' }],
+        onStream: vi.fn(),
+        requestTimeoutMs: 1000,
+      },
+      plan: { maxTokens: 32 },
+      contextLength: 4096,
+    })).rejects.toThrow('streaming response without a readable body');
+  });
+
   it('uses the native Ollama adapter for imports and normalizes runtime metrics', async () => {
     setAIProvider('ollama');
     setOllamaMainModel('qwen3.6:27b');

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.404';
+self.APP_VERSION = '1.10.405';


### PR DESCRIPTION
## Summary
- make Local AI discovery error/result contracts explicit across provider adapters
- guard Ollama retry and streaming response state before use
- keep the NDJSON stream buffer string-safe and report missing response bodies clearly
- reduce the strict-null baseline from 385 diagnostics across 133 files to 370 across 130 files
- bump the app version to 1.10.405

## Validation
- `npm test -- tests/api-provider-contracts.test.js tests/strict-null-ratchet.test.js` (37 passed)
- `PORT=8017 npx playwright test tests/playwright/api-provider-calls-browser-coverage.spec.js --workers=1` (1 passed)
- `npm run typecheck:strict-null`
- `npm run typecheck:checkjs`
- `npm run typecheck`
- `npm run quality`
- `npm run architecture:check`
- `npm run production:check`
- `git diff --check`