### PR TITLE
Normalize import benchmark timings

### DIFF
--- a/js/settings-data.js
+++ b/js/settings-data.js
@@ -313,9 +313,7 @@ function renderReferenceComparisonReviewControl(snap, id) {
 
 function importBenchmarkView(snap) {
   const isGoldStandard = !!snap.benchmarkLocked;
-  const analysisMs = isGoldStandard
-    ? null
-    : Number.isFinite(Number(snap.timings?.analysisMs))
+  const measuredAnalysisMs = Number.isFinite(Number(snap.timings?.analysisMs))
     ? Number(snap.timings.analysisMs)
     : (Number(snap.timings?.analysis) || 0) * 1000;
   const piiMs = Number.isFinite(Number(snap.timings?.piiMs))
@@ -324,7 +322,7 @@ function importBenchmarkView(snap) {
   const inputTokens = Number(snap.usage?.inputTokens ?? snap.costInfo?.inputTokens) || 0;
   const outputTokens = Number(snap.usage?.outputTokens ?? snap.costInfo?.outputTokens) || 0;
   const measuredThroughput = Number(snap.generationTokensPerSecond) || 0;
-  const endToEndRate = analysisMs > 0 && outputTokens > 0 ? outputTokens / (analysisMs / 1000) : 0;
+  const endToEndRate = measuredAnalysisMs > 0 && outputTokens > 0 ? outputTokens / (measuredAnalysisMs / 1000) : 0;
   const throughput = measuredThroughput || endToEndRate;
   const detectedMarkerCount = Number(snap.markerCount) || 0;
   const importedMarkerCount = snap.importedMarkerCount == null
@@ -365,9 +363,9 @@ function importBenchmarkView(snap) {
   return {
     id: importBenchmarkStorageId(snap),
     snap,
-    analysisMs,
+    analysisMs: isGoldStandard ? null : measuredAnalysisMs,
     piiMs,
-    totalMs: isGoldStandard ? null : Number(snap.totalMs) || analysisMs + piiMs,
+    totalMs: isGoldStandard ? null : Number(snap.totalMs) || measuredAnalysisMs + piiMs,
     pdfExtractionMs: isGoldStandard ? null : Number(snap.timings?.pdfExtractionMs) || 0,
     modelLoadMs: Number(snap.timings?.modelLoadMs) || 0,
     timeToFirstTokenMs: Number(snap.timings?.timeToFirstTokenMs) || 0,
@@ -548,6 +546,7 @@ function renderImportBenchmarkCards(snapshots, { selectable = true, emptyCopy = 
 
   return snapshots.map(snap => {
     const view = importBenchmarkView(snap);
+    const pdfExtractionMs = Number(view.pdfExtractionMs) || 0;
     const isReference = isReferenceBenchmark(snap);
     const isGoldStandard = !!snap.benchmarkLocked;
     const recordedAt = Number(snap.benchmarkAt || snap.importedAt);
@@ -642,7 +641,7 @@ function renderImportBenchmarkCards(snapshots, { selectable = true, emptyCopy = 
         ${qualityFields}
         <div><span>Input</span><strong>${Number(snap.inputChars) ? `${formatTokens(Number(snap.inputChars))} chars` : '\u2014'}${Number(snap.pageCount) ? ` \u00b7 ${Number(snap.pageCount)} pages` : ''}</strong></div>
         <div><span>Model setup</span><strong>${contextLength ? `${formatTokens(contextLength)} context` : 'context unknown'}${quant ? ` \u00b7 ${escapeHTML(quant)}` : ''}${executionLocation ? ` \u00b7 ${escapeHTML(executionLocation)}` : ''}${providerApi ? ` \u00b7 ${escapeHTML(providerApi)}` : ''}${loadState ? ` \u00b7 ${escapeHTML(loadState)}` : ''}</strong></div>
-        ${view.pdfExtractionMs > 0 ? `<div><span>Reading the PDF</span><strong>${formatBenchmarkDuration(view.pdfExtractionMs)}</strong></div>` : ''}
+        ${pdfExtractionMs > 0 ? `<div><span>Reading the PDF</span><strong>${formatBenchmarkDuration(pdfExtractionMs)}</strong></div>` : ''}
         ${view.piiMs > 0 ? `<div><span>Privacy preparation</span><strong>${formatBenchmarkDuration(view.piiMs)}</strong></div>` : ''}
         ${view.modelLoadMs > 0 || view.timeToFirstTokenMs > 0 ? `<div><span>Model load / first response</span><strong>${formatOptionalBenchmarkDuration(view.modelLoadMs)} / ${formatOptionalBenchmarkDuration(view.timeToFirstTokenMs)}</strong></div>` : ''}
         ${snap.error ? `<div style="grid-column:1/-1"><span>Error</span><strong>${escapeHTML(snap.error)}</strong></div>` : ''}

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 189,
+  "totalDiagnostics": 185,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -68,7 +68,6 @@
     "js/recommendations-products.js": 2,
     "js/recommendations-runtime.js": 2,
     "js/schema.js": 2,
-    "js/settings-data.js": 4,
     "js/settings-runtime.js": 2,
     "js/settings.js": 2,
     "js/startup-oauth-callbacks.js": 1,

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.434';
+self.APP_VERSION = '1.10.435';


### PR DESCRIPTION
## What changed

- keep measured analysis time numeric for throughput and total-duration calculations
- preserve `null` timing values for built-in answer-key cards
- normalize the optional PDF extraction duration before rendering
- lower the strict-null baseline from 189 to 185 and bump the app version to 1.10.435

## Why

The benchmark view intentionally uses `null` for timings that do not apply to the answer key, but those nullable display values were also used in numeric calculations and comparisons. Separating measured numeric values from display-state nulls removes four strict-null diagnostics without changing the UI semantics.

## Validation

- `npm run typecheck:strict-null`
- `npm run quality`
- `PORT=8144 npx playwright test tests/playwright/import-benchmarks.spec.js -g "import benchmarks compare multiple runs"`
- `git diff --check`