### PR TITLE
Type sync identity dependencies

### DIFF
--- a/js/sync-identity.js
+++ b/js/sync-identity.js
@@ -7,10 +7,16 @@ import {
 } from './sync-disable-cleanup.js';
 import { scheduleSyncRuntimeReload } from './sync-runtime.js';
 
+/** @typedef {{ id?: unknown, mnemonic?: string }} SyncAppOwner */
+/** @typedef {{ restoreAppOwner: (mnemonic: string) => unknown }} SyncEvolu */
+
 let _bip39Load = null;
 let _qrCodeLoad = null;
+/** @type {() => SyncAppOwner | null} */
 let _getAppOwner = () => null;
+/** @type {() => any} */
 let _getAppOwnerError = () => null;
+/** @type {() => SyncEvolu | null} */
 let _getEvolu = () => null;
 /** @type {(...args: any[]) => Promise<any>} */
 let _seedLocalProfiles = async () => {};
@@ -18,9 +24,9 @@ let _seedLocalProfiles = async () => {};
 export const RESTORE_JOIN_PENDING_KEY = 'labcharts-sync-restore-join-pending';
 
 /** @param {{
- *   getAppOwner?: () => any,
+ *   getAppOwner?: () => SyncAppOwner | null,
  *   getAppOwnerError?: () => any,
- *   getEvolu?: () => any,
+ *   getEvolu?: () => SyncEvolu | null,
  *   seedLocalProfiles?: (...args: any[]) => Promise<any>,
  * }} [deps]
  */

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 181,
+  "totalDiagnostics": 177,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -86,7 +86,6 @@
     "js/sync-diagnose-ui.js": 1,
     "js/sync-diagnostics-snapshot.js": 2,
     "js/sync-disable-cleanup.js": 1,
-    "js/sync-identity.js": 4,
     "js/sync-pull-rebroadcast.js": 1,
     "js/sync-push.js": 3,
     "js/sync-reconcile.js": 1,

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.436';
+self.APP_VERSION = '1.10.437';


### PR DESCRIPTION
## What changed

- define the owner and Evolu shapes consumed by sync identity helpers
- type injected owner, error, and Evolu callbacks explicitly instead of inferring their initial `null` return forever
- lower the strict-null baseline from 181 to 177 and bump the app version to 1.10.437

## Why

The dependency slots are initialized with callbacks that return `null`, but configuration replaces them with live runtime callbacks. Type inference treated the slots as permanently null-returning, making valid owner mnemonic, owner ID, and restore operations appear unreachable under strict null checking.

## Validation

- `PORT=8145 npx playwright test tests/playwright/sync-identity-browser-coverage.spec.js`
- `npm run typecheck:strict-null`
- `npm run quality`
- `git diff --check`