### PR TITLE
Guard category page DOM lifecycle

### DIFF
--- a/js/category-page-view.js
+++ b/js/category-page-view.js
@@ -172,13 +172,14 @@ export function showCategory(categoryKey, preData) {
   // anything that doesn't match the strict allowlist so a poisoned
   // customMarker key can't break out of the HTML attribute context.
   if (!safeMarkerId(categoryKey)) return;
+  const main = document.getElementById("main-content");
+  if (!main) return;
   // Ensure catalog is preloaded for sorting and rec links
   primeCategoryPageCatalogCache();
   const rawData = preData || getActiveData();
   const data = filterDatesByRange(rawData, { fallbackToAll: false });
   const cat = data.categories[categoryKey];
   const rawCat = rawData.categories[categoryKey];
-  const main = document.getElementById("main-content");
   const allEntries = Object.entries(cat.markers).filter(([, m]) => !m.hidden);
   const withData = allEntries.filter(([, m]) => markerHasData(m));
   const rawWithData = Object.values(rawCat?.markers || {}).filter(markerHasData).length;
@@ -243,6 +244,8 @@ export function switchView(view, categoryKey, btn) {
   // renderFattyAcidsView / renderTableView / renderHeatmapView. Same
   // allowlist guard as showCategory.
   if (!safeMarkerId(categoryKey)) return;
+  const container = document.getElementById("view-content");
+  if (!container) return;
   state.categoryView = view;
   document.querySelectorAll(".view-btn").forEach(b => {
     b.classList.remove("active");
@@ -257,7 +260,6 @@ export function switchView(view, categoryKey, btn) {
   const data = filterDatesByRange(rawData, { fallbackToAll: false });
   const cat = data.categories[categoryKey];
   const rawCat = rawData.categories[categoryKey];
-  const container = document.getElementById("view-content");
   // Pre-sanitize date labels at the call boundary — CodeQL's taint analysis
   // (js/xss-through-dom) doesn't trace sanitizers across function calls, so
   // even though renderTableView/renderHeatmapView re-escape internally,

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 326,
+  "totalDiagnostics": 318,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -20,7 +20,6 @@
     "js/biology-scores-runtime.js": 2,
     "js/blob-storage.js": 2,
     "js/category-customization-runtime.js": 4,
-    "js/category-page-view.js": 8,
     "js/chat-images.js": 1,
     "js/chat-onboarding.js": 2,
     "js/chat-panel.js": 2,

--- a/tests/category-page-view.test.js
+++ b/tests/category-page-view.test.js
@@ -1,0 +1,29 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { showCategory, switchView } from '../js/category-page-view.js';
+import { state } from '../js/state.js';
+
+const previousCategoryView = state.categoryView;
+
+afterEach(() => {
+  state.categoryView = previousCategoryView;
+  document.body.replaceChildren();
+});
+
+describe('Category page DOM lifecycle guards', () => {
+  it('does not partially switch views after the view container is removed', () => {
+    const button = document.createElement('button');
+
+    expect(() => switchView('table', 'biochemistry', button)).not.toThrow();
+    expect(state.categoryView).toBe(previousCategoryView);
+    expect(button.classList.contains('active')).toBe(false);
+  });
+
+  it('does not prepare category data after the main container is removed', () => {
+    const unusableData = {};
+
+    expect(() => showCategory('biochemistry', unusableData)).not.toThrow();
+  });
+});

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.410';
+self.APP_VERSION = '1.10.411';


### PR DESCRIPTION
## Summary
- stop category rendering before work begins when the main page container is gone
- stop view switching before state or chart mutations when the view container is gone
- add focused lifecycle regression coverage
- eliminate all 8 strict-null diagnostics from `category-page-view.js`
- lower the strict-null ratchet from 326 diagnostics / 125 files to 318 / 124
- bump the app version to 1.10.411

## Validation
- `npm run typecheck:strict-null`
- `npm run typecheck:checkjs`
- `npm test -- tests/category-page-view.test.js tests/strict-null-ratchet.test.js`
- `npx playwright test --workers=1 tests/playwright/audit-dom.spec.js`
- `npm run quality`
- `npm run architecture:check`
- `npm run production:check`
- `git diff --check`