### PR TITLE
Type Sun boundaries

### DIFF
--- a/js/sun-defaults.js
+++ b/js/sun-defaults.js
@@ -288,8 +288,10 @@ export function getSunDefaults() {
 
 export async function saveSunDefaults(patch) {
   const d = getSunDefaults();
+  if (!d) return false;
   Object.assign(d, patch);
   await saveImportedData();
+  return true;
 }
 
 export function isOnboardingComplete() {
@@ -871,9 +873,11 @@ async function saveSunSetup() {
     }
     return false;
   }
-  await persistSunSetupValues(collected.values);
+  const values = collected.values;
+  if (!values) return false;
+  await persistSunSetupValues(values);
   closeSunSetupOverlay();
-  showNotification(`Setup saved · light burden ${collected.values.ottScore}/10`);
+  showNotification(`Setup saved · light burden ${values.ottScore}/10`);
   maybeAnalyzeOnboardingAfterSave();
   navigateSunDefaultsRoute('light');
   return true;

--- a/js/sun-session-ui.js
+++ b/js/sun-session-ui.js
@@ -696,7 +696,9 @@ export function openDetailedSessionDialog() {
   endEl?.addEventListener('input', updateDurationHint);
   updateDurationHint();
 
-  overlay.querySelector('#det-save').addEventListener('click', async () => {
+  const saveButton = overlay.querySelector('#det-save');
+  if (!saveButton) return closeDialog();
+  saveButton.addEventListener('click', async () => {
     const eyeModeVal = /** @type {HTMLSelectElement | null} */ (overlay.querySelector('#det-eye-mode'))?.value || 'direct';
     const lensTintVal = /** @type {HTMLSelectElement | null} */ (overlay.querySelector('#det-lens-tint'))?.value || 'clear';
     const spf = parseInt(/** @type {HTMLInputElement | null} */ (overlay.querySelector('#det-spf'))?.value || '', 10) || null;

--- a/js/sun-uvdata.js
+++ b/js/sun-uvdata.js
@@ -746,7 +746,9 @@ function readStaleCache(rLat, rLon) {
       const k = localStorage.key(i);
       if (!k || !k.startsWith(prefix)) continue;
       try {
-        const obj = JSON.parse(localStorage.getItem(k));
+        const cached = localStorage.getItem(k);
+        if (!cached) continue;
+        const obj = JSON.parse(cached);
         if (obj && obj.fetchedAt && (!best || obj.fetchedAt > best.fetchedAt)) best = obj;
       } catch (e) {
         if (isSunDebugRuntime()) {

--- a/js/sun.js
+++ b/js/sun.js
@@ -356,6 +356,11 @@ export async function changeCoverageMidSession(id) {
   const selected = new Set(currentRegions);
   const slot = overlay.querySelector('#sun-coverage-silhouette-slot');
   const hint = overlay.querySelector('#sun-coverage-hint');
+  const confirmButton = overlay.querySelector('#coverage-confirm');
+  if (!hint || !confirmButton) {
+    closeDialog();
+    return;
+  }
   const updateHint = () => {
     const fraction = Array.from(selected).reduce((sum, key) => {
       const r = BODY_REGIONS.find(b => b.key === key);
@@ -375,7 +380,7 @@ export async function changeCoverageMidSession(id) {
   bindBodySilhouette(slot, selected, updateHint);
   updateHint();
 
-  overlay.querySelector('#coverage-confirm').addEventListener('click', async () => {
+  confirmButton.addEventListener('click', async () => {
     const regions = Array.from(selected);
     const updated = await setSessionCoverage(id, regions);
     const fraction = updated?.bodyExposure?.fraction || 0;

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 66,
+  "totalDiagnostics": 59,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/backup.js": 3,
@@ -33,10 +33,6 @@
     "js/recommendations-products.js": 2,
     "js/recommendations-runtime.js": 2,
     "js/schema.js": 2,
-    "js/sun-defaults.js": 2,
-    "js/sun-session-ui.js": 1,
-    "js/sun-uvdata.js": 1,
-    "js/sun.js": 3,
     "js/tour.js": 3,
     "js/utils.js": 4
   }

--- a/tests/test-sun-defaults.js
+++ b/tests/test-sun-defaults.js
@@ -352,6 +352,8 @@ const {
   state.importedData = null;
   assert('getSunDefaults() returns null when importedData missing',
     getSunDefaults() === null);
+  assert('saveSunDefaults() returns false when importedData missing',
+    await saveSunDefaults({ fitzpatrick: 'III' }) === false);
 
   // Restore
   state.importedData = orig;

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.449';
+self.APP_VERSION = '1.10.450';


### PR DESCRIPTION
## Summary

- guard Sun-default persistence when no active profile exists and reject incomplete setup collections safely
- validate detailed-session and coverage modal controls before wiring handlers
- tolerate cache entries disappearing between localStorage enumeration and retrieval
- reduce the strict-null baseline from 66 diagnostics across 37 files to 59 across 33 files
- bump the application version to 1.10.450

## Verification

- `node tests/test-sun-defaults.js` (95 passed)
- `node tests/test-sun.js` (109 passed)
- `node tests/test-sun-uvdata.js` (83 passed)
- `node tests/test-sun-uvdata-flow.js` (17 passed)
- `node tests/test-sun-session-ui-delegated-actions.js` (38 passed)
- `node tests/test-modal-lifecycle-integrations.js` (31 passed)
- focused Playwright: Sun facade, detailed-session UI, and UV-data browser coverage (8 passed)
- post-cleanup focused Playwright rerun: detailed-session UI (3 passed)
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run typecheck:strict-null` (59 diagnostics across 33 files, within baseline)
- `npm run quality` (11/11)
- `git diff --check`