### PR TITLE
Type category customization runtime

### DIFF
--- a/js/category-customization-runtime.js
+++ b/js/category-customization-runtime.js
@@ -3,12 +3,25 @@
 
 import { showPromptDialog } from './utils.js';
 
+/**
+ * @typedef {{
+ *   buildSidebar: ((data?: any) => void) | null,
+ *   navigate: ((route: string, data?: any) => void) | null,
+ *   showPromptDialog: (typeof showPromptDialog) | null
+ * }} CategoryCustomizationRuntimeDeps
+ */
+
+/** @type {CategoryCustomizationRuntimeDeps} */
 const categoryCustomizationRuntimeDeps = {
   buildSidebar: null,
   navigate: null,
   showPromptDialog,
 };
 
+/**
+ * @param {Partial<CategoryCustomizationRuntimeDeps>} [deps]
+ * @returns {CategoryCustomizationRuntimeDeps}
+ */
 export function configureCategoryCustomizationRuntimeDeps(deps = {}) {
   const previous = { ...categoryCustomizationRuntimeDeps };
   if ('buildSidebar' in deps) {

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 217,
+  "totalDiagnostics": 213,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -18,7 +18,6 @@
     "js/biology-score-thyroid.js": 3,
     "js/biology-scores-runtime.js": 2,
     "js/blob-storage.js": 2,
-    "js/category-customization-runtime.js": 4,
     "js/chat-images.js": 1,
     "js/chat-onboarding.js": 2,
     "js/chat-panel.js": 2,

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.427';
+self.APP_VERSION = '1.10.428';


### PR DESCRIPTION
## Summary
- define the callback/null contract for category customization runtime dependencies
- type dependency configuration inputs and its previous-state return value
- remove all four strict-null diagnostics from the runtime adapter
- ratchet strict-null diagnostics from 217 to 213 and bump the app version to 1.10.428

## Verification
- `npm run typecheck:strict-null` — 213 diagnostics across 107 files
- `npm test -- tests/_vitest-legacy.test.js -t "test-category-customization-runtime.js"` — 8 assertions passed
- `npm run quality` — 11/11 gates passed
- `git diff --check`