### PR TITLE
Type Lens and DNA boundaries

### DIFF
--- a/js/dna-runtime.js
+++ b/js/dna-runtime.js
@@ -20,7 +20,7 @@ const dnaRuntimeDeps = {
   isDebugMode,
   isImportRunning,
   navigate: /** @type {null | ((route: string) => void)} */ (null),
-  showConfirmDialog,
+  showConfirmDialog: /** @type {null | typeof showConfirmDialog} */ (showConfirmDialog),
 };
 
 function geneticsStylesheetUrl() {

--- a/js/dna.js
+++ b/js/dna.js
@@ -513,7 +513,7 @@ export function renderGeneticsSection() {
       value: genetics.mtdna.haplogroup,
       sub: genetics.mtdna.coupling?.shortLabel || 'Maternal lineage'
     } : null
-  ].filter(Boolean);
+  ].filter(card => card !== null);
 
   html += '<div class="genetics-overview-grid">';
   overviewCards.forEach(card => {

--- a/js/lens-local-worker.js
+++ b/js/lens-local-worker.js
@@ -149,6 +149,7 @@ let _rootDir = null;            // OPFS FileSystemDirectoryHandle at /lens-local
 // MessageChannel port gives a real task boundary without setTimeout's 4ms
 // clamp, so the queue gets pumped between every chunk at near-zero cost.
 const _yieldChannel = new MessageChannel();
+/** @returns {Promise<void>} */
 function macroYield() {
   return new Promise((resolve) => {
     _yieldChannel.port1.onmessage = () => resolve();

--- a/js/lens-pages.js
+++ b/js/lens-pages.js
@@ -59,7 +59,7 @@ function renderGenomeImportDetailsWidget(lensPageActionAttrs) {
       value: genetics.mtdna.haplogroup,
       sub: genetics.mtdna.coupling?.shortLabel || genetics.mtdna.source || 'Maternal lineage',
     } : null,
-  ].filter(Boolean);
+  ].filter(card => card !== null);
 
   const mtdnaDetail = hasMtdna ? `<div class="db-genome-import-note">
     <strong>mtDNA ${escapeHTML(genetics.mtdna.haplogroup)}</strong>

--- a/js/lens.js
+++ b/js/lens.js
@@ -545,23 +545,24 @@ function loadLensKnowledgeBaseUiRetryModule() {
 
 /** @returns {Promise<LensKnowledgeBaseUi>} */
 export function loadLensKnowledgeBaseUi() {
-  if (!lensKnowledgeBaseUiPromise) {
-    const load = useLensKnowledgeBaseUiRetryUrl
-      ? loadLensKnowledgeBaseUiRetryModule()
-      : import('./lens-knowledge-base-ui.js');
-    lensKnowledgeBaseUiPromise = load
-      .then(module => {
-        lensKnowledgeBaseUi = module.createLensKnowledgeBaseUi(lensKnowledgeBaseUiDeps);
-        return lensKnowledgeBaseUi;
-      })
-      .catch(err => {
-        lensKnowledgeBaseUiPromise = null;
-        lensKnowledgeBaseUi = null;
-        useLensKnowledgeBaseUiRetryUrl = true;
-        throw err;
-      });
-  }
-  return lensKnowledgeBaseUiPromise;
+  if (lensKnowledgeBaseUiPromise) return lensKnowledgeBaseUiPromise;
+  const load = useLensKnowledgeBaseUiRetryUrl
+    ? loadLensKnowledgeBaseUiRetryModule()
+    : import('./lens-knowledge-base-ui.js');
+  const promise = load
+    .then(module => {
+      const ui = module.createLensKnowledgeBaseUi(lensKnowledgeBaseUiDeps);
+      lensKnowledgeBaseUi = ui;
+      return ui;
+    })
+    .catch(err => {
+      lensKnowledgeBaseUiPromise = null;
+      lensKnowledgeBaseUi = null;
+      useLensKnowledgeBaseUiRetryUrl = true;
+      throw err;
+    });
+  lensKnowledgeBaseUiPromise = promise;
+  return promise;
 }
 
 /**

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,6 +1,6 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 59,
+  "totalDiagnostics": 49,
   "files": {
     "js/ai-verdict-engine-runtime.js": 2,
     "js/backup.js": 3,
@@ -12,8 +12,6 @@
     "js/dashboard-widget-runtime.js": 1,
     "js/dashboard-widgets.js": 1,
     "js/data.js": 2,
-    "js/dna-runtime.js": 1,
-    "js/dna.js": 3,
     "js/emf-interpretation.js": 2,
     "js/emf.js": 2,
     "js/export-report.js": 1,
@@ -22,9 +20,6 @@
     "js/image-utils.js": 2,
     "js/import-drop-zone-runtime.js": 1,
     "js/lab-entry.js": 1,
-    "js/lens-local-worker.js": 1,
-    "js/lens-pages.js": 3,
-    "js/lens.js": 2,
     "js/pdf-import-marker-mapping.js": 2,
     "js/pdf-import-review-runtime.js": 1,
     "js/pii.js": 1,

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.450';
+self.APP_VERSION = '1.10.451';


### PR DESCRIPTION
## Summary

- model the nullable DNA confirmation callback explicitly at its runtime injection boundary
- preserve non-null card types after conditional DNA and Genome Lens card filtering
- declare the local Lens worker's macrotask yield as a void promise
- return stable local values from the Knowledge Base UI lazy loader while preserving single-flight and retry behavior
- reduce the strict-null baseline from 59 diagnostics across 33 files to 49 across 28 files
- bump the application version to 1.10.451

## Verification

- `node tests/test-dna-runtime.js` (21 passed)
- `node tests/test-dna.js` (186 passed)
- `node tests/test-dna-illumina-and-valence.js` (134 passed)
- `node tests/test-dashboard-genetics-empty.js` (10 passed)
- `node tests/test-custom-lens.js` (188 passed)
- `node tests/test-dashboard-knowledge-base.js` (41 passed)
- `node tests/test-lens-page-shell-delegated-actions.js` (10 passed)
- focused Playwright: DNA browser coverage, Lens UI loader, Lens local worker, and Lens page shell (11 passed)
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run typecheck:strict-null` (49 diagnostics across 28 files, within baseline)
- `npm run quality` (11/11)
- `git diff --check`