### PR TITLE
Type light page boundaries

### DIFF
--- a/js/light-env-audits.js
+++ b/js/light-env-audits.js
@@ -250,7 +250,7 @@ function _auditRoomChannels(audit, room) {
     spec?.extra?.melanopic != null
       ? { key: 'melanopic', label: 'Melanopic', text: `${(spec.extra.melanopic * 100).toFixed(0)}%` }
       : null,
-  ].filter(Boolean);
+  ].filter(ch => ch !== null);
 }
 
 function renderLightAuditDetail(a) {

--- a/js/light-page-view.js
+++ b/js/light-page-view.js
@@ -414,6 +414,7 @@ export function showLight(_data) {
   try { lightPageDeps.resumeActiveTickerIfNeeded(); } catch (e) {}
   try { lightPageDeps.ensureActiveDeviceTicker(); } catch (e) {}
   const main = document.getElementById("main-content");
+  if (!main) return;
   const sessions = lightPageDeps.getSessions() || [];
   const totals7d = lightPageDeps.rollingChannelTotals(7) || {};
   const totals30d = lightPageDeps.rollingChannelTotals(30) || {};

--- a/js/light-today-ai.js
+++ b/js/light-today-ai.js
@@ -93,6 +93,7 @@ export function computeLightTrends(targetDate = new Date()) {
   const sessions = (state.importedData?.sunSessions || []).filter(s => s.endedAt);
   const devSessions = (state.importedData?.deviceSessions || []).filter(s => s.endedAt);
   const targetTs = targetDate.getTime();
+  /** @type {{ signals: string[] }} */
   const out = { signals: [] };
   const sunriseSessions = sessions.filter(s => {
     if (!s.location) return false;
@@ -304,7 +305,9 @@ const engine = createAIVerdict({
     // Trim cache: keep last 30 days only — stops the map growing unbounded.
     const allKeys = Object.keys(verdicts).sort();
     while (allKeys.length > 30) {
-      delete verdicts[allKeys.shift()];
+      const oldestKey = allKeys.shift();
+      if (!oldestKey) break;
+      delete verdicts[oldestKey];
     }
   },
   getFingerprint: getDayFingerprint,

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 138,
+  "totalDiagnostics": 130,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/app-event-listeners.js": 1,
@@ -38,9 +38,6 @@
     "js/lens-local-worker.js": 1,
     "js/lens-pages.js": 3,
     "js/lens.js": 2,
-    "js/light-env-audits.js": 2,
-    "js/light-page-view.js": 2,
-    "js/light-today-ai.js": 4,
     "js/nav.js": 1,
     "js/pdf-import-marker-mapping.js": 2,
     "js/pdf-import-review-runtime.js": 1,

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.443';
+self.APP_VERSION = '1.10.444';


### PR DESCRIPTION
## What changed

- narrow nullable light-audit channel rows after collection
- make the Light page renderer return safely when its host is absent
- type daily trend signals as strings and guard the oldest cache key before deletion
- lower the strict-null baseline from 138 diagnostics across 79 files to 130 across 76 files
- bump the app version to 1.10.444

## Why

The remaining Light-page diagnostics came from three boundary assumptions: `filter(Boolean)` did not preserve the non-null audit channel shape, the page host was treated as guaranteed, and empty array inference/cache shifting made daily-AI values narrower or more nullable than their runtime contract.

The changes make those contracts explicit while preserving complete-page behavior. A missing page host now becomes a safe no-op, and cache trimming only deletes a concrete date key.

## Validation

- `node tests/test-light-env.js` (123 passed)
- `node tests/test-light-ai-renders.js` (41 passed)
- `node tests/test-light-page-view-delegated-actions.js` (22 passed)
- `PORT=8134 npx playwright test tests/playwright/environment-coverage-batch.spec.js tests/playwright/light-page-view.spec.js tests/playwright/light-ai-analysis-coverage-batch.spec.js --workers=1` (11 passed)
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run typecheck:strict-null` (130 diagnostics across 76 files)
- `npm run quality`
- `git diff --check`