### PR TITLE
Split Client List form owner

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -9,8 +9,8 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 
 | Metric | Current |
 | --- | ---: |
-| Modules | 495 |
-| Internal import edges | 2232 |
+| Modules | 496 |
+| Internal import edges | 2238 |
 | Dynamic internal edges | 93 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -38,13 +38,13 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 
 | High fan-in | Dependants | High fan-out | Imports |
 | --- | ---: | --- | ---: |
-| [`js/utils.js`](js/utils.js) | 229 | [`js/app-shell-hooks.js`](js/app-shell-hooks.js) | 72 |
-| [`js/state.js`](js/state.js) | 154 | [`js/app-light-sun-modules.js`](js/app-light-sun-modules.js) | 36 |
+| [`js/utils.js`](js/utils.js) | 230 | [`js/app-shell-hooks.js`](js/app-shell-hooks.js) | 72 |
+| [`js/state.js`](js/state.js) | 155 | [`js/app-light-sun-modules.js`](js/app-light-sun-modules.js) | 36 |
 | [`js/caught-error.js`](js/caught-error.js) | 73 | [`js/sync-configure.js`](js/sync-configure.js) | 27 |
 | [`js/data.js`](js/data.js) | 72 | [`js/settings.js`](js/settings.js) | 25 |
 | [`js/modal-lifecycle.js`](js/modal-lifecycle.js) | 64 | [`js/pdf-import.js`](js/pdf-import.js) | 24 |
 | [`js/api.js`](js/api.js) | 63 | [`js/chat-send.js`](js/chat-send.js) | 22 |
-| [`js/profile.js`](js/profile.js) | 44 | [`js/views.js`](js/views.js) | 22 |
+| [`js/profile.js`](js/profile.js) | 45 | [`js/views.js`](js/views.js) | 22 |
 | [`js/schema.js`](js/schema.js) | 30 | [`js/wearables-connect.js`](js/wearables-connect.js) | 21 |
 | [`js/crypto.js`](js/crypto.js) | 29 | [`js/dashboard-view-composition.js`](js/dashboard-view-composition.js) | 20 |
 | [`js/data-merge.js`](js/data-merge.js) | 29 | [`js/biology-scores.js`](js/biology-scores.js) | 19 |
@@ -250,9 +250,10 @@ Native browser modules shipped with the static application.
 
 </details>
 
-<details><summary><code>client</code> family — 3 modules</summary>
+<details><summary><code>client</code> family — 4 modules</summary>
 
