### PR TITLE
Eliminate Cashu wallet store strict-null debt

### DIFF
--- a/js/cashu-wallet-store.js
+++ b/js/cashu-wallet-store.js
@@ -188,7 +188,7 @@ export async function _saveProofs(proofs, forMint) {
     const tx = db.transaction(STORE_PROOFS, 'readwrite');
     const store = tx.objectStore(STORE_PROOFS);
     for (const row of rows) store.put(row);
-    tx.oncomplete = () => resolve();
+    tx.oncomplete = () => resolve(undefined);
     tx.onerror = () => reject(tx.error);
   });
 }
@@ -201,7 +201,7 @@ async function _deleteProofs(proofs) {
     const tx = db.transaction(STORE_PROOFS, 'readwrite');
     const store = tx.objectStore(STORE_PROOFS);
     for (const key of keys) store.delete(key);
-    tx.oncomplete = () => resolve();
+    tx.oncomplete = () => resolve(undefined);
     tx.onerror = () => reject(tx.error);
   });
 }
@@ -222,7 +222,7 @@ export async function _replaceProofs(previousProofs, nextProofs, forMint) {
       reject(error);
       return;
     }
-    tx.oncomplete = () => resolve();
+    tx.oncomplete = () => resolve(undefined);
     tx.onerror = () => reject(tx.error);
     tx.onabort = () => reject(tx.error || new Error('Cashu proof update aborted'));
   });
@@ -274,7 +274,7 @@ export async function _setMeta(key, value) {
   return new Promise((resolve, reject) => {
     const tx = db.transaction(STORE_META, 'readwrite');
     tx.objectStore(STORE_META).put(row);
-    tx.oncomplete = () => resolve();
+    tx.oncomplete = () => resolve(undefined);
     tx.onerror = () => reject(tx.error);
   });
 }
@@ -284,7 +284,7 @@ export async function _deleteMeta(key) {
   return new Promise((resolve, reject) => {
     const tx = db.transaction(STORE_META, 'readwrite');
     tx.objectStore(STORE_META).delete(key);
-    tx.oncomplete = () => resolve();
+    tx.oncomplete = () => resolve(undefined);
     tx.onerror = () => reject(tx.error);
   });
 }
@@ -431,7 +431,7 @@ export async function _saveFeeProofs(proofs, forMint) {
     const tx = db.transaction(STORE_FEES, 'readwrite');
     const store = tx.objectStore(STORE_FEES);
     for (const row of rows) store.put(row);
-    tx.oncomplete = () => resolve();
+    tx.oncomplete = () => resolve(undefined);
     tx.onerror = () => reject(tx.error);
   });
 }
@@ -452,7 +452,7 @@ export async function _replaceFeeProofs(previousProofs, nextProofs, forMint) {
       reject(error);
       return;
     }
-    tx.oncomplete = () => resolve();
+    tx.oncomplete = () => resolve(undefined);
     tx.onerror = () => reject(tx.error);
     tx.onabort = () => reject(tx.error || new Error('Cashu fee proof update aborted'));
   });
@@ -616,7 +616,7 @@ export async function _destroyWalletDBStorage() {
   _legacyProofsMigrated = false;
   return new Promise((resolve, reject) => {
     const req = indexedDB.deleteDatabase(DB_NAME);
-    req.onsuccess = () => resolve();
+    req.onsuccess = () => resolve(undefined);
     req.onerror = () => reject(req.error);
   });
 }

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 342,
+  "totalDiagnostics": 334,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -19,7 +19,6 @@
     "js/biology-score-thyroid.js": 3,
     "js/biology-scores-runtime.js": 2,
     "js/blob-storage.js": 2,
-    "js/cashu-wallet-store.js": 8,
     "js/category-customization-runtime.js": 4,
     "js/category-page-view.js": 8,
     "js/chat-images.js": 1,

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.408';
+self.APP_VERSION = '1.10.409';


### PR DESCRIPTION
## Summary
- make IndexedDB write and delete completion values explicit
- eliminate all 8 strict-null diagnostics from `cashu-wallet-store.js`
- lower the strict-null ratchet from 342 diagnostics / 127 files to 334 / 126
- bump the app version to 1.10.409

## Validation
- `npm run typecheck:strict-null`
- `npm run typecheck:checkjs`
- `npm test -- tests/cashu-wallet-runtime.test.js tests/strict-null-ratchet.test.js`
- `node tests/test-cashu-wallet.js`
- `npx playwright test --grep "cashu wallet browser coverage" --workers=1 tests/playwright/cashu-wallet-browser-coverage.spec.js`
- `npm run quality`
- `npm run architecture:check`
- `npm run production:check`
- `git diff --check`