### PR TITLE
Split Wearables strip action owner

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -9,8 +9,8 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 
 | Metric | Current |
 | --- | ---: |
-| Modules | 501 |
-| Internal import edges | 2267 |
+| Modules | 502 |
+| Internal import edges | 2274 |
 | Dynamic internal edges | 93 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -38,8 +38,8 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 
 | High fan-in | Dependants | High fan-out | Imports |
 | --- | ---: | --- | ---: |
-| [`js/utils.js`](js/utils.js) | 234 | [`js/app-shell-hooks.js`](js/app-shell-hooks.js) | 72 |
-| [`js/state.js`](js/state.js) | 158 | [`js/app-light-sun-modules.js`](js/app-light-sun-modules.js) | 36 |
+| [`js/utils.js`](js/utils.js) | 235 | [`js/app-shell-hooks.js`](js/app-shell-hooks.js) | 72 |
+| [`js/state.js`](js/state.js) | 159 | [`js/app-light-sun-modules.js`](js/app-light-sun-modules.js) | 36 |
 | [`js/data.js`](js/data.js) | 75 | [`js/sync-configure.js`](js/sync-configure.js) | 27 |
 | [`js/caught-error.js`](js/caught-error.js) | 73 | [`js/settings.js`](js/settings.js) | 25 |
 | [`js/modal-lifecycle.js`](js/modal-lifecycle.js) | 66 | [`js/pdf-import.js`](js/pdf-import.js) | 24 |
@@ -922,7 +922,7 @@ Native browser modules shipped with the static application.
 
 </details>
 
-<details><summary><code>wearables</code> family — 30 modules</summary>
+<details><summary><code>wearables</code> family — 31 modules</summary>
 
 - [`js/wearables-apple-health-runtime.js`](js/wearables-apple-health-runtime.js) → no in-scope imports
 - [`js/wearables-apple-health.js`](js/wearables-apple-health.js) → [`js/caught-error.js`](js/caught-error.js), [`js/data.js`](js/data.js) *(dynamic)*, [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js) *(dynamic)*, [`js/utils.js`](js/utils.js), [`js/wearable-adapters.js`](js/wearable-adapters.js), [`js/wearables-apple-health-runtime.js`](js/wearables-apple-health-runtime.js), [`js/wearables-connect.js`](js/wearables-connect.js) *(dynamic)*, [`js/wearables-store.js`](js/wearables-store.js), [`js/wearables-summary.js`](js/wearables-summary.js)
@@ -946,6 +946,7 @@ Native browser modules shipped with the static application.
 - [`js/wearables-settings-panel.js`](js/wearables-settings-panel.js) → [`js/brand-assets.js`](js/brand-assets.js), [`js/caught-error.js`](js/caught-error.js), [`js/data.js`](js/data.js) *(dynamic)*, [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js), [`js/wearable-adapters.js`](js/wearable-adapters.js), [`js/wearables-apple-health.js`](js/wearables-apple-health.js) *(dynamic)*, [`js/wearables-connect.js`](js/wearables-connect.js), [`js/wearables-manual.js`](js/wearables-manual.js) *(dynamic)*, [`js/wearables-settings-runtime.js`](js/wearables-settings-runtime.js), [`js/wearables-store.js`](js/wearables-store.js) *(dynamic)*, [`js/wearables-summary.js`](js/wearables-summary.js)
 - [`js/wearables-settings-runtime.js`](js/wearables-settings-runtime.js) → [`js/settings-runtime-bridge.js`](js/settings-runtime-bridge.js), [`js/utils.js`](js/utils.js)
 - [`js/wearables-store.js`](js/wearables-store.js) → no in-scope imports
+- [`js/wearables-strip-actions.js`](js/wearables-strip-actions.js) → [`js/caught-error.js`](js/caught-error.js), [`js/data.js`](js/data.js) *(dynamic)*, [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js), [`js/wearable-adapters.js`](js/wearable-adapters.js), [`js/wearables-connect.js`](js/wearables-connect.js), [`js/wearables-detail-modal.js`](js/wearables-detail-modal.js), [`js/wearables-manual-form-ui.js`](js/wearables-manual-form-ui.js), [`js/wearables-manual.js`](js/wearables-manual.js) *(dynamic)*, [`js/wearables-runtime.js`](js/wearables-runtime.js), [`js/wearables-summary.js`](js/wearables-summary.js)
 - [`js/wearables-summary.js`](js/wearables-summary.js) → [`js/caught-error.js`](js/caught-error.js), [`js/data-merge.js`](js/data-merge.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js), [`js/wearable-adapters.js`](js/wearable-adapters.js), [`js/wearables-store.js`](js/wearables-store.js)
 - [`js/wearables-ultrahuman-auth.js`](js/wearables-ultrahuman-auth.js) → [`js/utils.js`](js/utils.js), [`js/wearables-auth-runtime.js`](js/wearables-auth-runtime.js)
 - [`js/wearables-ultrahuman.js`](js/wearables-ultrahuman.js) → [`js/caught-error.js`](js/caught-error.js), [`js/utils.js`](js/utils.js)
@@ -953,7 +954,7 @@ Native browser modules shipped with the static application.
 - [`js/wearables-whoop.js`](js/wearables-whoop.js) → [`js/caught-error.js`](js/caught-error.js), [`js/utils.js`](js/utils.js)
 - [`js/wearables-withings-auth.js`](js/wearables-withings-auth.js) → [`js/utils.js`](js/utils.js), [`js/wearables-auth-runtime.js`](js/wearables-auth-runtime.js), [`js/wearables-withings.js`](js/wearables-withings.js) *(dynamic)*
 - [`js/wearables-withings.js`](js/wearables-withings.js) → [`js/caught-error.js`](js/caught-error.js), [`js/utils.js`](js/utils.js), [`js/wearables-oura.js`](js/wearables-oura.js)
-- [`js/wearables.js`](js/wearables.js) → [`js/caught-error.js`](js/caught-error.js), [`js/data.js`](js/data.js) *(dynamic)*, [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js), [`js/wearable-adapters.js`](js/wearable-adapters.js), [`js/wearables-connect.js`](js/wearables-connect.js), [`js/wearables-detail-modal.js`](js/wearables-detail-modal.js), [`js/wearables-formatters.js`](js/wearables-formatters.js), [`js/wearables-manual-form-ui.js`](js/wearables-manual-form-ui.js), [`js/wearables-manual.js`](js/wearables-manual.js) *(dynamic)*, [`js/wearables-runtime.js`](js/wearables-runtime.js), [`js/wearables-settings-panel.js`](js/wearables-settings-panel.js), [`js/wearables-summary.js`](js/wearables-summary.js)
+- [`js/wearables.js`](js/wearables.js) → [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js), [`js/wearable-adapters.js`](js/wearable-adapters.js), [`js/wearables-detail-modal.js`](js/wearables-detail-modal.js), [`js/wearables-formatters.js`](js/wearables-formatters.js), [`js/wearables-manual-form-ui.js`](js/wearables-manual-form-ui.js), [`js/wearables-runtime.js`](js/wearables-runtime.js), [`js/wearables-settings-panel.js`](js/wearables-settings-panel.js), [`js/wearables-strip-actions.js`](js/wearables-strip-actions.js)
 
 </details>
 

