### PR TITLE
Narrow biology score summary rows

### DIFF
--- a/js/biology-score-render.js
+++ b/js/biology-score-render.js
@@ -220,7 +220,7 @@ function renderBiologicalCoherenceHero(score) {
     strongest ? ['Strongest', `${strongest.label} (${Math.round(strongest.partial || 0)}/100)`] : null,
     weakest && weakest !== strongest ? ['Most strained', `${weakest.label} (${Math.round(weakest.partial || 0)}/100)`] : null,
     ['Minimum panel', missingCount ? `${missingCount} domain${missingCount === 1 ? '' : 's'} still missing` : 'Enough data across domains'],
-  ].filter(Boolean);
+  ].filter(item => item !== null);
   const dashboardToggle = renderLensDashboardToggle('biology-score-biologicalCoherence');
   return `<section class="biology-coherence-hero biology-score-card-${escapeAttr(score.tone || 'unknown')}" id="biology-score-${escapeAttr(score.id)}">
     <div class="biology-coherence-copy">
@@ -373,6 +373,11 @@ export function renderBiologyScoresWidget(ctx, computeBiologyScores) {
 }
 
 
+/**
+ * @param {any[]} live
+ * @param {any[]} waiting
+ * @param {{ available?: any[] } | null} [coherence]
+ */
 export function renderBiologyScoresActionSummary(live, waiting, coherence = null) {
   if (!live.length) return '';
   const weakest = live.slice().sort((a, b) => a.score - b.score)[0];
@@ -396,7 +401,7 @@ export function renderBiologyScoresActionSummary(live, waiting, coherence = null
     openFirst ? { label: 'Open first', text: `${openFirst.title}: marker-level explanation behind the most strained domain.`, scoreId: openFirst.id } : null,
     nextMissing ? { label: 'Improve confidence', text: `${markerDisplayLabel(nextMissing)} would improve coverage${nextMissing.scoreTitle ? ` for ${nextMissing.scoreTitle}` : ''}.` } : null,
     stale ? { label: 'Retest together', text: `${stale.title}: ${stale.recencyBadge || 'some inputs are stale or date-mismatched'}.`, scoreId: stale.id } : { label: 'Avoid over-testing', text: 'Advanced and specialty markers add depth; they do not lower baseline Biological Coherence when absent.' },
-  ].filter(Boolean);
+  ].filter(row => row !== null);
   return `<section class="biology-score-action-summary"><div class="biology-scores-eyebrow">What matters now</div>${rows.map((row) => {
     const inner = `<strong>${escapeHTML(row.label)}</strong><span>${escapeHTML(row.text)}</span>`;
     return row.scoreId

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 255,
+  "totalDiagnostics": 249,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -15,7 +15,6 @@
     "js/biology-score-context-ai.js": 1,
     "js/biology-score-iron.js": 1,
     "js/biology-score-profile-modifiers.js": 2,
-    "js/biology-score-render.js": 6,
     "js/biology-score-thyroid.js": 3,
     "js/biology-scores-runtime.js": 2,
     "js/blob-storage.js": 2,

--- a/tests/test-biology-scores.js
+++ b/tests/test-biology-scores.js
@@ -10,7 +10,7 @@ import { buildBiologyScoresAIContext } from '../js/biology-score-ai-context.js';
 import { configureBiologyScoreAIDeps, generateBiologyScoreAIAnswer } from '../js/biology-score-ai.js';
 import { BIOLOGY_SCORE_COPY } from '../js/biology-score-copy.js';
 import { applyBiologyScoreContextFlag, buildBiologyScoreContextFingerprint, buildBiologyScoreContextFingerprintsByRange, buildBiologyScoreContextMaterialSignature, buildBiologyScoreContextMaterialSignaturesByRange, configureBiologyScoreContextAIDeps, generateBiologyScoreContextReview, hasCurrentBiologyScoreContextReview, renderBiologyScoreContextAI } from '../js/biology-score-context-ai.js';
-import { renderScoreDetail } from '../js/biology-score-render.js';
+import { renderBiologyScoresActionSummary, renderScoreDetail } from '../js/biology-score-render.js';
 import { renderScoreAIAnswer, writeScoreAIAnswer } from '../js/biology-score-sections.js';
 import { computeBiologyScores, getBiologyScoreLensWidgets, getBiologyScoreMapping, getBiologyScoreWidgetDefinitions, renderBiologyScoreCoveragePlanner, renderBiologyScoresLens, renderBiologyScoresWidget, renderDashboardBiologicalCoherenceWidget } from '../js/biology-scores.js';
 import { getActiveData, invalidateActiveDataCache, filterDatesByRange } from '../js/data.js';
@@ -755,6 +755,19 @@ if (coherenceNoJumpDomains.length) {
 
 const lensHtml = renderBiologyScoresLens({ data });
 const liveScoresDesc = scores.filter(s => s.id !== 'biologicalCoherence' && Number.isFinite(s.score)).sort((a, b) => b.score - a.score);
+const fallbackActionSummaryHtml = renderBiologyScoresActionSummary([{
+  id: 'fallback-score',
+  title: 'Fallback score',
+  score: 42,
+  scoreConfidence: 'high',
+  recencyStatus: 'fresh',
+  available: [],
+  missing: [],
+}], [], null);
+assert('action summary falls back to the weakest live score when coherence is unavailable',
+  fallbackActionSummaryHtml.includes('data-biology-score-id="fallback-score"')
+  && fallbackActionSummaryHtml.includes('Fallback score: marker-level explanation behind the most strained domain.')
+  && fallbackActionSummaryHtml.includes('Avoid over-testing'));
 assert('lens render includes drilldown stack', lensHtml.includes('biology-score-detail-stack'));
 assert('lens pins Biological Coherence as a distinguished hero before score details', lensHtml.includes('biology-coherence-hero') && lensHtml.indexOf('biology-coherence-hero') < lensHtml.indexOf('biology-score-detail-stack') && lensHtml.includes('System-level score'));
 assert('lens coherence hero has dashboard toggle via lens page shell', lensHtml.includes('data-lens-page-action="add-dashboard-widget"') || lensHtml.includes('data-lens-page-action="remove-dashboard-widget"'));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.420';
+self.APP_VERSION = '1.10.421';


### PR DESCRIPTION
## What changed

- narrow nullable coherence-summary tuples and action rows with null-specific predicates
- document the optional coherence input accepted by the action-summary renderer
- add a direct regression proving null coherence falls back to the weakest live score
- remove all 6 strict-null diagnostics from `biology-score-render.js`, moving the baseline from 255 diagnostics in 115 files to 249 in 114
- bump the app version to `1.10.421`

## Why

The renderer intentionally builds optional summary rows, but generic truthy filtering did not give the type checker a reliable non-null contract. Explicit narrowing now matches the rendered behavior and protects the null-coherence fallback without changing score calculations.

## Validation

- `npm run typecheck:strict-null`
- `npm run typecheck:checkjs`
- `node tests/test-biology-scores.js` (223 checks)
- `npm test -- tests/strict-null-ratchet.test.js`
- focused Chromium Biology Scores lens scenario
- `npm run quality`
- `npm run architecture:check`
- `npm run production:check`
- `git diff --check`