### PR TITLE
Type wearables boundaries

### DIFF
--- a/js/wearables-connect-runtime.js
+++ b/js/wearables-connect-runtime.js
@@ -1,13 +1,14 @@
 // @ts-check
 // wearables-connect-runtime.js - Browser runtime adapters for wearable connect orchestration.
 
+/** @type {{ navigate: ((route: string) => void) | null }} */
 const wearablesConnectRuntimeDeps = { navigate: null };
 
 export function configureWearablesConnectRuntimeDeps(deps = {}) {
   const previous = { ...wearablesConnectRuntimeDeps };
   if ('navigate' in deps) {
     wearablesConnectRuntimeDeps.navigate = typeof deps.navigate === 'function'
-      ? deps.navigate
+      ? /** @type {(route: string) => void} */ (deps.navigate)
       : null;
   }
   return previous;

--- a/js/wearables-connect.js
+++ b/js/wearables-connect.js
@@ -98,12 +98,14 @@ export function beginConnectOAuth(adapterId) {
   const adapter = adapterById(adapterId);
   if (!adapter) throw new Error(`Unknown adapter: ${adapterId}`);
   if (adapter.authType !== 'oauth2') throw new Error(`Adapter ${adapterId} is not OAuth2`);
+  const oauth = adapter.oauth;
+  if (!oauth) throw new Error(`Adapter ${adapterId} is missing OAuth configuration`);
   const kick = OAUTH_DISPATCH[adapter.id]?.begin;
   if (!kick) throw new Error(`Unsupported OAuth adapter: ${adapter.id}`);
   kick({
     clientId: getOAuthClientId(adapter),
-    registeredUris: adapter.oauth.redirectUris,
-    scopes: adapter.oauth.scopes,
+    registeredUris: oauth.redirectUris,
+    scopes: oauth.scopes,
     profileId: state.currentProfile,
   });
 }

--- a/js/wearables-oura-auth.js
+++ b/js/wearables-oura-auth.js
@@ -118,7 +118,7 @@ export async function completeOAuthCallback(urlParams) {
   // 5xx's the /oauth/token endpoint. The auth code is single-use and short-
   // lived, so we retry quickly — 3 tries, exponential backoff — before
   // surfacing the failure to the user.
-  let exchangeRes, body;
+  let exchangeRes = null, body;
   for (let attempt = 0; attempt < 3; attempt++) {
     exchangeRes = await fetch(PROXY_URL, {
       method: 'POST',
@@ -137,6 +137,7 @@ export async function completeOAuthCallback(urlParams) {
     if (exchangeRes.status < 500 || attempt === 2) break;
     await new Promise(r => setTimeout(r, 500 * (attempt + 1)));
   }
+  if (!exchangeRes) return { ok: false, error: 'Token exchange failed before receiving a response' };
   if (!exchangeRes.ok) {
     // Oura sometimes returns HTML (CloudFront error page) instead of JSON on 5xx;
     // body?.error is then undefined and we'd leak a wall of HTML into the toast.

--- a/js/wearables-settings-runtime.js
+++ b/js/wearables-settings-runtime.js
@@ -4,6 +4,7 @@
 import { showConfirmDialog } from './utils.js';
 import { getSettingsModuleFunction } from './settings-runtime-bridge.js';
 
+/** @type {{ navigate: ((route: string) => void) | null, showConfirmDialog: (typeof showConfirmDialog) | null }} */
 const wearableSettingsRuntimeDeps = {
   navigate: null,
   showConfirmDialog,
@@ -13,7 +14,7 @@ export function configureWearableSettingsRuntimeDeps(deps = {}) {
   const previous = { ...wearableSettingsRuntimeDeps };
   if ('navigate' in deps) {
     wearableSettingsRuntimeDeps.navigate = typeof deps.navigate === 'function'
-      ? deps.navigate
+      ? /** @type {(route: string) => void} */ (deps.navigate)
       : null;
   }
   if ('showConfirmDialog' in deps) {

--- a/js/wearables-store.js
+++ b/js/wearables-store.js
@@ -97,11 +97,13 @@ export function resetWearablesDB(profileId) {
 // ─────────────────────────────────────────────────────────
 
 function txPromise(tx) {
-  return new Promise((resolve, reject) => {
+  /** @type {Promise<void>} */
+  const complete = new Promise((resolve, reject) => {
     tx.oncomplete = () => resolve();
     tx.onerror = () => reject(tx.error);
     tx.onabort = () => reject(tx.error || new Error('Transaction aborted'));
   });
+  return complete;
 }
 
 // Field-level AES-GCM envelope around the non-key fields of an L1 row when
@@ -393,10 +395,12 @@ export async function deleteWearablesDB(profileId) {
     try { (await cached)?.close?.(); } catch { /* connection might be in error state */ }
   }
   resetWearablesDB(profileId);
-  return new Promise((resolve, reject) => {
+  /** @type {Promise<void>} */
+  const deleted = new Promise((resolve, reject) => {
     const req = indexedDB.deleteDatabase(name);
     req.onsuccess = () => resolve();
     req.onerror = () => reject(req.error);
     req.onblocked = () => reject(new Error('Wearable data deletion is blocked by another open tab.'));
   });
+  return deleted;
 }

--- a/js/wearables-summary.js
+++ b/js/wearables-summary.js
@@ -155,7 +155,7 @@ function deriveMetric(rowsByDate, metricId, primarySource, todayISO = isoDay()) 
   if (slopeNorm > 0.002)       trend30d = 'rising';
   else if (slopeNorm < -0.002) trend30d = 'declining';
 
-  const weekly = weeklyMeans(series, 12).map(w => Math.round(w.mean * 100) / 100);
+  const weekly = weeklyMeans(series, 12).map(w => Math.round((w.mean ?? 0) * 100) / 100);
 
   return {
     primarySource,

--- a/js/wearables.js
+++ b/js/wearables.js
@@ -599,7 +599,10 @@ export function renderWearableStrip() {
     ? (() => {
         const byId = new Map(displayOrder.map(d => [d.id, d]));
         const out = [];
-        for (const id of savedOrder) { if (byId.has(id)) { out.push(byId.get(id)); byId.delete(id); } }
+        for (const id of savedOrder) {
+          const item = byId.get(id);
+          if (item) { out.push(item); byId.delete(id); }
+        }
         for (const d of displayOrder) if (byId.has(d.id)) out.push(d);
         return out;
       })()

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 130,
+  "totalDiagnostics": 115,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/app-event-listeners.js": 1,
@@ -70,13 +70,6 @@
     "js/sync-save-hooks.js": 1,
     "js/sync-ui.js": 3,
     "js/tour.js": 3,
-    "js/utils.js": 4,
-    "js/wearables-connect-runtime.js": 2,
-    "js/wearables-connect.js": 2,
-    "js/wearables-oura-auth.js": 3,
-    "js/wearables-settings-runtime.js": 3,
-    "js/wearables-store.js": 2,
-    "js/wearables-summary.js": 1,
-    "js/wearables.js": 2
+    "js/utils.js": 4
   }
 }

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.444';
+self.APP_VERSION = '1.10.445';


### PR DESCRIPTION
## What changed

- type the injected wearable navigation and confirmation runtime hooks
- require OAuth metadata before launching a vendor connection
- guard the Oura token-exchange response before reading its status
- type IndexedDB transaction and database-deletion completion promises as `Promise<void>`
- normalize nullable weekly means and avoid adding missing saved-order entries to the card list
- lower the strict-null baseline from 130 diagnostics across 76 files to 115 across 69 files
- bump the app version to 1.10.445

## Why

The wearables stack crossed several nullable runtime boundaries: dependency injection started from null defaults, adapter OAuth metadata was optional at the registry type level, retry state was not proven initialized, IndexedDB completion promises lacked void contracts, and summary/card ordering helpers exposed nullable intermediate values.

The changes make those boundaries explicit, add safe failure behavior for incomplete OAuth metadata/response state, and preserve the existing successful auth, sync, storage, summary, and rendering paths.

## Validation

- `node tests/test-wearables-connect-runtime.js` (6 passed)
- `node tests/test-wearables-settings-runtime.js` (4 passed)
- `npx vitest run tests/wearables-summary.test.js --pool=forks --maxWorkers=1` (1 passed)
- `node tests/test-wearables.js` (588 passed)
- `node tests/test-wearables-sync-flow.js` (42 passed)
- `node tests/test-coverage-stragglers.js` (7 passed)
- `PORT=8135 npx playwright test tests/playwright/wearables-auth-browser-coverage.spec.js tests/playwright/wearables-connect-browser-coverage.spec.js tests/playwright/wearables-store-browser-coverage.spec.js tests/playwright/wearables-settings-browser-coverage.spec.js tests/playwright/wearables-strip-actions-browser-coverage.spec.js --workers=1` (8 passed)
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run typecheck:strict-null` (115 diagnostics across 69 files)
- `npm run quality`
- `git diff --check`