### PR TITLE
Split Sun location policy owner

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -9,8 +9,8 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 
 | Metric | Current |
 | --- | ---: |
-| Modules | 500 |
-| Internal import edges | 2262 |
+| Modules | 501 |
+| Internal import edges | 2267 |
 | Dynamic internal edges | 93 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -38,9 +38,9 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 
 | High fan-in | Dependants | High fan-out | Imports |
 | --- | ---: | --- | ---: |
-| [`js/utils.js`](js/utils.js) | 233 | [`js/app-shell-hooks.js`](js/app-shell-hooks.js) | 72 |
-| [`js/state.js`](js/state.js) | 157 | [`js/app-light-sun-modules.js`](js/app-light-sun-modules.js) | 36 |
-| [`js/data.js`](js/data.js) | 74 | [`js/sync-configure.js`](js/sync-configure.js) | 27 |
+| [`js/utils.js`](js/utils.js) | 234 | [`js/app-shell-hooks.js`](js/app-shell-hooks.js) | 72 |
+| [`js/state.js`](js/state.js) | 158 | [`js/app-light-sun-modules.js`](js/app-light-sun-modules.js) | 36 |
+| [`js/data.js`](js/data.js) | 75 | [`js/sync-configure.js`](js/sync-configure.js) | 27 |
 | [`js/caught-error.js`](js/caught-error.js) | 73 | [`js/settings.js`](js/settings.js) | 25 |
 | [`js/modal-lifecycle.js`](js/modal-lifecycle.js) | 66 | [`js/pdf-import.js`](js/pdf-import.js) | 24 |
 | [`js/api.js`](js/api.js) | 64 | [`js/chat-send.js`](js/chat-send.js) | 22 |
@@ -49,8 +49,8 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 | [`js/crypto.js`](js/crypto.js) | 29 | [`js/dashboard-view-composition.js`](js/dashboard-view-composition.js) | 20 |
 | [`js/data-merge.js`](js/data-merge.js) | 29 | [`js/biology-scores.js`](js/biology-scores.js) | 19 |
 | [`js/utils-runtime.js`](js/utils-runtime.js) | 20 | [`js/export.js`](js/export.js) | 18 |
-| [`js/constants.js`](js/constants.js) | 19 | [`js/sun.js`](js/sun.js) | 18 |
-| [`js/marker-analysis.js`](js/marker-analysis.js) | 18 | [`js/marker-detail-modal-impl.js`](js/marker-detail-modal-impl.js) | 17 |
+| [`js/constants.js`](js/constants.js) | 19 | [`js/marker-detail-modal-impl.js`](js/marker-detail-modal-impl.js) | 17 |
+| [`js/marker-analysis.js`](js/marker-analysis.js) | 18 | [`js/sun.js`](js/sun.js) | 17 |
 | [`js/chat-runtime.js`](js/chat-runtime.js) | 17 | [`js/profile.js`](js/profile.js) | 16 |
 | [`js/context-cards-runtime.js`](js/context-cards-runtime.js) | 16 | [`js/cycle-import.js`](js/cycle-import.js) | 15 |
 
@@ -751,7 +751,7 @@ Native browser modules shipped with the static application.
 
 </details>
 
