### PR TITLE
Harden profile data boundaries

### DIFF
--- a/js/profile.js
+++ b/js/profile.js
@@ -165,8 +165,12 @@ function refreshProfileWearables(profileId, biometrics) {
  */
 export function getProfiles() {
   // Read from in-memory cache (populated at init via initProfilesCache)
-  if (state.profiles) return state.profiles;
-  try { return JSON.parse(localStorage.getItem('labcharts-profiles')) || []; }
+  if (Array.isArray(state.profiles)) return state.profiles;
+  try {
+    const raw = localStorage.getItem('labcharts-profiles');
+    const profiles = raw ? JSON.parse(raw) : [];
+    return Array.isArray(profiles) ? profiles : [];
+  }
   catch(e) { return []; }
 }
 
@@ -175,9 +179,14 @@ export function getProfiles() {
  */
 export async function initProfilesCache() {
   const raw = await encryptedGetItem('labcharts-profiles');
-  try { state.profiles = raw ? JSON.parse(raw) : []; }
-  catch(e) { state.profiles = []; }
-  migrateProfiles(state.profiles);
+  /** @type {ProfileRecord[]} */
+  let profiles = [];
+  try {
+    const parsed = raw ? JSON.parse(raw) : [];
+    if (Array.isArray(parsed)) profiles = parsed;
+  } catch(e) {}
+  state.profiles = profiles;
+  migrateProfiles(profiles);
 }
 
 // Backfill new profile-level fields (tags, notes, status, timestamps, pinned)
@@ -352,6 +361,17 @@ export function migrateProfileData(data) {
   // Migrate old lightCircadian format (had practices/timing) → new format (amLight/daytime/uvExposure/evening/cold/grounding/latitude)
   if (data.lightCircadian && data.lightCircadian.timing && !data.lightCircadian.amLight) {
     const old = data.lightCircadian;
+    /** @type {{
+     *   amLight: string | null,
+     *   daytime: string | null,
+     *   uvExposure: string | null,
+     *   evening: string[],
+     *   cold: string | null,
+     *   grounding: string | null,
+     *   latitude: number | null,
+     *   mealTiming: string[],
+     *   note: string
+     * }} */
     const newLc = { amLight: null, daytime: null, uvExposure: null, evening: [], cold: null, grounding: null, latitude: null, mealTiming: old.mealTiming || [], note: old.note || '' };
     if (old.practices && old.practices.length) {
       for (const p of old.practices) {

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 274,
+  "totalDiagnostics": 267,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -74,7 +74,6 @@
     "js/pii.js": 1,
     "js/profile-context.js": 1,
     "js/profile-share.js": 3,
-    "js/profile.js": 7,
     "js/provider-panel-renderers.js": 1,
     "js/provider-panels.js": 2,
     "js/recommendations-products.js": 2,

--- a/tests/profile-data-boundaries.test.js
+++ b/tests/profile-data-boundaries.test.js
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  createDefaultProfileData,
+  getProfiles,
+  initProfilesCache,
+  migrateProfileData,
+} from '../js/profile.js';
+import { state } from '../js/state.js';
+
+const PROFILES_KEY = 'labcharts-profiles';
+let savedProfiles;
+let savedStoredProfiles;
+
+beforeEach(() => {
+  savedProfiles = state.profiles;
+  savedStoredProfiles = localStorage.getItem(PROFILES_KEY);
+});
+
+afterEach(() => {
+  state.profiles = savedProfiles;
+  if (savedStoredProfiles == null) localStorage.removeItem(PROFILES_KEY);
+  else localStorage.setItem(PROFILES_KEY, savedStoredProfiles);
+});
+
+describe('profile data boundaries', () => {
+  it('rejects non-array profile payloads from both storage paths', async () => {
+    state.profiles = null;
+    localStorage.setItem(PROFILES_KEY, JSON.stringify({ id: 'not-a-list' }));
+
+    expect(getProfiles()).toEqual([]);
+
+    await initProfilesCache();
+
+    expect(state.profiles).toEqual([]);
+  });
+
+  it('migrates every legacy light practice into the structured format', () => {
+    const data = createDefaultProfileData();
+    data.lightCircadian = {
+      timing: 'legacy',
+      practices: [
+        'morning sunlight',
+        'blue light blockers',
+        'no screens before bed',
+        'red light therapy',
+        'UVB exposure',
+      ],
+      mealTiming: ['early dinner'],
+      note: '',
+    };
+
+    const migrated = migrateProfileData(data);
+
+    expect(migrated.lightCircadian).toMatchObject({
+      amLight: 'morning outdoor (after sunrise)',
+      uvExposure: 'UVB lamp',
+      evening: ['blue blockers after sunset', 'no screens 1-2h before bed'],
+      mealTiming: ['early dinner'],
+      note: 'red light therapy',
+    });
+
+    const lampData = createDefaultProfileData();
+    lampData.lightCircadian = {
+      timing: 'legacy',
+      practices: ['light therapy lamp'],
+      mealTiming: [],
+      note: '',
+    };
+
+    expect(migrateProfileData(lampData).lightCircadian.amLight).toBe('light therapy lamp');
+  });
+});

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.417';
+self.APP_VERSION = '1.10.418';


### PR DESCRIPTION
## What changed

- validate in-memory, local, and encrypted-cache profile payloads before treating them as profile lists
- fall back to an empty list for malformed non-array storage data
- explicitly type the structured target for legacy light/circadian practice migration
- add direct regressions for malformed profile storage and every legacy light-practice conversion
- remove all 7 strict-null diagnostics from `profile.js`, moving the baseline from 274 diagnostics in 118 files to 267 in 117
- bump the app version to `1.10.418`

## Why

Profile CRUD assumed parsed storage always contained an array, while the legacy light migration relied on overly narrow inferred null/empty-array types. These boundaries now match the runtime data the application accepts and fail safely on malformed profile payloads.

## Validation

- `npm run typecheck:strict-null`
- `npm run typecheck:checkjs`
- `npm test -- tests/profile-data-boundaries.test.js tests/strict-null-ratchet.test.js`
- focused Chromium profile migration/storage/height/latitude spec
- `npm run quality`
- `npm run architecture:check`
- `npm run production:check`
- `git diff --check`