### PR TITLE
Eliminate strict-null diagnostic baseline

### DIFF
--- a/js/ai-verdict-engine-runtime.js
+++ b/js/ai-verdict-engine-runtime.js
@@ -2,7 +2,7 @@
 // ai-verdict-engine-runtime.js - Browser runtime adapters for AI verdicts.
 
 const aiVerdictRuntimeDeps = {
-  refreshSunSurfaces: null,
+  refreshSunSurfaces: /** @type {null | ((anchor: string | null) => any)} */ (null),
 };
 
 /** @param {{ refreshSunSurfaces?: ((anchor: string | null) => any) | null }} deps */

--- a/js/client-list-runtime.js
+++ b/js/client-list-runtime.js
@@ -8,7 +8,7 @@ import { showNotification } from './utils.js';
 const clientListRuntimeDeps = {
   navigate: /** @type {null | ((route: string) => void)} */ (null),
   renderProfileButton: /** @type {null | (() => void)} */ (null),
-  showNotification,
+  showNotification: /** @type {null | typeof showNotification} */ (showNotification),
 };
 
 export function configureClientListRuntimeDeps(deps = {}) {

--- a/js/context-card-lifestyle-editors-impl.js
+++ b/js/context-card-lifestyle-editors-impl.js
@@ -716,8 +716,8 @@ export function clearHealthGoals() {
 // ═══════════════════════════════════════════════
 
 export function openInterpretiveLensEditor() { if (!isContextEditorStylesheetLoaded()) return runWithContextEditorStylesheet(openInterpretiveLensEditor);
-  const modal = document.getElementById("detail-modal");
-  const overlay = document.getElementById("modal-overlay");
+  const modal = document.getElementById("detail-modal"), overlay = document.getElementById("modal-overlay");
+  if (!modal || !overlay) return;
   const current = state.importedData.interpretiveLens || '';
   renderContextEditorModal(modal, 'Interpretive Lens', 'List researchers, clinicians, or scientific paradigms whose frameworks you follow. The AI will consider their perspectives when interpreting your results.', `
     <textarea class="note-editor" id="interpretive-lens-textarea" placeholder="e.g. Longevity medicine, quantum biology, functional endocrinology framework...">${escapeHTML(current)}</textarea>
@@ -759,8 +759,8 @@ export function clearInterpretiveLens() {
 export function showDietContaminantsModal() {
   const warnings = scanDietForContaminants(state.importedData.diet);
   if (warnings.length === 0) return;
-  const modal = document.getElementById('detail-modal');
-  const overlay = document.getElementById('modal-overlay');
+  const modal = document.getElementById('detail-modal'), overlay = document.getElementById('modal-overlay');
+  if (!modal || !overlay) return;
   const pesticide = warnings.filter(w => w.type === 'pesticide');
   const plastic = warnings.filter(w => w.type === 'plastic');
   const clean = warnings.filter(w => w.type === 'clean');

--- a/js/context-source-registry.js
+++ b/js/context-source-registry.js
@@ -206,6 +206,10 @@ function getProfileContextSourceValue(idOrSlug) {
   return value === true || value === false ? value : null;
 }
 
+/**
+ * @param {string} idOrSlug
+ * @param {string | null} [legacyKey]
+ */
 function getStoredContextSourceValue(idOrSlug, legacyKey = null) {
   const storage = getStorage();
   if (!storage) return null;

--- a/js/dashboard-view-composition.js
+++ b/js/dashboard-view-composition.js
@@ -120,6 +120,10 @@ export function createDashboardViewComposition({
   });
   configureMarkerDetailModal({ navigate, isDashboardQuickMarkerPinned, toggleDashboardQuickMarkerPin, showEmojiPicker });
 
+  /**
+   * @param {string} widgetId
+   * @param {{data: any, filteredData: any} | null} [ctx]
+   */
   function getDashboardMarkerWidgetDefinition(widgetId, ctx = null) {
     const markerId = dashboardMarkerIdFromWidgetId(widgetId);
     if (!markerId) return null;

--- a/js/dashboard-widget-runtime.js
+++ b/js/dashboard-widget-runtime.js
@@ -143,7 +143,7 @@ export function triggerDashboardDnaPicker() {
 
 /** @param {number | null} [index] */
 export function openDashboardNoteEditor(index = null) {
-  if (Number.isInteger(index) && index >= 0) callDashboardNoteAction('openNoteEditor', null, index);
+  if (index != null && Number.isInteger(index) && index >= 0) callDashboardNoteAction('openNoteEditor', null, index);
   else callDashboardNoteAction('openNoteEditor');
 }
 

--- a/js/dashboard-widgets.js
+++ b/js/dashboard-widgets.js
@@ -120,7 +120,9 @@ export function createDashboardWidgetRegistry(renderers, opts = {}) {
   function getDashboardWidgetPrefs() {
     const fallback = getDashboardDefaultWidgetPrefs();
     try {
-      const raw = JSON.parse(localStorage.getItem(dashboardWidgetStorageKey()));
+      const stored = localStorage.getItem(dashboardWidgetStorageKey());
+      if (!stored) return fallback;
+      const raw = JSON.parse(stored);
       if (!raw || !Array.isArray(raw.order) || !Array.isArray(raw.hidden)) return fallback;
       const fixedIds = getAvailableDashboardFixedWidgetIds();
       const rawOrder = raw.order.filter(id => typeof id === 'string');

--- a/js/emf-interpretation.js
+++ b/js/emf-interpretation.js
@@ -365,6 +365,7 @@ export function interpretEMFComparison(deps = {}) {
   if (sorted.length < 2) return;
 
   const emf = state.importedData.emfAssessment;
+  if (!emf) return;
   const title = 'EMF Comparison \u2014 Before vs After';
   const before = serializeAssessment(sorted[1]);
   const after = serializeAssessment(sorted[0]);

--- a/js/emf.js
+++ b/js/emf.js
@@ -863,6 +863,7 @@ function showEMFImportPreview(parsed) {
   installEMFEditorDelegates();
   const modal = document.getElementById('detail-modal');
   const overlay = document.getElementById('modal-overlay');
+  if (!modal || !overlay) return;
   const fmtDate = parsed.date ? new Date(parsed.date + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }) : 'Unknown date';
 
   let html = `<button type="button" class="modal-close" aria-label="Close" ${emfActionAttrs('close-preview')}>&times;</button>
@@ -905,9 +906,11 @@ function showEMFImportPreview(parsed) {
   </div>`;
 
   modal.innerHTML = html;
+  const confirmButton = modal.querySelector('#emf-confirm-btn');
+  if (!confirmButton) return;
   openModalOverlay(overlay);
 
-  document.getElementById('emf-confirm-btn').addEventListener('click', () => {
+  confirmButton.addEventListener('click', () => {
     const assessments = ensureAssessments();
     const assessment = {
       id: 'emf_' + Date.now(),

--- a/js/hardware.js
+++ b/js/hardware.js
@@ -93,7 +93,7 @@ const LS_KEY = 'labcharts-hw-vram-override';
 
 export function getHardwareOverride() {
   try {
-    const v = parseFloat(localStorage.getItem(LS_KEY));
+    const v = parseFloat(localStorage.getItem(LS_KEY) || '');
     return isNaN(v) || v <= 0 ? null : v;
   } catch { return null; }
 }

--- a/js/import-drop-zone-runtime.js
+++ b/js/import-drop-zone-runtime.js
@@ -6,7 +6,11 @@ import { getDnaModuleFunction } from './dna-runtime-bridge.js';
 import { showNotification } from './utils.js';
 import { importDataJSON } from './export-loader.js';
 
-const importDropZoneRuntimeDeps = { importDataJSON, isImportRunning, showNotification };
+const importDropZoneRuntimeDeps = {
+  importDataJSON,
+  isImportRunning,
+  showNotification: /** @type {null | typeof showNotification} */ (showNotification),
+};
 
 export function configureImportDropZoneRuntimeDeps(deps = {}) {
   const previous = { ...importDropZoneRuntimeDeps };

--- a/js/lab-entry.js
+++ b/js/lab-entry.js
@@ -160,7 +160,7 @@ export function syncLabEntryInsulinMirror(entry, opts = {}) {
   const now = Number.isFinite(opts.now) ? opts.now : Date.now();
   const hormonesKey = 'hormones.insulin';
   const diabetesKey = 'diabetes.insulin_d';
-  let sourceKey = null;
+  let sourceKey = /** @type {'hormones.insulin' | 'diabetes.insulin_d' | null} */ (null);
   if (entry.markers[hormonesKey] !== undefined) {
     entry.markers[diabetesKey] = entry.markers[hormonesKey];
     sourceKey = hormonesKey;
@@ -170,9 +170,12 @@ export function syncLabEntryInsulinMirror(entry, opts = {}) {
   } else {
     return false;
   }
-  clearLabEntryMarkerTombstone(entry, getInsulinMirrorMarkerKey(sourceKey));
-  if (entry.markerSources?.[sourceKey]) {
-    ensureMarkerSources(entry)[getInsulinMirrorMarkerKey(sourceKey)] = entry.markerSources[sourceKey];
+  if (!sourceKey) return false;
+  const mirrorKey = sourceKey === hormonesKey ? diabetesKey : hormonesKey;
+  const markerSource = entry.markerSources?.[sourceKey];
+  clearLabEntryMarkerTombstone(entry, mirrorKey);
+  if (markerSource) {
+    ensureMarkerSources(entry)[mirrorKey] = markerSource;
   }
   recalculateLabEntryHOMAIR(entry);
   if (opts.stamp !== false) stampLabEntryUpdated(entry, now);

--- a/js/pdf-import-marker-mapping.js
+++ b/js/pdf-import-marker-mapping.js
@@ -100,7 +100,7 @@ function _isImportableCalculatedMarkerKey(key) {
   return !!MARKER_SCHEMA[catKey]?.calculated && !!MARKER_SCHEMA[catKey]?.markers?.[markerKey];
 }
 
-function _hasImportReferenceKey(key, refLookup, existingKeys = null) {
+function _hasImportReferenceKey(key, refLookup, existingKeys = /** @type {Set<string> | null} */ (null)) {
   return !!refLookup[key] || !!existingKeys?.has?.(key) || _isImportableCalculatedMarkerKey(key);
 }
 
@@ -572,7 +572,11 @@ function _buildStandardBloodNameLookup() {
   return lookup;
 }
 
-function _resolveStandardBloodImportKey(marker, refLookup, differentialPercentSuggestedKey = undefined) {
+function _resolveStandardBloodImportKey(
+  marker,
+  refLookup,
+  differentialPercentSuggestedKey = /** @type {string | null | undefined} */ (undefined),
+) {
   const rawName = marker.rawName || marker.suggestedName || '';
   const specimen = _getImportSpecimen(rawName);
   const unit = normalizeUnitStr(marker.unit || '');

--- a/js/pdf-import-review-runtime.js
+++ b/js/pdf-import-review-runtime.js
@@ -20,7 +20,7 @@ const pdfImportReviewRuntimeDeps = {
   buildSidebar: /** @type {null | (() => void)} */ (null),
   confirmImport: /** @type {null | (() => unknown)} */ (null),
   navigate: /** @type {null | ((route: string) => void)} */ (null),
-  updateHeaderDates,
+  updateHeaderDates: /** @type {null | typeof updateHeaderDates} */ (updateHeaderDates),
 };
 
 export function configurePdfImportReviewRuntimeDeps(deps = {}) {

--- a/js/pii.js
+++ b/js/pii.js
@@ -357,7 +357,7 @@ export async function sanitizeWithOllamaStreaming(pdfText, onChunk, signal, onTh
       if (done) break;
       buffer += decoder.decode(value, { stream: true });
       const lines = buffer.split('\n');
-      buffer = lines.pop(); // keep incomplete line
+      buffer = lines.pop() || ''; // keep incomplete line
       for (const line of lines) {
         if (processLine(line)) { streamDone = true; break; }
       }

--- a/js/profile-context.js
+++ b/js/profile-context.js
@@ -162,7 +162,7 @@ function collectLightModifiers(data, options = {}) {
   const lowVitaminDSynthesis = vitD7 != null && vitD7 < 4000;
   if (lowLoggedSunlight) flags.push('Light context: no recent outdoor sun sessions are logged; if accurate, vitamin D, inflammation, sleep, recovery, and hormone patterns may be light-constrained.');
   if (lowCircadianLight) flags.push('Light context: recent circadian-channel exposure appears absent/low; morning-light habits may be relevant to stress, sleep, glucose, and hormone patterns.');
-  if (lowVitaminDSynthesis) flags.push(`Light context: logged 7-day vitamin-D synthesis is low (~${Math.round(vitD7)} IU), so low 25-OH vitamin D should be interpreted with sunlight exposure, not only supplementation.`);
+  if (lowVitaminDSynthesis && vitD7 != null) flags.push(`Light context: logged 7-day vitamin-D synthesis is low (~${Math.round(vitD7)} IU), so low 25-OH vitamin D should be interpreted with sunlight exposure, not only supplementation.`);
   if (!hasLightData) flags.push('Light context: Light tracking is enabled by default for Biology Scores, but no light data is logged yet; scores can only infer light exposure from profile notes/labs.');
   return { includeLight, hasLightData, recentSunDays: recentSun.length, vitD7, circadian7, lowLoggedSunlight, lowCircadianLight, lowVitaminDSynthesis, flags };
 }

--- a/js/recommendations-products.js
+++ b/js/recommendations-products.js
@@ -275,8 +275,10 @@ export function copyCouponCode(btn) {
     const r = document.createRange();
     r.selectNodeContents(btn);
     const s = getSelection();
-    s.removeAllRanges();
-    s.addRange(r);
+    if (s) {
+      s.removeAllRanges();
+      s.addRange(r);
+    }
     flashCopied('Press Ctrl+C');
   }
 }

--- a/js/recommendations-runtime.js
+++ b/js/recommendations-runtime.js
@@ -7,7 +7,7 @@ const recommendationsRuntimeDeps = {
   closeModal: /** @type {null | (() => unknown)} */ (null),
   openEMFAssessmentEditor,
   openChatPanel: /** @type {null | ((prompt?: string) => unknown)} */ (null),
-  openProfileLocationEditor: null,
+  openProfileLocationEditor: /** @type {null | (() => unknown)} */ (null),
   openSettingsModal: /** @type {null | ((tab?: string) => unknown)} */ (null),
 };
 
@@ -66,7 +66,7 @@ export function configureRecommendationsRuntime(deps = {}) {
   }
   if ('openProfileLocationEditor' in deps) {
     recommendationsRuntimeDeps.openProfileLocationEditor = typeof deps.openProfileLocationEditor === 'function'
-      ? deps.openProfileLocationEditor
+      ? /** @type {() => unknown} */ (deps.openProfileLocationEditor)
       : null;
   }
   if ('openSettingsModal' in deps) {

--- a/js/schema.js
+++ b/js/schema.js
@@ -376,14 +376,21 @@ function isPercentClinicalUnit(unit) {
 
 function isFractionStoredPercentMarker(key) {
   const [catKey, markerKey] = String(key || '').split('.');
-  const marker = MARKER_SCHEMA[catKey]?.markers?.[markerKey];
+  const marker = /** @type {{unit?: string, refMax?: number} | undefined} */ (
+    MARKER_SCHEMA[catKey]?.markers?.[markerKey]
+  );
   const conversion = UNIT_CONVERSIONS[key];
   return !!marker && (marker.unit || '') === '' && marker.refMax != null && marker.refMax <= 1
     && conversion?.type === 'multiply'
     && conversion.factor === 100 && isPercentClinicalUnit(conversion.usUnit);
 }
 
-function normalizeFractionStoredPercentValue(key, value, unit, context = null) {
+function normalizeFractionStoredPercentValue(
+  key,
+  value,
+  unit,
+  context = /** @type {Record<string, any> | null} */ (null),
+) {
   if (!isFractionStoredPercentMarker(key) || !isPercentClinicalUnit(unit)) return null;
   const [catKey, markerKey] = String(key || '').split('.');
   const schemaRefMax = Number(MARKER_SCHEMA[catKey]?.markers?.[markerKey]?.refMax);

--- a/js/tour.js
+++ b/js/tour.js
@@ -177,9 +177,13 @@ function runTour(steps, storageKey, auto) {
     document.body.appendChild(tooltip);
   }
 
-  document.getElementById('tour-overlay').style.display = 'block';
-  document.getElementById('tour-spotlight').style.display = 'block';
-  document.getElementById('tour-tooltip').style.display = 'block';
+  const overlay = document.getElementById('tour-overlay');
+  const spotlight = document.getElementById('tour-spotlight');
+  const tooltip = document.getElementById('tour-tooltip');
+  if (!overlay || !spotlight || !tooltip) return false;
+  overlay.style.display = 'block';
+  spotlight.style.display = 'block';
+  tooltip.style.display = 'block';
 
   goToStep(0);
   return true;

--- a/js/utils.js
+++ b/js/utils.js
@@ -530,6 +530,12 @@ export function showConfirmDialog(message) {
       <button class="confirm-btn confirm-btn-cancel" id="confirm-cancel">Cancel</button>
       <button class="confirm-btn confirm-btn-danger" id="confirm-ok">Confirm</button>
     </div></div>`;
+    const ok = /** @type {HTMLButtonElement | null} */ (overlay.querySelector('#confirm-ok'));
+    const cancel = /** @type {HTMLButtonElement | null} */ (overlay.querySelector('#confirm-cancel'));
+    if (!ok || !cancel) {
+      resolve(false);
+      return;
+    }
     let settled = false;
     const previousOnclick = overlay.onclick;
     overlay.dataset.escapeOwner = 'utils-confirm';
@@ -562,8 +568,8 @@ export function showConfirmDialog(message) {
       }
     };
     openModalOverlay(overlay, { initialFocus: '#confirm-cancel', focusDelay: 0 });
-    document.getElementById("confirm-ok").onclick = () => close(true);
-    document.getElementById("confirm-cancel").onclick = () => close(false);
+    ok.onclick = () => close(true);
+    cancel.onclick = () => close(false);
   });
 }
 
@@ -595,9 +601,13 @@ export function showPromptDialog(message, { defaultValue = '', okLabel = 'OK', c
         <button class="confirm-btn confirm-btn-danger" id="prompt-ok" style="background:var(--accent)">${escapeHTML(okLabel)}</button>
       </div></div>`;
 
-    const input = /** @type {HTMLInputElement} */ (document.getElementById('prompt-dialog-input'));
-    const ok = document.getElementById('prompt-ok');
-    const cancel = document.getElementById('prompt-cancel');
+    const input = /** @type {HTMLInputElement | null} */ (overlay.querySelector('#prompt-dialog-input'));
+    const ok = /** @type {HTMLButtonElement | null} */ (overlay.querySelector('#prompt-ok'));
+    const cancel = /** @type {HTMLButtonElement | null} */ (overlay.querySelector('#prompt-cancel'));
+    if (!input || !ok || !cancel) {
+      resolve(null);
+      return;
+    }
     let settled = false;
     const previousOnclick = overlay.onclick;
 

--- a/scripts/strict-null-baseline.json
+++ b/scripts/strict-null-baseline.json
@@ -1,27 +1,5 @@
 {
   "description": "Maximum strictNullChecks diagnostics per file. New files and per-file growth fail the ratchet.",
-  "totalDiagnostics": 35,
-  "files": {
-    "js/ai-verdict-engine-runtime.js": 2,
-    "js/client-list-runtime.js": 1,
-    "js/context-card-lifestyle-editors-impl.js": 2,
-    "js/context-source-registry.js": 1,
-    "js/dashboard-view-composition.js": 2,
-    "js/dashboard-widget-runtime.js": 1,
-    "js/dashboard-widgets.js": 1,
-    "js/emf-interpretation.js": 2,
-    "js/emf.js": 2,
-    "js/hardware.js": 1,
-    "js/import-drop-zone-runtime.js": 1,
-    "js/lab-entry.js": 1,
-    "js/pdf-import-marker-mapping.js": 2,
-    "js/pdf-import-review-runtime.js": 1,
-    "js/pii.js": 1,
-    "js/profile-context.js": 1,
-    "js/recommendations-products.js": 2,
-    "js/recommendations-runtime.js": 2,
-    "js/schema.js": 2,
-    "js/tour.js": 3,
-    "js/utils.js": 4
-  }
+  "totalDiagnostics": 0,
+  "files": {}
 }

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.452';
+self.APP_VERSION = '1.10.453';


### PR DESCRIPTION
## Summary
- add explicit nullable contracts for runtime callback dependencies and dynamic schema/import boundaries
- guard nullable DOM, storage, selection, and imported-data access without changing successful-path behavior
- reduce the strict-null ratchet from 35 diagnostics in 21 files to zero and bump the app version to 1.10.453

## Verification
- `npx tsc --noEmit --strictNullChecks true --pretty false`
- `npm run typecheck:strict-null` (0 diagnostics across 0 files)
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
- 1,183 focused unit assertions across the affected modules
- 26 focused Chromium Playwright tests across dialogs, dashboard widgets, EMF, imports, PII, recommendations, schema, tours, hardware, and lifestyle editors