### PR TITLE
Type light tool camera state

### DIFF
--- a/js/light-tool-camera.js
+++ b/js/light-tool-camera.js
@@ -133,7 +133,10 @@ if (typeof window !== 'undefined') installAimingGuideDelegates();
 //
 // Returns: { exposure: 'manual' | 'auto', whiteBalance: 'manual' | 'auto',
 //            focus: 'manual' | 'auto', frameRate: <fps actually delivered> }
+/** @typedef {{ exposure: 'manual' | 'auto', whiteBalance: 'manual' | 'auto', focus: 'manual' | 'auto', frameRate: number | null, iso: number | null, exposureTime: number | null }} CameraLockResult */
+/** @returns {Promise<CameraLockResult>} */
 export async function lockCameraForMeasurement(stream, opts = {}) {
+  /** @type {CameraLockResult} */
   const result = { exposure: 'auto', whiteBalance: 'auto', focus: 'auto', frameRate: null, iso: null, exposureTime: null };
   if (!stream || !stream.getVideoTracks) return result;
   const track = stream.getVideoTracks()[0];
@@ -205,7 +208,7 @@ export async function lockCameraForMeasurement(stream, opts = {}) {
   } catch (e) {
     // Constraint rejected — typically iOS Safari. Report the auto fallback
     // honestly; caller decides whether to warn the user.
-    return { exposure: 'auto', whiteBalance: 'auto', focus: 'auto', frameRate: result.frameRate };
+    return { exposure: 'auto', whiteBalance: 'auto', focus: 'auto', frameRate: result.frameRate, iso: null, exposureTime: null };
   }
   // Re-read settings to confirm the lock actually applied — some platforms
   // accept the constraint without honoring it.
@@ -288,7 +291,7 @@ export function computeRowBanding(data, W, H) {
 
 // Shared lux calibration used by Lux, Darkness, Glass Transmission, and Eye-Level Audit.
 export function loadLuxCalibration() {
-  try { return parseFloat(localStorage.getItem('labcharts-lux-calibration')) || 1.0; }
+  try { return parseFloat(localStorage.getItem('labcharts-lux-calibration') || '') || 1.0; }
   catch (e) { return 1.0; }
 }
 

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 243,
+  "totalDiagnostics": 238,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -62,7 +62,6 @@
     "js/light-env-audits.js": 2,
     "js/light-page-view.js": 2,
     "js/light-today-ai.js": 4,
-    "js/light-tool-camera.js": 5,
     "js/local-ai-lifecycle.js": 2,
     "js/local-ai-provider-lmstudio.js": 1,
     "js/nav.js": 1,

--- a/tests/test-light-tools.js
+++ b/tests/test-light-tools.js
@@ -23,7 +23,7 @@ const tools = await import('../js/light-tools.js');
     cameraLockStatusLine,
     configureLightTools,
     getMeasurements, getMeasurementsForRoom, saveMeasurement, deleteMeasurement,
-    normalizeGoldenHourMinutes,
+    loadLuxCalibration, lockCameraForMeasurement, normalizeGoldenHourMinutes, saveLuxCalibration,
     } = tools;
     const lightToolsSrc = fs.readFileSync(new URL('../js/light-tools.js', import.meta.url), 'utf8');
     const lightAiSaveHooksSrc = fs.readFileSync(new URL('../js/light-ai-save-hooks.js', import.meta.url), 'utf8');
@@ -118,6 +118,51 @@ const tools = await import('../js/light-tools.js');
   const allAuto = cameraLockStatusLine({ exposure: 'auto', whiteBalance: 'auto' });
   assert('All-auto reports both warnings',
     /exposure/.test(allAuto) && /white-balance/.test(allAuto));
+
+  const appliedCameraConstraints = [];
+  const cameraTrack = {
+    getSettings: () => ({
+      exposureMode: 'manual',
+      whiteBalanceMode: 'manual',
+      focusMode: 'manual',
+      frameRate: 120,
+    }),
+    getCapabilities: () => ({
+      exposureMode: ['manual'],
+      exposureCompensation: { min: -2, max: 2 },
+      exposureTime: { min: 1, max: 500 },
+      iso: { min: 50, max: 800 },
+      whiteBalanceMode: ['manual'],
+      colorTemperature: { min: 2000, max: 8000 },
+      focusMode: ['manual'],
+    }),
+    applyConstraints: async constraints => appliedCameraConstraints.push(constraints),
+  };
+  const lockedCamera = await lockCameraForMeasurement({
+    getVideoTracks: () => [cameraTrack],
+  }, { shortExposure: true });
+  assert('Camera lock result preserves numeric frame-rate, exposure, and ISO metadata',
+    lockedCamera.frameRate === 120 && lockedCamera.exposureTime === 83 && lockedCamera.iso === 100);
+  assert('Short-exposure camera lock sends the matching numeric constraints',
+    appliedCameraConstraints[0]?.advanced?.some(item => item.exposureTime === 83)
+    && appliedCameraConstraints[0]?.advanced?.some(item => item.iso === 100));
+  cameraTrack.applyConstraints = async () => { throw new Error('constraints rejected'); };
+  const rejectedCameraLock = await lockCameraForMeasurement({
+    getVideoTracks: () => [cameraTrack],
+  }, { shortExposure: true });
+  assert('Rejected camera constraints return a stable auto-mode result shape',
+    rejectedCameraLock.exposure === 'auto' && rejectedCameraLock.iso === null
+    && rejectedCameraLock.exposureTime === null && rejectedCameraLock.frameRate === 120);
+
+  const savedCalibration = localStorage.getItem('labcharts-lux-calibration');
+  localStorage.removeItem('labcharts-lux-calibration');
+  assert('Missing lux calibration defaults to 1', loadLuxCalibration() === 1);
+  saveLuxCalibration(1.25);
+  assert('Saved lux calibration round-trips as a number', loadLuxCalibration() === 1.25);
+  localStorage.setItem('labcharts-lux-calibration', 'invalid');
+  assert('Invalid lux calibration defaults to 1', loadLuxCalibration() === 1);
+  if (savedCalibration == null) localStorage.removeItem('labcharts-lux-calibration');
+  else localStorage.setItem('labcharts-lux-calibration', savedCalibration);
 
   // ─── 5. getMeasurements lazy init + saveMeasurement ─────────────────
   console.log('%c 5. Measurement persistence ', 'font-weight:bold;color:#f59e0b');

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.422';
+self.APP_VERSION = '1.10.423';


### PR DESCRIPTION
## Summary

- give camera-lock results an explicit stable shape for numeric frame rate, ISO, and exposure metadata
- preserve the same result shape when browser camera constraints are rejected
- handle missing lux-calibration storage before numeric parsing
- add focused coverage for successful and rejected camera locks plus missing, saved, and invalid calibration values
- reduce the strict-null baseline from 243 to 238 and bump the app version to 1.10.423

## Why

The lock result initialized numeric fields with `null`, so strict null checking inferred that they could never hold measured numbers. Making the result contract explicit also revealed that the rejected-constraint path returned a narrower object without ISO or exposure fields. Lux calibration separately passed `Storage.getItem()`'s nullable result directly to `parseFloat`.

## Impact

Camera consumers now receive one predictable result shape across successful, unsupported, and rejected constraint paths. Missing or invalid calibration storage continues to fall back safely to `1.0`.

## Verification

- `npm run typecheck:strict-null`
- `npm test -- tests/_vitest-legacy.test.js -t "test-light-tools.js"`
- `npm run quality`
- `PORT=8138 npx playwright test tests/playwright/light-tool-camera-modals-browser-coverage.spec.js tests/playwright/light-tool-camera-modals-edge-browser-coverage.spec.js`
- `git diff --check`