--- a/js/wearables-strip-actions.js
+++ b/js/wearables-strip-actions.js
@@ -1,0 +1,395 @@
+// @ts-check
+// wearables-strip-actions.js — Wearable strip interaction and manual-log owner.
+
+import { getErrorMessage } from './caught-error.js';
+import { escapeHTML, showNotification } from './utils.js';
+import { state } from './state.js';
+import {
+  ADAPTERS,
+  adapterById,
+  canonicalMetric,
+  metricsForSources,
+  isoDay,
+} from './wearable-adapters.js';
+import { syncNow, listConnectedSources } from './wearables-connect.js';
+import { syncWearableSummary } from './wearables-summary.js';
+import { getActiveProfileId } from './profile.js';
+import {
+  _collectActiveChips,
+  _renderNoteField,
+  _renderTagChips,
+  inputValueById,
+  inputValueFromElement,
+} from './wearables-manual-form-ui.js';
+import { wearableActionAttrs } from './wearables-detail-modal.js';
+import {
+  getWearablesViewportSize,
+  navigateWearables,
+} from './wearables-runtime.js';
+
+function rerenderCurrentView() {
+  navigateWearables(state.currentView || 'dashboard');
+}
+
+export function resetOpenManualLogForms({ exceptMetricId = '' } = {}) {
+  const openForms = Array.from(document.querySelectorAll('.wearable-card-empty .wearable-log-form'));
+  const shouldReset = openForms.some(form => {
+    const card = form.closest('.wearable-card-empty');
+    return !(card instanceof HTMLElement) || card.dataset.emptyMetric !== exceptMetricId;
+  });
+  if (!shouldReset) return false;
+  rerenderCurrentView();
+  return true;
+}
+
+export function toggleWearableStrip() {
+  const grid = document.querySelector('.wearable-card-grid');
+  const footer = document.querySelector('.wearable-strip-footer');
+  const arrow = document.querySelector('.wearable-collapse-arrow');
+  if (!grid) return;
+  const hidden = grid.classList.toggle('hidden');
+  footer?.classList.toggle('hidden', hidden);
+  arrow?.classList.toggle('collapsed', hidden);
+  // Keep aria-expanded + aria-label on the chevron button in sync with the
+  // visual collapse state. Captured-at-render-time attributes go stale on
+  // every toggle without this — silent screen-reader regression.
+  if (arrow) {
+    arrow.setAttribute('aria-expanded', String(!hidden));
+    const expanded = !hidden;
+    const labelBase = arrow.getAttribute('aria-label') || '';
+    // Toggle "Expand"/"Collapse" prefix in-place; preserves the rest of the
+    // label that the renderer composed (e.g. "wearables strip").
+    if (expanded && /^Expand /i.test(labelBase)) {
+      arrow.setAttribute('aria-label', labelBase.replace(/^Expand /i, 'Collapse '));
+    } else if (!expanded && /^Collapse /i.test(labelBase)) {
+      arrow.setAttribute('aria-label', labelBase.replace(/^Collapse /i, 'Expand '));
+    }
+  }
+  localStorage.setItem('wearables-strip-collapsed', hidden ? '1' : '0');
+}
+
+// Per-metric primary-source override picker. Reads connected sources that
+// actually have data for this metric and lets the user pick one. The summary
+// pipeline respects `state.importedData.wearablePrimaryOverride[metricId]`.
+export async function chooseWearableSource(metricId, event) {
+  const canon = canonicalMetric(metricId);
+  if (!canon) return;
+  const connected = listConnectedSources();
+  // Sort connected vendors by ADAPTERS registry order so the picker presents
+  // them in the same order users see in Settings → Integrations.
+  const connectedIds = Object.keys(connected)
+    .sort((a, b) => {
+      const ai = ADAPTERS.findIndex(x => x.id === a);
+      const bi = ADAPTERS.findIndex(x => x.id === b);
+      return (ai === -1 ? 999 : ai) - (bi === -1 ? 999 : bi);
+    });
+  if (connectedIds.length < 2) return;
+
+  // Find sources that map this canonical metric in their adapter registry —
+  // no point offering WHOOP as a source for `weight` (it doesn't do scales).
+  const eligible = connectedIds.filter(sid => {
+    const a = adapterById(sid);
+    return !!a?.metrics?.[metricId];
+  });
+  if (eligible.length < 2) {
+    showNotification?.(`Only one connected wearable provides ${canon.label}`, 'info', 2500);
+    return;
+  }
+
+  // Close any existing picker, then build + position a new one near the click.
+  document.querySelectorAll('.wearable-source-picker').forEach(el => el.remove());
+  // Pick the EFFECTIVE primary first — `wearableSummary.metrics[mid].primarySource`
+  // is what the L2 picker actually used, which falls through to auto-pick when
+  // an override points at a source with no data. Reading the override directly
+  // would mark a stale checkmark and lie to the user about what's active.
+  const effectivePrimary = state.importedData?.wearableSummary?.metrics?.[metricId]?.primarySource;
+  const overrideSource = state.importedData?.wearablePrimaryOverride?.[metricId];
+  const current = effectivePrimary || overrideSource || eligible[0];
+  const picker = document.createElement('div');
+  picker.className = 'wearable-source-picker';
+  picker.innerHTML = `
+    <div class="wearable-source-picker-head">${escapeHTML(canon.label)} source</div>
+    ${eligible.map(sid => {
+      const a = adapterById(sid);
+      const selected = sid === current;
+      return `<button type="button" class="wearable-source-picker-item${selected ? ' selected' : ''}" data-source="${escapeHTML(sid)}">
+        <span>${escapeHTML(a?.displayName || sid)}</span>
+        ${selected ? '<span class="wearable-source-picker-check">✓</span>' : ''}
+      </button>`;
+    }).join('')}
+    <button type="button" class="wearable-source-picker-item wearable-source-picker-auto" data-source="">
+      <span>Auto (most recent)</span>
+      ${!state.importedData?.wearablePrimaryOverride?.[metricId] ? '<span class="wearable-source-picker-check">✓</span>' : ''}
+    </button>
+  `;
+  const rect = event.target.getBoundingClientRect();
+  picker.style.position = 'fixed';
+  picker.style.visibility = 'hidden';
+  picker.style.top = '0px';
+  picker.style.left = '0px';
+  picker.style.zIndex = '10000';
+  document.body.appendChild(picker);
+  // Clamp to viewport and flip above if opening below would collide with the
+  // chat FAB hotspot (bottom-right ~72px square) or overflow the viewport. On
+  // mobile the card is full-width, so a naive rect.left-60 can underflow and
+  // the dropdown can disappear under the FAB — measure after insert and nudge.
+  const pw = picker.offsetWidth || 200;
+  const ph = picker.offsetHeight || 180;
+  const { width: vw, height: vh } = getWearablesViewportSize();
+  const fabHotspot = { left: vw - 88, top: vh - 88 }; // chat-fab 56px + 24px margin + buffer
+  let top = rect.bottom + 4;
+  let left = Math.max(8, rect.left - 60);
+  // Flip above if bottom would overflow viewport OR intrude on FAB hotspot
+  if (top + ph > vh - 8 || (top + ph > fabHotspot.top && left + pw > fabHotspot.left)) {
+    top = Math.max(8, rect.top - ph - 4);
+  }
+  // Clamp right
+  if (left + pw > vw - 8) left = Math.max(8, vw - pw - 8);
+  picker.style.top = `${top}px`;
+  picker.style.left = `${left}px`;
+  picker.style.visibility = '';
+
+  // Wire clicks — pick a source, persist override, re-render strip.
+  picker.querySelectorAll('[data-source]').forEach(btn => {
+    if (!(btn instanceof HTMLElement)) return;
+    btn.addEventListener('click', async (e) => {
+      e.stopPropagation();
+      const sid = btn.dataset.source;
+      if (!state.importedData.wearablePrimaryOverride) state.importedData.wearablePrimaryOverride = {};
+      if (!sid) delete state.importedData.wearablePrimaryOverride[metricId];
+      else state.importedData.wearablePrimaryOverride[metricId] = sid;
+      const { saveImportedData } = await import('./data.js');
+      await saveImportedData();
+      await syncWearableSummary(getActiveProfileId(), listConnectedSources());
+      picker.remove();
+      navigateWearables('dashboard');
+    });
+  });
+
+  // Dismiss on outside click / Escape.
+  setTimeout(() => {
+    const dismiss = (e) => {
+      if (picker.contains(e.target)) return;
+      picker.remove();
+      document.removeEventListener('click', dismiss);
+      document.removeEventListener('keydown', onKey);
+    };
+    const onKey = (e) => {
+      if (e.key !== 'Escape') return;
+      picker.remove();
+      document.removeEventListener('keydown', onKey);
+      document.removeEventListener('click', dismiss);
+    };
+    document.addEventListener('click', dismiss);
+    document.addEventListener('keydown', onKey);
+  }, 0);
+}
+
+export async function syncWearableNow(triggerEl) {
+  const sources = Object.keys(listConnectedSources());
+  if (sources.length === 0) {
+    showNotification?.('Connect a wearable in Settings → Wearables first', 'info');
+    return;
+  }
+  // Spin the inline button icon for the duration of the sync. The button
+  // disables itself so a double-click can't kick off concurrent syncs.
+  const btn = triggerEl || document.querySelector('.wearable-strip-sync');
+  btn?.classList.add('is-syncing');
+  if (btn) btn.disabled = true;
+  try {
+    showNotification?.('Syncing wearables…', 'info', 1500);
+    // force:true → bypass L2 gate so the strip never appears stuck on a
+    // stale snapshot when a user explicitly clicks "sync now."
+    let totalRows = 0;
+    for (const sid of sources) {
+      const res = await syncNow(sid, { force: true });
+      totalRows += res?.rows ?? 0;
+    }
+    navigateWearables('dashboard');
+    showNotification?.(
+      totalRows > 0 ? `Wearables synced — ${totalRows} new row${totalRows === 1 ? '' : 's'}` : 'Wearables synced — already up to date',
+      'success', 2000
+    );
+  } catch { /* per-source error already surfaced */ }
+  finally {
+    btn?.classList.remove('is-syncing');
+    if (btn) btn.disabled = false;
+  }
+}
+
+// Reorder mode — toggle + per-card move handlers. Keeps the reorder flag
+// ephemeral (state._wearableReorderMode) so it auto-resets on reload; the
+// card ORDER itself is persisted per-profile in importedData.wearableCardOrder.
+export function toggleWearableReorder() {
+  state._wearableReorderMode = !state._wearableReorderMode;
+  navigateWearables('dashboard');
+}
+
+export async function moveWearableCard(metricId, delta) {
+  const summary = state.importedData?.wearableSummary;
+  if (!summary) return;
+  // Rebuild the CURRENT display order the same way renderWearableStrip does,
+  // so a move reflects exactly what the user sees (populated + empty cards
+  // combined, then the saved order applied).
+  const sourceIds = Object.keys(summary.sources || {})
+    .sort((a, b) => {
+      const ai = ADAPTERS.findIndex(x => x.id === a);
+      const bi = ADAPTERS.findIndex(x => x.id === b);
+      return (ai === -1 ? 999 : ai) - (bi === -1 ? 999 : bi);
+    });
+  const headerSourceIds = sourceIds.filter(s => (summary.sources[s].coverageDays || 0) > 0);
+  const baseOrder = metricsForSources(headerSourceIds.length ? headerSourceIds : sourceIds);
+  const MANUAL_EMPTY_METRICS_LOCAL = ['weight', 'bp_systolic', 'rhr'];
+  // Mirror the strip-render BP merge: dia folds into the sys card and never
+  // gets its own reorder slot when both are present.
+  const hasSysLocal = !!summary.metrics?.bp_systolic;
+  const display = [];
+  const seen = new Set();
+  for (const id of baseOrder) {
+    if (id === 'bp_diastolic' && hasSysLocal) continue;
+    if (summary.metrics?.[id]) { display.push(id); seen.add(id); }
+  }
+  for (const id of MANUAL_EMPTY_METRICS_LOCAL) {
+    if (!seen.has(id)) { display.push(id); seen.add(id); }
+  }
+  const savedOrder = Array.isArray(state.importedData?.wearableCardOrder)
+    ? state.importedData.wearableCardOrder : [];
+  const ordered = [];
+  for (const id of savedOrder) if (display.includes(id)) ordered.push(id);
+  for (const id of display) if (!ordered.includes(id)) ordered.push(id);
+  const idx = ordered.indexOf(metricId);
+  if (idx === -1) return;
+  const target = idx + delta;
+  if (target < 0 || target >= ordered.length) return;
+  const tmp = ordered[idx];
+  ordered[idx] = ordered[target];
+  ordered[target] = tmp;
+  state.importedData.wearableCardOrder = ordered;
+  const { saveImportedData } = await import('./data.js');
+  await saveImportedData();
+  navigateWearables('dashboard');
+}
+
+// Inline manual-log form (Phase 3) — opens from the empty strip cards.
+export function openManualLogForm(metricId, event, opts = {}) {
+  if (!opts.delegated && event?.target?.closest?.('[data-wearable-action]')) return;
+  if (event) event.stopPropagation();
+  let card = document.querySelector(`.wearable-card-empty[data-empty-metric="${metricId}"]`);
+  if (!card) return;
+  // Idempotent: clicks inside the form (e.g. tapping the dia field on the
+  // BP card) bubble to the card's delegated action. Without this guard we'd rebuild
+  // innerHTML and refocus the first input — yanking the cursor off whatever
+  // the user actually clicked.
+  if (card.querySelector('.wearable-log-form')) return;
+  if (resetOpenManualLogForms({ exceptMetricId: metricId })) {
+    card = document.querySelector(`.wearable-card-empty[data-empty-metric="${metricId}"]`);
+    if (!card) return;
+  }
+  const today = isoDay();
+  if (metricId === 'weight') {
+    card.innerHTML = `
+      <div class="wearable-card-top"><span class="wearable-metric-name">Weight</span></div>
+      <div class="wearable-log-form">
+        <input type="number" step="0.1" inputmode="decimal" class="wearable-log-input" id="wl-weight-val" placeholder="${state.unitSystem === 'US' ? 'lb' : 'kg'}" aria-label="${state.unitSystem === 'US' ? 'Weight in pounds' : 'Weight in kilograms'}" autofocus>
+        ${_renderNoteField('wl-weight-note')}
+        <div class="wearable-log-row">
+          <input type="date" class="wearable-log-date" id="wl-weight-date" value="${today}" max="${today}" aria-label="Date">
+          <button type="button" class="wearable-log-save" ${wearableActionAttrs('manual-log-save', { kind: 'weight' })}>Save</button>
+          <button type="button" class="wearable-log-cancel" ${wearableActionAttrs('manual-log-cancel')} aria-label="Cancel">✕</button>
+        </div>
+      </div>`;
+  } else if (metricId === 'bp_systolic') {
+    card.innerHTML = `
+      <div class="wearable-card-top"><span class="wearable-metric-name">Blood pressure</span></div>
+      <div class="wearable-log-form">
+        <div class="wearable-log-bp-row">
+          <input type="number" inputmode="numeric" class="wearable-log-input wearable-log-bp" id="wl-bp-sys" placeholder="sys" aria-label="Systolic" autofocus>
+          <span class="wearable-log-sep">/</span>
+          <input type="number" inputmode="numeric" class="wearable-log-input wearable-log-bp" id="wl-bp-dia" placeholder="dia" aria-label="Diastolic">
+        </div>
+        <input type="number" inputmode="numeric" class="wearable-log-input wearable-log-pulse-optional" id="wl-bp-pulse" placeholder="pulse (optional)" aria-label="Pulse (optional)">
+        ${_renderTagChips('bp_systolic')}
+        ${_renderNoteField('wl-bp-note')}
+        <div class="wearable-log-row">
+          <input type="date" class="wearable-log-date" id="wl-bp-date" value="${today}" max="${today}" aria-label="Date">
+          <button type="button" class="wearable-log-save" ${wearableActionAttrs('manual-log-save', { kind: 'bp' })}>Save</button>
+          <button type="button" class="wearable-log-cancel" ${wearableActionAttrs('manual-log-cancel')} aria-label="Cancel">✕</button>
+        </div>
+      </div>`;
+  } else if (metricId === 'rhr') {
+    card.innerHTML = `
+      <div class="wearable-card-top"><span class="wearable-metric-name">Resting HR</span></div>
+      <div class="wearable-log-form">
+        <input type="number" inputmode="numeric" class="wearable-log-input" id="wl-rhr-val" placeholder="bpm" aria-label="Resting heart rate in bpm" autofocus>
+        ${_renderTagChips('rhr')}
+        ${_renderNoteField('wl-rhr-note')}
+        <div class="wearable-log-row">
+          <input type="date" class="wearable-log-date" id="wl-rhr-date" value="${today}" max="${today}" aria-label="Date">
+          <button type="button" class="wearable-log-save" ${wearableActionAttrs('manual-log-save', { kind: 'rhr' })}>Save</button>
+          <button type="button" class="wearable-log-cancel" ${wearableActionAttrs('manual-log-cancel')} aria-label="Cancel">✕</button>
+        </div>
+      </div>`;
+  }
+  // Focus the first input.
+  setTimeout(() => {
+    const firstNumberInput = card.querySelector('input[type="number"]');
+    if (firstNumberInput instanceof HTMLElement) firstNumberInput.focus();
+  }, 0);
+  // Enter-to-save on the number inputs.
+  card.querySelectorAll('input[type="number"]').forEach((el) => {
+    el.addEventListener('keydown', (e) => {
+      const keyEvent = /** @type {KeyboardEvent} */ (e);
+      if (keyEvent.key === 'Enter') { e.preventDefault(); saveManualLog(metricId === 'bp_systolic' ? 'bp' : metricId, e); }
+      if (keyEvent.key === 'Escape') { e.preventDefault(); cancelManualLog(e); }
+    });
+  });
+}
+
+export async function saveManualLog(kind, event) {
+  if (event) event.stopPropagation();
+  const { logManualMetric, logManualBP, refreshManualSummary } = await import('./wearables-manual.js');
+  const profileId = state.currentProfile;
+  // Pull any active context chips before the DOM is swapped out by re-render.
+  const cardForTags =
+    kind === 'weight' ? document.querySelector('.wearable-card-empty[data-empty-metric="weight"]') :
+    kind === 'rhr'    ? document.querySelector('.wearable-card-empty[data-empty-metric="rhr"]') :
+    kind === 'bp'     ? document.querySelector('.wearable-card-empty[data-empty-metric="bp_systolic"]') : null;
+  const tags = cardForTags ? _collectActiveChips(cardForTags) : [];
+  // Note field — id varies by kind ('wl-weight-note' / 'wl-bp-note' / 'wl-rhr-note').
+  const note = inputValueFromElement(document.getElementById(`wl-${kind === 'bp' ? 'bp' : kind}-note`));
+  try {
+    if (kind === 'weight') {
+      const val = parseFloat(inputValueById('wl-weight-val'));
+      const date = inputValueById('wl-weight-date');
+      if (!val || val <= 0 || !date) { showNotification?.('Enter a weight and date', 'error'); return; }
+      if (val > 500) { showNotification?.('Weight over 500 kg seems unlikely', 'error'); return; }
+      await logManualMetric(profileId, 'weight', { date, value: val, tags, note });
+    } else if (kind === 'rhr') {
+      const val = parseInt(inputValueById('wl-rhr-val'), 10);
+      const date = inputValueById('wl-rhr-date');
+      if (!val || val <= 0 || !date) { showNotification?.('Enter a pulse and date', 'error'); return; }
+      if (val > 250) { showNotification?.('Pulse over 250 bpm seems unlikely', 'error'); return; }
+      await logManualMetric(profileId, 'rhr', { date, value: val, tags, note });
+    } else if (kind === 'bp') {
+      const sys = parseInt(inputValueById('wl-bp-sys'), 10);
+      const dia = parseInt(inputValueById('wl-bp-dia'), 10);
+      const pulse = parseInt(inputValueById('wl-bp-pulse'), 10);
+      const date = inputValueById('wl-bp-date');
+      if (!sys || !dia || sys <= 0 || dia <= 0 || !date) { showNotification?.('Enter systolic, diastolic, and date', 'error'); return; }
+      if (sys > 300 || dia > 200) { showNotification?.('BP values seem too high', 'error'); return; }
+      if (dia >= sys) { showNotification?.('Diastolic should be lower than systolic', 'error'); return; }
+      await logManualBP(profileId, { date, systolic: sys, diastolic: dia, pulse: isFinite(pulse) && pulse > 0 ? pulse : undefined, tags, note });
+    }
+    await refreshManualSummary(profileId);
+    rerenderCurrentView();
+    showNotification?.('Saved', 'success');
+  } catch (e) {
+    showNotification?.('Could not save: ' + getErrorMessage(e), 'error');
+  }
+}
+
+export function cancelManualLog(event) {
+  if (event) event.stopPropagation();
+  // Re-render the current dashboard/body surface to restore the empty card.
+  rerenderCurrentView();
+}

