### PR TITLE
Type cycle data boundaries

### DIFF
--- a/js/cycle-import-file.js
+++ b/js/cycle-import-file.js
@@ -7,6 +7,16 @@ const appWindow = /** @type {Window & typeof globalThis & { JSZip?: any }} */ (
   typeof window !== 'undefined' ? window : {}
 );
 
+/**
+ * @typedef {{
+ *   file: File,
+ *   kind: string,
+ *   text: string | null,
+ *   archive: any,
+ *   entries: any[],
+ * }} CycleFileContext
+ */
+
 let jszipLoad = null;
 function loadJSZip() {
   if (appWindow.JSZip) return Promise.resolve(appWindow.JSZip);
@@ -35,18 +45,20 @@ export function cycleFileKind(file) {
 
 export async function buildCycleFileContext(file) {
   const kind = cycleFileKind(file);
+  /** @type {CycleFileContext} */
   const context = { file, kind, text: null, archive: null, entries: [] };
   if (kind === 'zip') {
     const JSZip = await loadJSZip();
     try {
-      context.archive = await JSZip.loadAsync(file);
+      const archive = await JSZip.loadAsync(file);
+      context.archive = archive;
+      context.entries = Object.values(archive.files || {}).filter(entry => !entry.dir);
     } catch (err) {
       if (/encrypt|password/i.test(String(getErrorMessage(err, err)))) {
         throw new Error('This cycle ZIP is password-protected. Extract it first, then import the Clue JSON file inside.');
       }
       throw err;
     }
-    context.entries = Object.values(context.archive.files || {}).filter(entry => !entry.dir);
   } else if (kind !== 'xml') {
     context.text = await file.text();
   }

--- a/js/cycle-import.js
+++ b/js/cycle-import.js
@@ -63,6 +63,14 @@ const SOURCE_LABELS = {
   tempdrop: 'Tempdrop',
   manual: 'Manual',
 };
+/**
+ * @typedef {{
+ *   parsed: Record<string, any>,
+ *   conflictMode: string,
+ *   resolve: (value: any) => void,
+ * }} PendingCycleImport
+ */
+/** @type {PendingCycleImport | null} */
 let pendingCycleImport = null;
 
 function navigateCycleImportView(category) {
@@ -226,6 +234,11 @@ export function parseAppleHealthCycleXml(xmlText, fileName = 'apple-health-expor
   while ((match = RECORD_RE.exec(xmlText)) !== null) processAppleCycleRecord(match[1], byKey);
   return finalizeAppleHealthCycleImport(byKey, fileName);
 }
+/**
+ * @param {Blob} blob
+ * @param {string} [fileName]
+ * @param {((progress: { stage: string, pct: number }) => void) | null} [onProgress]
+ */
 export async function parseAppleHealthCycleBlob(blob, fileName = 'apple-health-export.xml', onProgress = null) {
   const byKey = new Map();
   const reader = blob.stream()
@@ -638,6 +651,7 @@ export async function showCycleImportPreview(parsed) {
   });
 }
 
+/** @param {any} [value] */
 function closeCycleImportPreview(value = null) {
   const pending = pendingCycleImport;
   pendingCycleImport = null;

--- a/js/cycle-store.js
+++ b/js/cycle-store.js
@@ -82,6 +82,10 @@ export function openCycleDB(profileId) {
       const oldVersion = /** @type {IDBVersionChangeEvent} */ (event).oldVersion;
       if (oldVersion < 2 && db.objectStoreNames.contains(STORE_DAILY)) {
         const upgradeTx = req.transaction;
+        if (!upgradeTx) {
+          reject(new Error('Cycle database upgrade transaction is unavailable'));
+          return;
+        }
         const legacyRows = upgradeTx.objectStore(STORE_DAILY).getAll();
         legacyRows.onsuccess = () => {
           db.deleteObjectStore(STORE_DAILY);
@@ -115,6 +119,10 @@ export function resetCycleDB(profileId) {
   _dbPromises.delete(dbNameFor(profileId));
 }
 
+/**
+ * @param {IDBTransaction} tx
+ * @returns {Promise<void>}
+ */
 function txPromise(tx) {
   return new Promise((resolve, reject) => {
     tx.oncomplete = () => resolve();
@@ -414,6 +422,7 @@ export async function clearCycleDB(profileId) {
   return txPromise(tx);
 }
 
+/** @returns {Promise<void>} */
 export async function deleteCycleDB(profileId) {
   const name = dbNameFor(profileId);
   const cached = _dbPromises.get(name);

--- a/js/cycle-summary.js
+++ b/js/cycle-summary.js
@@ -449,6 +449,10 @@ export function isCycleBleedingObservation(row) {
   return !!observationFlow(row);
 }
 
+/**
+ * @param {any} observations
+ * @param {{ source?: string, importId?: string | null, updatedAt?: string }} [options]
+ */
 export function stitchCyclePeriodsFromObservations(observations, {
   source = 'import',
   importId = null,

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 169,
+  "totalDiagnostics": 159,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/api-local.js": 3,
@@ -26,10 +26,6 @@
     "js/client-list-runtime.js": 1,
     "js/context-card-lifestyle-editors-impl.js": 2,
     "js/context-source-registry.js": 1,
-    "js/cycle-import-adapters.js": 1,
-    "js/cycle-import-file.js": 2,
-    "js/cycle-import.js": 3,
-    "js/cycle-store.js": 4,
     "js/dashboard-view-composition.js": 2,
     "js/dashboard-widget-runtime.js": 1,
     "js/dashboard-widgets.js": 1,

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.439';
+self.APP_VERSION = '1.10.440';


### PR DESCRIPTION
## What changed

- add explicit cycle import, preview, and ZIP context contracts so nullable defaults do not narrow valid runtime values
- guard the IndexedDB upgrade transaction boundary and type transaction/deletion completion as `Promise<void>`
- type cycle-period import metadata accepted by the shared stitching helper
- lower the strict-null baseline from 169 to 159 and bump the app version to 1.10.440

## Why

Cycle import and local storage code relied on runtime invariants that TypeScript could not infer from null defaults, mutable context objects, and IndexedDB event state. That left 10 strict-null diagnostics across the cycle data/import domain even though callers already handled the valid values.

The explicit contracts preserve the existing behavior while making the callback, result, archive, import metadata, and transaction boundaries checkable. The IndexedDB upgrade path now also fails clearly if its required upgrade transaction is unavailable.

## Validation

- `npm test -- tests/cycle-import-phase1.test.js` (25 passed)
- `PORT=8130 npx playwright test tests/playwright/cycle-import-browser-coverage.spec.js --workers=1` (9 passed)
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run typecheck:strict-null` (159 diagnostics across 92 files)
- `npm run quality`
- `git diff --check`