### PR TITLE
Type Biology Scores boundaries

### DIFF
--- a/js/biology-score-context-ai.js
+++ b/js/biology-score-context-ai.js
@@ -363,7 +363,7 @@ export function installBiologyScoreContextAIDelegates() {
     const el = event.target instanceof Element ? event.target.closest('[data-biology-score-action]') : null;
     if (!(el instanceof HTMLElement)) return;
     const action = el.dataset.biologyScoreAction;
-    if (!['analyze-context-ai','apply-context-ai','dismiss-context-ai'].includes(action)) return;
+    if (!action || !['analyze-context-ai','apply-context-ai','dismiss-context-ai'].includes(action)) return;
     event.preventDefault();
     try {
       if (action === 'analyze-context-ai') {

--- a/js/biology-score-iron.js
+++ b/js/biology-score-iron.js
@@ -33,7 +33,9 @@ export function computeIronHandling(data, def, options = {}) {
   if (ferritin) {
     const ferritinHighPenalty = scoreHighOnly(ferritin.value, 300, 800);
     const ferritinLowPenalty = scoreLowOnly(ferritin.value, 30, 5);
-    const ferritinPartial = Math.min(ferritinHighPenalty, ferritinLowPenalty);
+    const ferritinPartial = ferritinHighPenalty == null || ferritinLowPenalty == null
+      ? null
+      : Math.min(ferritinHighPenalty, ferritinLowPenalty);
     add(ferritin, 'ferritin', 'Ferritin', 1.15, ferritinPartial, true);
     if (ferritin.value < 30) flags.push('Low ferritin pattern: possible depleted iron stores.');
     if (tsat && tsat.value >= 45 && ferritin.value > 300) flags.push('High TSAT + high ferritin pattern: overload workup context, not a wellness score.');

--- a/js/biology-score-profile-modifiers.js
+++ b/js/biology-score-profile-modifiers.js
@@ -101,7 +101,8 @@ function isCyclingFemale(profileContext, entryContext) {
  * @param {{lowMuscleMass?: boolean, lowMuscleReason?: string, sex?: string | null, lowSunlightExposure?: boolean, lowSunlightReason?: string, hormoneTherapy?: boolean, cycleStatus?: string | null, menopauseStatus?: string | null, recentHardTraining?: boolean, acuteInflammationContext?: boolean, genetic?: any, body?: any, light?: any, contextFlags?: string[]}} profileContext
  */
 export function getInputProfileModifier(hit, input, profileContext) {
-  const sexScale = input.sexWeightScale?.[profileContext?.sex] ?? 1;
+  const profileSex = profileContext?.sex;
+  const sexScale = profileSex ? input.sexWeightScale?.[profileSex] ?? 1 : 1;
   const dotKey = hit?.dotKey || '';
   const entryContext = getEntryContext(hit);
   if (input.profileContext === 'always-score') return { score: true, flag: '', weightScale: sexScale };

--- a/js/biology-score-thyroid.js
+++ b/js/biology-score-thyroid.js
@@ -66,23 +66,32 @@ export function computeThyroidCoherence(data, def) {
 
   if (reverseT3) {
     const partial = scoreHighOnly(reverseT3.value, reverseT3.range?.max ?? 0.54, (reverseT3.range?.max ?? 0.54) * 2.4);
-    available.push({ ...reverseT3, key: 'reverseT3', label: 'Reverse T3', partial, weight: weights.reverseT3 });
-    availableWeight += weights.reverseT3;
-    scoreSum += partial * weights.reverseT3;
+    if (partial == null) missing.push({ key: 'reverseT3', label: 'Reverse T3', weight: weights.reverseT3 });
+    else {
+      available.push({ ...reverseT3, key: 'reverseT3', label: 'Reverse T3', partial, weight: weights.reverseT3 });
+      availableWeight += weights.reverseT3;
+      scoreSum += partial * weights.reverseT3;
+    }
   } else missing.push({ key: 'reverseT3', label: 'Reverse T3', weight: weights.reverseT3 });
 
   if (tpoAb) {
     const partial = scoreHighOnly(tpoAb.value, tpoAb.range?.max ?? 34, (tpoAb.range?.max ?? 34) * 5);
-    available.push({ ...tpoAb, key: 'tpoAb', label: 'TPO antibodies', partial, weight: weights.tpoAb });
-    availableWeight += weights.tpoAb;
-    scoreSum += partial * weights.tpoAb;
+    if (partial == null) missing.push({ key: 'tpoAb', label: 'TPO antibodies', weight: weights.tpoAb });
+    else {
+      available.push({ ...tpoAb, key: 'tpoAb', label: 'TPO antibodies', partial, weight: weights.tpoAb });
+      availableWeight += weights.tpoAb;
+      scoreSum += partial * weights.tpoAb;
+    }
   } else missing.push({ key: 'tpoAb', label: 'TPO antibodies', weight: weights.tpoAb });
 
   if (tgAb) {
     const partial = scoreHighOnly(tgAb.value, tgAb.range?.max ?? 115, (tgAb.range?.max ?? 115) * 4);
-    available.push({ ...tgAb, key: 'tgAb', label: 'Thyroglobulin antibodies', partial, weight: weights.tgAb });
-    availableWeight += weights.tgAb;
-    scoreSum += partial * weights.tgAb;
+    if (partial == null) missing.push({ key: 'tgAb', label: 'Thyroglobulin antibodies', weight: weights.tgAb });
+    else {
+      available.push({ ...tgAb, key: 'tgAb', label: 'Thyroglobulin antibodies', partial, weight: weights.tgAb });
+      availableWeight += weights.tgAb;
+      scoreSum += partial * weights.tgAb;
+    }
   } else missing.push({ key: 'tgAb', label: 'Thyroglobulin antibodies', weight: weights.tgAb });
 
   const score = availableWeight > 0 && tsh && ft3 ? Math.round(scoreSum / availableWeight) : null;

--- a/js/biology-scores-runtime.js
+++ b/js/biology-scores-runtime.js
@@ -6,11 +6,11 @@ import { getActiveData } from './data.js';
 import { showNotification } from './utils.js';
 
 const biologyScoresRuntimeDeps = {
-  getActiveData,
+  getActiveData: /** @type {null | typeof getActiveData} */ (getActiveData),
   navigate: /** @type {null | ((route: string) => unknown)} */ (null),
   openChatPanel: /** @type {null | ((prompt?: string) => unknown)} */ (null),
   showDetailModal: /** @type {null | ((markerId: string) => unknown)} */ (null),
-  showNotification,
+  showNotification: /** @type {null | typeof showNotification} */ (showNotification),
   useChatPrompt: /** @type {null | ((prompt: string) => unknown)} */ (null),
 };
 

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,16 +1,11 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 94,
+  "totalDiagnostics": 85,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/app-event-listeners.js": 1,
     "js/app-shell-hooks.js": 2,
     "js/backup.js": 3,
-    "js/biology-score-context-ai.js": 1,
-    "js/biology-score-iron.js": 1,
-    "js/biology-score-profile-modifiers.js": 2,
-    "js/biology-score-thyroid.js": 3,
-    "js/biology-scores-runtime.js": 2,
     "js/blob-storage.js": 2,
     "js/chat-images.js": 1,
     "js/chat-onboarding.js": 2,

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.446';
+self.APP_VERSION = '1.10.447';


### PR DESCRIPTION
## Summary
- guard optional Biology Scores delegated actions and profile-sex lookups
- preserve missing-data semantics when iron and thyroid score helpers return no partial score
- make resettable Biology Scores runtime dependencies explicitly nullable
- reduce the strict-null baseline from 94 diagnostics across 55 files to 85 across 50 files
- bump the app version to 1.10.447

## Verification
- `node tests/test-biology-scores.js` (223 passed)
- `node tests/test-biology-scores-runtime.js` (8 passed)
- `npx vitest run tests/sync-biology-context.test.js --pool=forks --maxWorkers=1` (4 passed)
- `npx playwright test tests/playwright/biology-scores-dashboard-lens.spec.js --workers=1` (6 passed)
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run typecheck:strict-null`
- `npm run quality`
- `git diff --check`