### PR TITLE
Guard dashboard lab values

### DIFF
--- a/js/dashboard-lab-widget-renderers.js
+++ b/js/dashboard-lab-widget-renderers.js
@@ -90,7 +90,7 @@ export function createDashboardLabWidgetRenderers(deps) {
   function renderDashboardBioAgeWidget(ctx) {
     const hit = getDashboardBioAgeMarker(ctx);
     const age = getDashboardAge();
-    const value = hit ? Number(hit.value) : null;
+    const value = Number(hit?.value);
     const profileContext = getBiologyProfileContext();
     const hasBioAge = Number.isFinite(value);
     const display = hasBioAge ? value.toFixed(1) : '—';
@@ -208,7 +208,7 @@ export function createDashboardLabWidgetRenderers(deps) {
 
   function getDashboardQuickMarkerPins() {
     try {
-      return normalizeDashboardQuickMarkerPins(JSON.parse(localStorage.getItem(dashboardQuickMarkerPinsKey())));
+      return normalizeDashboardQuickMarkerPins(JSON.parse(localStorage.getItem(dashboardQuickMarkerPinsKey()) || '[]'));
     } catch (e) {
       return [];
     }

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 193,
+  "totalDiagnostics": 189,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -31,7 +31,6 @@
     "js/cycle-import-file.js": 2,
     "js/cycle-import.js": 3,
     "js/cycle-store.js": 4,
-    "js/dashboard-lab-widget-renderers.js": 4,
     "js/dashboard-view-composition.js": 2,
     "js/dashboard-widget-runtime.js": 1,
     "js/dashboard-widgets.js": 1,

--- a/tests/dashboard-lab-widget-renderers.test.js
+++ b/tests/dashboard-lab-widget-renderers.test.js
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createDashboardLabWidgetRenderers } from '../js/dashboard-lab-widget-renderers.js';
+import { profileStorageKey } from '../js/profile.js';
+import { state } from '../js/state.js';
+
+let savedState;
+
+function createRenderers() {
+  return createDashboardLabWidgetRenderers({
+    markerHasData: marker => marker.values.some(value => value != null),
+    rerenderDashboardFromWidgetChange: vi.fn(),
+  });
+}
+
+function bioAgeData(value) {
+  return {
+    dates: ['2026-01-15'],
+    categories: {
+      calculatedRatios: {
+        label: 'Calculated ratios',
+        markers: {
+          biologicalAge: {
+            name: 'Biological Age',
+            unit: 'yr',
+            values: [value],
+            refMin: 0,
+            refMax: 100,
+          },
+        },
+      },
+    },
+  };
+}
+
+describe('dashboard lab widget renderers', () => {
+  beforeEach(() => {
+    savedState = {
+      currentProfile: state.currentProfile,
+      importedData: state.importedData,
+      markerRegistry: state.markerRegistry,
+      profileDob: state.profileDob,
+    };
+    state.currentProfile = 'dashboard-lab-renderer-test';
+    state.importedData = {};
+    state.markerRegistry = {};
+    state.profileDob = '1985-01-15';
+    localStorage.clear();
+    document.body.innerHTML = '<div id="notification-container"></div>';
+  });
+
+  afterEach(() => {
+    state.currentProfile = savedState.currentProfile;
+    state.importedData = savedState.importedData;
+    state.markerRegistry = savedState.markerRegistry;
+    state.profileDob = savedState.profileDob;
+    localStorage.clear();
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('renders finite biological age and falls back cleanly without a value', () => {
+    const renderers = createRenderers();
+
+    const available = renderers.renderDashboardBioAgeWidget({ data: bioAgeData(42.5) });
+    expect(available).toContain('42.5');
+    expect(available).toContain('yr vs chronological');
+
+    const unavailable = renderers.renderDashboardBioAgeWidget({ data: bioAgeData(null) });
+    expect(unavailable).toContain('Biological-age comparison unavailable');
+    expect(unavailable).toContain('db-hero-bio-num">—');
+  });
+
+  it('recovers malformed quick-pin storage and toggles a safe marker id', () => {
+    const renderers = createRenderers();
+    const storageKey = profileStorageKey(state.currentProfile, 'dashboardQuickMarkerPinsV1');
+    localStorage.setItem(storageKey, '{not-json');
+
+    expect(renderers.isDashboardQuickMarkerPinned('lipids_apoB')).toBe(false);
+    renderers.toggleDashboardQuickMarkerPin('lipids_apoB');
+    expect(JSON.parse(localStorage.getItem(storageKey))).toEqual(['lipids_apoB']);
+    expect(renderers.isDashboardQuickMarkerPinned('lipids_apoB')).toBe(true);
+
+    renderers.toggleDashboardQuickMarkerPin('lipids_apoB');
+    expect(JSON.parse(localStorage.getItem(storageKey))).toEqual([]);
+  });
+});

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.433';
+self.APP_VERSION = '1.10.434';


### PR DESCRIPTION
## Summary
- normalize missing biological-age readings to non-finite numeric state before rendering
- parse absent quick-marker pin storage through an explicit empty-array fallback
- add direct tests for finite/missing biological age and malformed pin recovery/toggling
- ratchet strict-null diagnostics from 193 to 189 and bump the app version to 1.10.434

## Verification
- `npm run typecheck:strict-null` — 189 diagnostics across 101 files
- `npm test -- tests/dashboard-lab-widget-renderers.test.js` — 2 passed
- `npm run quality` — 11/11 gates passed
- `git diff --check`