### PR TITLE
Type PDF import batch state

### DIFF
--- a/js/pdf-import-progress.js
+++ b/js/pdf-import-progress.js
@@ -6,6 +6,7 @@ import { navigateImportReviewRuntime } from './pdf-import-review-runtime.js';
 import { escapeHTML } from './utils.js';
 
 const STEP_START_PCT = [5, 8, 12, 15, 95];
+/** @type {{ running: boolean, pct: number, failed: boolean, done: boolean, fileName: string, batch: { current: number, total: number } | null }} */
 const importStatus = { running: false, pct: 0, failed: false, done: false, fileName: '', batch: null };
 let statusDismissTimer = null;
 let progressBarVisible = false;

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 205,
+  "totalDiagnostics": 201,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -62,7 +62,6 @@
     "js/local-ai-provider-lmstudio.js": 1,
     "js/nav.js": 1,
     "js/pdf-import-marker-mapping.js": 2,
-    "js/pdf-import-progress.js": 4,
     "js/pdf-import-review-runtime.js": 1,
     "js/pii.js": 1,
     "js/profile-context.js": 1,

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.430';
+self.APP_VERSION = '1.10.431';


### PR DESCRIPTION
## Summary
- model PDF import status batch progress as nullable `{ current, total }` state
- preserve single-file and batch progress rendering behavior
- remove all four strict-null diagnostics from PDF import progress
- ratchet strict-null diagnostics from 205 to 201 and bump the app version to 1.10.431

## Verification
- `npm run typecheck:strict-null` — 201 diagnostics across 104 files
- `PORT=8142 npx playwright test tests/playwright/pdf-import-browser-coverage.spec.js -g "PDF import progress"` — 1 passed
- `npm run quality` — 11/11 gates passed
- `git diff --check`