### PR TITLE
Harden light tools audit boundaries

### DIFF
--- a/js/light-tools.js
+++ b/js/light-tools.js
@@ -12,7 +12,7 @@ import { escapeHTML, escapeAttr, queryRequired, showNotification } from './utils
 import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
 import { saveImportedData } from './data.js';
 import { deleteImportedArrayItem } from './data-merge.js';
-import { aimingGuideHTML, lockCameraForMeasurement, loadLuxCalibration } from './light-tool-camera.js';
+import { aimingGuideHTML, getRequired2DContext, lockCameraForMeasurement, loadLuxCalibration } from './light-tool-camera.js';
 /** @typedef {typeof import('./light-tool-camera-modals.js')} LightToolCameraModals */
 /** @type {Promise<LightToolCameraModals> | null} */ let lightToolCameraModalsPromise = null;
 /** @type {LightToolCameraModals | null} */ let lightToolCameraModals = null;
@@ -467,9 +467,7 @@ export function openSunriseLogger() {
 
 // ─── Tool 8: Eye-Level Audit (10-min walkthrough) ─────────────────────
 
-/** @typedef {{ t: number, luma: number }} EyeLevelAuditSample */
-/** @typedef {{ at: number, luma: number, lux: number, label: string }} EyeLevelAuditPause */
-/** @type {{ running: boolean, stream: MediaStream | null, samples: EyeLevelAuditSample[] }} */
+/** @type {{ running: boolean, stream: MediaStream | null, samples: Array<{ t: number, luma: number }> }} */
 let _auditState = { running: false, stream: null, samples: [] };
 /** @type {AnyFunction | null} */
 let activeEyeLevelAuditCloser = null;
@@ -512,8 +510,7 @@ export async function openEyeLevelAudit() {
   const statusEl = /** @type {HTMLElement} */ (queryRequired(overlay, '#audit-status'));
   const listEl = /** @type {HTMLElement} */ (queryRequired(overlay, '#audit-room-list'));
   const toggleBtn = /** @type {HTMLButtonElement} */ (queryRequired(overlay, '#audit-toggle'));
-  /** @type {EyeLevelAuditPause[]} */
-  let pauseDetections = [];
+  /** @type {Array<{ at: number, luma: number, lux: number, label: string }>} */ let pauseDetections = [];
 
   // Common room labels for one-tap selection. The free-text input is
   // always available; this just removes the typing burden mid-walkthrough.
@@ -569,16 +566,8 @@ export async function openEyeLevelAudit() {
         if (lock.exposure !== 'manual') {
           statusEl.innerHTML = `Recording… <span style="color:var(--orange);font-size:11px">⚠ camera auto-exposure on — per-room values will be relative, not absolute lux.</span>`;
         }
-        const canvas = document.createElement('canvas');
-        canvas.width = 32; canvas.height = 24;
-        const ctx = canvas.getContext('2d', { willReadFrequently: true });
-        if (!ctx) {
-          statusEl.textContent = 'Camera processing is unavailable in this browser.';
-          _auditState.running = false;
-          try { stream.getTracks().forEach(t => t.stop()); } catch (e) {}
-          _auditState.stream = null;
-          return;
-        }
+        const canvas = document.createElement('canvas'); canvas.width = 32; canvas.height = 24;
+        const ctx = getRequired2DContext(canvas);
         let lastSampleLuma = null;
         let pauseStart = null;
         let waitingForMovement = false;
@@ -616,8 +605,8 @@ export async function openEyeLevelAudit() {
         };
         tick();
       } catch (e) {
-        statusEl.innerHTML = 'Camera access denied — audit unavailable. <br><span style="font-size:11px;color:var(--text-muted)">The walkthrough captures 4 frames per second to detect when you\'ve paused in a new room. Open your browser\'s site settings to allow camera access, or log rooms manually from the Light Environment section.</span>';
-        _auditState.running = false;
+        statusEl.innerHTML = e instanceof Error && e.message.includes('2D canvas context') ? 'Camera processing is unavailable in this browser.' : 'Camera access denied — audit unavailable. <br><span style="font-size:11px;color:var(--text-muted)">The walkthrough captures 4 frames per second to detect when you\'ve paused in a new room. Open your browser\'s site settings to allow camera access, or log rooms manually from the Light Environment section.</span>';
+        _auditState.running = false; if (_auditState.stream) { try { _auditState.stream.getTracks().forEach(t => t.stop()); } catch (stopError) {} _auditState.stream = null; }
       }
     } else {
       // Stop

--- a/js/light-tools.js
+++ b/js/light-tools.js
@@ -467,6 +467,9 @@ export function openSunriseLogger() {
 
 // ─── Tool 8: Eye-Level Audit (10-min walkthrough) ─────────────────────
 
+/** @typedef {{ t: number, luma: number }} EyeLevelAuditSample */
+/** @typedef {{ at: number, luma: number, lux: number, label: string }} EyeLevelAuditPause */
+/** @type {{ running: boolean, stream: MediaStream | null, samples: EyeLevelAuditSample[] }} */
 let _auditState = { running: false, stream: null, samples: [] };
 /** @type {AnyFunction | null} */
 let activeEyeLevelAuditCloser = null;
@@ -509,6 +512,7 @@ export async function openEyeLevelAudit() {
   const statusEl = /** @type {HTMLElement} */ (queryRequired(overlay, '#audit-status'));
   const listEl = /** @type {HTMLElement} */ (queryRequired(overlay, '#audit-room-list'));
   const toggleBtn = /** @type {HTMLButtonElement} */ (queryRequired(overlay, '#audit-toggle'));
+  /** @type {EyeLevelAuditPause[]} */
   let pauseDetections = [];
 
   // Common room labels for one-tap selection. The free-text input is
@@ -568,6 +572,13 @@ export async function openEyeLevelAudit() {
         const canvas = document.createElement('canvas');
         canvas.width = 32; canvas.height = 24;
         const ctx = canvas.getContext('2d', { willReadFrequently: true });
+        if (!ctx) {
+          statusEl.textContent = 'Camera processing is unavailable in this browser.';
+          _auditState.running = false;
+          try { stream.getTracks().forEach(t => t.stop()); } catch (e) {}
+          _auditState.stream = null;
+          return;
+        }
         let lastSampleLuma = null;
         let pauseStart = null;
         let waitingForMovement = false;

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 249,
+  "totalDiagnostics": 243,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -63,7 +63,6 @@
     "js/light-page-view.js": 2,
     "js/light-today-ai.js": 4,
     "js/light-tool-camera.js": 5,
-    "js/light-tools.js": 6,
     "js/local-ai-lifecycle.js": 2,
     "js/local-ai-provider-lmstudio.js": 1,
     "js/nav.js": 1,

--- a/tests/playwright/light-tools-browser-coverage.spec.js
+++ b/tests/playwright/light-tools-browser-coverage.spec.js
@@ -334,6 +334,20 @@ test('light tools browser coverage exercises storage render and modal flows', as
       lightTools.closeGlassTransmission();
       results.cameraFacadeStreamsStoppedOnClose = streamStops.length >= 5;
 
+      const streamStopsBeforeMissingCanvas = streamStops.length;
+      Object.defineProperty(navigator, 'mediaDevices', {
+        configurable: true,
+        value: { getUserMedia: async () => makeStream() },
+      });
+      HTMLCanvasElement.prototype.getContext = () => null;
+      await lightTools.openEyeLevelAudit();
+      document.getElementById('audit-toggle')?.click();
+      await waitUntil(() => (document.getElementById('audit-status')?.textContent || '')
+        .includes('Camera processing is unavailable'));
+      results.auditMissingCanvasStopsStreamAndShowsMessage =
+        streamStops.length === streamStopsBeforeMissingCanvas + 1;
+      lightTools.closeEyeLevelAudit();
+
       Object.defineProperty(navigator, 'mediaDevices', {
         configurable: true,
         value: {

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.421';
+self.APP_VERSION = '1.10.422';


### PR DESCRIPTION
## Summary

- define explicit eye-level audit stream, sample, and pause state shapes
- handle an unavailable 2D canvas context by stopping the camera and showing a clear message
- cover the canvas-unavailable cleanup path in the focused browser spec
- reduce the strict-null baseline from 249 to 243 and bump the app version to 1.10.422

## Why

The audit state initializer caused TypeScript to infer the stream as permanently `null` and its arrays as unable to accept entries. Separately, `getContext('2d')` is nullable by contract and the runtime path did not handle that failure.

## Impact

The eye-level audit now releases its camera stream instead of failing if canvas processing is unavailable. This clears all six strict-null diagnostics from `js/light-tools.js` without using assertions that hide runtime risk.

## Verification

- `npm run typecheck:strict-null`
- `npm test -- tests/_vitest-legacy.test.js -t "test-light-tools.js|test-light-tools-flow.js"`
- `PORT=8137 npx playwright test tests/playwright/light-tools-browser-coverage.spec.js`
- `git diff --check`