-- [`js/client-list-impl.js`](js/client-list-impl.js) → [`js/client-list-runtime.js`](js/client-list-runtime.js), [`js/constants.js`](js/constants.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/nav.js`](js/nav.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
+- [`js/client-list-form.js`](js/client-list-form.js) → [`js/client-list-runtime.js`](js/client-list-runtime.js), [`js/constants.js`](js/constants.js), [`js/nav.js`](js/nav.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
+- [`js/client-list-impl.js`](js/client-list-impl.js) → [`js/client-list-form.js`](js/client-list-form.js), [`js/client-list-runtime.js`](js/client-list-runtime.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/nav.js`](js/nav.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/client-list-runtime.js`](js/client-list-runtime.js) → [`js/api.js`](js/api.js), [`js/dna-runtime-bridge.js`](js/dna-runtime-bridge.js), [`js/utils.js`](js/utils.js)
 - [`js/client-list.js`](js/client-list.js) → [`js/client-list-impl.js`](js/client-list-impl.js) *(dynamic)*, [`js/client-list-runtime.js`](js/client-list-runtime.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js)
 

--- a/js/client-list-form.js
+++ b/js/client-list-form.js
@@ -1,0 +1,656 @@
+// @ts-check
+// client-list-form.js — Create/edit form owner for the Client List modal
+
+import { state } from './state.js';
+import { escapeAttr, escapeHTML } from './utils.js';
+import {
+  createProfile,
+  detectLatitudeWithAI,
+  getLatitudeFromLocation,
+  getLocationCache,
+  getProfileHeight,
+  getProfiles,
+  latitudeToBand,
+  switchProfile,
+  updateProfileMeta,
+} from './profile.js';
+import { LATITUDE_BANDS } from './constants.js';
+import { getAvatarColor } from './nav.js';
+import {
+  getClientHaplogroupList,
+  hasClientListAIProvider,
+  navigateClientListRoute,
+  refreshClientProfileButton,
+  setClientManualHaplogroup,
+  showClientListNotification,
+} from './client-list-runtime.js';
+
+const FORM_ICONS = Object.freeze({
+  arrowLeft: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="m15 18-6-6 6-6"/></svg>',
+  camera: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M14.5 4 13 6H8a3 3 0 0 0-3 3v8a3 3 0 0 0 3 3h8a3 3 0 0 0 3-3V9a3 3 0 0 0-3-3h-.5L14.5 4z"/><circle cx="12" cy="13" r="3"/></svg>',
+  close: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>',
+});
+
+/**
+ * @typedef {{
+ *   closeClientList: () => void,
+ *   renderClientList: () => void,
+ * }} ClientListFormRuntime
+ */
+
+/** @type {ClientListFormRuntime} */
+const clientListFormRuntime = {
+  closeClientList: () => {},
+  renderClientList: () => {},
+};
+
+/** @param {Partial<ClientListFormRuntime>} [runtime] */
+export function configureClientListFormRuntime(runtime = {}) {
+  const previous = { ...clientListFormRuntime };
+  Object.assign(clientListFormRuntime, runtime);
+  return previous;
+}
+
+/** @type {string | null} */
+let editingId = null;
+/** @type {string | null | undefined} */
+let pendingAvatar;
+/** @type {ReturnType<typeof setTimeout> | null} */
+let latitudeTimer = null;
+
+export function resetClientListFormState() {
+  editingId = null;
+  pendingAvatar = undefined;
+}
+
+function _clActionAttrs(action, attrs = {}) {
+  return Object.entries({ 'data-cl-action': action, ...attrs })
+    .filter(([, value]) => value !== undefined && value !== null)
+    .map(([name, value]) => `${name}="${escapeAttr(String(value))}"`)
+    .join(' ');
+}
+
+function _clInputAttrs(action) {
+  return `data-cl-input-action="${escapeAttr(action)}"`;
+}
+
+function _clChangeAttrs(action) {
+  return `data-cl-change-action="${escapeAttr(action)}"`;
+}
+
+function _clKeyAttrs(action) {
+  return `data-cl-key-action="${escapeAttr(action)}"`;
+}
+
+/**
+ * @param {string} id
+ * @returns {HTMLInputElement | null}
+ */
+function _clInput(id) {
+  const el = document.getElementById(id);
+  return el instanceof HTMLInputElement ? el : null;
+}
+
+/**
+ * @param {string} id
+ * @returns {HTMLTextAreaElement | null}
+ */
+function _clTextarea(id) {
+  const el = document.getElementById(id);
+  return el instanceof HTMLTextAreaElement ? el : null;
+}
+
+/**
+ * @param {string} id
+ * @returns {HTMLSelectElement | null}
+ */
+function _clSelectElement(id) {
+  const el = document.getElementById(id);
+  return el instanceof HTMLSelectElement ? el : null;
+}
+
+/** @param {Element} pill */
+function _clTagText(pill) {
+  return pill.firstChild?.textContent?.trim() || '';
+}
+
+/** @param {File} file */
+function _resizeAvatar(file) {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => {
+      const size = 80;
+      const canvas = document.createElement('canvas');
+      canvas.width = size;
+      canvas.height = size;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) {
+        reject(new Error('Canvas 2D context is unavailable'));
+        return;
+      }
+      const min = Math.min(img.width, img.height);
+      const sx = (img.width - min) / 2;
+      const sy = (img.height - min) / 2;
+      ctx.drawImage(img, sx, sy, min, min, 0, 0, size, size);
+      resolve(canvas.toDataURL('image/jpeg', 0.8));
+    };
+    img.onerror = reject;
+    img.src = URL.createObjectURL(file);
+  });
+}
+
+function _isSafeAvatarSrc(src) {
+  return typeof src === 'string' && src.startsWith('data:image/');
+}
+
+/** @param {string} [profileId] */
+export function openClientForm(profileId) {
+  editingId = profileId || null;
+  pendingAvatar = undefined;
+  const modal = document.getElementById('client-list-modal');
+  if (!modal) return;
+  const profiles = getProfiles();
+  const profile = profileId ? profiles.find(candidate => candidate.id === profileId) : null;
+
+  const name = profile ? profile.name : '';
+  const sex = profile ? (profile.sex || '') : '';
+  const dob = profile ? (profile.dob || '') : '';
+  const country = profile ? ((profile.location || {}).country || '') : '';
+  const zip = profile ? ((profile.location || {}).zip || '') : '';
+  const tags = profile ? (profile.tags || []) : [];
+  const notes = profile ? (profile.notes || '') : '';
+  const status = profile ? (profile.status || 'active') : 'active';
+  const avatar = profile ? (profile.avatar || '') : '';
+  const heightData = profile ? getProfileHeight(profile.id) : { height: null, unit: 'cm' };
+  const heightUnit = heightData.unit || 'cm';
+  const heightValue = heightData.height == null || heightData.height === '' ? null : Number(heightData.height);
+  const heightDisplay = heightValue ? _clFormatHeightInput(heightValue, heightUnit) : '';
+
+  const avatarColor = getAvatarColor(profile ? profile.id : 'new');
+  const avatarInitial = (name || '?')[0].toUpperCase();
+  const avatarPreview = avatar && _isSafeAvatarSrc(avatar)
+    ? `<img class="cl-avatar-preview-img" id="cl-avatar-img" src="${escapeAttr(avatar)}" alt="">`
+    : `<span class="cl-avatar-preview-initial" id="cl-avatar-img" style="background:${avatarColor}">${escapeHTML(avatarInitial)}</span>`;
+
+  modal.innerHTML = `<div class="cl-header cl-form-header">
+    <div class="cl-header-left">
+      <button type="button" class="cl-back-btn cl-icon-btn" ${_clActionAttrs('back-to-list')} aria-label="Back to clients">${FORM_ICONS.arrowLeft}</button>
+      <div>
+        <h2 class="cl-title">${profile ? 'Edit Client' : 'New Client'}</h2>
+        <div class="cl-count">${profile ? escapeHTML(profile.name || 'Profile') : 'Create a local profile'}</div>
+      </div>
+    </div>
+    <div class="cl-header-right">
+      <button type="button" class="modal-close cl-icon-btn" ${_clActionAttrs('close')} aria-label="Close">${FORM_ICONS.close}</button>
+    </div>
+  </div>
+  <form class="cl-form" data-cl-submit-action="save-form">
+    <div class="cl-form-body">
+      <section class="cl-form-section">
+        <div class="cl-section-title">Profile</div>
+        <div class="cl-form-row cl-avatar-row">
+          <div class="cl-avatar-picker" ${_clActionAttrs('choose-avatar')} ${_clKeyAttrs('choose-avatar')} role="button" tabindex="0">
+            ${avatarPreview}
+            <span class="cl-avatar-edit-icon">${FORM_ICONS.camera}</span>
+          </div>
+          <input type="file" id="cl-avatar-input" accept="image/*" style="display:none" ${_clChangeAttrs('avatar-changed')}>
+          ${avatar ? `<button type="button" class="cl-avatar-remove" ${_clActionAttrs('remove-avatar')}>Remove photo</button>` : ''}
+        </div>
+        <div class="cl-form-row">
+          <label class="cl-form-label" for="cl-name">Name <span class="cl-required">*</span></label>
+          <input type="text" class="cl-form-input" id="cl-name" value="${escapeHTML(name)}" required autofocus>
+        </div>
+        <div class="cl-form-row-split">
+          <div class="cl-form-row cl-form-col">
+            <label class="cl-form-label">Sex</label>
+            <div class="cl-sex-toggle" id="cl-sex-toggle">
+              <button type="button" class="sex-toggle-btn${sex === 'male' ? ' active' : ''}" data-sex="male" ${_clActionAttrs('set-sex', { 'data-cl-sex': 'male' })}>Male</button>
+              <button type="button" class="sex-toggle-btn${sex === 'female' ? ' active' : ''}" data-sex="female" ${_clActionAttrs('set-sex', { 'data-cl-sex': 'female' })}>Female</button>
+            </div>
+          </div>
+          <div class="cl-form-row cl-form-col">
+            <label class="cl-form-label" for="cl-dob">Date of Birth</label>
+            <input type="date" class="cl-form-input cl-form-date" id="cl-dob" value="${escapeHTML(dob)}">
+          </div>
+        </div>
+      </section>
+
+      <section class="cl-form-section">
+        <div class="cl-section-title">Region</div>
+        <div class="cl-form-row">
+          <label class="cl-form-label" for="cl-country">Location <span class="cl-label-detail">drives regional recommendations and affiliate URLs</span></label>
+          <div class="cl-form-row-split">
+            <div class="cl-form-col">
+              <input type="text" class="cl-form-input" id="cl-country" value="${escapeHTML(country)}" placeholder="Country (e.g. Slovakia)" ${_clInputAttrs('update-lat')} list="cl-country-list" autocomplete="country-name">
+              <datalist id="cl-country-list">
+                <option value="Czech Republic"></option>
+                <option value="Slovakia"></option>
+                <option value="Germany"></option>
+                <option value="Austria"></option>
+                <option value="United States"></option>
+                <option value="France"></option>
+                <option value="Italy"></option>
+                <option value="Spain"></option>
+                <option value="Netherlands"></option>
+                <option value="Belgium"></option>
+                <option value="Poland"></option>
+                <option value="Hungary"></option>
+                <option value="Portugal"></option>
+                <option value="Ireland"></option>
+                <option value="Denmark"></option>
+                <option value="Sweden"></option>
+                <option value="Finland"></option>
+                <option value="United Kingdom"></option>
+                <option value="Canada"></option>
+                <option value="Australia"></option>
+              </datalist>
+            </div>
+            <div class="cl-form-col">
+              <input type="text" class="cl-form-input" id="cl-zip" value="${escapeHTML(zip)}" placeholder="ZIP / postal code" ${_clInputAttrs('update-lat')}>
+            </div>
+          </div>
+          <div id="cl-lat-display" class="cl-lat-display"></div>
+        </div>
+      </section>
+
+      <section class="cl-form-section">
+        <div class="cl-section-title">Health Metadata</div>
+        <div class="cl-form-row-split">
+          <div class="cl-form-row cl-form-col">
+            <label class="cl-form-label" for="cl-height">Height <a href="#" class="cl-bio-unit-toggle" id="cl-height-unit-toggle" data-unit="${heightUnit}" ${_clActionAttrs('height-unit')}>${heightUnit}</a></label>
+            <input type="number" class="cl-form-input" id="cl-height" value="${escapeHTML(String(heightDisplay))}" step="${heightUnit === 'in' ? '0.1' : '1'}" placeholder="${heightUnit === 'in' ? 'inches' : 'cm'}" ${_clInputAttrs('update-bmi')}>
+            <input type="hidden" id="cl-height-unit" value="${heightUnit}">
+          </div>
+          ${profile ? `<div class="cl-form-row cl-form-col">
+            <label class="cl-form-label">BMI</label>
+            <div class="mc-auto-value cl-bmi-display" id="cl-bmi-display"></div>
+          </div>` : ''}
+        </div>
+        <div class="cl-health-note">
+          ${profile
+            ? `<a href="#" class="cl-health-link" ${_clActionAttrs('health-metrics')}>Log weight, blood pressure and pulse on the dashboard</a>`
+            : 'Log weight, blood pressure and pulse on the dashboard after creating the client.'}
+        </div>
+        <div class="cl-form-row">
+          <label class="cl-form-label" for="cl-haplogroup">mtDNA Haplogroup <span class="cl-label-detail">maternal lineage</span></label>
+          <div class="cl-haplogroup-row">
+            <select class="cl-form-input cl-haplogroup-select" id="cl-haplogroup" ${_clChangeAttrs('haplogroup-changed')}>
+              <option value="">Not set</option>
+              ${getClientHaplogroupList().map(haplogroup => '<option value="' + haplogroup + '"' + (state.importedData?.genetics?.mtdna?.haplogroup === haplogroup ? ' selected' : '') + '>' + haplogroup + '</option>').join('')}
+            </select>
+            <span id="cl-hg-coupling" class="cl-hg-coupling">${state.importedData?.genetics?.mtdna?.coupling?.shortLabel || ''}</span>
+          </div>
+        </div>
+      </section>
+
+      <section class="cl-form-section">
+        <div class="cl-section-title">Client Notes</div>
+        <div class="cl-form-row">
+          <label class="cl-form-label">Tags</label>
+          <div class="cl-tags-wrap" id="cl-tags-wrap">
+            ${tags.map(tag => `<span class="cl-tag-pill">${escapeHTML(tag)}<button type="button" class="cl-tag-remove" ${_clActionAttrs('remove-tag')} aria-label="Remove tag">${FORM_ICONS.close}</button></span>`).join('')}
+            <input type="text" class="cl-tag-input" id="cl-tag-input" placeholder="Add tag + Enter" ${_clKeyAttrs('tag-input')}>
+          </div>
+        </div>
+        <div class="cl-form-row">
+          <label class="cl-form-label" for="cl-notes">Notes</label>
+          <textarea class="cl-form-textarea" id="cl-notes" rows="3" placeholder="Practitioner notes...">${escapeHTML(notes)}</textarea>
+        </div>
+        <div class="cl-form-row">
+          <label class="cl-form-label">Status</label>
+          <div class="cl-status-radios">
+            <label class="cl-radio"><input type="radio" name="cl-status" value="active"${status === 'active' ? ' checked' : ''}> Active</label>
+            <label class="cl-radio"><input type="radio" name="cl-status" value="flagged"${status === 'flagged' ? ' checked' : ''}> Flagged</label>
+            <label class="cl-radio"><input type="radio" name="cl-status" value="archived"${status === 'archived' ? ' checked' : ''}> Archived</label>
+          </div>
+        </div>
+      </section>
+    </div>
+    <div class="cl-form-actions">
+      <button type="button" class="cl-form-cancel" ${_clActionAttrs('back-to-list')}>Cancel</button>
+      <button type="submit" class="cl-form-save">${profile ? 'Save Changes' : 'Create Client'}</button>
+    </div>
+  </form>`;
+  requestAnimationFrame(() => {
+    _clUpdateLat();
+    _clUpdateBMI();
+  });
+}
+
+/** @param {Event} event */
+function _clGoToHealthMetrics(event) {
+  event.preventDefault();
+  clientListFormRuntime.closeClientList();
+  navigateClientListRoute('dashboard');
+  requestAnimationFrame(() => {
+    document.getElementById('wearable-strip')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  });
+}
+
+/** @param {SubmitEvent | Event} event */
+function _clSaveForm(event) {
+  event.preventDefault();
+  const name = (_clInput('cl-name')?.value || '').trim();
+  if (!name) return;
+  const sexButton = document.querySelector('#cl-sex-toggle .sex-toggle-btn.active');
+  const sex = sexButton instanceof HTMLElement ? sexButton.dataset.sex || null : null;
+  const dob = _clInput('cl-dob')?.value || null;
+  const country = (_clInput('cl-country')?.value || '').trim();
+  const zip = (_clInput('cl-zip')?.value || '').trim();
+  const notes = (_clTextarea('cl-notes')?.value || '').trim();
+  const statusRadio = document.querySelector('input[name="cl-status"]:checked');
+  const status = statusRadio instanceof HTMLInputElement ? statusRadio.value : 'active';
+
+  const tags = [];
+  document.querySelectorAll('#cl-tags-wrap .cl-tag-pill').forEach(pill => {
+    const text = _clTagText(pill);
+    if (text && !tags.includes(text)) tags.push(text);
+  });
+
+  const heightRaw = parseFloat(_clInput('cl-height')?.value || '');
+  const heightUnit = _clInput('cl-height-unit')?.value || 'cm';
+  const height = heightRaw ? (heightUnit === 'in' ? Math.round(heightRaw * 2.54 * 10) / 10 : Math.round(heightRaw)) : null;
+
+  const avatarUpdate = {};
+  if (pendingAvatar !== undefined) avatarUpdate.avatar = pendingAvatar;
+
+  if (editingId) {
+    updateProfileMeta(editingId, { name, sex, dob, location: { country, zip }, tags, notes, status, height, heightUnit, ...avatarUpdate });
+    if (editingId === state.currentProfile) {
+      if (sex !== undefined) state.profileSex = sex;
+      if (dob !== undefined) state.profileDob = dob;
+    }
+    refreshClientProfileButton();
+    showClientListNotification(`"${name}" updated`, 'info');
+  } else {
+    const id = createProfile(name, { sex, dob, location: { country, zip }, tags, notes, status, height, heightUnit, ...avatarUpdate });
+    switchProfile(id);
+    refreshClientProfileButton();
+    showClientListNotification(`"${name}" created`, 'success');
+  }
+  editingId = null;
+  clientListFormRuntime.renderClientList();
+}
+
+async function _clHaplogroupChanged() {
+  const select = _clSelectElement('cl-haplogroup');
+  const label = document.getElementById('cl-hg-coupling');
+  if (!select) return;
+  const haplogroup = select.value;
+  if (!haplogroup) {
+    if (label) label.textContent = '';
+    return;
+  }
+  await setClientManualHaplogroup(haplogroup);
+  const mitochondrial = state.importedData?.genetics?.mtdna;
+  if (label) label.textContent = mitochondrial?.coupling?.shortLabel || '';
+}
+
+/** @param {HTMLInputElement} input */
+async function _clAvatarChanged(input) {
+  const file = input.files?.[0];
+  if (!file) return;
+  try {
+    const dataUrl = await _resizeAvatar(file);
+    pendingAvatar = dataUrl;
+    const container = document.querySelector('.cl-avatar-picker');
+    if (container) {
+      container.innerHTML = `<img class="cl-avatar-preview-img" id="cl-avatar-img" src="${escapeAttr(dataUrl)}" alt=""><span class="cl-avatar-edit-icon">${FORM_ICONS.camera}</span>`;
+    }
+    if (!document.querySelector('.cl-avatar-remove')) {
+      const row = document.querySelector('.cl-avatar-row');
+      if (row) {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'cl-avatar-remove';
+        button.textContent = 'Remove photo';
+        button.setAttribute('data-cl-action', 'remove-avatar');
+        row.appendChild(button);
+      }
+    }
+  } catch {
+    showClientListNotification('Could not load image', 'error');
+  }
+  input.value = '';
+}
+
+function _clRemoveAvatar() {
+  pendingAvatar = null;
+  const container = document.querySelector('.cl-avatar-picker');
+  if (container) {
+    const color = getAvatarColor(editingId || 'new');
+    const nameInput = _clInput('cl-name');
+    const initial = ((nameInput?.value || '?')[0]).toUpperCase();
+    container.innerHTML = `<span class="cl-avatar-preview-initial" id="cl-avatar-img" style="background:${color}">${escapeHTML(initial)}</span><span class="cl-avatar-edit-icon">${FORM_ICONS.camera}</span>`;
+  }
+  document.querySelector('.cl-avatar-remove')?.remove();
+}
+
+/** @param {string} sex */
+function _clSetSex(sex) {
+  document.querySelectorAll('#cl-sex-toggle .sex-toggle-btn').forEach(button => {
+    if (button instanceof HTMLElement) button.classList.toggle('active', button.dataset.sex === sex);
+  });
+}
+
+/** @param {HTMLElement} element */
+function _clShowLat(element, latitude, suffix) {
+  const band = latitudeToBand(latitude);
+  element.style.color = 'var(--green)';
+  element.textContent = '\u2713 ' + Math.abs(Math.round(latitude)) + '\u00b0' + (latitude >= 0 ? 'N' : 'S') + ' \u2014 ' + LATITUDE_BANDS[band] + (suffix || '');
+}
+
+function _clUpdateLat() {
+  const country = (_clInput('cl-country')?.value || '').trim();
+  const zip = (_clInput('cl-zip')?.value || '').trim();
+  const element = document.getElementById('cl-lat-display');
+  if (!element) return;
+  if (!country) {
+    element.textContent = '';
+    return;
+  }
+
+  const cache = getLocationCache();
+  const cacheKey = (country + '|' + zip).toLowerCase();
+  const cached = cache[cacheKey];
+  const hasAIProvider = hasClientListAIProvider();
+
+  if (cached !== undefined) {
+    const countryLatitude = zip ? cache[(country + '|').toLowerCase()] : undefined;
+    let zipSuffix = '';
+    if (zip && countryLatitude !== undefined) zipSuffix = Math.round(cached) !== Math.round(countryLatitude) ? ' (ZIP-refined)' : ' (ZIP \u2014 same area)';
+    _clShowLat(element, cached, zipSuffix);
+    return;
+  }
+
+  const countryOnly = zip ? cache[(country + '|').toLowerCase()] : undefined;
+  if (countryOnly !== undefined) {
+    _clShowLat(element, countryOnly, ' \u2014 refining with ZIP\u2026');
+  } else {
+    const bandLabel = getLatitudeFromLocation(country, zip);
+    if (bandLabel) {
+      element.style.color = 'var(--green)';
+      element.textContent = '\u2713 ' + bandLabel + (hasAIProvider ? ' \u2014 refining\u2026' : '');
+    } else if (hasAIProvider) {
+      element.style.color = 'var(--text-muted)';
+      element.textContent = 'Detecting\u2026';
+    } else {
+      element.style.color = 'var(--text-muted)';
+      element.textContent = 'Country not recognized \u2014 try the full name';
+    }
+  }
+
+  if (latitudeTimer) clearTimeout(latitudeTimer);
+  latitudeTimer = setTimeout(() => {
+    if (!hasClientListAIProvider()) return;
+    detectLatitudeWithAI(country, zip).then(() => {
+      const freshCache = getLocationCache();
+      const updated = freshCache[(country + '|' + zip).toLowerCase()];
+      if (updated === undefined) return;
+      const countryLatitude = zip ? freshCache[(country + '|').toLowerCase()] : undefined;
+      let zipSuffix = '';
+      if (zip && countryLatitude !== undefined) zipSuffix = Math.round(updated) !== Math.round(countryLatitude) ? ' (ZIP-refined)' : ' (ZIP \u2014 same area)';
+      const display = document.getElementById('cl-lat-display');
+      if (display) _clShowLat(display, updated, zipSuffix);
+    });
+  }, 1500);
+}
+
+/** @param {KeyboardEvent} event */
+function _clTagKeydown(event) {
+  if (event.key !== 'Enter') return;
+  event.preventDefault();
+  const input = event.target;
+  if (!(input instanceof HTMLInputElement)) return;
+  const value = input.value.trim();
+  if (!value) return;
+  const existing = [];
+  document.querySelectorAll('#cl-tags-wrap .cl-tag-pill').forEach(pill => {
+    existing.push(_clTagText(pill).toLowerCase());
+  });
+  if (existing.includes(value.toLowerCase())) {
+    input.value = '';
+    return;
+  }
+  const wrap = document.getElementById('cl-tags-wrap');
+  if (!wrap) return;
+  const pill = document.createElement('span');
+  pill.className = 'cl-tag-pill';
+  pill.innerHTML = `${escapeHTML(value)}<button type="button" class="cl-tag-remove" ${_clActionAttrs('remove-tag')} aria-label="Remove tag">${FORM_ICONS.close}</button>`;
+  wrap.insertBefore(pill, input);
+  input.value = '';
+}
+
+/** @param {Element} button */
+function _clRemoveTag(button) {
+  button.parentElement?.remove();
+}
+
+function _clBackToList() {
+  editingId = null;
+  clientListFormRuntime.renderClientList();
+}
+
+function _clUpdateBMI() {
+  const element = document.getElementById('cl-bmi-display');
+  if (!element) return;
+  const heightRaw = parseFloat(_clInput('cl-height')?.value || '');
+  const heightUnit = _clInput('cl-height-unit')?.value || 'cm';
+  const heightCm = heightRaw ? (heightUnit === 'in' ? heightRaw * 2.54 : heightRaw) : null;
+  const weightKg = state.importedData?.wearableSummary?.metrics?.weight?.latest ?? null;
+
+  if (heightCm && weightKg) {
+    const heightMeters = heightCm / 100;
+    const bmi = weightKg / (heightMeters * heightMeters);
+    let category = '> 30';
+    if (bmi < 18.5) category = '< 18.5';
+    else if (bmi < 25) category = 'normal';
+    else if (bmi < 30) category = '25–30';
+    element.className = 'mc-auto-value';
+    element.textContent = `${bmi.toFixed(1)} (${category})`;
+  } else {
+    element.className = 'mc-auto-value mc-auto-pending';
+    element.textContent = heightCm ? 'add weight' : weightKg ? 'add height' : '--';
+  }
+}
+
+/**
+ * @param {number} heightCm
+ * @param {string} unit
+ */
+function _clFormatHeightInput(heightCm, unit) {
+  return unit === 'in' ? (heightCm / 2.54).toFixed(1) : String(Math.round(heightCm));
+}
+
+function _clHeightUnitChanged() {
+  const input = _clInput('cl-height');
+  const hidden = _clInput('cl-height-unit');
+  const toggle = document.getElementById('cl-height-unit-toggle');
+  if (!input || !hidden || !toggle) return;
+  const current = hidden.value;
+  const next = current === 'cm' ? 'in' : 'cm';
+  const value = parseFloat(input.value);
+  if (value) {
+    const heightCm = current === 'in' ? value * 2.54 : value;
+    input.value = _clFormatHeightInput(heightCm, next);
+  }
+  input.placeholder = next === 'in' ? 'inches' : 'cm';
+  input.step = next === 'in' ? '0.1' : '1';
+  hidden.value = next;
+  toggle.textContent = next;
+  toggle.dataset.unit = next;
+  _clUpdateBMI();
+}
+
+/** @param {string} id */
+function _clickFileInput(id) {
+  const input = document.getElementById(id);
+  if (input instanceof HTMLInputElement) input.click();
+}
+
+/**
+ * @param {string} action
+ * @param {HTMLElement} actionElement
+ * @param {Event} event
+ */
+export function handleClientFormClick(action, actionElement, event) {
+  if (action === 'back-to-list') _clBackToList();
+  else if (action === 'choose-avatar') _clickFileInput('cl-avatar-input');
+  else if (action === 'remove-avatar') _clRemoveAvatar();
+  else if (action === 'set-sex') _clSetSex(actionElement.dataset.clSex || '');
+  else if (action === 'remove-tag') _clRemoveTag(actionElement);
+  else if (action === 'height-unit') _clHeightUnitChanged();
+  else if (action === 'health-metrics') _clGoToHealthMetrics(event);
+  else return false;
+  return true;
+}
+
+/** @param {string} action */
+export function handleClientFormInput(action) {
+  if (action === 'update-lat') _clUpdateLat();
+  else if (action === 'update-bmi') _clUpdateBMI();
+  else return false;
+  return true;
+}
+
+/**
+ * @param {string} action
+ * @param {HTMLElement} element
+ */
+export function handleClientFormChange(action, element) {
+  if (action === 'avatar-changed' && element instanceof HTMLInputElement) {
+    _clAvatarChanged(element);
+  } else if (action === 'haplogroup-changed') {
+    _clHaplogroupChanged();
+  } else {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * @param {string} action
+ * @param {SubmitEvent | Event} event
+ */
+export function handleClientFormSubmit(action, event) {
+  if (action !== 'save-form') return false;
+  _clSaveForm(event);
+  return true;
+}
+
+/**
+ * @param {string} action
+ * @param {KeyboardEvent} event
+ */
+export function handleClientFormKeydown(action, event) {
+  if (action === 'tag-input') {
+    _clTagKeydown(event);
+    return true;
+  }
+  if (action !== 'choose-avatar') return false;
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault();
+    _clickFileInput('cl-avatar-input');
+  }
+  return true;
+}

--- a/js/client-list-impl.js
+++ b/js/client-list-impl.js
@@ -3,18 +3,22 @@
 
 import { state } from './state.js';
 import { escapeHTML, escapeAttr } from './utils.js';
-import { getProfiles, getActiveProfileId, createProfile, switchProfile, deleteProfile, updateProfileMeta, getAllTags, getLocationCache, latitudeToBand, getLatitudeFromLocation, detectLatitudeWithAI, getProfileHeight } from './profile.js';
-import { LATITUDE_BANDS } from './constants.js';
+import { getProfiles, getActiveProfileId, switchProfile, deleteProfile, updateProfileMeta, getAllTags } from './profile.js';
 import { getAvatarColor } from './nav.js';
 import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
+import { refreshClientProfileButton } from './client-list-runtime.js';
 import {
-  getClientHaplogroupList,
-  hasClientListAIProvider,
-  navigateClientListRoute,
-  refreshClientProfileButton,
-  setClientManualHaplogroup,
-  showClientListNotification,
-} from './client-list-runtime.js';
+  configureClientListFormRuntime,
+  handleClientFormChange,
+  handleClientFormClick,
+  handleClientFormInput,
+  handleClientFormKeydown,
+  handleClientFormSubmit,
+  openClientForm,
+  resetClientListFormState,
+} from './client-list-form.js';
+
+export { openClientForm };
 
 const CLIENT_LIST_STYLESHEET_URL = new URL('../css/client-list.css', import.meta.url).href;
 
@@ -48,8 +52,6 @@ let _search = '';
 let _sort = 'lastUpdated';
 let _statusFilter = 'active';
 let _tagFilter = '';
-let _editingId = null;
-let _pendingAvatar = undefined; // undefined = no change, null = remove, string = new dataURL
 let clientListDelegatesInstalled = false;
 /** @type {Promise<HTMLLinkElement> | null} */
 let _clientListStylesheetLoad = null;
@@ -59,8 +61,6 @@ let _useClientListStylesheetRetryUrl = false;
 
 const CL_ICONS = Object.freeze({
   archive: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M21 8v13H3V8"/><path d="M1 3h22v5H1z"/><path d="M10 12h4"/></svg>',
-  arrowLeft: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="m15 18-6-6 6-6"/></svg>',
-  camera: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M14.5 4 13 6H8a3 3 0 0 0-3 3v8a3 3 0 0 0 3 3h8a3 3 0 0 0 3-3V9a3 3 0 0 0-3-3h-.5L14.5 4z"/><circle cx="12" cy="13" r="3"/></svg>',
   close: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>',
   edit: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>',
   export: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="M7 10l5 5 5-5"/><path d="M12 15V3"/></svg>',
@@ -94,67 +94,8 @@ function _clKeyAttrs(action) {
   return `data-cl-key-action="${escapeAttr(action)}"`;
 }
 
-/**
- * @param {string} id
- * @returns {HTMLInputElement | null}
- */
-function _clInput(id) {
-  const el = document.getElementById(id);
-  return el instanceof HTMLInputElement ? el : null;
-}
-
-/**
- * @param {string} id
- * @returns {HTMLTextAreaElement | null}
- */
-function _clTextarea(id) {
-  const el = document.getElementById(id);
-  return el instanceof HTMLTextAreaElement ? el : null;
-}
-
-/**
- * @param {string} id
- * @returns {HTMLSelectElement | null}
- */
-function _clSelectElement(id) {
-  const el = document.getElementById(id);
-  return el instanceof HTMLSelectElement ? el : null;
-}
-
 function _clMenuButton({ icon, label, action, profileId, danger = false }) {
   return `<button type="button" class="cl-menu-item${danger ? ' cl-menu-danger' : ''}" ${_clActionAttrs(action, { 'data-cl-profile-id': profileId })}>${icon}<span>${escapeHTML(label)}</span></button>`;
-}
-
-/** @param {Element} pill */
-function _clTagText(pill) {
-  return pill.firstChild?.textContent?.trim() || '';
-}
-
-// ═══════════════════════════════════════════════
-// AVATAR HELPERS
-// ═══════════════════════════════════════════════
-function _resizeAvatar(file) {
-  return new Promise((resolve, reject) => {
-    const img = new Image();
-    img.onload = () => {
-      const size = 80;
-      const canvas = document.createElement('canvas');
-      canvas.width = size; canvas.height = size;
-      const ctx = canvas.getContext('2d');
-      if (!ctx) {
-        reject(new Error('Canvas 2D context is unavailable'));
-        return;
-      }
-      // Center-crop to square
-      const min = Math.min(img.width, img.height);
-      const sx = (img.width - min) / 2;
-      const sy = (img.height - min) / 2;
-      ctx.drawImage(img, sx, sy, min, min, 0, 0, size, size);
-      resolve(canvas.toDataURL('image/jpeg', 0.8));
-    };
-    img.onerror = reject;
-    img.src = URL.createObjectURL(file);
-  });
 }
 
 function _isSafeAvatarSrc(s) { return typeof s === 'string' && s.startsWith('data:image/'); }
@@ -214,8 +155,7 @@ export function openClientList() {
         _search = '';
         _statusFilter = 'active';
         _tagFilter = '';
-        _editingId = null;
-        _pendingAvatar = undefined;
+        resetClientListFormState();
         const overlay = document.getElementById('client-list-overlay');
         if (!overlay) return false;
         renderClientList();
@@ -235,7 +175,7 @@ export function openClientList() {
 
 export function closeClientList() {
   closeModalOverlay('client-list-overlay');
-  _editingId = null;
+  resetClientListFormState();
 }
 
 // ═══════════════════════════════════════════════
@@ -420,404 +360,6 @@ function _timeAgo(ts) {
 }
 
 // ═══════════════════════════════════════════════
-// CLIENT FORM (create / edit)
-// ═══════════════════════════════════════════════
-export function openClientForm(profileId) {
-  _editingId = profileId || null;
-  _pendingAvatar = undefined;
-  const modal = document.getElementById('client-list-modal');
-  if (!modal) return;
-  const profiles = getProfiles();
-  const p = profileId ? profiles.find(pr => pr.id === profileId) : null;
-
-  const name = p ? p.name : '';
-  const sex = p ? (p.sex || '') : '';
-  const dob = p ? (p.dob || '') : '';
-  const country = p ? ((p.location || {}).country || '') : '';
-  const zip = p ? ((p.location || {}).zip || '') : '';
-  const tags = p ? (p.tags || []) : [];
-  const notes = p ? (p.notes || '') : '';
-  const status = p ? (p.status || 'active') : 'active';
-  const avatar = p ? (p.avatar || '') : '';
-  const heightData = p ? getProfileHeight(p.id) : { height: null, unit: 'cm' };
-  const heightUnit = heightData.unit || 'cm';
-  const heightValue = heightData.height == null || heightData.height === '' ? null : Number(heightData.height);
-  const heightDisplay = heightValue ? _clFormatHeightInput(heightValue, heightUnit) : '';
-
-  const avatarColor = getAvatarColor(p ? p.id : 'new');
-  const avatarInitial = (name || '?')[0].toUpperCase();
-  const avatarPreview = avatar && _isSafeAvatarSrc(avatar)
-    ? `<img class="cl-avatar-preview-img" id="cl-avatar-img" src="${escapeAttr(avatar)}" alt="">`
-    : `<span class="cl-avatar-preview-initial" id="cl-avatar-img" style="background:${avatarColor}">${escapeHTML(avatarInitial)}</span>`;
-
-  modal.innerHTML = `<div class="cl-header cl-form-header">
-    <div class="cl-header-left">
-      <button type="button" class="cl-back-btn cl-icon-btn" ${_clActionAttrs('back-to-list')} aria-label="Back to clients">${CL_ICONS.arrowLeft}</button>
-      <div>
-        <h2 class="cl-title">${p ? 'Edit Client' : 'New Client'}</h2>
-        <div class="cl-count">${p ? escapeHTML(p.name || 'Profile') : 'Create a local profile'}</div>
-      </div>
-    </div>
-    <div class="cl-header-right">
-      <button type="button" class="modal-close cl-icon-btn" ${_clActionAttrs('close')} aria-label="Close">${CL_ICONS.close}</button>
-    </div>
-  </div>
-  <form class="cl-form" data-cl-submit-action="save-form">
-    <div class="cl-form-body">
-      <section class="cl-form-section">
-        <div class="cl-section-title">Profile</div>
-        <div class="cl-form-row cl-avatar-row">
-          <div class="cl-avatar-picker" ${_clActionAttrs('choose-avatar')} ${_clKeyAttrs('choose-avatar')} role="button" tabindex="0">
-            ${avatarPreview}
-            <span class="cl-avatar-edit-icon">${CL_ICONS.camera}</span>
-          </div>
-          <input type="file" id="cl-avatar-input" accept="image/*" style="display:none" ${_clChangeAttrs('avatar-changed')}>
-          ${avatar ? `<button type="button" class="cl-avatar-remove" ${_clActionAttrs('remove-avatar')}>Remove photo</button>` : ''}
-        </div>
-        <div class="cl-form-row">
-          <label class="cl-form-label" for="cl-name">Name <span class="cl-required">*</span></label>
-          <input type="text" class="cl-form-input" id="cl-name" value="${escapeHTML(name)}" required autofocus>
-        </div>
-        <div class="cl-form-row-split">
-          <div class="cl-form-row cl-form-col">
-            <label class="cl-form-label">Sex</label>
-            <div class="cl-sex-toggle" id="cl-sex-toggle">
-              <button type="button" class="sex-toggle-btn${sex === 'male' ? ' active' : ''}" data-sex="male" ${_clActionAttrs('set-sex', { 'data-cl-sex': 'male' })}>Male</button>
-              <button type="button" class="sex-toggle-btn${sex === 'female' ? ' active' : ''}" data-sex="female" ${_clActionAttrs('set-sex', { 'data-cl-sex': 'female' })}>Female</button>
-            </div>
-          </div>
-          <div class="cl-form-row cl-form-col">
-            <label class="cl-form-label" for="cl-dob">Date of Birth</label>
-            <input type="date" class="cl-form-input cl-form-date" id="cl-dob" value="${escapeHTML(dob)}">
-          </div>
-        </div>
-      </section>
-
-      <section class="cl-form-section">
-        <div class="cl-section-title">Region</div>
-        <div class="cl-form-row">
-          <label class="cl-form-label" for="cl-country">Location <span class="cl-label-detail">drives regional recommendations and affiliate URLs</span></label>
-          <div class="cl-form-row-split">
-            <div class="cl-form-col">
-              <input type="text" class="cl-form-input" id="cl-country" value="${escapeHTML(country)}" placeholder="Country (e.g. Slovakia)" ${_clInputAttrs('update-lat')} list="cl-country-list" autocomplete="country-name">
-              <datalist id="cl-country-list">
-                <option value="Czech Republic"></option>
-                <option value="Slovakia"></option>
-                <option value="Germany"></option>
-                <option value="Austria"></option>
-                <option value="United States"></option>
-                <option value="France"></option>
-                <option value="Italy"></option>
-                <option value="Spain"></option>
-                <option value="Netherlands"></option>
-                <option value="Belgium"></option>
-                <option value="Poland"></option>
-                <option value="Hungary"></option>
-                <option value="Portugal"></option>
-                <option value="Ireland"></option>
-                <option value="Denmark"></option>
-                <option value="Sweden"></option>
-                <option value="Finland"></option>
-                <option value="United Kingdom"></option>
-                <option value="Canada"></option>
-                <option value="Australia"></option>
-              </datalist>
-            </div>
-            <div class="cl-form-col">
-              <input type="text" class="cl-form-input" id="cl-zip" value="${escapeHTML(zip)}" placeholder="ZIP / postal code" ${_clInputAttrs('update-lat')}>
-            </div>
-          </div>
-          <div id="cl-lat-display" class="cl-lat-display"></div>
-        </div>
-      </section>
-
-      <section class="cl-form-section">
-        <div class="cl-section-title">Health Metadata</div>
-        <div class="cl-form-row-split">
-          <div class="cl-form-row cl-form-col">
-            <label class="cl-form-label" for="cl-height">Height <a href="#" class="cl-bio-unit-toggle" id="cl-height-unit-toggle" data-unit="${heightUnit}" ${_clActionAttrs('height-unit')}>${heightUnit}</a></label>
-            <input type="number" class="cl-form-input" id="cl-height" value="${escapeHTML(String(heightDisplay))}" step="${heightUnit === 'in' ? '0.1' : '1'}" placeholder="${heightUnit === 'in' ? 'inches' : 'cm'}" ${_clInputAttrs('update-bmi')}>
-            <input type="hidden" id="cl-height-unit" value="${heightUnit}">
-          </div>
-          ${p ? `<div class="cl-form-row cl-form-col">
-            <label class="cl-form-label">BMI</label>
-            <div class="mc-auto-value cl-bmi-display" id="cl-bmi-display"></div>
-          </div>` : ''}
-        </div>
-        <div class="cl-health-note">
-          ${p
-            ? `<a href="#" class="cl-health-link" ${_clActionAttrs('health-metrics')}>Log weight, blood pressure and pulse on the dashboard</a>`
-            : 'Log weight, blood pressure and pulse on the dashboard after creating the client.'}
-        </div>
-        <div class="cl-form-row">
-          <label class="cl-form-label" for="cl-haplogroup">mtDNA Haplogroup <span class="cl-label-detail">maternal lineage</span></label>
-          <div class="cl-haplogroup-row">
-            <select class="cl-form-input cl-haplogroup-select" id="cl-haplogroup" ${_clChangeAttrs('haplogroup-changed')}>
-              <option value="">Not set</option>
-              ${getClientHaplogroupList().map(h => '<option value="' + h + '"' + (state.importedData?.genetics?.mtdna?.haplogroup === h ? ' selected' : '') + '>' + h + '</option>').join('')}
-            </select>
-            <span id="cl-hg-coupling" class="cl-hg-coupling">${state.importedData?.genetics?.mtdna?.coupling?.shortLabel || ''}</span>
-          </div>
-        </div>
-      </section>
-
-      <section class="cl-form-section">
-        <div class="cl-section-title">Client Notes</div>
-        <div class="cl-form-row">
-          <label class="cl-form-label">Tags</label>
-          <div class="cl-tags-wrap" id="cl-tags-wrap">
-            ${tags.map(t => `<span class="cl-tag-pill">${escapeHTML(t)}<button type="button" class="cl-tag-remove" ${_clActionAttrs('remove-tag')} aria-label="Remove tag">${CL_ICONS.close}</button></span>`).join('')}
-            <input type="text" class="cl-tag-input" id="cl-tag-input" placeholder="Add tag + Enter" ${_clKeyAttrs('tag-input')}>
-          </div>
-        </div>
-        <div class="cl-form-row">
-          <label class="cl-form-label" for="cl-notes">Notes</label>
-          <textarea class="cl-form-textarea" id="cl-notes" rows="3" placeholder="Practitioner notes...">${escapeHTML(notes)}</textarea>
-        </div>
-        <div class="cl-form-row">
-          <label class="cl-form-label">Status</label>
-          <div class="cl-status-radios">
-            <label class="cl-radio"><input type="radio" name="cl-status" value="active"${status === 'active' ? ' checked' : ''}> Active</label>
-            <label class="cl-radio"><input type="radio" name="cl-status" value="flagged"${status === 'flagged' ? ' checked' : ''}> Flagged</label>
-            <label class="cl-radio"><input type="radio" name="cl-status" value="archived"${status === 'archived' ? ' checked' : ''}> Archived</label>
-          </div>
-        </div>
-      </section>
-    </div>
-    <div class="cl-form-actions">
-      <button type="button" class="cl-form-cancel" ${_clActionAttrs('back-to-list')}>Cancel</button>
-      <button type="submit" class="cl-form-save">${p ? 'Save Changes' : 'Create Client'}</button>
-    </div>
-  </form>`;
-  requestAnimationFrame(() => {
-    _clUpdateLat();
-    _clUpdateBMI();
-  });
-}
-
-function _clGoToHealthMetrics(event) {
-  if (event) event.preventDefault();
-  closeClientList();
-  navigateClientListRoute('dashboard');
-  requestAnimationFrame(() => {
-    document.getElementById('wearable-strip')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-  });
-}
-
-// ═══════════════════════════════════════════════
-// FORM HANDLERS
-// ═══════════════════════════════════════════════
-function _clSaveForm(e) {
-  e.preventDefault();
-  const name = (_clInput('cl-name')?.value || '').trim();
-  if (!name) return;
-  const sexBtn = document.querySelector('#cl-sex-toggle .sex-toggle-btn.active');
-  const sex = sexBtn instanceof HTMLElement ? sexBtn.dataset.sex || null : null;
-  const dob = _clInput('cl-dob')?.value || null;
-  const country = (_clInput('cl-country')?.value || '').trim();
-  const zip = (_clInput('cl-zip')?.value || '').trim();
-  const notes = (_clTextarea('cl-notes')?.value || '').trim();
-  const statusRadio = document.querySelector('input[name="cl-status"]:checked');
-  const status = statusRadio instanceof HTMLInputElement ? statusRadio.value : 'active';
-
-  // Collect tags from pills
-  const tags = [];
-  document.querySelectorAll('#cl-tags-wrap .cl-tag-pill').forEach(pill => {
-    const text = _clTagText(pill);
-    if (text && !tags.includes(text)) tags.push(text);
-  });
-
-  // Height — stored in cm
-  const heightRaw = parseFloat(_clInput('cl-height')?.value || '');
-  const heightUnit = _clInput('cl-height-unit')?.value || 'cm';
-  const height = heightRaw ? (heightUnit === 'in' ? Math.round(heightRaw * 2.54 * 10) / 10 : Math.round(heightRaw)) : null;
-
-  // Build avatar update
-  const avatarUpdate = {};
-  if (_pendingAvatar !== undefined) {
-    avatarUpdate.avatar = _pendingAvatar; // null = remove, string = new
-  }
-
-  if (_editingId) {
-    // Update existing profile
-    updateProfileMeta(_editingId, { name, sex, dob, location: { country, zip }, tags, notes, status, height, heightUnit, ...avatarUpdate });
-    // If editing the active profile, sync runtime state so data pipeline uses fresh values
-    if (_editingId === state.currentProfile) {
-      if (sex !== undefined) state.profileSex = sex;
-      if (dob !== undefined) state.profileDob = dob;
-    }
-    refreshClientProfileButton();
-    showClientListNotification(`"${name}" updated`, 'info');
-  } else {
-    // Create new profile
-    const id = createProfile(name, { sex, dob, location: { country, zip }, tags, notes, status, height, heightUnit, ...avatarUpdate });
-    switchProfile(id);
-    refreshClientProfileButton();
-    showClientListNotification(`"${name}" created`, 'success');
-  }
-  _editingId = null;
-  renderClientList();
-}
-
-async function _clHaplogroupChanged() {
-  const sel = _clSelectElement('cl-haplogroup');
-  const label = document.getElementById('cl-hg-coupling');
-  if (!sel) return;
-  const hg = sel.value;
-  if (!hg) {
-    if (label) label.textContent = '';
-    return;
-  }
-  await setClientManualHaplogroup(hg);
-  // Update coupling label
-  const mt = state.importedData?.genetics?.mtdna;
-  if (label) label.textContent = mt?.coupling?.shortLabel || '';
-}
-
-async function _clAvatarChanged(input) {
-  const file = input.files?.[0];
-  if (!file) return;
-  try {
-    const dataUrl = await _resizeAvatar(file);
-    _pendingAvatar = dataUrl;
-    const container = document.querySelector('.cl-avatar-picker');
-    if (container) {
-      container.innerHTML = `<img class="cl-avatar-preview-img" id="cl-avatar-img" src="${escapeAttr(dataUrl)}" alt=""><span class="cl-avatar-edit-icon">${CL_ICONS.camera}</span>`;
-    }
-    // Add remove button if not present
-    if (!document.querySelector('.cl-avatar-remove')) {
-      const row = document.querySelector('.cl-avatar-row');
-      if (row) {
-        const btn = document.createElement('button');
-        btn.type = 'button';
-        btn.className = 'cl-avatar-remove';
-        btn.textContent = 'Remove photo';
-        btn.setAttribute('data-cl-action', 'remove-avatar');
-        row.appendChild(btn);
-      }
-    }
-  } catch {
-    showClientListNotification('Could not load image', 'error');
-  }
-  input.value = '';
-}
-
-function _clRemoveAvatar() {
-  _pendingAvatar = null;
-  const container = document.querySelector('.cl-avatar-picker');
-  if (container) {
-    const color = getAvatarColor(_editingId || 'new');
-    const nameInput = _clInput('cl-name');
-    const initial = ((nameInput?.value || '?')[0]).toUpperCase();
-    container.innerHTML = `<span class="cl-avatar-preview-initial" id="cl-avatar-img" style="background:${color}">${escapeHTML(initial)}</span><span class="cl-avatar-edit-icon">${CL_ICONS.camera}</span>`;
-  }
-  const removeBtn = document.querySelector('.cl-avatar-remove');
-  if (removeBtn) removeBtn.remove();
-}
-
-function _clSetSex(sex) {
-  document.querySelectorAll('#cl-sex-toggle .sex-toggle-btn').forEach(btn => {
-    if (btn instanceof HTMLElement) btn.classList.toggle('active', btn.dataset.sex === sex);
-  });
-}
-
-function _clShowLat(el, lat, suffix) {
-  var band = latitudeToBand(lat);
-  el.style.color = 'var(--green)';
-  el.textContent = '\u2713 ' + Math.abs(Math.round(lat)) + '\u00b0' + (lat >= 0 ? 'N' : 'S') + ' \u2014 ' + LATITUDE_BANDS[band] + (suffix || '');
-}
-
-var _clLatTimer = null;
-function _clUpdateLat() {
-  const country = (_clInput('cl-country')?.value || '').trim();
-  const zip = (_clInput('cl-zip')?.value || '').trim();
-  const el = document.getElementById('cl-lat-display');
-  if (!el) return;
-  if (!country) { el.textContent = ''; return; }
-
-  var cache = getLocationCache();
-  var cacheKey = (country + '|' + zip).toLowerCase();
-  var cached = cache[cacheKey];
-  const hasAIProvider = hasClientListAIProvider();
-
-  // Exact cache hit — show immediately, done
-  if (cached !== undefined) {
-    var countryLat = zip ? cache[(country + '|').toLowerCase()] : undefined;
-    var zipSuffix = '';
-    if (zip && countryLat !== undefined) zipSuffix = Math.round(cached) !== Math.round(countryLat) ? ' (ZIP-refined)' : ' (ZIP \u2014 same area)';
-    _clShowLat(el, cached, zipSuffix);
-    return;
-  }
-
-  // No exact hit — check if country-only is cached (show it as interim when ZIP is being refined)
-  var countryOnly = zip ? cache[(country + '|').toLowerCase()] : undefined;
-  if (countryOnly !== undefined) {
-    _clShowLat(el, countryOnly, ' \u2014 refining with ZIP\u2026');
-  } else {
-    // Hardcoded fallback (instant, no AI needed)
-    var bandLabel = getLatitudeFromLocation(country, zip);
-    if (bandLabel) {
-      el.style.color = 'var(--green)';
-      el.textContent = '\u2713 ' + bandLabel + (hasAIProvider ? ' \u2014 refining\u2026' : '');
-    } else if (hasAIProvider) {
-      el.style.color = 'var(--text-muted)';
-      el.textContent = 'Detecting\u2026';
-    } else {
-      el.style.color = 'var(--text-muted)';
-      el.textContent = 'Country not recognized \u2014 try the full name';
-    }
-  }
-
-  // Debounced AI refinement
-  if (_clLatTimer) clearTimeout(_clLatTimer);
-  _clLatTimer = setTimeout(function() {
-    if (!hasClientListAIProvider()) return;
-    detectLatitudeWithAI(country, zip).then(() => {
-      var freshCache = getLocationCache();
-      var updated = freshCache[(country + '|' + zip).toLowerCase()];
-      if (updated !== undefined) {
-        var cOnly = zip ? freshCache[(country + '|').toLowerCase()] : undefined;
-        var zSuffix = '';
-        if (zip && cOnly !== undefined) zSuffix = Math.round(updated) !== Math.round(cOnly) ? ' (ZIP-refined)' : ' (ZIP \u2014 same area)';
-        var display = document.getElementById('cl-lat-display');
-        if (display) _clShowLat(display, updated, zSuffix);
-      }
-    });
-  }, 1500);
-}
-
-function _clTagKeydown(e) {
-  if (e.key !== 'Enter') return;
-  e.preventDefault();
-  const input = e.target;
-  if (!(input instanceof HTMLInputElement)) return;
-  const val = input.value.trim();
-  if (!val) return;
-  // Check for duplicates
-  const existing = [];
-  document.querySelectorAll('#cl-tags-wrap .cl-tag-pill').forEach(pill => {
-    existing.push(_clTagText(pill).toLowerCase());
-  });
-  if (existing.includes(val.toLowerCase())) { input.value = ''; return; }
-  const wrap = document.getElementById('cl-tags-wrap');
-  if (!wrap) return;
-  const pill = document.createElement('span');
-  pill.className = 'cl-tag-pill';
-  pill.innerHTML = `${escapeHTML(val)}<button type="button" class="cl-tag-remove" ${_clActionAttrs('remove-tag')} aria-label="Remove tag">${CL_ICONS.close}</button>`;
-  wrap.insertBefore(pill, input);
-  input.value = '';
-}
-
-function _clRemoveTag(btn) {
-  btn.parentElement.remove();
-}
-
-function _clBackToList() {
-  _editingId = null;
-  renderClientList();
-}
-
-// ═══════════════════════════════════════════════
 // LIST ACTIONS
 // ═══════════════════════════════════════════════
 function _clSelect(id) {
@@ -952,7 +494,6 @@ function _handleClientClick(event) {
 
   if (action === 'close') closeClientList();
   else if (action === 'open-form') openClientForm();
-  else if (action === 'back-to-list') _clBackToList();
   else if (action === 'select-profile') _clSelect(id);
   else if (action === 'edit-profile') _clEdit(id);
   else if (action === 'toggle-tools-menu') _clToggleToolsMenu(event);
@@ -961,12 +502,6 @@ function _handleClientClick(event) {
   else if (action === 'load-demo') { closeClientList(); clientListRuntime.loadDemoData(actionEl.dataset.clDemo || 'female'); }
   else if (action === 'tag-filter') _clTagFilter(actionEl.dataset.clTag || '');
   else if (action === 'toggle-menu') _clToggleMenu(event, id, actionEl);
-  else if (action === 'choose-avatar') _clickFileInput('cl-avatar-input');
-  else if (action === 'remove-avatar') _clRemoveAvatar();
-  else if (action === 'set-sex') _clSetSex(actionEl.dataset.clSex || '');
-  else if (action === 'remove-tag') _clRemoveTag(actionEl);
-  else if (action === 'height-unit') _clHeightUnitChanged();
-  else if (action === 'health-metrics') _clGoToHealthMetrics(event);
   else if (action === 'pin-profile') _clPin(id);
   else if (action === 'unpin-profile') _clUnpin(id);
   else if (action === 'flag-profile') _clFlag(id);
@@ -977,7 +512,7 @@ function _handleClientClick(event) {
   else if (action === 'export-profile') _clExport(id);
   else if (action === 'export-profile-chat') _clExportChat(id);
   else if (action === 'delete-profile') _clDelete(id);
-  else handled = false;
+  else handled = handleClientFormClick(action || '', actionEl, event);
 
   if (handled) event.preventDefault();
 }
@@ -988,8 +523,7 @@ function _handleClientInput(event) {
 
   const action = input.dataset.clInputAction;
   if (action === 'search') _clSearch(input.value);
-  else if (action === 'update-lat') _clUpdateLat();
-  else if (action === 'update-bmi') _clUpdateBMI();
+  else handleClientFormInput(action || '');
 }
 
 function _handleClientChange(event) {
@@ -1007,36 +541,27 @@ function _handleClientChange(event) {
     _clSort(el.value);
   } else if (action === 'status-filter' && el instanceof HTMLSelectElement) {
     _clStatusFilter(el.value);
-  } else if (action === 'avatar-changed' && el instanceof HTMLInputElement) {
-    _clAvatarChanged(el);
-  } else if (action === 'haplogroup-changed') {
-    _clHaplogroupChanged();
+  } else {
+    handleClientFormChange(action || '', el);
   }
 }
 
 function _handleClientSubmit(event) {
   const form = _closestClientEl(event, '[data-cl-submit-action]');
   if (!(form instanceof HTMLFormElement)) return;
-  if (form.dataset.clSubmitAction === 'save-form') _clSaveForm(event);
+  handleClientFormSubmit(form.dataset.clSubmitAction || '', event);
 }
 
 function _handleClientKeydown(event) {
   const el = _closestClientEl(event, '[data-cl-key-action]');
   if (!el) return;
   const action = el.dataset.clKeyAction;
-
-  if (action === 'tag-input') {
-    _clTagKeydown(event);
-    return;
-  }
+  if (handleClientFormKeydown(action, event)) return;
   if (event.key !== 'Enter' && event.key !== ' ') return;
 
   if (action === 'select-profile') {
     event.preventDefault();
     _clSelect(el.dataset.clProfileId || '');
-  } else if (action === 'choose-avatar') {
-    event.preventDefault();
-    _clickFileInput('cl-avatar-input');
   }
 }
 
@@ -1057,62 +582,6 @@ function installClientListDelegates() {
   document.addEventListener('submit', _handleClientSubmit);
   document.addEventListener('keydown', _handleClientKeydown);
   document.addEventListener('click', _handleClientDocumentClick);
-}
-
-function _clUpdateBMI() {
-  const el = document.getElementById('cl-bmi-display');
-  if (!el) return;
-  const heightRaw = parseFloat(_clInput('cl-height')?.value || '');
-  const heightUnit = _clInput('cl-height-unit')?.value || 'cm';
-  const heightCm = heightRaw ? (heightUnit === 'in' ? heightRaw * 2.54 : heightRaw) : null;
-
-  // Weight now lives in the wearables summary (single source of truth after
-  // the Health Metrics unification). Any manual entry is canonicalized to kg
-  // on write, so no unit conversion needed here.
-  const weightKg = state.importedData?.wearableSummary?.metrics?.weight?.latest ?? null;
-
-  if (heightCm && weightKg) {
-    const htM = heightCm / 100;
-    const bmi = weightKg / (htM * htM);
-    let cat = '> 30';
-    if (bmi < 18.5) cat = '< 18.5';
-    else if (bmi < 25) cat = 'normal';
-    else if (bmi < 30) cat = '25–30';
-    el.className = 'mc-auto-value';
-    el.textContent = `${bmi.toFixed(1)} (${cat})`;
-  } else {
-    el.className = 'mc-auto-value mc-auto-pending';
-    el.textContent = heightCm ? 'add weight' : weightKg ? 'add height' : '--';
-  }
-}
-
-/**
- * @param {number} heightCm
- * @param {string} unit
- * @returns {string}
- */
-function _clFormatHeightInput(heightCm, unit) {
-  return unit === 'in' ? (heightCm / 2.54).toFixed(1) : String(Math.round(heightCm));
-}
-
-function _clHeightUnitChanged() {
-  const input = _clInput('cl-height');
-  const hidden = _clInput('cl-height-unit');
-  const toggle = document.getElementById('cl-height-unit-toggle');
-  if (!input || !hidden || !toggle) return;
-  const current = hidden.value;
-  const next = current === 'cm' ? 'in' : 'cm';
-  const val = parseFloat(input.value);
-  if (val) {
-    const heightCm = current === 'in' ? val * 2.54 : val;
-    input.value = _clFormatHeightInput(heightCm, next);
-  }
-  input.placeholder = next === 'in' ? 'inches' : 'cm';
-  input.step = next === 'in' ? '0.1' : '1';
-  hidden.value = next;
-  toggle.textContent = next;
-  toggle.dataset.unit = next;
-  _clUpdateBMI();
 }
 
 // Open the current profile's edit form, focused on the country field.
@@ -1140,4 +609,8 @@ export async function openProfileLocationEditor() {
   return true;
 }
 
+configureClientListFormRuntime({
+  closeClientList,
+  renderClientList,
+});
 installClientListDelegates();

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -7,6 +7,6 @@
   "viewRuntimeBridgeLookups": 0,
   "labStateAppFiles": 0,
   "labStateTestFiles": 0,
-  "largeJsFilesOver800Lines": 21,
+  "largeJsFilesOver800Lines": 20,
   "maxJsFileLines": 1168
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -273,6 +273,7 @@ const APP_SHELL = [
   '/js/client-list-runtime.js',
   '/js/client-list.js',
   '/js/client-list-impl.js',
+  '/js/client-list-form.js',
   '/js/nav-runtime.js',
   '/js/nav.js',
   '/js/views-router-runtime.js',

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -295,6 +295,8 @@ assert('client list implementation stays behind its public lazy entry',
   !appUiShellModulesSrc.includes("import './client-list.js'"));
 assert('SW APP_SHELL includes offline client list implementation',
   swAuditSrc.includes("'/js/client-list-impl.js'"));
+assert('SW APP_SHELL includes offline client list form owner',
+  swAuditSrc.includes("'/js/client-list-form.js'"));
 assert('index defers wearables CSS behind its ordered lazy-load anchor',
   !indexSrc.includes('href="css/wearables.css"') &&
   indexSrc.includes('data-wearables-stylesheet-anchor') &&

--- a/tests/test-client-list-delegated-actions.js
+++ b/tests/test-client-list-delegated-actions.js
@@ -7,7 +7,9 @@ import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
-const clientListSrc = fs.readFileSync(path.join(root, 'js/client-list-impl.js'), 'utf8');
+const clientListImplSrc = fs.readFileSync(path.join(root, 'js/client-list-impl.js'), 'utf8');
+const clientListFormSrc = fs.readFileSync(path.join(root, 'js/client-list-form.js'), 'utf8');
+const clientListSrc = `${clientListImplSrc}\n${clientListFormSrc}`;
 const clientListUsesScrollLockedOverlay = /openModalOverlay\s*\(\s*overlay\s*,\s*\{\s*initialFocus:\s*['"]#cl-search['"]\s*,\s*scrollLock:\s*true\s*,?\s*\}\s*\)/s.test(clientListSrc);
 const clientListClosesOverlay = /closeModalOverlay\s*\(\s*['"]client-list-overlay['"]\s*\)/.test(clientListSrc);
 
@@ -69,7 +71,7 @@ assert('client-list modal uses shared overlay lifecycle helpers',
     !clientListSrc.includes("document.body.style.overflow = 'hidden'") &&
     !clientListSrc.includes("document.body.style.overflow = ''"));
 assert('dynamic avatar and tag buttons avoid direct onclick assignment',
-  clientListSrc.includes("btn.setAttribute('data-cl-action', 'remove-avatar')") &&
+  /\.setAttribute\(\s*['"]data-cl-action['"]\s*,\s*['"]remove-avatar['"]\s*\)/.test(clientListSrc) &&
     !clientListSrc.includes('.onclick'));
 assert('height display rounds cm to whole numbers and inches to one decimal',
   clientListSrc.includes("unit === 'in' ? (heightCm / 2.54).toFixed(1) : String(Math.round(heightCm))") &&
@@ -78,7 +80,7 @@ assert('height display rounds cm to whole numbers and inches to one decimal',
 assert('latitude AI refinement rechecks provider availability inside debounce',
   clientListSrc.includes('const hasAIProvider = hasClientListAIProvider();') &&
     clientListSrc.includes('if (!hasClientListAIProvider()) return;') &&
-    /_clLatTimer\s*=\s*setTimeout/.test(clientListSrc));
+    /latitudeTimer\s*=\s*setTimeout/.test(clientListSrc));
 
 [
   'close',

--- a/tests/test-correctness-phase2.js
+++ b/tests/test-correctness-phase2.js
@@ -97,6 +97,7 @@ const pwaAppShellAssets = [
   '/js/profile-share-loader.js',
   '/js/app-ai-interaction-modules.js',
   '/js/app-ui-shell-modules.js',
+  '/js/client-list-form.js',
   '/js/app-event-listeners.js',
   '/js/crypto-key-cache.js',
   '/js/startup-orchestrator.js',

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -194,6 +194,7 @@ const highValueCheckJsModules = [
   'js/client-list-runtime.js',
   'js/client-list.js',
   'js/client-list-impl.js',
+  'js/client-list-form.js',
   'js/dashboard-lab-widget-renderers.js',
   'js/dashboard-widget-renderers.js',
   'js/dna.js',

--- a/tests/test-wearables-manual.js
+++ b/tests/test-wearables-manual.js
@@ -96,7 +96,10 @@ assert('wearables manual form UI delegates tag chip actions',
     manualFormUiSrc.includes('installWearablesManualFormDelegates') &&
     !inlineHandlerRe.test(manualFormUiSrc));
 
-const clSrc = await fetch('js/client-list-impl.js').then(r => r.text());
+const clSrc = [
+  await fetch('js/client-list-impl.js').then(r => r.text()),
+  await fetch('js/client-list-form.js').then(r => r.text()),
+].join('\n');
 assert('Edit Client modal no longer renders the cl-bio-weight container',
   !clSrc.includes('id="cl-bio-weight"'));
 assert('Edit Client modal no longer renders the cl-bio-bp container',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -96,6 +96,7 @@
     "js/client-list-runtime.js",
     "js/client-list.js",
     "js/client-list-impl.js",
+    "js/client-list-form.js",
     "js/constants.js",
     "js/context-card-dashboard-ai-actions.js",
     "js/context-card-dashboard-ai-runtime.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -93,6 +93,7 @@
     "js/client-list-runtime.js",
     "js/client-list.js",
     "js/client-list-impl.js",
+    "js/client-list-form.js",
     "js/changelog.js",
     "js/changelog-impl.js",
     "js/commit-hash.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.455';
+self.APP_VERSION = '1.10.456';


### PR DESCRIPTION
## Summary

- move the complete Client List create/edit workflow into a cohesive form owner
- keep lazy loading, modal lifecycle, list rendering, filters, row menus, and delegated event installation in the existing controller
- preserve the five public Client List exports through a stable re-export
- register the form owner in offline caching, typechecking, architecture, and source-contract coverage
- reduce `client-list-impl.js` from 1,143 to 616 lines and lower the ≥800-line JavaScript baseline from 21 to 20

## Verification

- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run typecheck:strict-null`
- `npm run quality`
- `npm run architecture:check`
- `node tests/verify-modules.js`
- focused client-list/service-worker Vitest slice (11/11)
- focused legacy audits and source contracts
- production build tests (4/4)
- focused Client List Playwright slice (8/8)