### PR TITLE
Guard sun silhouette canvas boundaries

### DIFF
--- a/js/sun-body-silhouette.js
+++ b/js/sun-body-silhouette.js
@@ -316,6 +316,7 @@ function _loadRegionMap() {
     const c = document.createElement('canvas');
     c.width = W; c.height = H;
     const ctx = c.getContext('2d');
+    if (!ctx) throw new Error('Body silhouette requires a 2D canvas context');
     ctx.drawImage(img, 0, 0, W, H);
     const src = ctx.getImageData(0, 0, W, H);
     const out = ctx.createImageData(W, H);
@@ -396,6 +397,7 @@ function _renderSelectionOverlay(selected, onReady) {
   c.width = W;
   c.height = H;
   const ctx = c.getContext('2d');
+  if (!ctx) return _overlayCache.url || null;
   const out = ctx.createImageData(W, H);
   const outData = out.data;
   for (let i = 0; i < inData.length; i += 4) {

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 227,
+  "totalDiagnostics": 222,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -81,7 +81,6 @@
     "js/settings.js": 2,
     "js/startup-oauth-callbacks.js": 1,
     "js/startup-ui.js": 1,
-    "js/sun-body-silhouette.js": 5,
     "js/sun-defaults.js": 2,
     "js/sun-session-ui.js": 1,
     "js/sun-uvdata.js": 1,

--- a/tests/playwright/sun-body-silhouette-browser-coverage.spec.js
+++ b/tests/playwright/sun-body-silhouette-browser-coverage.spec.js
@@ -14,7 +14,7 @@ function expectAll(outcomes) {
 test('sun body silhouette covers stock render region map overlay and input paths', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
 
-  const outcomes = await page.evaluate(async ({ pathsUrl, silhouetteUrl }) => {
+  const outcomes = await page.evaluate(async ({ missingCanvasSilhouetteUrl, pathsUrl, silhouetteUrl }) => {
     const [silhouette, silhouetteRuntime] = await Promise.all([
       import(silhouetteUrl),
       import('/js/sun-body-silhouette-runtime.js'),
@@ -153,6 +153,28 @@ test('sun body silhouette covers stock render region map overlay and input paths
       window.dispatchEvent(new CustomEvent('sun-overlay-ready'));
       await delay(0);
       outcomes.detachedOverlayReadyDoesNotMutateHost = detachedHost.innerHTML === detachedSnapshot;
+
+      const originalGetContext = HTMLCanvasElement.prototype.getContext;
+      silhouette.resetBodySilhouetteState();
+      HTMLCanvasElement.prototype.getContext = () => null;
+      try {
+        const missingOverlayContextMarkup = silhouette.renderBodySilhouette(new Set(['face']));
+        outcomes.missingOverlayContextKeepsPickerUsable =
+          missingOverlayContextMarkup.includes('data-selection-overlay="pending"')
+          && !missingOverlayContextMarkup.includes('blob:');
+
+        const missingCanvasSilhouette = await import(missingCanvasSilhouetteUrl);
+        let missingMapContextError = '';
+        try {
+          await missingCanvasSilhouette._testLoadRegionMap();
+        } catch (error) {
+          missingMapContextError = error?.message || String(error);
+        }
+        outcomes.missingMapContextFailsClearly =
+          missingMapContextError === 'Body silhouette requires a 2D canvas context';
+      } finally {
+        HTMLCanvasElement.prototype.getContext = originalGetContext;
+      }
     } finally {
       silhouette.resetBodySilhouetteState();
       silhouetteRuntime.configureSunBodySilhouetteRuntimeDeps(previousSilhouetteRuntimeDeps);
@@ -161,6 +183,7 @@ test('sun body silhouette covers stock render region map overlay and input paths
 
     return outcomes;
   }, {
+    missingCanvasSilhouetteUrl: moduleUrl('/js/sun-body-silhouette.js'),
     pathsUrl: moduleUrl('/js/silhouette-paths.js'),
     silhouetteUrl: moduleUrl('/js/sun-body-silhouette.js'),
   });

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.425';
+self.APP_VERSION = '1.10.426';


### PR DESCRIPTION
## Summary
- fail the silhouette region-map load with a clear error when no 2D canvas context is available
- keep the body-region picker usable when selection-overlay canvas creation is unavailable
- add focused browser coverage for both missing-context paths
- ratchet strict-null diagnostics from 227 to 222 and bump the app version to 1.10.426

## Verification
- `npm run typecheck:strict-null` — 222 diagnostics across 109 files
- `npm run quality` — 11/11 gates passed
- `PORT=8140 npx playwright test tests/playwright/sun-body-silhouette-browser-coverage.spec.js` — 1 passed
- `git diff --check`