### PR TITLE
Harden client list DOM boundaries

### DIFF
--- a/js/client-list-impl.js
+++ b/js/client-list-impl.js
@@ -125,6 +125,11 @@ function _clMenuButton({ icon, label, action, profileId, danger = false }) {
   return `<button type="button" class="cl-menu-item${danger ? ' cl-menu-danger' : ''}" ${_clActionAttrs(action, { 'data-cl-profile-id': profileId })}>${icon}<span>${escapeHTML(label)}</span></button>`;
 }
 
+/** @param {Element} pill */
+function _clTagText(pill) {
+  return pill.firstChild?.textContent?.trim() || '';
+}
+
 // ═══════════════════════════════════════════════
 // AVATAR HELPERS
 // ═══════════════════════════════════════════════
@@ -136,6 +141,10 @@ function _resizeAvatar(file) {
       const canvas = document.createElement('canvas');
       canvas.width = size; canvas.height = size;
       const ctx = canvas.getContext('2d');
+      if (!ctx) {
+        reject(new Error('Canvas 2D context is unavailable'));
+        return;
+      }
       // Center-crop to square
       const min = Math.min(img.width, img.height);
       const sx = (img.width - min) / 2;
@@ -614,7 +623,7 @@ function _clSaveForm(e) {
   // Collect tags from pills
   const tags = [];
   document.querySelectorAll('#cl-tags-wrap .cl-tag-pill').forEach(pill => {
-    const text = pill.firstChild.textContent.trim();
+    const text = _clTagText(pill);
     if (text && !tags.includes(text)) tags.push(text);
   });
 
@@ -781,18 +790,20 @@ function _clTagKeydown(e) {
   if (e.key !== 'Enter') return;
   e.preventDefault();
   const input = e.target;
+  if (!(input instanceof HTMLInputElement)) return;
   const val = input.value.trim();
   if (!val) return;
   // Check for duplicates
   const existing = [];
   document.querySelectorAll('#cl-tags-wrap .cl-tag-pill').forEach(pill => {
-    existing.push(pill.firstChild.textContent.trim().toLowerCase());
+    existing.push(_clTagText(pill).toLowerCase());
   });
   if (existing.includes(val.toLowerCase())) { input.value = ''; return; }
+  const wrap = document.getElementById('cl-tags-wrap');
+  if (!wrap) return;
   const pill = document.createElement('span');
   pill.className = 'cl-tag-pill';
   pill.innerHTML = `${escapeHTML(val)}<button type="button" class="cl-tag-remove" ${_clActionAttrs('remove-tag')} aria-label="Remove tag">${CL_ICONS.close}</button>`;
-  const wrap = document.getElementById('cl-tags-wrap');
   wrap.insertBefore(pill, input);
   input.value = '';
 }
@@ -873,6 +884,7 @@ function _clToggleMenu(e, id, buttonEl = null) {
   const btn = buttonEl || e.currentTarget;
   if (!(btn instanceof Element)) return;
   const modal = menu.parentElement;
+  if (!modal) return;
   const modalRect = modal.getBoundingClientRect();
   const btnRect = btn.getBoundingClientRect();
   menu.style.right = (modalRect.right - btnRect.right) + 'px';

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 281,
+  "totalDiagnostics": 274,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -27,7 +27,6 @@
     "js/chat-summaries.js": 1,
     "js/chat-thread-search.js": 4,
     "js/chat-threads.js": 1,
-    "js/client-list-impl.js": 7,
     "js/client-list-runtime.js": 1,
     "js/context-card-lifestyle-editors-impl.js": 2,
     "js/context-source-registry.js": 1,

--- a/tests/client-list-runtime.test.js
+++ b/tests/client-list-runtime.test.js
@@ -153,6 +153,9 @@ describe('client list runtime behavior', () => {
     tagInput.value = 'longevity';
     tagInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }));
     expect([...document.querySelectorAll('.cl-tag-pill')].map(el => el.firstChild.textContent.trim())).toContain('longevity');
+    const emptyTagPill = document.createElement('span');
+    emptyTagPill.className = 'cl-tag-pill';
+    document.getElementById('cl-tags-wrap').prepend(emptyTagPill);
 
     document.getElementById('cl-height').value = '170';
     document.getElementById('cl-height-unit-toggle').click();

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.416';
+self.APP_VERSION = '1.10.417';


### PR DESCRIPTION
## What changed

- fail safely when avatar resizing cannot acquire a 2D canvas context
- centralize safe tag-pill text extraction and ignore empty/malformed pills
- stop stale tag input and row-menu work when their expected containers are gone
- add regression coverage for a tag pill with no text node
- remove all 7 strict-null diagnostics from `client-list-impl.js`, moving the baseline from 281 diagnostics in 119 files to 274 in 118
- bump the app version to `1.10.417`

## Why

Client-list helpers assumed their canvas and generated DOM nodes always remained available. Explicit boundary checks make delayed or malformed UI state safe while preserving the normal client-management flow.

## Validation

- `npm run typecheck:strict-null`
- `npm run typecheck:checkjs`
- `npm test -- tests/client-list-runtime.test.js tests/strict-null-ratchet.test.js`
- focused Chromium client-list avatar/tag/menu/profile scenario
- `npm run quality`
- `npm run architecture:check`
- `npm run production:check`
- `git diff --check`