### PR TITLE
Type light device session inputs

### DIFF
--- a/js/light-device-session-engine.js
+++ b/js/light-device-session-engine.js
@@ -16,7 +16,7 @@ import {
 /**
  * @typedef {object} DeviceSessionDoseInput
  * @property {any} [device]
- * @property {number} [durationMin]
+ * @property {number} [durationMin=0]
  * @property {number} [distanceCm]
  * @property {string} [bodyArea]
  * @property {string[]|null} [bodyAreas]
@@ -52,6 +52,11 @@ function _runtimeDeps(deps = {}) {
   };
 }
 
+/**
+ * @param {any} device
+ * @param {string|null} [mode]
+ * @param {any} [deps]
+ */
 export function resolveDeviceMode(device, mode = null, deps = {}) {
   if (!Array.isArray(device?.modes) || device.modes.length === 0) return mode ?? null;
   const found = device.modes.find(m => m.id === mode);
@@ -65,6 +70,10 @@ export function resolveDeviceMode(device, mode = null, deps = {}) {
   return resolvedMode;
 }
 
+/**
+ * @param {{ bodyAreas?: string[] | null, bodyArea?: string }} [selection]
+ * @param {Array<{ key: string, fraction: number }> | null} [bodyRegions]
+ */
 export function bodyFractionForDeviceSession({ bodyAreas = null, bodyArea = 'torso' } = {}, bodyRegions = BODY_REGIONS) {
   if (Array.isArray(bodyAreas) && bodyAreas.length > 0) {
     const fracByKey = Object.fromEntries((bodyRegions || []).map(r => [r.key, r.fraction]));
@@ -87,7 +96,7 @@ export function deviceDistanceFactor(device, distanceCm = 15) {
  */
 export function computeDeviceSessionDoses({
   device,
-  durationMin,
+  durationMin = 0,
   distanceCm = 15,
   bodyArea = 'torso',
   bodyAreas = null,

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 238,
+  "totalDiagnostics": 232,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -53,11 +53,10 @@
     "js/lens-local-worker.js": 1,
     "js/lens-pages.js": 3,
     "js/lens.js": 2,
-    "js/light-device-session-engine.js": 5,
     "js/light-device-session-modal.js": 3,
     "js/light-device-setup-modal.js": 2,
     "js/light-devices-actions.js": 4,
-    "js/light-devices-store.js": 2,
+    "js/light-devices-store.js": 1,
     "js/light-devices.js": 1,
     "js/light-env-audits.js": 2,
     "js/light-page-view.js": 2,

--- a/tests/test-light-devices.js
+++ b/tests/test-light-devices.js
@@ -106,6 +106,9 @@ const {
   });
   assert('computeDeviceSessionDoses blocks SAD eye dose when eyes protected',
     sadProtected.doses.circadian === undefined);
+  const emptyDose = computeDeviceSessionDoses();
+  assert('computeDeviceSessionDoses defaults an omitted duration to a zero-length session',
+    emptyDose.durationSec === 0 && Object.keys(emptyDose.doses).length === 0);
   const spectrumArgs = [];
   const spectrumDose = computeDeviceSessionDoses({
     device: { peakWavelengths: [660], mwPerCm2At15cm: 20, recommendedDistanceCm: 20, modes: [{ id: 'all-on', default: true }, { id: 'red-only' }] },

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.423';
+self.APP_VERSION = '1.10.424';


### PR DESCRIPTION
## Summary

- type device-mode resolution across nullable and explicit mode selections
- type precise body-area arrays and region-fraction inputs
- default omitted session duration to zero instead of allowing `NaN` dose math
- cover the empty-input zero-duration path
- reduce the strict-null baseline from 238 to 232, including one downstream store improvement, and bump the app version to 1.10.424

## Why

Untyped destructuring defaults caused body-area arrays to infer as `never`, while mode helpers inferred that only `null` was accepted. The optional duration contract also flowed into arithmetic without a runtime default, allowing an omitted duration to create `NaN` values.

## Impact

Device-session dose calculations now accept their documented nullable and array inputs consistently. Empty or partial calls produce a safe zero-length session rather than invalid numeric output.

## Verification

- `npm run typecheck:strict-null`
- `npm test -- tests/_vitest-legacy.test.js -t "test-light-devices.js"`
- `npm run quality`
- `PORT=8139 npx playwright test tests/playwright/light-device-session-engine-browser-coverage.spec.js`
- `git diff --check`