### PR TITLE
Type light device boundaries

### DIFF
--- a/js/light-device-session-modal.js
+++ b/js/light-device-session-modal.js
@@ -30,6 +30,15 @@ function _input(root, selector) {
   return /** @type {HTMLInputElement|null} */ (root.querySelector(selector));
 }
 
+/**
+ * @param {ParentNode} root
+ * @param {string} selector
+ * @returns {HTMLButtonElement|null}
+ */
+function _button(root, selector) {
+  return /** @type {HTMLButtonElement|null} */ (root.querySelector(selector));
+}
+
 function _wireDeviceSessionModal(overlay, closeFn) {
   if (typeof window === 'undefined') { document.body.appendChild(overlay); return; }
   openAppendedModalOverlay(overlay, closeFn);
@@ -68,7 +77,7 @@ function _broadAreaForRegions(bodyAreas) {
 
 function _readDistanceCm(overlay, fallbackCm) {
   const distInput = _input(overlay, '#dev-session-distance');
-  const distVal = parseFloat(distInput?.value);
+  const distVal = parseFloat(distInput?.value || '');
   const distUnit = distInput?.dataset.unit || 'cm';
   return Number.isFinite(distVal)
     ? (distUnit === 'in' ? distVal * 2.54 : distVal)
@@ -282,7 +291,7 @@ export async function openDeviceSessionDialog(deviceId, deps = {}) {
     });
   }
 
-  overlay.querySelector('#dev-session-save').addEventListener('click', async () => {
+  _button(overlay, '#dev-session-save')?.addEventListener('click', async () => {
     const durationMin = parseInt(_input(overlay, '#dev-session-duration')?.value || '', 10) || 10;
     const distanceCm = _readDistanceCm(overlay, device.recommendedDistanceCm || 15);
     const bodyAreas = Array.from(selectedRegions);
@@ -299,7 +308,7 @@ export async function openDeviceSessionDialog(deviceId, deps = {}) {
     navigate?.('light');
   });
 
-  overlay.querySelector('#dev-session-start').addEventListener('click', async () => {
+  _button(overlay, '#dev-session-start')?.addEventListener('click', async () => {
     if (getActiveDeviceSession()) {
       showNotification('Another device session is already running. Stop it first.', 'error');
       return;

--- a/js/light-device-setup-modal.js
+++ b/js/light-device-setup-modal.js
@@ -121,7 +121,7 @@ export async function openAddDeviceDialog() {
     btn.addEventListener('click', closeDialog);
   });
 
-  overlay.querySelector('#add-device-custom').addEventListener('click', () => {
+  _button(overlay, '#add-device-custom')?.addEventListener('click', () => {
     closeDialog();
     openCustomDeviceDialog();
   });
@@ -282,7 +282,7 @@ export async function openCustomDeviceDialog() {
   }
 
   if (hasAI) {
-    overlay.querySelector('#custom-dev-fetch').addEventListener('click', () => _fetchCustomDeviceFromURL(overlay));
+    _button(overlay, '#custom-dev-fetch')?.addEventListener('click', () => _fetchCustomDeviceFromURL(overlay));
     if (hasVision) {
       const imageInput = _input(overlay, '#custom-dev-image');
       _button(overlay, '#custom-dev-scan')?.addEventListener('click', () => imageInput?.click());

--- a/js/light-devices-store.js
+++ b/js/light-devices-store.js
@@ -125,7 +125,7 @@ export async function deleteDevice(id) {
 /**
  * @param {{deviceId?: string, durationMin?: number, distanceCm?: number, bodyArea?: string, bodyAreas?: string[]|null, eyesProtected?: boolean, notes?: string, mode?: string|null}} [input]
  */
-export async function logDeviceSession({ deviceId, durationMin, distanceCm = 15, bodyArea = 'torso', bodyAreas = null, eyesProtected = true, notes = '', mode = null } = {}) {
+export async function logDeviceSession({ deviceId, durationMin = 0, distanceCm = 15, bodyArea = 'torso', bodyAreas = null, eyesProtected = true, notes = '', mode = null } = {}) {
   const device = getDevices().find(d => d.id === deviceId);
   if (!device) return null;
   const now = Date.now();

--- a/js/light-devices.js
+++ b/js/light-devices.js
@@ -204,7 +204,7 @@ export async function editDeviceSessionMode(id) {
   overlay.querySelectorAll('[data-device-mode-close]').forEach(btn => {
     btn.addEventListener('click', closeDialog);
   });
-  overlay.querySelector('#dev-edit-mode-save').addEventListener('click', async () => {
+  overlay.querySelector('#dev-edit-mode-save')?.addEventListener('click', async () => {
     const next = _select(overlay, '#dev-edit-mode')?.value || '';
     closeDialog();
     if (next === sess.mode) return;

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 145,
+  "totalDiagnostics": 138,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/app-event-listeners.js": 1,
@@ -38,10 +38,6 @@
     "js/lens-local-worker.js": 1,
     "js/lens-pages.js": 3,
     "js/lens.js": 2,
-    "js/light-device-session-modal.js": 3,
-    "js/light-device-setup-modal.js": 2,
-    "js/light-devices-store.js": 1,
-    "js/light-devices.js": 1,
     "js/light-env-audits.js": 2,
     "js/light-page-view.js": 2,
     "js/light-today-ai.js": 4,

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.442';
+self.APP_VERSION = '1.10.443';


### PR DESCRIPTION
## What changed

- parse an absent device-session distance input through the existing recommended-distance fallback
- bind device-session, setup, custom-fetch, and mode-save controls through nullable DOM boundaries
- align persisted session logging with the dose engine's zero-minute default when duration is omitted
- lower the strict-null baseline from 145 diagnostics across 83 files to 138 across 79 files
- bump the app version to 1.10.443

## Why

The light-device modal and store code treated markup-created controls and optional session fields as always present. That behavior worked with complete templates, but the JavaScript contracts did not preserve those runtime assumptions and produced seven strict-null diagnostics.

Narrowing the controls at their binding sites keeps normal behavior unchanged while making incomplete modal markup safe. Defaulting an omitted duration to zero matches the existing shared dose engine contract and prevents undefined arithmetic at the persistence boundary.

## Validation

- `node tests/test-light-devices-store.js` (22 passed)
- `node tests/test-light-devices.js` (63 passed)
- `node tests/test-modal-lifecycle-integrations.js` (31 passed)
- `PORT=8133 npx playwright test tests/playwright/light-devices-browser-coverage.spec.js tests/playwright/light-coverage-batch-2.spec.js tests/playwright/modal-session-coverage-batch.spec.js --workers=1` (10 passed)
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run typecheck:strict-null` (138 diagnostics across 79 files)
- `npm run quality`
- `git diff --check`