### PR TITLE
Guard settings sync setup lifecycle

### DIFF
--- a/js/settings-sync-panel-impl.js
+++ b/js/settings-sync-panel-impl.js
@@ -425,11 +425,12 @@ export async function closeSyncSetup() {
 let _syncSetupInProgress = false;
 async function syncSetupNew() {
   if (_syncSetupInProgress) return;
-  _syncSetupInProgress = true;
   const choicesEl = document.getElementById('sync-setup-choices');
   const newEl = document.getElementById('sync-setup-new');
-  if (choicesEl) choicesEl.style.display = 'none';
-  if (newEl) newEl.style.display = 'block';
+  if (!choicesEl || !newEl) return;
+  _syncSetupInProgress = true;
+  choicesEl.style.display = 'none';
+  newEl.style.display = 'block';
   newEl.innerHTML = '<div style="text-align:center;padding:16px 0;color:var(--text-muted);font-size:13px">Generating identity...</div>';
 
   try {
@@ -489,16 +490,23 @@ function syncSetupDone() {
 }
 
 function syncSetupRestore() {
-  document.getElementById('sync-setup-choices').style.display = 'none';
-  document.getElementById('sync-setup-restore').style.display = 'block';
+  const choicesEl = document.getElementById('sync-setup-choices');
+  const restoreEl = document.getElementById('sync-setup-restore');
+  if (!choicesEl || !restoreEl) return;
+  choicesEl.style.display = 'none';
+  restoreEl.style.display = 'block';
   const input = document.getElementById('sync-setup-restore-input');
   if (input) input.focus();
 }
 
 function syncSetupBack() {
-  document.getElementById('sync-setup-choices').style.display = '';
-  document.getElementById('sync-setup-restore').style.display = 'none';
-  document.getElementById('sync-setup-new').style.display = 'none';
+  const choicesEl = document.getElementById('sync-setup-choices');
+  const restoreEl = document.getElementById('sync-setup-restore');
+  const newEl = document.getElementById('sync-setup-new');
+  if (!choicesEl || !restoreEl || !newEl) return;
+  choicesEl.style.display = '';
+  restoreEl.style.display = 'none';
+  newEl.style.display = 'none';
 }
 
 async function syncSetupDoRestore() {

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 318,
+  "totalDiagnostics": 310,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -88,7 +88,6 @@
     "js/settings-data.js": 4,
     "js/settings-import-benchmark-controller.js": 5,
     "js/settings-runtime.js": 2,
-    "js/settings-sync-panel-impl.js": 8,
     "js/settings.js": 2,
     "js/startup-oauth-callbacks.js": 1,
     "js/startup-ui.js": 1,

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.411';
+self.APP_VERSION = '1.10.412';


### PR DESCRIPTION
## Summary
- make new-identity, restore, and back setup transitions require their complete modal DOM before mutating state
- avoid starting async identity generation after a setup modal has been replaced
- eliminate all 8 strict-null diagnostics from `settings-sync-panel-impl.js`
- lower the strict-null ratchet from 318 diagnostics / 124 files to 310 / 123
- bump the app version to 1.10.412

## Validation
- `npm run typecheck:strict-null`
- `npm run typecheck:checkjs`
- `npm test -- tests/strict-null-ratchet.test.js`
- `node tests/test-settings-sync-delegated-actions.js`
- `node tests/test-modal-lifecycle-integrations.js`
- `npx playwright test --workers=1 tests/playwright/settings-sync-setup-browser-coverage.spec.js`
- `npm run quality`
- `npm run architecture:check`
- `npm run production:check`
- `git diff --check`