### PR TITLE
Type sync pull refresh adapters

### DIFF
--- a/js/sync-pull-active-refresh-runtime.js
+++ b/js/sync-pull-active-refresh-runtime.js
@@ -1,6 +1,18 @@
 // @ts-check
 // sync-pull-active-refresh-runtime.js - Browser runtime adapters for active sync pull refresh hooks.
 
+/**
+ * @typedef {{
+ *   buildSidebar: null | (() => unknown),
+ *   ensureActiveThread: () => unknown,
+ *   loadChatHistory: () => unknown | Promise<unknown>,
+ *   loadChatThreads: () => boolean | undefined | Promise<boolean | undefined>,
+ *   navigate: null | ((route: string, options?: Record<string, unknown>) => unknown),
+ *   renderThreadList: () => unknown,
+ * }} SyncPullActiveRefreshDeps
+ */
+
+/** @type {SyncPullActiveRefreshDeps} */
 const syncPullActiveRefreshDeps = {
   buildSidebar: null,
   ensureActiveThread: () => {},
@@ -10,6 +22,7 @@ const syncPullActiveRefreshDeps = {
   renderThreadList: () => {},
 };
 
+/** @param {Partial<SyncPullActiveRefreshDeps>} [deps] */
 export function configureSyncPullActiveRefreshDeps(deps = {}) {
   const previous = { ...syncPullActiveRefreshDeps };
   if ('buildSidebar' in deps) syncPullActiveRefreshDeps.buildSidebar = typeof deps.buildSidebar === 'function' ? deps.buildSidebar : null;
@@ -27,6 +40,15 @@ function getRuntimeWindow() {
     : null;
 }
 
+/**
+ * @param {unknown} value
+ * @returns {value is PromiseLike<boolean | undefined>}
+ */
+function isThenableThreadLoad(value) {
+  if ((typeof value !== 'object' && typeof value !== 'function') || value === null) return false;
+  return typeof /** @type {{ then?: unknown }} */ (value).then === 'function';
+}
+
 export function refreshPulledChatRuntime() {
   const finishRefresh = (threadsLoaded) => {
     if (threadsLoaded === false) {
@@ -39,7 +61,7 @@ export function refreshPulledChatRuntime() {
   };
 
   const loaded = syncPullActiveRefreshDeps.loadChatThreads();
-  if (loaded && typeof loaded.then === 'function') {
+  if (isThenableThreadLoad(loaded)) {
     return loaded.then(finishRefresh);
   }
   return finishRefresh(loaded);

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 267,
+  "totalDiagnostics": 261,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -103,7 +103,6 @@
     "js/sync-diagnostics-snapshot.js": 2,
     "js/sync-disable-cleanup.js": 1,
     "js/sync-identity.js": 4,
-    "js/sync-pull-active-refresh-runtime.js": 6,
     "js/sync-pull-rebroadcast.js": 1,
     "js/sync-push.js": 3,
     "js/sync-reconcile.js": 1,

--- a/tests/test-sync-pull-active-refresh-runtime.js
+++ b/tests/test-sync-pull-active-refresh-runtime.js
@@ -81,6 +81,27 @@ try {
       'dispatchEvent|labcharts-sync-applied',
     ].join(','));
 
+  const asyncCalls = [];
+  configureSyncPullActiveRefreshDeps({
+    loadChatThreads: async () => { asyncCalls.push('loadChatThreads'); return false; },
+    ensureActiveThread: () => asyncCalls.push('ensureActiveThread'),
+    renderThreadList: () => asyncCalls.push('renderThreadList'),
+    loadChatHistory: async () => { asyncCalls.push('loadChatHistory'); return 'history-loaded'; },
+  });
+  const blockedRefresh = await refreshPulledChatRuntime();
+  assert('async thread load failure renders the safe list without selecting or loading a thread',
+    blockedRefresh === false
+      && asyncCalls.join('|') === 'loadChatThreads|renderThreadList');
+
+  asyncCalls.length = 0;
+  configureSyncPullActiveRefreshDeps({
+    loadChatThreads: async () => { asyncCalls.push('loadChatThreads'); return true; },
+  });
+  const completedRefresh = await refreshPulledChatRuntime();
+  assert('async thread load success preserves refresh ordering and awaits history',
+    completedRefresh === 'history-loaded'
+      && asyncCalls.join('|') === 'loadChatThreads|ensureActiveThread|renderThreadList|loadChatHistory');
+
   configureSyncPullActiveRefreshDeps({ buildSidebar: () => { throw new Error('sidebar boom'); } });
   assert('sync pull active refresh runtime guards sidebar rebuild failures',
     rebuildPulledSidebarRuntime() === undefined);

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.418';
+self.APP_VERSION = '1.10.419';


### PR DESCRIPTION
## What changed

- define the sync-pull refresh adapter contract for optional shell hooks and sync-or-async chat loaders
- preserve safe Promise-like detection without assuming every truthy callback result is asynchronous
- add direct ordering regressions for failed and successful asynchronous thread-index loads
- remove all 6 strict-null diagnostics from `sync-pull-active-refresh-runtime.js`, moving the baseline from 267 diagnostics in 117 files to 261 in 116
- bump the app version to `1.10.419`

## Why

The adapter previously relied on narrow values inferred from its empty defaults, obscuring the real callback shapes used by the app. The explicit contract now documents and checks the runtime boundary while preserving synchronous fallback behavior and asynchronous chat refresh ordering.

## Validation

- `npm run typecheck:strict-null`
- `npm run typecheck:checkjs`
- `node tests/test-sync-pull-active-refresh-runtime.js`
- `npm test -- tests/strict-null-ratchet.test.js`
- focused Chromium sync-pull refresh spec
- `npm run quality`
- `npm run architecture:check`
- `npm run production:check`
- `git diff --check`