### PR TITLE
Guard supplement editor modal

### DIFF
--- a/js/supplements.js
+++ b/js/supplements.js
@@ -566,6 +566,7 @@ export function toggleSuppAccordion(idx) {
 export function openSupplementsEditor(editIdx) {
   const modal = document.getElementById("detail-modal");
   const overlay = document.getElementById("modal-overlay");
+  if (!modal || !overlay) return;
   const supps = state.importedData.supplements || [];
   const isEdit = typeof editIdx === 'number' && !!supps[editIdx];
   let html = `<button class="modal-close" ${suppActionAttrs('close-modal')}>&times;</button>

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 177,
+  "totalDiagnostics": 173,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -76,7 +76,6 @@
     "js/sun-uvdata.js": 1,
     "js/sun.js": 3,
     "js/supplement-impact.js": 4,
-    "js/supplements.js": 4,
     "js/sync-actions.js": 1,
     "js/sync-delta-merge.js": 1,
     "js/sync-delta-planner-context.js": 1,

--- a/tests/playwright/supplements-browser-coverage.spec.js
+++ b/tests/playwright/supplements-browser-coverage.spec.js
@@ -269,6 +269,11 @@ test('supplements browser coverage handles editor ingredients imports sync and A
         calls.some(call => call[0] === 'ask-ai-click')
         && calls.some(call => call[0] === 'chat-input')
         && document.activeElement === textarea;
+
+      document.getElementById('detail-modal')?.remove();
+      document.getElementById('modal-overlay')?.remove();
+      supplements.openSupplementsEditor();
+      outcomes.editorIgnoresMissingModalShell = true;
     } finally {
       document.getElementById('modal-overlay')?.classList.remove('show');
       document.querySelectorAll('.notification-toast').forEach(el => el.remove());

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.437';
+self.APP_VERSION = '1.10.438';


### PR DESCRIPTION
## What changed

- exit the supplements editor cleanly when its required detail modal or overlay shell is unavailable
- extend the focused browser coverage with a missing-shell regression assertion
- lower the strict-null baseline from 177 to 173 and bump the app version to 1.10.438

## Why

The editor assumed app-shell modal elements always existed and dereferenced the detail modal repeatedly. During partial shell initialization or isolated module use, those lookups can be null. Guarding both required elements prevents a runtime crash and removes four strict-null diagnostics.

## Validation

- `PORT=8146 npx playwright test tests/playwright/supplements-browser-coverage.spec.js`
- `npm run typecheck:strict-null`
- `npm run quality`
- `git diff --check`