### PR TITLE
Guard Venice E2EE stream boundaries

### DIFF
--- a/js/api-venice.js
+++ b/js/api-venice.js
@@ -163,6 +163,7 @@ export async function callVeniceAPI(opts) {
     };
   }
 
+  if (!res.body) throw new Error('Venice E2EE returned no response stream.');
   const reader = res.body.getReader();
   const decoder = new TextDecoder();
   let buffer = '';
@@ -177,7 +178,7 @@ export async function callVeniceAPI(opts) {
     eventCount: 0,
     contentChunks: 0,
     reasoningChunks: 0,
-    deltaFields: [],
+    deltaFields: /** @type {string[]} */ ([]),
     finishReason: null,
     usageSeen: false,
     doneSeen: false,
@@ -239,7 +240,7 @@ export async function callVeniceAPI(opts) {
     if (done) break;
     buffer += decoder.decode(value, { stream: true });
     const lines = buffer.split('\n');
-    buffer = lines.pop();
+    buffer = lines.pop() || '';
     for (const line of lines) await handleVeniceLine(line, true);
   }
   if (buffer.startsWith('data: ')) await handleVeniceLine(buffer, false);

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 185,
+  "totalDiagnostics": 181,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -8,7 +8,6 @@
     "js/api-openai-compatible.js": 1,
     "js/api-ppq.js": 1,
     "js/api-routstr.js": 1,
-    "js/api-venice.js": 4,
     "js/app-event-listeners.js": 1,
     "js/app-shell-hooks.js": 2,
     "js/backup.js": 3,

--- a/tests/api-provider-contracts.test.js
+++ b/tests/api-provider-contracts.test.js
@@ -1082,6 +1082,24 @@ describe('AI provider request contracts', () => {
     });
   });
 
+  it('rejects a Venice E2EE streaming response without a body', async () => {
+    setAIProvider('venice');
+    updateKeyCache('labcharts-venice-key', 'sk-venice-no-stream');
+    setVeniceE2EE(true);
+    setVeniceModel('e2ee-no-stream-contract');
+    localStorage.setItem('labcharts-venice-models', '[]');
+    localStorage.setItem('labcharts-venice-e2ee-models', JSON.stringify([{ id: 'e2ee-no-stream-contract' }]));
+    localStorage.setItem('labcharts-venice-models-fetched-at', String(Date.now()));
+    globalThis.fetch = vi.fn(async () => new Response(null, { status: 200 }));
+
+    await expect(callClaudeAPI({
+      messages: [{ role: 'user', content: 'stream through e2ee' }],
+      maxTokens: 16,
+      onStream: vi.fn(),
+      requestTimeoutMs: 1000,
+    })).rejects.toThrow('Venice E2EE returned no response stream');
+  });
+
   it('returns encrypted Venice reasoning when a reasoning model emits no final content', async () => {
     setAIProvider('venice');
     updateKeyCache('labcharts-venice-key', 'sk-venice-reasoning');

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.435';
+self.APP_VERSION = '1.10.436';


### PR DESCRIPTION
## What changed

- reject successful Venice E2EE streaming responses that do not include a readable body
- give collected SSE delta fields an explicit string-array type
- keep the incremental SSE buffer a string when a split has no trailing remainder
- add a provider-contract regression test for the missing-body response
- lower the strict-null baseline from 185 to 181 and bump the app version to 1.10.436

## Why

The streaming path assumed every successful response exposed a body, while its diagnostic field list and line remainder were inferred too narrowly under strict null checking. These boundaries now fail clearly or normalize to their runtime-safe types without changing successful stream processing.

## Validation

- `npm test -- tests/api-provider-contracts.test.js`
- `npm test -- tests/api-provider-contracts.test.js -t "Venice E2EE"`
- `npm run typecheck:strict-null`
- `npm run quality`
- `git diff --check`