### PR TITLE
Eliminate biology score engine strict-null debt

### DIFF
--- a/js/biology-score-engine.js
+++ b/js/biology-score-engine.js
@@ -252,6 +252,14 @@ function deriveTotalCholesterolHdlRatio(data) {
   return { value: parseFloat((total / hdl).toPrecision(6)), date, ageDays: getAgeDays(date) };
 }
 
+/**
+ * @param {any} data
+ * @param {any} category
+ * @param {string} leftKey
+ * @param {string} rightKey
+ * @param {(left: number, right: number) => number | null} compute
+ * @param {((left: number, right: number, leftMarker: any, rightMarker: any) => boolean) | null} [valuesOk]
+ */
 function deriveRatioFromMarkers(data, category, leftKey, rightKey, compute, valuesOk = null) {
   const leftMarker = category?.markers?.[leftKey];
   const rightMarker = category?.markers?.[rightKey];
@@ -264,7 +272,7 @@ function deriveRatioFromMarkers(data, category, leftKey, rightKey, compute, valu
   if (!Number.isFinite(left) || !Number.isFinite(right)) return null;
   if (valuesOk && !valuesOk(left, right, leftMarker, rightMarker)) return null;
   const raw = compute(left, right);
-  if (!Number.isFinite(raw)) return null;
+  if (raw == null || !Number.isFinite(raw)) return null;
   const leftDate = leftMarker.singleDate || category.singleDate || data?.dates?.[leftIdx] || '';
   const rightDate = rightMarker.singleDate || category.singleDate || data?.dates?.[rightIdx] || '';
   const date = rightDate && leftDate && rightDate !== leftDate ? rightDate : (leftDate || rightDate);
@@ -296,6 +304,7 @@ export function scoreAgainstRange(value, range) {
     return Math.round(clamp(lerp(clamp(value, min - buffer, min), min - buffer, min, 0, 99), 0, 99));
   }
 
+  if (min == null || max == null) return null;
   if (value >= min && value <= max) return 100;
   const span = Math.max(max - min, 1);
   const lowFloor = Math.max(0, min - span);

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 351,
+  "totalDiagnostics": 342,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -13,7 +13,6 @@
     "js/app-shell-hooks.js": 2,
     "js/backup.js": 3,
     "js/biology-score-context-ai.js": 1,
-    "js/biology-score-engine.js": 9,
     "js/biology-score-iron.js": 1,
     "js/biology-score-profile-modifiers.js": 2,
     "js/biology-score-render.js": 6,

--- a/tests/test-biology-scores.js
+++ b/tests/test-biology-scores.js
@@ -1277,7 +1277,7 @@ assert('female hormone axis does not require male testosterone core group',
   JSON.stringify(femaleHormoneScoreThin));
 
 // Severity sub-bands: resolveScoreTone now distinguishes poor/concerning/severe
-import { resolveScoreConfidence, resolveScoreTone, resolveScoreSeverity } from '../js/biology-score-engine.js';
+import { resolveScoreConfidence, resolveScoreTone, resolveScoreSeverity, scoreAgainstRange } from '../js/biology-score-engine.js';
 assert('severity sub-band: score 40 → poor tone', resolveScoreTone(40) === 'poor');
 assert('severity sub-band: score 25 → concerning tone', resolveScoreTone(25) === 'concerning');
 assert('severity sub-band: score 10 → severe tone', resolveScoreTone(10) === 'severe');
@@ -1285,6 +1285,10 @@ assert('severity sub-band: score 40 → mild severity', resolveScoreSeverity(40)
 assert('severity sub-band: score 25 → moderate severity', resolveScoreSeverity(25) === 'moderate');
 assert('severity sub-band: score 10 → severe severity', resolveScoreSeverity(10) === 'severe');
 assert('severity sub-band: score 60 → null severity', resolveScoreSeverity(60) === null);
+assert('range scoring accepts a value inside a two-sided range', scoreAgainstRange(5, { min: 0, max: 10 }) === 100);
+assert('range scoring supports an upper-only bound', scoreAgainstRange(5, { min: null, max: 5 }) === 100);
+assert('range scoring supports a lower-only bound', scoreAgainstRange(5, { min: 5, max: null }) === 100);
+assert('range scoring rejects a range with no finite bounds', scoreAgainstRange(5, { min: null, max: null }) === null);
 assert('score confidence labels missing core markers as low confidence', resolveScoreConfidence({ score: 95, coverage: 0.7, missing: [{ label: 'ApoB', core: true }] }).level === 'low');
 
 // Vitamin D sunlight profile modifier: wheelchair context raises D floor to 100 nmol/L

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.407';
+self.APP_VERSION = '1.10.408';


### PR DESCRIPTION
## Summary
- type derived-ratio compute and validation callbacks explicitly
- reject null/non-finite derived values before precision formatting
- make the two-sided range invariant explicit after one-sided scoring branches
- add direct coverage for two-sided, upper-only, lower-only, and unbounded ranges
- reduce the strict-null baseline from 351 diagnostics across 128 files to 342 across 127 files
- bump the app version to 1.10.408

## Validation
- `npm run typecheck:strict-null`
- `npm run typecheck:checkjs`
- `npm run typecheck`
- `npm test -- tests/strict-null-ratchet.test.js` (4 passed)
- `node tests/test-biology-scores.js` (222 passed)
- `node tests/test-demo.js` (52 passed)
- `PORT=8021 npx playwright test tests/playwright/biology-scores-dashboard-lens.spec.js --workers=1` (6 passed)
- `node tests/test-audit.js` (363 passed)
- `npm run quality`
- `npm run architecture:check`
- `npm run production:check`
- `git diff --check`