### PR TITLE
Type data wipe deletion promise

### DIFF
--- a/js/data-wipe.js
+++ b/js/data-wipe.js
@@ -3,7 +3,8 @@
 
 async function deleteIndexedDBDatabase(name) {
   if (!name || typeof indexedDB === 'undefined') return;
-  await new Promise((resolve) => {
+  /** @type {Promise<void>} */
+  const deletion = new Promise((resolve) => {
     try {
       const req = indexedDB.deleteDatabase(name);
       req.onsuccess = () => resolve();
@@ -15,6 +16,7 @@ async function deleteIndexedDBDatabase(name) {
       resolve();
     }
   });
+  await deletion;
 }
 
 function collectKnownProfileIds() {

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 209,
+  "totalDiagnostics": 205,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -35,7 +35,6 @@
     "js/dashboard-view-composition.js": 2,
     "js/dashboard-widget-runtime.js": 1,
     "js/dashboard-widgets.js": 1,
-    "js/data-wipe.js": 4,
     "js/data.js": 2,
     "js/dna-runtime.js": 1,
     "js/dna.js": 3,

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.429';
+self.APP_VERSION = '1.10.430';


### PR DESCRIPTION
## Summary
- give the IndexedDB deletion settlement promise an explicit `void` contract
- preserve success, error, blocked, and synchronous-failure settlement behavior
- remove all four strict-null diagnostics from the data-wipe helper
- ratchet strict-null diagnostics from 209 to 205 and bump the app version to 1.10.430

## Verification
- `npm run typecheck:strict-null` — 205 diagnostics across 105 files
- `npm test -- tests/data-wipe.test.js` — 4 passed
- `npm run quality` — 11/11 gates passed
- `git diff --check`