### PR TITLE
Eliminate blood pressure chart strict-null debt

### DIFF
--- a/js/wearables-bp-detail-chart.js
+++ b/js/wearables-bp-detail-chart.js
@@ -7,7 +7,17 @@ import { createChartRuntime, hasChartRuntime } from './charts-runtime.js';
 import { getChartColors } from './theme.js';
 import { formatValue, shortDate } from './wearables-formatters.js';
 
-export function renderBloodPressureChart(canvas, canon, m, systolicSeries, diastolicSeries = [], manualSeries = [], pairedMetric = null) {
+/** @typedef {{ primarySource?: string, baseline?: number | null }} BloodPressureMetricSummary */
+
+export function renderBloodPressureChart(
+  canvas,
+  canon,
+  m,
+  systolicSeries,
+  diastolicSeries = [],
+  manualSeries = [],
+  pairedMetric = /** @type {BloodPressureMetricSummary | null} */ (null),
+) {
   if (!hasChartRuntime() || !isChartDateAdapterReady()) {
     const retryToken = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
     canvas.dataset.bpRenderToken = retryToken;

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 334,
+  "totalDiagnostics": 326,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -120,7 +120,6 @@
     "js/touch-tooltip.js": 6,
     "js/tour.js": 3,
     "js/utils.js": 4,
-    "js/wearables-bp-detail-chart.js": 8,
     "js/wearables-connect-runtime.js": 2,
     "js/wearables-connect.js": 2,
     "js/wearables-oura-auth.js": 3,

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.409';
+self.APP_VERSION = '1.10.410';


### PR DESCRIPTION
## Summary
- define the nullable paired blood-pressure metric contract at the chart boundary
- eliminate all 8 strict-null diagnostics from `wearables-bp-detail-chart.js`
- lower the strict-null ratchet from 334 diagnostics / 126 files to 326 / 125
- bump the app version to 1.10.410

## Validation
- `npm run typecheck:strict-null`
- `npm run typecheck:checkjs`
- `npm test -- tests/wearables-bp-detail-chart.test.js tests/strict-null-ratchet.test.js`
- `npm run quality`
- `npm run architecture:check`
- `npm run production:check`
- `git diff --check`