### PR TITLE
Type import benchmark refresh state

### DIFF
--- a/js/settings-import-benchmark-controller.js
+++ b/js/settings-import-benchmark-controller.js
@@ -24,6 +24,10 @@ import { isDebugMode, showConfirmDialog, showNotification } from './utils.js';
 
 const IMPORT_BENCHMARKS_REFRESH_EVENT = 'import-benchmarks-refresh';
 
+/** @typedef {Awaited<ReturnType<typeof runBundledImportReferenceBenchmark>>} ImportReferenceBenchmarkCompletion */
+/** @typedef {{ benchmarkId: string, manifestId: string }} ImportBenchmarksRefreshDetail */
+
+/** @param {ImportReferenceBenchmarkCompletion | null} [completed] */
 function refreshOpenImportBenchmarksModal(completed = null) {
   const activeOverlay = document.getElementById('import-benchmarks-overlay');
   if (!activeOverlay) return;
@@ -70,6 +74,7 @@ export function openImportBenchmarksModal() {
       ${renderImportBenchmarksBody(snapshots)}
     </div>
   </div>`;
+  /** @param {ImportBenchmarksRefreshDetail | null} [detail] */
   const refreshOverlay = (detail = null) => {
     snapshots = getImportBenchmarkSnapshots();
     selectedIds.clear();

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 222,
+  "totalDiagnostics": 217,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -76,7 +76,6 @@
     "js/recommendations-runtime.js": 2,
     "js/schema.js": 2,
     "js/settings-data.js": 4,
-    "js/settings-import-benchmark-controller.js": 5,
     "js/settings-runtime.js": 2,
     "js/settings.js": 2,
     "js/startup-oauth-callbacks.js": 1,

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.426';
+self.APP_VERSION = '1.10.427';


### PR DESCRIPTION
## Summary
- derive the completed reference-benchmark type from the benchmark runner
- type the modal refresh event detail boundary explicitly
- remove all five strict-null diagnostics from the controller
- ratchet strict-null diagnostics from 222 to 217 and bump the app version to 1.10.427

## Verification
- `npm run typecheck:strict-null` — 217 diagnostics across 108 files
- `npm test -- tests/settings-import-benchmark-controller-runtime.test.js` — 1 passed
- `npm run quality` — 11/11 gates passed
- `git diff --check`