-<details><summary><code>sun</code> family — 22 modules</summary>
+<details><summary><code>sun</code> family — 23 modules</summary>
 
 - [`js/sun-active-session.js`](js/sun-active-session.js) → [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/state.js`](js/state.js), [`js/sun-body-silhouette.js`](js/sun-body-silhouette.js), [`js/sun-session-model.js`](js/sun-session-model.js), [`js/sun-session-ui.js`](js/sun-session-ui.js), [`js/utils.js`](js/utils.js)
 - [`js/sun-ai-analysis.js`](js/sun-ai-analysis.js) → [`js/ai-action-delegates.js`](js/ai-action-delegates.js), [`js/ai-verdict-engine.js`](js/ai-verdict-engine.js), [`js/api.js`](js/api.js), [`js/health-goals-utils.js`](js/health-goals-utils.js), [`js/state.js`](js/state.js), [`js/sun-defaults.js`](js/sun-defaults.js), [`js/sun-spectrum.js`](js/sun-spectrum.js), [`js/sun-uvdata.js`](js/sun-uvdata.js), [`js/sun.js`](js/sun.js), [`js/utils.js`](js/utils.js)
@@ -763,6 +763,7 @@ Native browser modules shipped with the static application.
 - [`js/sun-correlations.js`](js/sun-correlations.js) → [`js/state.js`](js/state.js), [`js/sun.js`](js/sun.js)
 - [`js/sun-defaults-runtime.js`](js/sun-defaults-runtime.js) → [`js/profile.js`](js/profile.js)
 - [`js/sun-defaults.js`](js/sun-defaults.js) → [`js/constants.js`](js/constants.js), [`js/data.js`](js/data.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/state.js`](js/state.js), [`js/sun-defaults-runtime.js`](js/sun-defaults-runtime.js), [`js/utils.js`](js/utils.js)
+- [`js/sun-location.js`](js/sun-location.js) → [`js/constants.js`](js/constants.js), [`js/data.js`](js/data.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/sun-runtime.js`](js/sun-runtime.js), [`js/utils.js`](js/utils.js)
 - [`js/sun-onboarding-ai.js`](js/sun-onboarding-ai.js) → [`js/ai-action-delegates.js`](js/ai-action-delegates.js), [`js/ai-verdict-engine.js`](js/ai-verdict-engine.js), [`js/api.js`](js/api.js), [`js/health-goals-utils.js`](js/health-goals-utils.js), [`js/lighting-hardware-caveats.js`](js/lighting-hardware-caveats.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/sun-runtime.js`](js/sun-runtime.js) → [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/sun-session-actions.js`](js/sun-session-actions.js) → [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/utils.js`](js/utils.js)
@@ -774,7 +775,7 @@ Native browser modules shipped with the static application.
 - [`js/sun-spectrum.js`](js/sun-spectrum.js) → no in-scope imports
 - [`js/sun-uvdata-config.js`](js/sun-uvdata-config.js) → [`js/crypto.js`](js/crypto.js)
 - [`js/sun-uvdata.js`](js/sun-uvdata.js) → [`js/caught-error.js`](js/caught-error.js), [`js/sun-runtime.js`](js/sun-runtime.js), [`js/sun-uvdata-config.js`](js/sun-uvdata-config.js), [`js/url-safety.js`](js/url-safety.js)
