### PR TITLE
Guard compare and correlation view lifecycle

### DIFF
--- a/js/compare-correlations.js
+++ b/js/compare-correlations.js
@@ -135,8 +135,9 @@ export function installCompareCorrelationDelegates(root = (typeof document !== '
 // Compare Dates
 
 export function showCompare(data) {
-  if (!data) data = getActiveData();
   const main = document.getElementById("main-content");
+  if (!main) return;
+  if (!data) data = getActiveData();
   let html = `<div class="category-header"><h2>Compare Dates</h2>
     <p>Side-by-side comparison of biomarker values between two collection dates</p></div>`;
   if (data.dates.length < 2) {
@@ -164,8 +165,8 @@ export function showCompare(data) {
   main.innerHTML = html;
   const select1 = /** @type {HTMLSelectElement | null} */ (document.getElementById('compare-select-1'));
   const select2 = /** @type {HTMLSelectElement | null} */ (document.getElementById('compare-select-2'));
-  if (select1) select1.value = state.compareDate1;
-  if (select2) select2.value = state.compareDate2;
+  if (select1) select1.value = state.compareDate1 || '';
+  if (select2) select2.value = state.compareDate2 || '';
   updateCompare();
 }
 
@@ -188,8 +189,8 @@ export function swapCompareDates() {
   state.compareDate2 = tmp;
   const s1 = /** @type {HTMLSelectElement | null} */ (document.getElementById('compare-select-1'));
   const s2 = /** @type {HTMLSelectElement | null} */ (document.getElementById('compare-select-2'));
-  if (s1) s1.value = state.compareDate1;
-  if (s2) s2.value = state.compareDate2;
+  if (s1) s1.value = state.compareDate1 || '';
+  if (s2) s2.value = state.compareDate2 || '';
   updateCompare();
 }
 
@@ -255,8 +256,9 @@ export function renderCompareTable(data, idx1, idx2) {
 // Correlations
 
 export function showCorrelations(data) {
-  if (!data) data = getActiveData();
   const main = document.getElementById("main-content");
+  if (!main) return;
+  if (!data) data = getActiveData();
   let html = `<div class="category-header"><h2>Correlations</h2>
     <p>Compare biomarkers across categories on a normalized scale</p></div>`;
   html += `<div class="correlation-controls">

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 302,
+  "totalDiagnostics": 295,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -29,7 +29,6 @@
     "js/chat-threads.js": 1,
     "js/client-list-impl.js": 7,
     "js/client-list-runtime.js": 1,
-    "js/compare-correlations.js": 7,
     "js/context-card-lifestyle-editors-impl.js": 2,
     "js/context-source-registry.js": 1,
     "js/cycle-import-adapters.js": 1,

--- a/tests/compare-correlations-boundaries.test.js
+++ b/tests/compare-correlations-boundaries.test.js
@@ -1,0 +1,19 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { showCompare, showCorrelations } from '../js/compare-correlations.js';
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe('Compare and correlations DOM boundaries', () => {
+  it('does not prepare compare data after the main container is removed', () => {
+    expect(() => showCompare({ dates: null })).not.toThrow();
+  });
+
+  it('does not prepare correlation data after the main container is removed', () => {
+    expect(() => showCorrelations({ categories: null })).not.toThrow();
+  });
+});

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.413';
+self.APP_VERSION = '1.10.414';


### PR DESCRIPTION
## Summary
- stop compare/correlation rendering before data work when the main page container is gone
- normalize intentionally nullable compare-date state before assigning select values
- add focused stale-view boundary regressions
- eliminate all 7 strict-null diagnostics from `compare-correlations.js`
- lower the strict-null ratchet from 302 diagnostics / 122 files to 295 / 121
- bump the app version to 1.10.414

## Validation
- `npm run typecheck:strict-null`
- `npm run typecheck:checkjs`
- `npm test -- tests/compare-correlations-boundaries.test.js tests/strict-null-ratchet.test.js`
- `node tests/test-compare-correlations-delegated-actions.js`
- `npx playwright test --workers=1 tests/playwright/compare-correlations-browser-coverage.spec.js`
- `npm run quality`
- `npm run architecture:check`
- `npm run production:check`
- `git diff --check`