### PR TITLE
Type sync boundaries

### DIFF
--- a/js/sync-actions.js
+++ b/js/sync-actions.js
@@ -19,6 +19,7 @@ let _pushProfile = async () => {};
 let _forcePull = () => {};
 let _isSyncEnabled = () => false;
 let _isEvoluReady = () => false;
+/** @type {() => any[]} */
 let _getProfiles = () => [];
 let _createDefaultProfileData = () => ({ entries: [] });
 

--- a/js/sync-delta-merge.js
+++ b/js/sync-delta-merge.js
@@ -7,7 +7,9 @@ import {
   mergeArrayRowsIntoImported, mergeMapRowsIntoImported, mergeScalarRowsIntoImported,
 } from './sync-delta-merge-shapes.js';
 
+/** @type {() => any} */
 let _getEvolu = () => null;
+/** @type {() => any} */
 let _getItemRowQuery = () => null;
 
 /** @param {{ getEvolu?: () => any, getItemRowQuery?: () => any }} [deps] */

--- a/js/sync-delta-observability-context.js
+++ b/js/sync-delta-observability-context.js
@@ -1,7 +1,9 @@
 // @ts-check
 // sync-delta-observability-context.js - Shared Evolu query access for delta observability.
 
+/** @type {() => any} */
 let _getEvolu = () => null;
+/** @type {() => any} */
 let _getItemRowQuery = () => null;
 
 /**

--- a/js/sync-delta-planner-context.js
+++ b/js/sync-delta-planner-context.js
@@ -1,7 +1,9 @@
 // @ts-check
 // sync-delta-planner-context.js - Shared dependency access for push-side delta planners.
 
+/** @type {() => any} */
 let _getEvolu = () => null;
+/** @type {() => any} */
 let _getItemRowQuery = () => null;
 
 /** @param {{ getEvolu?: () => any, getItemRowQuery?: () => any }} [deps] */

--- a/js/sync-delta.js
+++ b/js/sync-delta.js
@@ -17,7 +17,9 @@ export {
 } from './sync-delta-observability.js';
 export { _mergeItemRowsIntoImported } from './sync-delta-merge.js';
 
+/** @type {() => any} */
 let _getEvolu = () => null;
+/** @type {() => any} */
 let _getItemRowQuery = () => null;
 
 /** @param {{ getEvolu?: () => any, getItemRowQuery?: () => any }} [deps] */

--- a/js/sync-diagnose-runtime.js
+++ b/js/sync-diagnose-runtime.js
@@ -3,6 +3,7 @@
 
 import { showConfirmDialog } from './utils.js';
 