--- a/js/wearables.js
+++ b/js/wearables.js
@@ -16,23 +16,12 @@
 //                  weekly: number[]         // up to 12 weekly means (oldest → newest)
 //                } }
 
-import { getErrorMessage } from './caught-error.js';
-import { escapeHTML, escapeAttr, showNotification } from './utils.js';
+import { escapeHTML, escapeAttr } from './utils.js';
 import { state } from './state.js';
-import { ADAPTERS, adapterById, canonicalMetric, metricsForSources, isoDay } from './wearable-adapters.js';
-import { syncNow, listConnectedSources } from './wearables-connect.js';
-import { syncWearableSummary } from './wearables-summary.js';
+import { ADAPTERS, adapterById, canonicalMetric, metricsForSources } from './wearable-adapters.js';
 import { isWearableStripHidden } from './wearables-settings-panel.js';
-import { getActiveProfileId } from './profile.js';
 import { formatValue, shortDate } from './wearables-formatters.js';
-import {
-  _collectActiveChips,
-  _renderNoteField,
-  _renderTagChips,
-  inputValueById,
-  inputValueFromElement,
-  toggleManualLogChip,
-} from './wearables-manual-form-ui.js';
+import { toggleManualLogChip } from './wearables-manual-form-ui.js';
 import {
   _uninstallWearableModalFocusTrap,
   closeManualAddFromDetail,
@@ -46,11 +35,21 @@ import {
 import {
   closeWearablesModal,
   configureWearablesModuleBridge,
-  getWearablesViewportSize,
   navigateWearables,
   openEMFAssessmentAfterWearablesModalClose,
   openWearablesSettings,
 } from './wearables-runtime.js';
+import {
+  cancelManualLog,
+  chooseWearableSource,
+  moveWearableCard,
+  openManualLogForm,
+  resetOpenManualLogForms,
+  saveManualLog,
+  syncWearableNow,
+  toggleWearableReorder,
+  toggleWearableStrip,
+} from './wearables-strip-actions.js';
 
 export { isWearableStripHidden, setWearableStripHidden, renderWearablesSettingsSection } from './wearables-settings-panel.js';
 export {
@@ -61,6 +60,14 @@ export {
   saveManualEntryFromDetail,
   setWearableDetailRange,
   toggleManualLogChip,
+  cancelManualLog,
+  chooseWearableSource,
+  moveWearableCard,
+  openManualLogForm,
+  saveManualLog,
+  syncWearableNow,
+  toggleWearableReorder,
+  toggleWearableStrip,
 };
 
 let wearableDelegatesInstalled = false;
@@ -151,21 +158,6 @@ function installWearableDelegates() {
   document.addEventListener('click', handleWearableActionClick);
   document.addEventListener('keydown', handleWearableActionKeydown);
   document.addEventListener('submit', handleWearableFormSubmit);
-}
-
-function rerenderCurrentView() {
-  navigateWearables(state.currentView || 'dashboard');
-}
-
-function resetOpenManualLogForms({ exceptMetricId = '' } = {}) {
-  const openForms = Array.from(document.querySelectorAll('.wearable-card-empty .wearable-log-form'));
-  const shouldReset = openForms.some(form => {
-    const card = form.closest('.wearable-card-empty');
-    return !(card instanceof HTMLElement) || card.dataset.emptyMetric !== exceptMetricId;
-  });
-  if (!shouldReset) return false;
-  rerenderCurrentView();
-  return true;
 }
 
 export function openWearableDetail(metricId, opts = {}) {
@@ -748,362 +740,6 @@ export function renderWearableStrip() {
   html += `</section>`;
   return html;
 }
-
-// ─────────────────────────────────────────────────────────
-// INTERACTIONS
-// ─────────────────────────────────────────────────────────
-
-export function toggleWearableStrip() {
-  const grid = document.querySelector('.wearable-card-grid');
-  const footer = document.querySelector('.wearable-strip-footer');
-  const arrow = document.querySelector('.wearable-collapse-arrow');
-  if (!grid) return;
-  const hidden = grid.classList.toggle('hidden');
-  footer?.classList.toggle('hidden', hidden);
-  arrow?.classList.toggle('collapsed', hidden);
-  // Keep aria-expanded + aria-label on the chevron button in sync with the
-  // visual collapse state. Captured-at-render-time attributes go stale on
-  // every toggle without this — silent screen-reader regression.
-  if (arrow) {
-    arrow.setAttribute('aria-expanded', String(!hidden));
-    const expanded = !hidden;
-    const labelBase = arrow.getAttribute('aria-label') || '';
-    // Toggle "Expand"/"Collapse" prefix in-place; preserves the rest of the
-    // label that the renderer composed (e.g. "wearables strip").
-    if (expanded && /^Expand /i.test(labelBase)) {
-      arrow.setAttribute('aria-label', labelBase.replace(/^Expand /i, 'Collapse '));
-    } else if (!expanded && /^Collapse /i.test(labelBase)) {
-      arrow.setAttribute('aria-label', labelBase.replace(/^Collapse /i, 'Expand '));
-    }
-  }
-  localStorage.setItem('wearables-strip-collapsed', hidden ? '1' : '0');
-}
-
-// Per-metric primary-source override picker. Reads connected sources that
-// actually have data for this metric and lets the user pick one. The summary
-// pipeline respects `state.importedData.wearablePrimaryOverride[metricId]`.
-export async function chooseWearableSource(metricId, event) {
-  const canon = canonicalMetric(metricId);
-  if (!canon) return;
-  const connected = listConnectedSources();
-  // Sort connected vendors by ADAPTERS registry order so the picker presents
-  // them in the same order users see in Settings → Integrations.
-  const connectedIds = Object.keys(connected)
-    .sort((a, b) => {
-      const ai = ADAPTERS.findIndex(x => x.id === a);
-      const bi = ADAPTERS.findIndex(x => x.id === b);
-      return (ai === -1 ? 999 : ai) - (bi === -1 ? 999 : bi);
-    });
-  if (connectedIds.length < 2) return;
-
-  // Find sources that map this canonical metric in their adapter registry —
-  // no point offering WHOOP as a source for `weight` (it doesn't do scales).
-  const eligible = connectedIds.filter(sid => {
-    const a = adapterById(sid);
-    return !!a?.metrics?.[metricId];
-  });
-  if (eligible.length < 2) {
-    showNotification?.(`Only one connected wearable provides ${canon.label}`, 'info', 2500);
-    return;
-  }
-
-  // Close any existing picker, then build + position a new one near the click.
-  document.querySelectorAll('.wearable-source-picker').forEach(el => el.remove());
-  // Pick the EFFECTIVE primary first — `wearableSummary.metrics[mid].primarySource`
-  // is what the L2 picker actually used, which falls through to auto-pick when
-  // an override points at a source with no data. Reading the override directly
-  // would mark a stale checkmark and lie to the user about what's active.
-  const effectivePrimary = state.importedData?.wearableSummary?.metrics?.[metricId]?.primarySource;
-  const overrideSource = state.importedData?.wearablePrimaryOverride?.[metricId];
-  const current = effectivePrimary || overrideSource || eligible[0];
-  const picker = document.createElement('div');
-  picker.className = 'wearable-source-picker';
-  picker.innerHTML = `
-    <div class="wearable-source-picker-head">${escapeHTML(canon.label)} source</div>
-    ${eligible.map(sid => {
-      const a = adapterById(sid);
-      const selected = sid === current;
-      return `<button type="button" class="wearable-source-picker-item${selected ? ' selected' : ''}" data-source="${escapeHTML(sid)}">
-        <span>${escapeHTML(a?.displayName || sid)}</span>
-        ${selected ? '<span class="wearable-source-picker-check">✓</span>' : ''}
-      </button>`;
-    }).join('')}
-    <button type="button" class="wearable-source-picker-item wearable-source-picker-auto" data-source="">
-      <span>Auto (most recent)</span>
-      ${!state.importedData?.wearablePrimaryOverride?.[metricId] ? '<span class="wearable-source-picker-check">✓</span>' : ''}
-    </button>
-  `;
-  const rect = event.target.getBoundingClientRect();
-  picker.style.position = 'fixed';
-  picker.style.visibility = 'hidden';
-  picker.style.top = '0px';
-  picker.style.left = '0px';
-  picker.style.zIndex = '10000';
-  document.body.appendChild(picker);
-  // Clamp to viewport and flip above if opening below would collide with the
-  // chat FAB hotspot (bottom-right ~72px square) or overflow the viewport. On
-  // mobile the card is full-width, so a naive rect.left-60 can underflow and
-  // the dropdown can disappear under the FAB — measure after insert and nudge.
-  const pw = picker.offsetWidth || 200;
-  const ph = picker.offsetHeight || 180;
-  const { width: vw, height: vh } = getWearablesViewportSize();
-  const fabHotspot = { left: vw - 88, top: vh - 88 }; // chat-fab 56px + 24px margin + buffer
-  let top = rect.bottom + 4;
-  let left = Math.max(8, rect.left - 60);
-  // Flip above if bottom would overflow viewport OR intrude on FAB hotspot
-  if (top + ph > vh - 8 || (top + ph > fabHotspot.top && left + pw > fabHotspot.left)) {
-    top = Math.max(8, rect.top - ph - 4);
-  }
-  // Clamp right
-  if (left + pw > vw - 8) left = Math.max(8, vw - pw - 8);
-  picker.style.top = `${top}px`;
-  picker.style.left = `${left}px`;
-  picker.style.visibility = '';
-
-  // Wire clicks — pick a source, persist override, re-render strip.
-  picker.querySelectorAll('[data-source]').forEach(btn => {
-    if (!(btn instanceof HTMLElement)) return;
-    btn.addEventListener('click', async (e) => {
-      e.stopPropagation();
-      const sid = btn.dataset.source;
-      if (!state.importedData.wearablePrimaryOverride) state.importedData.wearablePrimaryOverride = {};
-      if (!sid) delete state.importedData.wearablePrimaryOverride[metricId];
-      else state.importedData.wearablePrimaryOverride[metricId] = sid;
-      const { saveImportedData } = await import('./data.js');
-      await saveImportedData();
-      await syncWearableSummary(getActiveProfileId(), listConnectedSources());
-      picker.remove();
-      navigateWearables('dashboard');
-    });
-  });
-
-  // Dismiss on outside click / Escape.
-  setTimeout(() => {
-    const dismiss = (e) => {
-      if (picker.contains(e.target)) return;
-      picker.remove();
-      document.removeEventListener('click', dismiss);
-      document.removeEventListener('keydown', onKey);
-    };
-    const onKey = (e) => { if (e.key === 'Escape') { picker.remove(); document.removeEventListener('keydown', onKey); document.removeEventListener('click', dismiss); } };
-    document.addEventListener('click', dismiss);
-    document.addEventListener('keydown', onKey);
-  }, 0);
-}
-
-export async function syncWearableNow(triggerEl) {
-  const sources = Object.keys(listConnectedSources());
-  if (sources.length === 0) {
-    showNotification?.('Connect a wearable in Settings → Wearables first', 'info');
-    return;
-  }
-  // Spin the inline button icon for the duration of the sync. The button
-  // disables itself so a double-click can't kick off concurrent syncs.
-  const btn = triggerEl || document.querySelector('.wearable-strip-sync');
-  btn?.classList.add('is-syncing');
-  if (btn) btn.disabled = true;
-  try {
-    showNotification?.('Syncing wearables…', 'info', 1500);
-    // force:true → bypass L2 gate so the strip never appears stuck on a
-    // stale snapshot when a user explicitly clicks "sync now."
-    let totalRows = 0;
-    for (const sid of sources) {
-      const res = await syncNow(sid, { force: true });
-      totalRows += res?.rows ?? 0;
-    }
-    navigateWearables('dashboard');
-    showNotification?.(
-      totalRows > 0 ? `Wearables synced — ${totalRows} new row${totalRows === 1 ? '' : 's'}` : 'Wearables synced — already up to date',
-      'success', 2000
-    );
-  } catch { /* per-source error already surfaced */ }
-  finally {
-    btn?.classList.remove('is-syncing');
-    if (btn) btn.disabled = false;
-  }
-}
-
-// Reorder mode — toggle + per-card move handlers. Keeps the reorder flag
-// ephemeral (state._wearableReorderMode) so it auto-resets on reload; the
-// card ORDER itself is persisted per-profile in importedData.wearableCardOrder.
-export function toggleWearableReorder() {
-  state._wearableReorderMode = !state._wearableReorderMode;
-  navigateWearables('dashboard');
-}
-
-export async function moveWearableCard(metricId, delta) {
-  const summary = state.importedData?.wearableSummary;
-  if (!summary) return;
-  // Rebuild the CURRENT display order the same way renderWearableStrip does,
-  // so a move reflects exactly what the user sees (populated + empty cards
-  // combined, then the saved order applied).
-  const sourceIds = Object.keys(summary.sources || {})
-    .sort((a, b) => {
-      const ai = ADAPTERS.findIndex(x => x.id === a);
-      const bi = ADAPTERS.findIndex(x => x.id === b);
-      return (ai === -1 ? 999 : ai) - (bi === -1 ? 999 : bi);
-    });
-  const headerSourceIds = sourceIds.filter(s => (summary.sources[s].coverageDays || 0) > 0);
-  const baseOrder = metricsForSources(headerSourceIds.length ? headerSourceIds : sourceIds);
-  const MANUAL_EMPTY_METRICS_LOCAL = ['weight', 'bp_systolic', 'rhr'];
-  // Mirror the strip-render BP merge: dia folds into the sys card and never
-  // gets its own reorder slot when both are present.
-  const hasSysLocal = !!summary.metrics?.bp_systolic;
-  const display = [];
-  const seen = new Set();
-  for (const id of baseOrder) {
-    if (id === 'bp_diastolic' && hasSysLocal) continue;
-    if (summary.metrics?.[id]) { display.push(id); seen.add(id); }
-  }
-  for (const id of MANUAL_EMPTY_METRICS_LOCAL) {
-    if (!seen.has(id)) { display.push(id); seen.add(id); }
-  }
-  const savedOrder = Array.isArray(state.importedData?.wearableCardOrder)
-    ? state.importedData.wearableCardOrder : [];
-  const ordered = [];
-  for (const id of savedOrder) if (display.includes(id)) ordered.push(id);
-  for (const id of display) if (!ordered.includes(id)) ordered.push(id);
-  const idx = ordered.indexOf(metricId);
-  if (idx === -1) return;
-  const target = idx + delta;
-  if (target < 0 || target >= ordered.length) return;
-  const tmp = ordered[idx];
-  ordered[idx] = ordered[target];
-  ordered[target] = tmp;
-  state.importedData.wearableCardOrder = ordered;
-  const { saveImportedData } = await import('./data.js');
-  await saveImportedData();
-  navigateWearables('dashboard');
-}
-
-// ─────────────────────────────────────────────────────────
-// Inline manual-log form (Phase 3) — opens from the empty strip cards.
-// ─────────────────────────────────────────────────────────
-
-
-export function openManualLogForm(metricId, event, opts = {}) {
-  if (!opts.delegated && event?.target?.closest?.('[data-wearable-action]')) return;
-  if (event) event.stopPropagation();
-  let card = document.querySelector(`.wearable-card-empty[data-empty-metric="${metricId}"]`);
-  if (!card) return;
-  // Idempotent: clicks inside the form (e.g. tapping the dia field on the
-  // BP card) bubble to the card's delegated action. Without this guard we'd rebuild
-  // innerHTML and refocus the first input — yanking the cursor off whatever
-  // the user actually clicked.
-  if (card.querySelector('.wearable-log-form')) return;
-  if (resetOpenManualLogForms({ exceptMetricId: metricId })) {
-    card = document.querySelector(`.wearable-card-empty[data-empty-metric="${metricId}"]`);
-    if (!card) return;
-  }
-  const today = isoDay();
-  if (metricId === 'weight') {
-    card.innerHTML = `
-      <div class="wearable-card-top"><span class="wearable-metric-name">Weight</span></div>
-      <div class="wearable-log-form">
-        <input type="number" step="0.1" inputmode="decimal" class="wearable-log-input" id="wl-weight-val" placeholder="${state.unitSystem === 'US' ? 'lb' : 'kg'}" aria-label="${state.unitSystem === 'US' ? 'Weight in pounds' : 'Weight in kilograms'}" autofocus>
-        ${_renderNoteField('wl-weight-note')}
-        <div class="wearable-log-row">
-          <input type="date" class="wearable-log-date" id="wl-weight-date" value="${today}" max="${today}" aria-label="Date">
-          <button type="button" class="wearable-log-save" ${wearableActionAttrs('manual-log-save', { kind: 'weight' })}>Save</button>
-          <button type="button" class="wearable-log-cancel" ${wearableActionAttrs('manual-log-cancel')} aria-label="Cancel">✕</button>
-        </div>
-      </div>`;
-  } else if (metricId === 'bp_systolic') {
-    card.innerHTML = `
-      <div class="wearable-card-top"><span class="wearable-metric-name">Blood pressure</span></div>
-      <div class="wearable-log-form">
-        <div class="wearable-log-bp-row">
-          <input type="number" inputmode="numeric" class="wearable-log-input wearable-log-bp" id="wl-bp-sys" placeholder="sys" aria-label="Systolic" autofocus>
-          <span class="wearable-log-sep">/</span>
-          <input type="number" inputmode="numeric" class="wearable-log-input wearable-log-bp" id="wl-bp-dia" placeholder="dia" aria-label="Diastolic">
-        </div>
-        <input type="number" inputmode="numeric" class="wearable-log-input wearable-log-pulse-optional" id="wl-bp-pulse" placeholder="pulse (optional)" aria-label="Pulse (optional)">
-        ${_renderTagChips('bp_systolic')}
-        ${_renderNoteField('wl-bp-note')}
-        <div class="wearable-log-row">
-          <input type="date" class="wearable-log-date" id="wl-bp-date" value="${today}" max="${today}" aria-label="Date">
-          <button type="button" class="wearable-log-save" ${wearableActionAttrs('manual-log-save', { kind: 'bp' })}>Save</button>
-          <button type="button" class="wearable-log-cancel" ${wearableActionAttrs('manual-log-cancel')} aria-label="Cancel">✕</button>
-        </div>
-      </div>`;
-  } else if (metricId === 'rhr') {
-    card.innerHTML = `
-      <div class="wearable-card-top"><span class="wearable-metric-name">Resting HR</span></div>
-      <div class="wearable-log-form">
-        <input type="number" inputmode="numeric" class="wearable-log-input" id="wl-rhr-val" placeholder="bpm" aria-label="Resting heart rate in bpm" autofocus>
-        ${_renderTagChips('rhr')}
-        ${_renderNoteField('wl-rhr-note')}
-        <div class="wearable-log-row">
-          <input type="date" class="wearable-log-date" id="wl-rhr-date" value="${today}" max="${today}" aria-label="Date">
-          <button type="button" class="wearable-log-save" ${wearableActionAttrs('manual-log-save', { kind: 'rhr' })}>Save</button>
-          <button type="button" class="wearable-log-cancel" ${wearableActionAttrs('manual-log-cancel')} aria-label="Cancel">✕</button>
-        </div>
-      </div>`;
-  }
-  // Focus the first input.
-  setTimeout(() => {
-    const firstNumberInput = card.querySelector('input[type="number"]');
-    if (firstNumberInput instanceof HTMLElement) firstNumberInput.focus();
-  }, 0);
-  // Enter-to-save on the number inputs.
-  card.querySelectorAll('input[type="number"]').forEach((el) => {
-    el.addEventListener('keydown', (e) => {
-      const keyEvent = /** @type {KeyboardEvent} */ (e);
-      if (keyEvent.key === 'Enter') { e.preventDefault(); saveManualLog(metricId === 'bp_systolic' ? 'bp' : metricId, e); }
-      if (keyEvent.key === 'Escape') { e.preventDefault(); cancelManualLog(e); }
-    });
-  });
-}
-
-export async function saveManualLog(kind, event) {
-  if (event) event.stopPropagation();
-  const { logManualMetric, logManualBP, refreshManualSummary } = await import('./wearables-manual.js');
-  const profileId = state.currentProfile;
-  // Pull any active context chips before the DOM is swapped out by re-render.
-  const cardForTags =
-    kind === 'weight' ? document.querySelector('.wearable-card-empty[data-empty-metric="weight"]') :
-    kind === 'rhr'    ? document.querySelector('.wearable-card-empty[data-empty-metric="rhr"]') :
-    kind === 'bp'     ? document.querySelector('.wearable-card-empty[data-empty-metric="bp_systolic"]') : null;
-  const tags = cardForTags ? _collectActiveChips(cardForTags) : [];
-  // Note field — id varies by kind ('wl-weight-note' / 'wl-bp-note' / 'wl-rhr-note').
-  const note = inputValueFromElement(document.getElementById(`wl-${kind === 'bp' ? 'bp' : kind}-note`));
-  try {
-    if (kind === 'weight') {
-      const val = parseFloat(inputValueById('wl-weight-val'));
-      const date = inputValueById('wl-weight-date');
-      if (!val || val <= 0 || !date) { showNotification?.('Enter a weight and date', 'error'); return; }
-      if (val > 500) { showNotification?.('Weight over 500 kg seems unlikely', 'error'); return; }
-      await logManualMetric(profileId, 'weight', { date, value: val, tags, note });
-    } else if (kind === 'rhr') {
-      const val = parseInt(inputValueById('wl-rhr-val'), 10);
-      const date = inputValueById('wl-rhr-date');
-      if (!val || val <= 0 || !date) { showNotification?.('Enter a pulse and date', 'error'); return; }
-      if (val > 250) { showNotification?.('Pulse over 250 bpm seems unlikely', 'error'); return; }
-      await logManualMetric(profileId, 'rhr', { date, value: val, tags, note });
-    } else if (kind === 'bp') {
-      const sys = parseInt(inputValueById('wl-bp-sys'), 10);
-      const dia = parseInt(inputValueById('wl-bp-dia'), 10);
-      const pulse = parseInt(inputValueById('wl-bp-pulse'), 10);
-      const date = inputValueById('wl-bp-date');
-      if (!sys || !dia || sys <= 0 || dia <= 0 || !date) { showNotification?.('Enter systolic, diastolic, and date', 'error'); return; }
-      if (sys > 300 || dia > 200) { showNotification?.('BP values seem too high', 'error'); return; }
-      if (dia >= sys) { showNotification?.('Diastolic should be lower than systolic', 'error'); return; }
-      await logManualBP(profileId, { date, systolic: sys, diastolic: dia, pulse: isFinite(pulse) && pulse > 0 ? pulse : undefined, tags, note });
-    }
-    await refreshManualSummary(profileId);
-    rerenderCurrentView();
-    showNotification?.('Saved', 'success');
-  } catch (e) {
-    showNotification?.('Could not save: ' + getErrorMessage(e), 'error');
-  }
-}
-
-export function cancelManualLog(event) {
-  if (event) event.stopPropagation();
-  // Re-render the current dashboard/body surface to restore the empty card.
-  rerenderCurrentView();
-}
-
 installWearableDelegates();
 
 configureWearablesModuleBridge({

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -7,6 +7,6 @@
   "viewRuntimeBridgeLookups": 0,
   "labStateAppFiles": 0,
   "labStateTestFiles": 0,
-  "largeJsFilesOver800Lines": 17,
+  "largeJsFilesOver800Lines": 16,
   "maxJsFileLines": 1168
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -458,6 +458,7 @@ const APP_SHELL = [
   // Wearables (added v1.22.0)
   '/js/wearable-adapters.js',
   '/js/wearables.js',
+  '/js/wearables-strip-actions.js',
   '/js/wearables-bp-detail-chart.js',
   '/js/wearables-detail-runtime.js',
   '/js/wearables-detail-modal.js',

--- a/tests/test-a11y-phase3.js
+++ b/tests/test-a11y-phase3.js
@@ -295,12 +295,15 @@ console.log('=== Phase 3 A11y Tests ===\n');
 
   // ─── 12. Weight input respects unit system ───
   const wearSrc = read('/js/wearables.js');
+  const wearActionsSrc = read('/js/wearables-strip-actions.js');
   const wearRuntimeSrc = read('/js/wearables-runtime.js');
   assert('weight log inputs respect state.unitSystem',
-    wearSrc.includes("state.unitSystem === 'US' ? 'lb' : 'kg'"));
+    wearActionsSrc.includes("state.unitSystem === 'US' ? 'lb' : 'kg'"));
   assert('wearables dashboard browser hooks are isolated in runtime adapter',
     wearSrc.includes("from './wearables-runtime.js'")
       && !/\bwindow\b/.test(wearSrc)
+      && wearActionsSrc.includes("from './wearables-runtime.js'")
+      && !/\bwindow\b/.test(wearActionsSrc)
       && wearRuntimeSrc.includes('configureWearablesModuleBridge')
       && wearRuntimeSrc.includes('getWearablesModuleFunction')
       && wearRuntimeSrc.includes('getWearablesViewportSize'));

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -230,6 +230,7 @@ const highValueCheckJsModules = [
   'js/sun-location.js',
   'js/sun-uvdata-config.js',
   'js/wearables.js',
+  'js/wearables-strip-actions.js',
 ];
 const missingHighValueCheckJsModules = highValueCheckJsModules
   .filter(file => !checkJsConfig.include?.includes(file));

--- a/tests/test-wearables-bp-merge.js
+++ b/tests/test-wearables-bp-merge.js
@@ -7,7 +7,8 @@
 // Run: node tests/test-wearables-bp-merge.js  (or via npm test)
 //
 // All assertions here are source-inspection regexes against wearables.js /
-// wearable-adapters.js / wearables-manual.js. The section-4 *live* DOM
+// wearables-strip-actions.js / wearable-adapters.js / wearables-manual.js.
+// The section-4 *live* DOM
 // idempotency probe (openManualLogForm called twice -> still one form) lives
 // in tests/playwright/wearables-bp-merge.spec.js.
 
@@ -29,6 +30,7 @@ function assert(name, condition, detail) {
 console.log('=== BP Card Merge Tests ===\n');
 
 const wearablesSrc = read('js/wearables.js');
+const wearablesActionsSrc = read('js/wearables-strip-actions.js');
 
 // ═══════════════════════════════════════
 // 1. Strip-render filter — dia hidden when sys present
@@ -68,7 +70,7 @@ assert("Aria-label uses 'Blood pressure' for the paired card",
 console.log('3. Reorder filter');
 
 assert('moveWearableCard mirrors the same dia-skip when sys present',
-  /const hasSysLocal = !!summary\.metrics\?\.bp_systolic[\s\S]{0,400}if \(id === 'bp_diastolic' && hasSysLocal\) continue/.test(wearablesSrc));
+  /const hasSysLocal = !!summary\.metrics\?\.bp_systolic[\s\S]{0,400}if \(id === 'bp_diastolic' && hasSysLocal\) continue/.test(wearablesActionsSrc));
 
 // ═══════════════════════════════════════
 // 4. BP form idempotency (the dia-click bug fix) — source asserts
@@ -78,9 +80,9 @@ assert('moveWearableCard mirrors the same dia-skip when sys present',
 console.log('4. Form idempotency (source)');
 
 assert('openManualLogForm returns early when the form is already rendered',
-  /openManualLogForm[\s\S]{0,700}if \(card\.querySelector\('\.wearable-log-form'\)\) return/.test(wearablesSrc));
+  /openManualLogForm[\s\S]{0,700}if \(card\.querySelector\('\.wearable-log-form'\)\) return/.test(wearablesActionsSrc));
 assert('Idempotency guard has a comment explaining the dia-click bug',
-  /clicks inside the form \(e\.g\. tapping the dia field on the[\s\S]{0,200}Without this guard we'd rebuild/.test(wearablesSrc));
+  /clicks inside the form \(e\.g\. tapping the dia field on the[\s\S]{0,200}Without this guard we'd rebuild/.test(wearablesActionsSrc));
 
 // ═══════════════════════════════════════
 // 5. Storage untouched — underlying metric storage didn't change

--- a/tests/test-wearables-delegated-actions.js
+++ b/tests/test-wearables-delegated-actions.js
@@ -8,9 +8,11 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
 const stripSrc = fs.readFileSync(path.join(root, 'js/wearables.js'), 'utf8');
+const stripActionsSrc = fs.readFileSync(path.join(root, 'js/wearables-strip-actions.js'), 'utf8');
 const detailSrc = fs.readFileSync(path.join(root, 'js/wearables-detail-modal.js'), 'utf8');
 const settingsPanelSrc = fs.readFileSync(path.join(root, 'js/wearables-settings-panel.js'), 'utf8');
 const stripImportsSharedActionHelper = /import\s*{[^}]*\bwearableActionAttrs\b[^}]*}\s*from\s+'\.\/wearables-detail-modal\.js';/s.test(stripSrc);
+const stripActionsImportSharedActionHelper = /import\s*{[^}]*\bwearableActionAttrs\b[^}]*}\s*from\s+'\.\/wearables-detail-modal\.js';/s.test(stripActionsSrc);
 
 let passed = 0;
 let failed = 0;
@@ -30,17 +32,18 @@ console.log('=== Wearables Delegated Actions ===');
 const inlineHandlerRe = /\bon(?:click|keydown|submit|change|input)=/;
 
 assert('wearables strip renders no inline event attributes',
-  !inlineHandlerRe.test(stripSrc));
+  !inlineHandlerRe.test(stripSrc) && !inlineHandlerRe.test(stripActionsSrc));
 assert('wearables detail modal renders no inline event attributes',
   !inlineHandlerRe.test(detailSrc));
 assert('wearables settings panel renders no inline event attributes',
   !inlineHandlerRe.test(settingsPanelSrc));
 assert('wearables strip renders delegated action attributes',
   stripImportsSharedActionHelper &&
+    stripActionsImportSharedActionHelper &&
     stripSrc.includes("wearableActionAttrs('open-manual-log'") &&
     stripSrc.includes("wearableActionAttrs('open-detail'") &&
     stripSrc.includes("wearableActionAttrs('move-card'") &&
-    stripSrc.includes("wearableActionAttrs('manual-log-save'"));
+    stripActionsSrc.includes("wearableActionAttrs('manual-log-save'"));
 assert('wearables detail modal renders delegated action and form attributes',
   detailSrc.includes('export function wearableActionAttrs') &&
     detailSrc.includes('function wearableFormAttrs') &&
@@ -54,8 +57,10 @@ assert('wearables detail modal opens through shared overlay lifecycle helper',
     detailSrc.includes('openModalOverlay(overlay)'));
 assert('wearable action attr helper has one shared definition',
   (stripSrc.match(/\bfunction\s+wearableActionAttrs\b/g) || []).length === 0 &&
+    (stripActionsSrc.match(/\bfunction\s+wearableActionAttrs\b/g) || []).length === 0 &&
     (detailSrc.match(/\bfunction\s+wearableActionAttrs\b/g) || []).length === 1 &&
-    stripImportsSharedActionHelper);
+    stripImportsSharedActionHelper &&
+    stripActionsImportSharedActionHelper);
 assert('wearables module installs idempotent click keydown and submit delegates',
   stripSrc.includes('let wearableDelegatesInstalled = false') &&
     stripSrc.includes("document.addEventListener('click', handleWearableActionClick)") &&
@@ -71,8 +76,8 @@ assert('wearables detail opens reset any active manual inline form',
     stripSrc.includes('openWearableDetail,'));
 assert('wearables delegated manual log open bypasses only the legacy inline-card guard',
   stripSrc.includes("openManualLogForm(metricId, event, { delegated: true })") &&
-    stripSrc.includes("!opts.delegated && event?.target?.closest?.('[data-wearable-action]')") &&
-    !stripSrc.includes("if (event?.target?.closest?.('[data-wearable-action]')) return;"));
+    stripActionsSrc.includes("!opts.delegated && event?.target?.closest?.('[data-wearable-action]')") &&
+    !stripActionsSrc.includes("if (event?.target?.closest?.('[data-wearable-action]')) return;"));
 assert('wearables delegated keyboard ignores form controls',
   stripSrc.includes("target.closest('input, textarea, select, button, a')"));
 assert('wearables settings panel installs delegated click change and drop handlers',

--- a/tests/test-wearables-manual.js
+++ b/tests/test-wearables-manual.js
@@ -82,6 +82,7 @@ assert('manual dashboard actions are module exports',
     && typeof wearables.cancelManualLog === 'function');
 
 const wearablesSrc = await fetch('js/wearables.js').then(r => r.text());
+const wearablesActionsSrc = await fetch('js/wearables-strip-actions.js').then(r => r.text());
 const wearablesDetailSrc = await fetch('js/wearables-detail-modal.js').then(r => r.text());
 const wearablesDetailRuntimeSrc = await fetch('js/wearables-detail-runtime.js').then(r => r.text());
 const manualFormUiSrc = await fetch('js/wearables-manual-form-ui.js').then(r => r.text());
@@ -293,7 +294,7 @@ try {
     weightRow?.tags?.includes('resting') &&
     weightRow?.tags?.includes('post-workout'));
 
-  assert('wearables.js renders tag chips on bp form', wearablesSrc.includes('_renderTagChips'));
+  assert('wearables strip actions render tag chips on bp form', wearablesActionsSrc.includes('_renderTagChips'));
   assert('toggleManualLogChip is a module export',
     typeof wearables.toggleManualLogChip === 'function');
 
@@ -375,7 +376,7 @@ try {
     rows4[0].note === 'after run' && rows4[0].tags?.includes('post-workout'));
 
   // Detail-modal form has chips for rhr + bp (parity with empty-card form).
-  const combinedManualFormSrc = wearablesSrc + '\n' + wearablesDetailSrc;
+  const combinedManualFormSrc = wearablesActionsSrc + '\n' + wearablesDetailSrc;
   const rhrChipMatches = (combinedManualFormSrc.match(/_renderTagChips\('rhr'\)/g) || []).length;
   const bpChipMatches = (combinedManualFormSrc.match(/_renderTagChips\('bp_systolic'\)/g) || []).length;
   assert("_renderTagChips('rhr') called from both empty-card AND detail-modal forms",
@@ -396,18 +397,18 @@ try {
   assert('Detail-modal form renders the wlad-note textarea',
     /openManualAddFromDetail[\s\S]{0,3000}_renderNoteField\('wlad-note'\)/.test(wearablesDetailSrc));
   assert('Empty-card weight form renders wl-weight-note textarea',
-    /metricId === 'weight'[\s\S]{0,1000}_renderNoteField\('wl-weight-note'\)/.test(wearablesSrc));
+    /metricId === 'weight'[\s\S]{0,1000}_renderNoteField\('wl-weight-note'\)/.test(wearablesActionsSrc));
   assert('Empty-card BP form renders wl-bp-note textarea',
-    /metricId === 'bp_systolic'[\s\S]{0,1500}_renderNoteField\('wl-bp-note'\)/.test(wearablesSrc));
+    /metricId === 'bp_systolic'[\s\S]{0,1500}_renderNoteField\('wl-bp-note'\)/.test(wearablesActionsSrc));
   assert('Empty-card RHR form renders wl-rhr-note textarea',
-    /metricId === 'rhr'[\s\S]{0,1000}_renderNoteField\('wl-rhr-note'\)/.test(wearablesSrc));
+    /metricId === 'rhr'[\s\S]{0,1000}_renderNoteField\('wl-rhr-note'\)/.test(wearablesActionsSrc));
 
   assert('_renderNoteField helper defined',
     /function _renderNoteField\(idSuffix = 'wl-note'\)/.test(manualFormUiSrc));
   assert('_renderNoteField outputs a wearable-log-note textarea',
     /<textarea class="wearable-log-note"/.test(manualFormUiSrc));
 
-  const saveLogFn = wearablesSrc.match(/async function saveManualLog[\s\S]*?\n\}\s*\n/)?.[0] || '';
+  const saveLogFn = wearablesActionsSrc.match(/async function saveManualLog[\s\S]*?\n\}\s*\n/)?.[0] || '';
   assert('saveManualLog reads note from `wl-${kind}-note` (or `wl-bp-note`)',
     /document\.getElementById\(`wl-\$\{kind === 'bp' \? 'bp' : kind\}-note`\)/.test(saveLogFn));
   assert('saveManualLog passes note to logManualMetric (weight + rhr) and logManualBP',

--- a/tests/test-wearables.js
+++ b/tests/test-wearables.js
@@ -1921,7 +1921,8 @@ assert('Service-worker static cache lists extracted wearable detail modules',
   /\/js\/wearables-detail-runtime\.js/.test(swSrc) &&
   /\/js\/wearables-bp-detail-chart\.js/.test(swSrc) &&
   /\/js\/wearables-formatters\.js/.test(swSrc) &&
-  /\/js\/wearables-manual-form-ui\.js/.test(swSrc));
+  /\/js\/wearables-manual-form-ui\.js/.test(swSrc) &&
+  /\/js\/wearables-strip-actions\.js/.test(swSrc));
 const bpChartSrc = await fetch('/js/wearables-bp-detail-chart.js').then(r => r.text());
 assert('Manual diastolic scatter color is distinct from primary diastolic line',
   /const\s+diaColor\s*=\s*['"]#a78bfa['"]/.test(bpChartSrc) &&
@@ -1943,9 +1944,9 @@ assert('deleteMeta imported from wearables-store',
 
 // Source picker now uses the EFFECTIVE primary (the L2 picker's actual
 // pick) rather than the raw override which can be stale/invalid.
-const wearablesSrc3 = await fetch('/js/wearables.js').then(r => r.text());
+const wearablesActionsSrc3 = await fetch('/js/wearables-strip-actions.js').then(r => r.text());
 assert('Source picker prefers wearableSummary.metrics primarySource (effective) over raw override',
-  /effectivePrimary\s*=\s*state\.importedData\?\.wearableSummary\?\.metrics\?\.\[metricId\]\?\.primarySource/.test(wearablesSrc3));
+  /effectivePrimary\s*=\s*state\.importedData\?\.wearableSummary\?\.metrics\?\.\[metricId\]\?\.primarySource/.test(wearablesActionsSrc3));
 
 // Polar memberId guard: refuses connect when token grant lacks userId.
 assert('Polar postConnect refuses to register when result.tokens.userId missing',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -321,6 +321,7 @@
     "js/wearables-settings-runtime.js",
     "js/wearables-settings-panel.js",
     "js/wearables-store.js",
+    "js/wearables-strip-actions.js",
     "js/wearables-summary.js",
     "js/wearables-ultrahuman-auth.js",
     "js/wearables-ultrahuman.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -405,6 +405,7 @@
     "js/wearables-settings-runtime.js",
     "js/wearables-settings-panel.js",
     "js/wearables-store.js",
+    "js/wearables-strip-actions.js",
     "js/wearables-summary.js",
     "js/wearables-ultrahuman-auth.js",
     "js/wearables-ultrahuman.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.459';
+self.APP_VERSION = '1.10.460';


### PR DESCRIPTION
## Summary
- extract strip collapse, source selection, sync, reorder, and inline manual-log behavior into `wearables-strip-actions.js`
- keep `wearables.js` as the public facade and delegated-event/render owner, reducing it from 1,114 to 750 lines
- register the new owner for offline caching, strict checkJs, architecture mapping, and focused source contracts
- lower the >=800-line JavaScript maintainability baseline from 17 to 16

## Verification
- strict TypeScript, full-app checkJs, and strict-null ratchet
- quality guardrails: 16/16 large modules, 525 JS/MJS parse
- architecture: 502 modules, 0 cycles
- module verification: 141/141
- Wearables suites: 588/588 core, 101/101 manual, delegated actions 32/32, BP merge 15/15
- production/service-worker: 30/30
- audit: 365/365
- focused Chromium: strip actions, BP idempotency, and both legacy Wearables browser-flow fixtures (4/4)