### PR TITLE
Guard chat thread search boundaries

### DIFF
--- a/js/chat-thread-search.js
+++ b/js/chat-thread-search.js
@@ -58,7 +58,7 @@ export function filterThreadList(value) {
   // Instant: filter thread names
   threadSearchCallbacks.renderThreadList(value);
   // Debounced: search message content
-  clearTimeout(_threadSearchTimer);
+  if (_threadSearchTimer !== null) clearTimeout(_threadSearchTimer);
   _threadSearchTimer = setTimeout(() => searchThreadContent(value.trim()), 250);
 }
 
@@ -170,7 +170,7 @@ function highlightInMessage(el, query) {
     let remainder = node;
     for (let j = positions.length - 1; j >= 0; j--) {
       const idx = positions[j];
-      const current = remainder.textContent;
+      const current = remainder.textContent || '';
       const before = current.slice(0, idx);
       const match = current.slice(idx, idx + qLen);
       const after = current.slice(idx + qLen);

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 213,
+  "totalDiagnostics": 209,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -23,7 +23,6 @@
     "js/chat-panel.js": 2,
     "js/chat-personalities.js": 2,
     "js/chat-summaries.js": 1,
-    "js/chat-thread-search.js": 4,
     "js/chat-threads.js": 1,
     "js/client-list-runtime.js": 1,
     "js/context-card-lifestyle-editors-impl.js": 2,

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.428';
+self.APP_VERSION = '1.10.429';


### PR DESCRIPTION
## Summary
- clear the debounced search timer only when a timer handle exists
- normalize nullable DOM text content before splitting highlighted matches
- remove all four strict-null diagnostics from chat thread search
- ratchet strict-null diagnostics from 213 to 209 and bump the app version to 1.10.429

## Verification
- `npm run typecheck:strict-null` — 209 diagnostics across 106 files
- `PORT=8141 npx playwright test tests/playwright/chat-discussion-edge-browser-coverage.spec.js -g "chat thread search"` — 2 passed
- `npm run quality` — 11/11 gates passed
- `git diff --check`