### PR TITLE
Type light device actions

### DIFF
--- a/js/light-devices-actions.js
+++ b/js/light-devices-actions.js
@@ -7,6 +7,8 @@ const LIGHT_DEVICE_SESSION_ID_ATTR = 'data-light-device-session-id';
 const LIGHT_DEVICES_ACTION_DELEGATE_KEY = Symbol.for('getbased.lightDevicesActionDelegatesInstalled');
 const lightDevicesActionDelegateRoots = new WeakSet();
 
+/** @typedef {'stopDeviceSessionAndNotify' | 'openAddDeviceDialog' | 'deleteLightDevice' | 'openDeviceSessionDialog'} LightDevicesActionName */
+/** @type {Record<LightDevicesActionName, ((id?: string) => unknown) | null>} */
 const lightDevicesActions = {
   stopDeviceSessionAndNotify: null,
   openAddDeviceDialog: null,
@@ -14,10 +16,13 @@ const lightDevicesActions = {
   openDeviceSessionDialog: null,
 };
 
-/** @param {Record<string, Function | null>} [actions] */
+/**
+ * @param {Partial<typeof lightDevicesActions>} [actions]
+ * @returns {typeof lightDevicesActions}
+ */
 export function configureLightDevicesActions(actions = {}) {
   const previous = { ...lightDevicesActions };
-  for (const name of Object.keys(lightDevicesActions)) {
+  for (const name of /** @type {LightDevicesActionName[]} */ (Object.keys(lightDevicesActions))) {
     if (name in actions) {
       lightDevicesActions[name] = typeof actions[name] === 'function' ? actions[name] : null;
     }

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 197,
+  "totalDiagnostics": 193,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -51,7 +51,6 @@
     "js/lens.js": 2,
     "js/light-device-session-modal.js": 3,
     "js/light-device-setup-modal.js": 2,
-    "js/light-devices-actions.js": 4,
     "js/light-devices-store.js": 1,
     "js/light-devices.js": 1,
     "js/light-env-audits.js": 2,

--- a/tests/light-devices-actions.test.js
+++ b/tests/light-devices-actions.test.js
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  configureLightDevicesActions,
+  installLightDevicesActionDelegates,
+} from '../js/light-devices-actions.js';
+
+const defaultActions = configureLightDevicesActions();
+
+describe('light device delegated actions', () => {
+  afterEach(() => {
+    configureLightDevicesActions(defaultActions);
+    document.body.innerHTML = '';
+  });
+
+  it('routes each card action once and allows callbacks to be removed', () => {
+    const stopDeviceSessionAndNotify = vi.fn();
+    const openAddDeviceDialog = vi.fn();
+    const deleteLightDevice = vi.fn();
+    const openDeviceSessionDialog = vi.fn();
+    configureLightDevicesActions({
+      stopDeviceSessionAndNotify,
+      openAddDeviceDialog,
+      deleteLightDevice,
+      openDeviceSessionDialog,
+    });
+
+    const root = document.createElement('div');
+    root.innerHTML = `
+      <button data-light-devices-action="stop-device-session" data-light-device-session-id="session-1">Stop</button>
+      <button data-light-devices-action="add-device">Add</button>
+      <button data-light-devices-action="delete-device" data-light-device-id="device-1">Delete</button>
+      <button data-light-devices-action="log-device-session" data-light-device-id="device-2">Log</button>
+    `;
+    document.body.appendChild(root);
+    installLightDevicesActionDelegates(root);
+    installLightDevicesActionDelegates(root);
+
+    root.querySelector('[data-light-devices-action="stop-device-session"]').click();
+    root.querySelector('[data-light-devices-action="add-device"]').click();
+    root.querySelector('[data-light-devices-action="delete-device"]').click();
+    root.querySelector('[data-light-devices-action="log-device-session"]').click();
+
+    expect(stopDeviceSessionAndNotify).toHaveBeenCalledOnce();
+    expect(stopDeviceSessionAndNotify).toHaveBeenCalledWith('session-1');
+    expect(openAddDeviceDialog).toHaveBeenCalledOnce();
+    expect(deleteLightDevice).toHaveBeenCalledWith('device-1');
+    expect(openDeviceSessionDialog).toHaveBeenCalledWith('device-2');
+
+    configureLightDevicesActions({ openAddDeviceDialog: null });
+    root.querySelector('[data-light-devices-action="add-device"]').click();
+    expect(openAddDeviceDialog).toHaveBeenCalledOnce();
+  });
+});

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.432';
+self.APP_VERSION = '1.10.433';


### PR DESCRIPTION
## Summary
- define the callback/null contract for all four delegated light-device actions
- type action configuration and preserve removable callbacks
- add direct jsdom coverage for stop, add, delete, log, and idempotent delegate installation
- ratchet strict-null diagnostics from 197 to 193 and bump the app version to 1.10.433

## Verification
- `npm run typecheck:strict-null` — 193 diagnostics across 102 files
- `npm test -- tests/light-devices-actions.test.js` — 1 passed
- `npm run quality` — 11/11 gates passed
- `git diff --check`