### PR TITLE
Type supplement impact percentages

### DIFF
--- a/js/supplement-impact.js
+++ b/js/supplement-impact.js
@@ -94,9 +94,8 @@ export function computeAllImpacts(supplement, data) {
         supplement, dotKey, marker.name, marker.unit,
         marker.values, data.dates, marker.refMin, marker.refMax
       );
-      if (impact && impact.pctChange !== null && Math.abs(impact.pctChange) >= 1) {
-        results.push(impact);
-      }
+      if (!impact || impact.pctChange === null || Math.abs(impact.pctChange) < 1) continue;
+      results.push({ ...impact, pctChange: impact.pctChange });
     }
   }
   results.sort((a, b) => Math.abs(b.pctChange) - Math.abs(a.pctChange));

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 173,
+  "totalDiagnostics": 169,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -75,7 +75,6 @@
     "js/sun-session-ui.js": 1,
     "js/sun-uvdata.js": 1,
     "js/sun.js": 3,
-    "js/supplement-impact.js": 4,
     "js/sync-actions.js": 1,
     "js/sync-delta-merge.js": 1,
     "js/sync-delta-planner-context.js": 1,

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.438';
+self.APP_VERSION = '1.10.439';


### PR DESCRIPTION
## What changed

- reject null or insignificant percentage changes before adding impacts to the result list
- store the already-narrowed numeric percentage explicitly so sorting and AI prompt formatting retain that invariant
- lower the strict-null baseline from 173 to 169 and bump the app version to 1.10.439

## Why

`computeAllImpacts` already filtered out null percentage changes at runtime, but the narrowed property type was lost when the original impact object entered the array. Downstream numeric sorting, sign formatting, and rounding therefore appeared nullable under strict null checking.

## Validation

- `node tests/test-supplement-impact.js` (84 passed)
- `PORT=8147 npx playwright test tests/playwright/supplement-impact-browser-coverage.spec.js`
- `npm run typecheck:strict-null`
- `npm run quality`
- `git diff --check`