-- [`js/sun.js`](js/sun.js) → [`js/ai-verdict-engine-runtime.js`](js/ai-verdict-engine-runtime.js), [`js/constants.js`](js/constants.js), [`js/data.js`](js/data.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/profile-context.js`](js/profile-context.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/sun-active-session.js`](js/sun-active-session.js), [`js/sun-body-silhouette.js`](js/sun-body-silhouette.js), [`js/sun-channel-metrics.js`](js/sun-channel-metrics.js), [`js/sun-defaults-runtime.js`](js/sun-defaults-runtime.js), [`js/sun-runtime.js`](js/sun-runtime.js), [`js/sun-session-model.js`](js/sun-session-model.js), [`js/sun-session-ui.js`](js/sun-session-ui.js), [`js/sun-sessions-store.js`](js/sun-sessions-store.js), [`js/sun-spectrum.js`](js/sun-spectrum.js), [`js/sun-uvdata.js`](js/sun-uvdata.js), [`js/utils.js`](js/utils.js)
+- [`js/sun.js`](js/sun.js) → [`js/ai-verdict-engine-runtime.js`](js/ai-verdict-engine-runtime.js), [`js/data.js`](js/data.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/profile-context.js`](js/profile-context.js), [`js/state.js`](js/state.js), [`js/sun-active-session.js`](js/sun-active-session.js), [`js/sun-body-silhouette.js`](js/sun-body-silhouette.js), [`js/sun-channel-metrics.js`](js/sun-channel-metrics.js), [`js/sun-defaults-runtime.js`](js/sun-defaults-runtime.js), [`js/sun-location.js`](js/sun-location.js), [`js/sun-runtime.js`](js/sun-runtime.js), [`js/sun-session-model.js`](js/sun-session-model.js), [`js/sun-session-ui.js`](js/sun-session-ui.js), [`js/sun-sessions-store.js`](js/sun-sessions-store.js), [`js/sun-spectrum.js`](js/sun-spectrum.js), [`js/sun-uvdata.js`](js/sun-uvdata.js), [`js/utils.js`](js/utils.js)
 
 </details>
 

--- a/js/sun-location.js
+++ b/js/sun-location.js
@@ -1,0 +1,81 @@
+// @ts-check
+// sun-location.js — Deterministic Sun coordinates and precise-location upgrade.
+
+import { state } from './state.js';
+import { showNotification } from './utils.js';
+import { saveImportedData } from './data.js';
+import { getProfileLocation } from './profile.js';
+import { COUNTRY_CENTROIDS, COUNTRY_LATITUDES } from './constants.js';
+import {
+  hasSunGeolocationRuntime,
+  requestSunGeolocationPositionRuntime,
+} from './sun-runtime.js';
+
+// Country band → centroid lat (0=tropical, 4=subarctic). Used as the lat
+// fallback when a country lacks an explicit COUNTRY_CENTROIDS entry.
+//
+// Bands follow the Holick UV-availability scheme (Holick 2007 NEJM,
+// "Vitamin D Deficiency"): tropical 0-23.5°, subtropical 23.5-35°,
+// temperate 35-50°, cold-temperate 50-60°, subarctic 60°+. Centroid
+// values are band midpoints, capped at 65° because cutaneous vitamin-D
+// synthesis below 5° solar elevation is negligible (Webb 2018).
+const BAND_CENTROID_LAT = [15, 32, 45, 55, 65];
+
+export function getSunCoords() {
+  // 1. Profile-cached precise coordinates.
+  const profileLocation = state.importedData?.sunDefaults?.coords;
+  if (profileLocation && Number.isFinite(profileLocation.lat) && Number.isFinite(profileLocation.lon)) {
+    return {
+      lat: profileLocation.lat,
+      lon: profileLocation.lon,
+      source: 'profile-precise',
+    };
+  }
+
+  // 2. Profile country → deterministic centroid. Never derive longitude
+  // from the current device timezone: that would make the same profile
+  // produce different solar-position results across devices and DST states.
+  const country = (getProfileLocation()?.country || '').toLowerCase().trim();
+  if (country && COUNTRY_LATITUDES[country] !== undefined) {
+    const centroid = COUNTRY_CENTROIDS[country];
+    if (centroid && Number.isFinite(centroid.lat) && Number.isFinite(centroid.lon)) {
+      return { lat: centroid.lat, lon: centroid.lon, source: 'country-band' };
+    }
+    const bandIndex = COUNTRY_LATITUDES[country];
+    const lat = BAND_CENTROID_LAT[bandIndex] ?? 45;
+    return { lat, lon: 0, source: 'country-band' };
+  }
+
+  // A timezone-only latitude fallback is physically wrong for users in
+  // another hemisphere. Callers already surface country/location setup.
+  return null;
+}
+
+// Explicit one-time geolocation upgrade. Surfaces in Settings → Light & Sun
+// and through the matching action on the Light page.
+export async function requestPreciseLocation() {
+  if (!hasSunGeolocationRuntime()) {
+    showNotification('Browser geolocation not available — country-level estimate will be used.');
+    return null;
+  }
+  try {
+    const position = await requestSunGeolocationPositionRuntime({
+      timeout: 8000,
+      maximumAge: 60_000 * 30,
+      enableHighAccuracy: true,
+    });
+    if (!state.importedData.sunDefaults) state.importedData.sunDefaults = {};
+    state.importedData.sunDefaults.coords = {
+      lat: position.coords.latitude,
+      lon: position.coords.longitude,
+      altitudeM: position.coords.altitude || 0,
+      capturedAt: Date.now(),
+    };
+    await saveImportedData();
+    showNotification('Precise location saved — sun calculations will be more accurate.');
+    return state.importedData.sunDefaults.coords;
+  } catch {
+    showNotification('Location not shared — your country still gives a reasonable estimate.');
+    return null;
+  }
+}

--- a/js/sun.js
+++ b/js/sun.js
@@ -13,8 +13,6 @@
 import { state } from './state.js';
 import { showNotification, showPromptDialog, showConfirmDialog } from './utils.js';
 import { saveImportedData } from './data.js';
-import { getProfileLocation } from './profile.js';
-import { COUNTRY_LATITUDES, COUNTRY_CENTROIDS } from './constants.js';
 import {
   wireBackdropClose as _wireBackdropClose,
   trapModalFocus,
@@ -98,20 +96,20 @@ import {
   addSunProfileSwitchListener,
   getSunDeviceSessionsRuntime,
   hasSunBrowserRuntime,
-  hasSunGeolocationRuntime,
   navigateSunRuntime,
   openSunChannelOnLightPageRuntime,
   rebuildSunSidebarRuntime,
   renderLightChannelsLiveRuntime,
   renderLightTodayStripRuntime,
-  requestSunGeolocationPositionRuntime,
 } from './sun-runtime.js';
+import { getSunCoords, requestPreciseLocation } from './sun-location.js';
 import { configureAIVerdictRuntimeDeps } from './ai-verdict-engine-runtime.js';
 import { configureProfileContextLightDeps } from './profile-context.js';
 import { configureSunDefaultsRuntimeDeps } from './sun-defaults-runtime.js';
 export { BODY_REGIONS, renderBodySilhouette, bindBodySilhouette };
 export { renderSessionsList, renderSunSessionRow, openDetailedSessionDialog, openSunSessionDetail };
 export { quickLogSunSession, openStartSunSessionDialog, _wireBackdropClose, trapModalFocus };
+export { getSunCoords, requestPreciseLocation };
 export {
   TOO_SHORT_FOR_CHANNEL_VERDICT_MIN,
   formatChannelUnit,
@@ -628,76 +626,6 @@ function _refreshSurfaces(scrollAnchor) {
     navigateSunRuntime(view, navOpts);
     setTimeout(() => _resumeActiveTickerIfNeeded(), 100);
   }, 150);
-}
-
-// Country band → centroid lat (0=tropical, 4=subarctic). Used as the lat
-// fallback when a country lacks an explicit COUNTRY_CENTROIDS entry.
-//
-// Bands follow the Holick UV-availability scheme (Holick 2007 NEJM,
-// "Vitamin D Deficiency"): tropical 0-23.5°, subtropical 23.5-35°,
-// temperate 35-50°, cold-temperate 50-60°, subarctic 60°+. Centroid
-// values picked at band-midpoint, capped at 65° because cutaneous
-// vit-D synthesis below 5° solar elevation is negligible (Webb 2018).
-// Drives the lat-only fallback for synthesis math when a country lacks
-// a precise centroid; the AI verdict for "should I be supplementing in
-// winter?" depends on this lat resolving correctly.
-const BAND_CENTROID_LAT = [15, 32, 45, 55, 65];
-
-export function getSunCoords() {
-  // 1. Profile-cached precise coords (set via "Use precise location" upgrade)
-  const profileLoc = state.importedData?.sunDefaults?.coords;
-  if (profileLoc && Number.isFinite(profileLoc.lat) && Number.isFinite(profileLoc.lon)) {
-    return { lat: profileLoc.lat, lon: profileLoc.lon, source: 'profile-precise' };
-  }
-  // 2. Profile country → deterministic centroid (lat + lon both keyed off the
-  // country, never off the device's tz). Earlier versions derived lon from
-  // `new Date().getTimezoneOffset()`, which produced different solar-position
-  // results across devices in different OS timezones (or DST states) for the
-  // same profile — surfaced as cross-device "last UV-A" / UVI mismatches.
-  const country = (getProfileLocation()?.country || '').toLowerCase().trim();
-  if (country && COUNTRY_LATITUDES[country] !== undefined) {
-    const centroid = COUNTRY_CENTROIDS[country];
-    if (centroid && Number.isFinite(centroid.lat) && Number.isFinite(centroid.lon)) {
-      return { lat: centroid.lat, lon: centroid.lon, source: 'country-band' };
-    }
-    // Country listed in band table but missing centroid — degrade to band
-    // centroid lat + Greenwich. Still device-independent.
-    const bandIdx = COUNTRY_LATITUDES[country];
-    const lat = BAND_CENTROID_LAT[bandIdx] ?? 45;
-    return { lat, lon: 0, source: 'country-band' };
-  }
-  // No country, no precise coords — return null. The previous tz-only
-  // fallback hardcoded lat=45 (NH temperate), which produces physically
-  // wrong UV math for southern-hemisphere users (Sydney/Tokyo via UTC+9-10
-  // mapped to lat 45° N → winter↔summer flipped). Callers (the strip,
-  // session start, etc.) already render "set country" CTAs when this
-  // returns null, so dropping the lying fallback is the honest move.
-  return null;
-}
-
-// Explicit one-time geolocation upgrade. Surfaces in Settings → Light & Sun
-// or via a "use precise location" button on the Light & Sun page.
-export async function requestPreciseLocation() {
-  if (!hasSunGeolocationRuntime()) {
-    showNotification('Browser geolocation not available — country-level estimate will be used.');
-    return null;
-  }
-  try {
-    const pos = await requestSunGeolocationPositionRuntime({ timeout: 8000, maximumAge: 60_000 * 30, enableHighAccuracy: true });
-    if (!state.importedData.sunDefaults) state.importedData.sunDefaults = {};
-    state.importedData.sunDefaults.coords = {
-      lat: pos.coords.latitude,
-      lon: pos.coords.longitude,
-      altitudeM: pos.coords.altitude || 0,
-      capturedAt: Date.now(),
-    };
-    await saveImportedData();
-    showNotification('Precise location saved — sun calculations will be more accurate.');
-    return state.importedData.sunDefaults.coords;
-  } catch (e) {
-    showNotification('Location not shared — your country still gives a reasonable estimate.');
-    return null;
-  }
 }
 
 // Compact body-exposure summary for the session-list row. Detailed

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -7,6 +7,6 @@
   "viewRuntimeBridgeLookups": 0,
   "labStateAppFiles": 0,
   "labStateTestFiles": 0,
-  "largeJsFilesOver800Lines": 18,
+  "largeJsFilesOver800Lines": 17,
   "maxJsFileLines": 1168
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -491,6 +491,7 @@ const APP_SHELL = [
   '/js/modal-lifecycle.js',
   // Sun + light modules are statically reachable from the app shell.
   '/js/sun.js',
+  '/js/sun-location.js',
   '/js/sun-active-session.js',
   '/js/sun-channel-metrics.js',
   '/js/sun-session-model.js',

--- a/tests/test-correctness-phase2.js
+++ b/tests/test-correctness-phase2.js
@@ -182,6 +182,7 @@ const pwaAppShellAssets = [
   '/js/marker-detail-custom-markers.js',
   '/js/marker-detail-manual-entry.js',
   '/js/sun.js',
+  '/js/sun-location.js',
   '/js/sun-active-session.js',
   '/js/sun-session-model.js',
   '/js/sun-sessions-store.js',

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -227,6 +227,7 @@ const highValueCheckJsModules = [
   'js/settings-sync-panel.js',
   'js/settings-sync-panel-impl.js',
   'js/sun.js',
+  'js/sun-location.js',
   'js/sun-uvdata-config.js',
   'js/wearables.js',
 ];
@@ -250,6 +251,7 @@ const domainUiCheckJsModules = [
   'js/sun-context.js',
   'js/sun-defaults.js',
   'js/sun-defaults-runtime.js',
+  'js/sun-location.js',
   'js/sun-runtime.js',
   'js/sun-spectrum.js',
   'js/sun-uvdata.js',

--- a/tests/test-sun.js
+++ b/tests/test-sun.js
@@ -578,6 +578,7 @@ const {
   const fs = await import('node:fs/promises');
   const sunSrc = await fs.readFile(new URL('../js/sun.js', import.meta.url), 'utf8');
   const metricsSrc = await fs.readFile(new URL('../js/sun-channel-metrics.js', import.meta.url), 'utf8');
+  const locationSrc = await fs.readFile(new URL('../js/sun-location.js', import.meta.url), 'utf8');
   const modelSrc = await fs.readFile(new URL('../js/sun-session-model.js', import.meta.url), 'utf8');
   const storeSrc = await fs.readFile(new URL('../js/sun-sessions-store.js', import.meta.url), 'utf8');
   const runtimeSrc = await fs.readFile(new URL('../js/sun-runtime.js', import.meta.url), 'utf8');
@@ -626,6 +627,14 @@ const {
     runtimeSrc.includes('export function renderLightTodayStripRuntime') &&
     runtimeSrc.includes('export function requestSunGeolocationPositionRuntime') &&
     swSrc.includes("'/js/sun-runtime.js'"));
+  assert('Sun coordinate policy and precise-location upgrade have one owner',
+    sunSrc.includes("from './sun-location.js'") &&
+    sunSrc.includes('export { getSunCoords, requestPreciseLocation };') &&
+    locationSrc.includes('export function getSunCoords()') &&
+    locationSrc.includes('export async function requestPreciseLocation()') &&
+    locationSrc.includes('COUNTRY_CENTROIDS') &&
+    !sunSrc.includes('const BAND_CENTROID_LAT') &&
+    swSrc.includes("'/js/sun-location.js'"));
   const formerSunGlobals = [
     'SUN_ENGINE_VERSION', '_refreshSunSurfaces', 'quickLogSunSession', 'startSession', 'stopSession',
     'pauseSession', 'resumeSession', 'pauseSunSession', 'resumeSunSession', 'applySunscreenMidSession',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -275,6 +275,7 @@
     "js/sun-correlations.js",
     "js/sun-defaults.js",
     "js/sun-defaults-runtime.js",
+    "js/sun-location.js",
     "js/sun-onboarding-ai.js",
     "js/sun-runtime.js",
     "js/sun-session-actions.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -290,6 +290,7 @@
     "js/sun-defaults.js",
     "js/sun-defaults-runtime.js",
     "js/sun-onboarding-ai.js",
+    "js/sun-location.js",
     "js/sun-runtime.js",
     "js/sun-session-actions.js",
     "js/sun-session-model.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.458';
+self.APP_VERSION = '1.10.459';


### PR DESCRIPTION
## Summary
- extract deterministic country-coordinate resolution and the explicit precise-geolocation upgrade into `sun-location.js`
- keep `getSunCoords` and `requestPreciseLocation` re-exported through the existing `sun.js` public facade
- leave session lifecycle, rendering composition, and runtime dependency wiring unchanged
- update offline precache, architecture/checkJs coverage, owner contracts, and ratchet the >=800-line baseline from 18 to 17

`sun.js` is reduced from 816 to 744 lines; the new location owner is 81 lines. The dependency graph remains cycle-free (501 modules, 0 cycles).

## Verification
- `npm run quality`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run typecheck:strict-null`
- `npm run architecture:build`
- `npm run architecture:check`
- `node tests/verify-modules.js`
- focused legacy Sun/defaults/Light Tools/correctness/quality suite (5 passed)
- Sun behavior and facade contracts (110 passed)
- Sun defaults (95 passed)
- downstream Light Tools integration (68 passed)
- `node tests/test-audit.js` (365 passed)
- production build and service-worker runtime/app-shell tests (17 passed)
- focused Sun browser coverage, including country and precise-location paths (2 passed)