### PR TITLE
Eliminate Ultrahuman strict-null debt

### DIFF
--- a/js/wearables-ultrahuman.js
+++ b/js/wearables-ultrahuman.js
@@ -15,6 +15,32 @@ import { isDebugMode } from './utils.js';
 const UH_API = 'https://partner.ultrahuman.com';
 const PROXY_URL = '/api/proxy';
 
+/**
+ * @typedef {{
+ *   source: 'ultrahuman',
+ *   date: string,
+ *   hrv_rmssd: number | null,
+ *   hrv_sdnn: number | null,
+ *   rhr: number | null,
+ *   hrv_day: number | null,
+ *   hr_day: number | null,
+ *   sleep_score: number | null,
+ *   readiness_score: number | null,
+ *   activity_score: number | null,
+ *   steps: number | null,
+ *   strain: number | null,
+ *   stress_high_min: number | null,
+ *   resilience_level: number | null,
+ *   cardio_age: number | null,
+ *   weight: number | null,
+ *   bp_systolic: number | null,
+ *   bp_diastolic: number | null,
+ *   spo2_avg: number | null,
+ *   body_temp_delta: number | null,
+ *   glucose_avg: number | null,
+ * }} UltrahumanDailyRow
+ */
+
 async function uhGET(path, accessToken, params = {}) {
   const qs = new URLSearchParams(params).toString();
   const url = `${UH_API}/${path.replace(/^\//, '')}${qs ? '?' + qs : ''}`;
@@ -77,8 +103,12 @@ export async function fetchUltrahumanDailyRange(accessToken, startDate, endDate)
 // Ultrahuman returns nested `metric_data` blocks; the exact shape varies by
 // scope (ring_data vs cgm_data). This function is the ONE place that knows
 // vendor-specific field names — if Ultrahuman renames anything, patch here.
+/**
+ * @returns {UltrahumanDailyRow | null}
+ */
 function canonicalizeDay(day, payload) {
   const data = payload?.data?.metric_data || payload?.metric_data || payload?.data || payload || {};
+  /** @type {UltrahumanDailyRow} */
   const row = {
     source: 'ultrahuman', date: day,
     hrv_rmssd: null, hrv_sdnn: null, rhr: null,
@@ -107,7 +137,8 @@ function canonicalizeDay(day, payload) {
   row.glucose_avg     = numOrNull(pick('glucose.avg'))             ?? numOrNull(pick('glucose'));
 
   // Drop entirely-null days (ring wasn't worn, scope didn't cover this user)
-  if (Object.keys(row).filter(k => k !== 'source' && k !== 'date').every(k => row[k] === null)) return null;
+  const metrics = Object.entries(row).filter(([key]) => key !== 'source' && key !== 'date');
+  if (metrics.every(([, value]) => value === null)) return null;
   return row;
 }
 

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 360,
+  "totalDiagnostics": 351,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -129,7 +129,6 @@
     "js/wearables-settings-runtime.js": 3,
     "js/wearables-store.js": 2,
     "js/wearables-summary.js": 1,
-    "js/wearables-ultrahuman.js": 9,
     "js/wearables.js": 2
   }
 }

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.406';
+self.APP_VERSION = '1.10.407';


### PR DESCRIPTION
## Summary
- define the Ultrahuman canonical daily-row contract explicitly
- keep numeric metric assignments null-safe while preserving missing values
- check typed metric entries when dropping entirely empty wearable days
- reduce the strict-null baseline from 360 diagnostics across 129 files to 351 across 128 files
- bump the app version to 1.10.407

## Validation
- `npm run typecheck:strict-null`
- `npm run typecheck:checkjs`
- `npm run typecheck`
- `npm test -- tests/strict-null-ratchet.test.js` (4 passed)
- `node tests/test-wearables-fetchers.js` (106 passed)
- `node tests/test-vendor-personal-info.js` (18 passed)
- `node tests/test-wearables.js` (588 passed)
- `PORT=8019 npx playwright test tests/playwright/wearables-provider-browser-coverage.spec.js --grep "Fitbit Ultrahuman" --workers=1` (1 passed)
- `npm run quality`
- `npm run architecture:check`
- `npm run production:check`
- `git diff --check`