### PR TITLE
Guard focus card null state

### DIFF
--- a/js/focus-card.js
+++ b/js/focus-card.js
@@ -57,7 +57,7 @@ function getFocusFlaggedMarkers(data) {
 
 export function renderFocusCard() {
   const cacheKey = profileStorageKey(state.currentProfile, 'focusCard');
-  const cached = (() => { try { return JSON.parse(localStorage.getItem(cacheKey)); } catch(e) { return null; } })();
+  const cached = (() => { try { return JSON.parse(localStorage.getItem(cacheKey) || 'null'); } catch(e) { return null; } })();
   const fp = getFocusCardFingerprint();
   const text = (cached && cached.fingerprint === fp) ? cached.text : null;
   return `<div class="focus-card" id="focus-card">
@@ -135,9 +135,12 @@ export function buildFocusContext() {
       if (!timing && data.dates.length >= 2) {
         const impacts = computeAllImpacts(s, data);
         if (impacts && impacts.length > 0) {
-          const top = impacts.slice(0, 2).filter(im => im.confidence !== 'low');
+          const top = impacts.slice(0, 2).filter(im => typeof im.pctChange === 'number' && im.confidence !== 'low');
           if (top.length > 0) {
-            impactNote = ' \u2014 impacts: ' + top.map(im => `${im.markerName} ${im.pctChange > 0 ? '+' : ''}${im.pctChange.toFixed(1)}%`).join(', ');
+            impactNote = ' \u2014 impacts: ' + top.map(im => {
+              const pctChange = typeof im.pctChange === 'number' ? im.pctChange : 0;
+              return `${im.markerName} ${pctChange > 0 ? '+' : ''}${pctChange.toFixed(1)}%`;
+            }).join(', ');
           }
         }
       }
@@ -175,7 +178,7 @@ export async function loadFocusCard(opts = {}) {
   if (!el) return;
   const refreshStale = opts.refreshStale !== false;
   const cacheKey = profileStorageKey(state.currentProfile, 'focusCard');
-  const cached = (() => { try { return JSON.parse(localStorage.getItem(cacheKey)); } catch(e) { return null; } })();
+  const cached = (() => { try { return JSON.parse(localStorage.getItem(cacheKey) || 'null'); } catch(e) { return null; } })();
   const fp = getFocusCardFingerprint();
   if (cached && cached.text) {
     el.innerHTML = `<span class="focus-card-text">${applyInlineMarkdown(cached.text)}</span>`;

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 201,
+  "totalDiagnostics": 197,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -42,7 +42,6 @@
     "js/emf.js": 2,
     "js/export-report.js": 1,
     "js/export.js": 1,
-    "js/focus-card.js": 4,
     "js/hardware.js": 1,
     "js/image-utils.js": 2,
     "js/import-drop-zone-runtime.js": 1,

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.431';
+self.APP_VERSION = '1.10.432';


### PR DESCRIPTION
## Summary
- parse missing focus-card cache entries through an explicit JSON `null` fallback
- exclude nullable supplement impact percentages before formatting
- prevent a latent `null.toFixed()` crash while preserving impact ordering
- ratchet strict-null diagnostics from 201 to 197 and bump the app version to 1.10.432

## Verification
- `npm run typecheck:strict-null` — 197 diagnostics across 103 files
- `PORT=8143 npx playwright test tests/playwright/context-coverage-batch.spec.js -g "context health dots and focus card"` — 1 passed
- `npm run quality` — 11/11 gates passed
- `git diff --check`