### PR TITLE
Type API provider boundaries

### DIFF
--- a/js/api-local.js
+++ b/js/api-local.js
@@ -74,6 +74,7 @@ export async function callOllamaChat({ system, messages, maxTokens, onStream, si
   const config = getOllamaConfig();
   const model = getOllamaMainModel();
   const adapter = getLocalAiProviderAdapter('ollama');
+  if (!adapter.infer) throw new Error('Ollama inference adapter is unavailable.');
   await prepareLocalAiRuntimeHandoff({ baseUrl: config.url, model });
   try {
     return await adapter.infer({
@@ -147,6 +148,7 @@ export async function callOpenAICompatibleLocalAPI(opts) {
   }
 
   const compatibleAdapter = getLocalAiProviderAdapter('openai-compatible');
+  if (!compatibleAdapter.infer) throw new Error('OpenAI-compatible inference adapter is unavailable.');
   let result;
   try {
     result = await compatibleAdapter.infer({ config, model, opts, plan, modelDetail });

--- a/js/api-models.js
+++ b/js/api-models.js
@@ -97,7 +97,7 @@ function isCustomRecommendedModel(modelId) {
 function modelStartsWithRecommended(modelId, prefix) {
   const id = normalizedModelId(modelId);
   const p = normalizedModelId(prefix);
-  const slug = id.split('/').pop();
+  const slug = id.split('/').pop() || '';
   return id.startsWith(p) || slug.startsWith(p);
 }
 
@@ -363,6 +363,6 @@ export function supportsVision() {
 export function needsMaxCompletionTokens(modelId) {
   if (!modelId) return false;
   const id = String(modelId).toLowerCase();
-  const bare = id.includes('/') ? id.split('/').pop() : id;
+  const bare = id.includes('/') ? id.split('/').pop() || '' : id;
   return /^(gpt-5|o[1-9])([-.]|$)/.test(bare);
 }

--- a/js/api-openai-compatible.js
+++ b/js/api-openai-compatible.js
@@ -44,6 +44,14 @@ export function useCustomApiProxy() {
 
 const proxyFetch = createProxyFetch(useCustomApiProxy);
 
+/**
+ * @typedef {{
+ *   useProxy?: boolean,
+ *   extraBody?: Record<string, any>,
+ *   fetchImpl?: typeof fetch | null,
+ * }} OpenAICompatibleTransportOptions
+ */
+
 export async function fetchWithApiRetry(url, options, retries = 2, useProxy = true, requestTimeoutMs = FETCH_REQUEST_TIMEOUT_MS) {
   return fetchWithRetry(url, options, {
     retries,
@@ -92,7 +100,7 @@ function localAIReasoningControlRejected(res, errorText) {
   return (res.status === 400 || res.status === 422) && /reasoning[_ .-]?(?:effort|control)|invalid.*reasoning/i.test(errorText);
 }
 
-export async function callOpenAICompatibleAPI(endpoint, key, model, providerName, { system, messages, maxTokens, onStream, signal, requestTimeoutMs, jsonMode, jsonSchema, forceNonStream }, extraHeaders = {}, { useProxy = true, extraBody = {}, fetchImpl = null } = {}) {
+export async function callOpenAICompatibleAPI(endpoint, key, model, providerName, { system, messages, maxTokens, onStream, signal, requestTimeoutMs, jsonMode, jsonSchema, forceNonStream }, extraHeaders = {}, { useProxy = true, extraBody = {}, fetchImpl = null } = /** @type {OpenAICompatibleTransportOptions} */ ({})) {
   const apiMessages = [];
   if (system) apiMessages.push({ role: 'system', content: system });
   for (const msg of messages) apiMessages.push({ role: msg.role, content: msg.content });
@@ -240,7 +248,7 @@ export async function callOpenAICompatibleAPI(endpoint, key, model, providerName
         throw new Error(`${providerName} stream exceeded ${MAX_SSE_BUFFER} bytes without a newline - aborting.`);
       }
       const lines = buffer.split('\n');
-      buffer = lines.pop();
+      buffer = lines.pop() || '';
       for (const line of lines) handleSSELine(line, true);
     }
     if (buffer.startsWith('data: ')) handleSSELine(buffer, false);

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,13 +1,8 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 159,
+  "totalDiagnostics": 151,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
-    "js/api-local.js": 3,
-    "js/api-models.js": 2,
-    "js/api-openai-compatible.js": 1,
-    "js/api-ppq.js": 1,
-    "js/api-routstr.js": 1,
     "js/app-event-listeners.js": 1,
     "js/app-shell-hooks.js": 2,
     "js/backup.js": 3,

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.440';
+self.APP_VERSION = '1.10.441';


### PR DESCRIPTION
## What changed

- guard local provider inference hooks before invoking adapter methods
- normalize empty model-ID segments before recommended-model and token-field matching
- type the OpenAI-compatible transport override used by PPQ and Routstr private fetch wrappers
- keep streaming buffers string-valued when consuming newline-delimited SSE chunks
- lower the strict-null baseline from 159 to 151 and bump the app version to 1.10.441

## Why

The API provider layer relied on runtime guarantees that were wider than their inferred JavaScript types: registered adapters provide inference hooks, model ID splits produce a usable string, private transports may inject a fetch implementation, and an SSE buffer remains a string after removing complete lines.

Making those contracts explicit removes 8 strict-null diagnostics across the shared local, model, OpenAI-compatible, PPQ, and Routstr paths. The adapter guards also turn a missing provider hook into a clear error instead of an undefined-function failure.

## Validation

- `npm test -- tests/api-provider-runtime.test.js tests/api-transport.test.js tests/api-provider-contracts.test.js tests/api-network-runtime.test.js` (64 passed)
- `PORT=8131 npx playwright test tests/playwright/api-provider-calls-browser-coverage.spec.js tests/playwright/api-transport-browser-coverage.spec.js --workers=1` (2 passed)
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run typecheck:strict-null` (151 diagnostics across 87 files)
- `npm run quality`
- `git diff --check`