+/** @type {{ showConfirmDialog: (typeof showConfirmDialog) | null }} */
 const syncDiagnoseRuntimeDeps = { showConfirmDialog };
 
 export function configureSyncDiagnoseRuntimeDeps(deps = {}) {

--- a/js/sync-diagnose-ui.js
+++ b/js/sync-diagnose-ui.js
@@ -93,6 +93,7 @@ export function configureSyncDiagnoseUI({
 // other's data despite using the same relay URL.
 export async function showSyncDiagnose() {
   const diagnostics = await getEvoluDiagnostics();
+  /** @type {{ verdict: string, at: number, reason: string | null }} */
   let healthVerdict = { verdict: 'unknown', at: 0, reason: null };
   try { healthVerdict = await verifyPushLanded(); } catch {}
 

--- a/js/sync-diagnostics-snapshot.js
+++ b/js/sync-diagnostics-snapshot.js
@@ -44,7 +44,7 @@ export function _syncDiag() {
   for (let i = 0; i < localStorage.length; i++) {
     const key = localStorage.key(i);
     if (key?.endsWith('-sync-ts')) {
-      const ts = parseInt(localStorage.getItem(key), 10);
+      const ts = parseInt(localStorage.getItem(key) || '', 10);
       tsList.push({ key, ts, date: new Date(ts).toISOString() });
     }
   }
@@ -71,7 +71,7 @@ export async function getEvoluDiagnostics() {
     relay: getSyncRelay(),
     ownerId: appOwner?.id ? String(appOwner.id).slice(0, 12) + '…' : null,
     mnemonicPrefix: appOwner?.mnemonic ? appOwner.mnemonic.split(' ').slice(0, 2).join(' ') + ' …' : null,
-    rows: [],
+    rows: /** @type {any[]} */ ([]),
     activeProfileId: state.currentProfile,
     activeImported: { sunSessions: 0, lightDevices: 0 },
   };

--- a/js/sync-disable-cleanup.js
+++ b/js/sync-disable-cleanup.js
@@ -18,6 +18,6 @@ export function clearSyncDisableStorage() {
 
   for (let i = localStorage.length - 1; i >= 0; i--) {
     const key = localStorage.key(i);
-    if (isSyncDisableCleanupKey(key)) localStorage.removeItem(key);
+    if (key && isSyncDisableCleanupKey(key)) localStorage.removeItem(key);
   }
 }

--- a/js/sync-pull-rebroadcast.js
+++ b/js/sync-pull-rebroadcast.js
@@ -31,7 +31,7 @@ export function maybeScheduleRebroadcast({
   // chat/profile/aiSettings appliers a chance to settle first. Skipped
   // for non-active profiles - pushProfile uses state.importedData,
   // which is only valid for the current profile.
-  if (!needsRebroadcast || profileId !== state.currentProfile) return false;
+  if (!needsRebroadcast || profileId !== state.currentProfile || typeof pushProfile !== 'function') return false;
 
   // Don't pile rebroadcast pushes on top of an in-flight push - Evolu
   // serializes them and the relay can lag, producing the

--- a/js/sync-push.js
+++ b/js/sync-push.js
@@ -13,7 +13,9 @@ import { getDeltaCutoverReadiness } from './sync-delta.js';
 import { migrateProfileData } from './profile.js';
 import { applyCommittedDeltas, planProfileDeltas } from './sync-push-deltas.js';
 
+/** @type {() => any} */
 let _getEvolu = () => null;
+/** @type {() => any} */
 let _getProfileQuery = () => null;
 let _isSyncEnabled = () => false;
 /** @type {(profileId?: any) => boolean} */

--- a/js/sync-reconcile.js
+++ b/js/sync-reconcile.js
@@ -8,7 +8,9 @@ import { parseSyncPayload } from './sync-payload.js';
 import { logSyncEvent } from './sync-state.js';
 import { isRestoreJoinPending } from './sync-identity.js';
 
+/** @type {() => any} */
 let _getEvolu = () => null;
+/** @type {() => any} */
 let _getProfileQuery = () => null;
 let _isSyncEnabled = () => false;
 /** @type {(...args: any[]) => Promise<any>} */

--- a/js/sync-save-hooks.js
+++ b/js/sync-save-hooks.js
@@ -110,6 +110,7 @@ export async function readProfileImportedData(profileId, fallback = null) {
   };
   if (fallback && typeof fallback === 'object') return normalize(fallback);
   if (profileId === state.currentProfile && state.importedData) return normalize(state.importedData);
+  if (!profileId) return _createDefaultProfileData();
   try {
     const storageKey = profileStorageKey(profileId, 'imported');
     const raw = getEncryptionEnabled()

--- a/js/sync-ui.js
+++ b/js/sync-ui.js
@@ -136,7 +136,8 @@ export function updateSyncIndicator() {
   const ds = getSyncDisplayState();
   dot.className = `sync-dot sync-dot-${ds}`;
   const titles = { synced: 'Synced', syncing: 'Syncing\u2026', offline: 'Offline \u2014 changes saved locally', error: 'Sync error' };
-  dot.parentElement.title = titles[ds] || '';
+  const button = dot.parentElement;
+  if (button) button.title = titles[ds] || '';
 }
 
 export function toggleSyncDetail() {
@@ -212,8 +213,10 @@ export function toggleSyncDetail() {
         <button class="ctx-btn-option" style="font-size:12px" ${syncUiActionAttrs('show-diagnose')}>Diagnose</button>
       ` : ''}
     </div>`;
-  btn.parentElement.style.position = 'relative';
-  btn.parentElement.appendChild(pop);
+  const parent = btn.parentElement;
+  if (!parent) return;
+  parent.style.position = 'relative';
+  parent.appendChild(pop);
   // Close on outside click.
   const close = (e) => { if (!pop.contains(e.target) && e.target !== btn && !btn.contains(e.target)) { pop.remove(); document.removeEventListener('click', close); } };
   setTimeout(() => document.addEventListener('click', close), 0);

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 115,
+  "totalDiagnostics": 94,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/app-event-listeners.js": 1,
@@ -55,20 +55,6 @@
     "js/sun-session-ui.js": 1,
     "js/sun-uvdata.js": 1,
     "js/sun.js": 3,
-    "js/sync-actions.js": 1,
-    "js/sync-delta-merge.js": 1,
-    "js/sync-delta-planner-context.js": 1,
-    "js/sync-delta-readiness.js": 1,
-    "js/sync-delta.js": 3,
-    "js/sync-diagnose-runtime.js": 1,
-    "js/sync-diagnose-ui.js": 1,
-    "js/sync-diagnostics-snapshot.js": 2,
-    "js/sync-disable-cleanup.js": 1,
-    "js/sync-pull-rebroadcast.js": 1,
-    "js/sync-push.js": 3,
-    "js/sync-reconcile.js": 1,
-    "js/sync-save-hooks.js": 1,
-    "js/sync-ui.js": 3,
     "js/tour.js": 3,
     "js/utils.js": 4
   }

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.445';
+self.APP_VERSION = '1.10.446';


### PR DESCRIPTION
## Summary
- make sync dependency providers and runtime slots explicit under strict null checking
- guard nullable DOM/storage/function boundaries in sync diagnostics, cleanup, rebroadcast, save hooks, and status UI
- reduce the strict-null baseline from 115 diagnostics across 69 files to 94 across 55 files
- bump the app version to 1.10.446

## Verification
- `npx vitest run tests/sync-runtime.test.js tests/sync-actions.test.js tests/sync-save-hooks.test.js tests/sync-recovery-runtime.test.js --pool=forks --maxWorkers=1` (47 passed)
- `npx vitest run tests/sync-lifecycle-runtime.test.js --pool=forks --maxWorkers=1` (4 passed)
- `node tests/test-sync.js` (834 passed)
- `node tests/test-sync-diagnose-runtime.js` (4 passed)
- `node tests/test-sync-modal-refresh.js` (22 passed)
- `node tests/test-modal-lifecycle-integrations.js` (31 passed)
- `node tests/test-correctness-phase2.js` (191 passed)
- focused Playwright sync/diagnose coverage (21 passed)
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run typecheck:strict-null`
- `npm run quality`
- `git diff --check`