### PR TITLE
Guard dashboard page lifecycle

### DIFF
--- a/js/dashboard-page-view.js
+++ b/js/dashboard-page-view.js
@@ -187,13 +187,14 @@ export function createDashboardPageView(deps) {
   }
 
   function showDashboard(data) {
+    const main = document.getElementById("main-content");
+    if (!main) return;
     // Resume the live-session ticker if a session was started before this
     // page loaded — keeps the dashboard Light Today surface ticking after a
     // hard reload mid-session.
     try { resumeActiveTickerIfNeeded(); } catch (e) {}
     try { ensureActiveDeviceTicker(); } catch (e) {}
     if (!data) data = getActiveData();
-    const main = document.getElementById("main-content");
     if (main.hasAttribute('aria-busy')) main.removeAttribute('aria-busy');
     const wasMobileDashboardActive = document.body.classList.contains('mobile-dashboard-active');
     document.body.classList.remove('mobile-dashboard-active');

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 288,
+  "totalDiagnostics": 281,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -36,7 +36,6 @@
     "js/cycle-import.js": 3,
     "js/cycle-store.js": 4,
     "js/dashboard-lab-widget-renderers.js": 4,
-    "js/dashboard-page-view.js": 7,
     "js/dashboard-view-composition.js": 2,
     "js/dashboard-widget-runtime.js": 1,
     "js/dashboard-widgets.js": 1,

--- a/tests/dashboard-page-view-boundaries.test.js
+++ b/tests/dashboard-page-view-boundaries.test.js
@@ -1,0 +1,17 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createDashboardPageView } from '../js/dashboard-page-view.js';
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe('Dashboard page DOM boundary', () => {
+  it('does not start dashboard work after the main container is removed', () => {
+    const { showDashboard } = createDashboardPageView({});
+
+    expect(() => showDashboard({ dates: null })).not.toThrow();
+  });
+});

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.415';
+self.APP_VERSION = '1.10.416';


### PR DESCRIPTION
## What changed

- stop dashboard rendering immediately when its `#main-content` mount point has already been removed
- avoid starting stale-view ticker and data work after navigation
- add a direct regression test for the missing-container boundary
- remove all 7 strict-null diagnostics from `dashboard-page-view.js`, moving the baseline from 288 diagnostics in 120 files to 281 in 119
- bump the app version to `1.10.416`

## Why

A delayed dashboard render could continue after navigation had removed its container. Making that lifecycle boundary explicit prevents stale work and gives the type checker the same guarantee the runtime now enforces.

## Validation

- `npm run typecheck:strict-null`
- `npm run typecheck:checkjs`
- `npm test -- tests/dashboard-page-view-boundaries.test.js tests/strict-null-ratchet.test.js`
- focused Chromium dashboard welcome-hero Playwright scenario
- `npm run quality`
- `npm run architecture:check`
- `npm run production:check`
- `git diff --check`