### PR TITLE
Type sun defaults runtime dependencies

### DIFF
--- a/js/sun-defaults-runtime.js
+++ b/js/sun-defaults-runtime.js
@@ -3,6 +3,7 @@
 
 import { getProfileLocation } from './profile.js';
 
+/** @type {{ getProfileLocation: AnyFunction, getSunCoords: AnyFunction | null, navigate: AnyFunction | null, requestPreciseLocation: AnyFunction | null, openProfileLocationEditor: AnyFunction | null, openClientList: AnyFunction | null }} */
 const sunDefaultsRuntimeDeps = {
   getProfileLocation,
   getSunCoords: null,

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 232,
+  "totalDiagnostics": 227,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -82,7 +82,6 @@
     "js/startup-oauth-callbacks.js": 1,
     "js/startup-ui.js": 1,
     "js/sun-body-silhouette.js": 5,
-    "js/sun-defaults-runtime.js": 5,
     "js/sun-defaults.js": 2,
     "js/sun-session-ui.js": 1,
     "js/sun-uvdata.js": 1,

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.424';
+self.APP_VERSION = '1.10.425';


### PR DESCRIPTION
## Summary

- define the runtime dependency shape for Sun/Light setup callbacks
- preserve nullable optional callback behavior and the required profile-location provider
- reduce the strict-null baseline from 232 to 227 and bump the app version to 1.10.425

## Why

The optional runtime callbacks were initialized as `null` without an explicit dependency contract. Strict null checking therefore inferred them as permanently non-callable even though startup wiring injects functions and the adapter already guards missing callbacks.

## Impact

Sun/Light setup callback injection is now represented accurately to the type checker while retaining the existing safe fallbacks for unavailable navigation, location, and profile actions.

## Verification

- `npm run typecheck:strict-null`
- `npm test -- tests/_vitest-legacy.test.js -t "test-sun-defaults-runtime.js"`
- `npm run quality`
- `PORT=8140 npx playwright test tests/playwright/setup-onboarding-coverage-batch.spec.js -g "Light setup overlay"`
- `git diff --check`