### PR TITLE
Type touch tooltip anchors

### DIFF
--- a/js/touch-tooltip.js
+++ b/js/touch-tooltip.js
@@ -113,6 +113,10 @@ function _positionTooltip() {
   _tooltip.dataset.placement = placement;
 }
 
+/**
+ * @param {Element} target
+ * @param {{ clientX: number, clientY: number } | null} [touchPoint]
+ */
 function _showTooltip(target, touchPoint = null) {
   const text = _tooltipText(target).trim();
   if (!text) return;

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 261,
+  "totalDiagnostics": 255,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -108,7 +108,6 @@
     "js/sync-reconcile.js": 1,
     "js/sync-save-hooks.js": 1,
     "js/sync-ui.js": 3,
-    "js/touch-tooltip.js": 6,
     "js/tour.js": 3,
     "js/utils.js": 4,
     "js/wearables-connect-runtime.js": 2,

--- a/tests/playwright/ui-helper-modules-browser-coverage.spec.js
+++ b/tests/playwright/ui-helper-modules-browser-coverage.spec.js
@@ -217,7 +217,9 @@ test('touch tooltip browser coverage handles long press drift and touch focus su
       const touchTip = document.getElementById('app-tooltip');
       const longPressShown = touchTip?.textContent === 'Touch tip'
         && touchTip.classList.contains('is-visible')
-        && target.getAttribute('aria-describedby') === 'app-tooltip';
+        && target.getAttribute('aria-describedby') === 'app-tooltip'
+        && Number.isFinite(Number.parseInt(touchTip.style.left, 10))
+        && Number.isFinite(Number.parseInt(touchTip.style.top, 10));
       dispatchTouch(target, 'touchmove', [{ clientX: 45, clientY: 65 }]);
       await waitFrame();
       const smallDriftKeepsTooltip = touchTip.classList.contains('is-visible');

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.419';
+self.APP_VERSION = '1.10.420';


### PR DESCRIPTION
## What changed

- define the optional touch-point coordinate contract used to anchor long-press tooltips
- strengthen browser coverage to verify long-press positioning writes numeric viewport coordinates
- remove all 6 strict-null diagnostics from `touch-tooltip.js`, moving the baseline from 261 diagnostics in 116 files to 255 in 115
- bump the app version to `1.10.420`

## Why

The tooltip renderer accepted touch coordinates at runtime, but its default null value made the type checker infer that coordinate path as impossible. The explicit contract now matches the existing long-press behavior and protects its anchored positioning.

## Validation

- `npm run typecheck:strict-null`
- `npm run typecheck:checkjs`
- `npm test -- tests/touch-tooltip-runtime.test.js tests/strict-null-ratchet.test.js`
- focused Chromium touch-tooltip long-press scenario
- `npm run quality`
- `npm run architecture:check`
- `npm run production:check`
- `git diff --check`