### PR TITLE
Scope PDF preflight dialog actions

### DIFF
--- a/js/pdf-import-preflight.js
+++ b/js/pdf-import-preflight.js
@@ -46,6 +46,22 @@ function openPreflightOverlay(overlay, cancel) {
   };
 }
 
+/**
+ * @param {HTMLElement} overlay
+ * @param {Record<string, () => void>} actions
+ * @param {() => void} fallback
+ */
+function bindPreflightActions(overlay, actions, fallback) {
+  for (const [id, handler] of Object.entries(actions)) {
+    const button = overlay.querySelector(`#${id}`);
+    if (!(button instanceof HTMLButtonElement)) {
+      fallback();
+      return;
+    }
+    button.onclick = handler;
+  }
+}
+
 function showPreflightConfirm(message, confirmLabel = 'Import Anyway') {
   return new Promise(resolve => {
     const overlay = ensurePreflightOverlay();
@@ -65,8 +81,10 @@ function showPreflightConfirm(message, confirmLabel = 'Import Anyway') {
       resolve(result);
     };
     cleanup = openPreflightOverlay(overlay, () => close(false));
-    document.getElementById('confirm-ok').onclick = () => close(true);
-    document.getElementById('confirm-cancel').onclick = () => close(false);
+    bindPreflightActions(overlay, {
+      'confirm-ok': () => close(true),
+      'confirm-cancel': () => close(false),
+    }, () => close(false));
   });
 }
 
@@ -131,12 +149,14 @@ function showModelMismatchDialog(mismatch) {
       resolve(result);
     };
     cleanup = openPreflightOverlay(overlay, () => close('cancel'));
-    document.getElementById('confirm-switch').onclick = () => {
-      tryAutoSwitchModel(mismatch.prevModel, mismatch.prevProvider);
-      close('switched');
-    };
-    document.getElementById('confirm-continue').onclick = () => close('continue');
-    document.getElementById('confirm-cancel').onclick = () => close('cancel');
+    bindPreflightActions(overlay, {
+      'confirm-switch': () => {
+        tryAutoSwitchModel(mismatch.prevModel, mismatch.prevProvider);
+        close('switched');
+      },
+      'confirm-continue': () => close('continue'),
+      'confirm-cancel': () => close('cancel'),
+    }, () => close('cancel'));
   });
 }
 
@@ -212,8 +232,10 @@ function showUnsupportedLabDialog(testType) {
       resolve(result);
     };
     cleanup = openPreflightOverlay(overlay, () => close(false));
-    document.getElementById('confirm-ok').onclick = () => close(true);
-    document.getElementById('confirm-cancel').onclick = () => close(false);
+    bindPreflightActions(overlay, {
+      'confirm-ok': () => close(true),
+      'confirm-cancel': () => close(false),
+    }, () => close(false));
   });
 }
 

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 295,
+  "totalDiagnostics": 288,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -71,7 +71,6 @@
     "js/local-ai-provider-lmstudio.js": 1,
     "js/nav.js": 1,
     "js/pdf-import-marker-mapping.js": 2,
-    "js/pdf-import-preflight.js": 7,
     "js/pdf-import-progress.js": 4,
     "js/pdf-import-review-runtime.js": 1,
     "js/pii.js": 1,

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.414';
+self.APP_VERSION = '1.10.415';


### PR DESCRIPTION
## Summary
- bind preflight actions inside their owning overlay instead of using global IDs
- verify dialog controls before wiring them and safely resolve with the dialog fallback if a template is incomplete
- remove repeated button-binding code across duplicate, model-mismatch, and unsupported-lab dialogs
- eliminate all 7 strict-null diagnostics from `pdf-import-preflight.js`
- lower the strict-null ratchet from 295 diagnostics / 121 files to 288 / 120
- bump the app version to 1.10.415

## Validation
- `npm run typecheck:strict-null`
- `npm run typecheck:checkjs`
- `npm test -- tests/strict-null-ratchet.test.js`
- `node tests/test-modal-lifecycle-integrations.js`
- `npx playwright test --grep "PDF import preflight" --workers=1 tests/playwright/pdf-import-browser-coverage.spec.js`
- `npm run quality`
- `npm run architecture:check`
- `npm run production:check`
- `git diff --check`