### PR TITLE
Split EMF editor owner

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -9,8 +9,8 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 
 | Metric | Current |
 | --- | ---: |
-| Modules | 505 |
-| Internal import edges | 2281 |
+| Modules | 507 |
+| Internal import edges | 2289 |
 | Dynamic internal edges | 93 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -38,14 +38,14 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 
 | High fan-in | Dependants | High fan-out | Imports |
 | --- | ---: | --- | ---: |
-| [`js/utils.js`](js/utils.js) | 235 | [`js/app-shell-hooks.js`](js/app-shell-hooks.js) | 72 |
-| [`js/state.js`](js/state.js) | 161 | [`js/app-light-sun-modules.js`](js/app-light-sun-modules.js) | 36 |
-| [`js/data.js`](js/data.js) | 75 | [`js/sync-configure.js`](js/sync-configure.js) | 27 |
+| [`js/utils.js`](js/utils.js) | 236 | [`js/app-shell-hooks.js`](js/app-shell-hooks.js) | 72 |
+| [`js/state.js`](js/state.js) | 162 | [`js/app-light-sun-modules.js`](js/app-light-sun-modules.js) | 36 |
+| [`js/data.js`](js/data.js) | 76 | [`js/sync-configure.js`](js/sync-configure.js) | 27 |
 | [`js/caught-error.js`](js/caught-error.js) | 73 | [`js/settings.js`](js/settings.js) | 25 |
-| [`js/modal-lifecycle.js`](js/modal-lifecycle.js) | 66 | [`js/pdf-import.js`](js/pdf-import.js) | 24 |
+| [`js/modal-lifecycle.js`](js/modal-lifecycle.js) | 67 | [`js/pdf-import.js`](js/pdf-import.js) | 24 |
 | [`js/api.js`](js/api.js) | 64 | [`js/chat-send.js`](js/chat-send.js) | 22 |
 | [`js/profile.js`](js/profile.js) | 45 | [`js/views.js`](js/views.js) | 22 |
-| [`js/schema.js`](js/schema.js) | 32 | [`js/wearables-connect.js`](js/wearables-connect.js) | 21 |
+| [`js/schema.js`](js/schema.js) | 33 | [`js/wearables-connect.js`](js/wearables-connect.js) | 21 |
 | [`js/crypto.js`](js/crypto.js) | 29 | [`js/dashboard-view-composition.js`](js/dashboard-view-composition.js) | 20 |
 | [`js/data-merge.js`](js/data-merge.js) | 29 | [`js/biology-scores.js`](js/biology-scores.js) | 19 |
 | [`js/utils-runtime.js`](js/utils-runtime.js) | 20 | [`js/export.js`](js/export.js) | 18 |
@@ -351,11 +351,13 @@ Native browser modules shipped with the static application.
 
 </details>
 
-<details><summary><code>emf</code> family — 3 modules</summary>
+<details><summary><code>emf</code> family — 5 modules</summary>
 
+- [`js/emf-editor.js`](js/emf-editor.js) → [`js/constants.js`](js/constants.js), [`js/context-card-editor-ui.js`](js/context-card-editor-ui.js), [`js/data.js`](js/data.js), [`js/emf-model.js`](js/emf-model.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/recommendations.js`](js/recommendations.js), [`js/schema.js`](js/schema.js), [`js/utils.js`](js/utils.js)
 - [`js/emf-interpretation.js`](js/emf-interpretation.js) → [`js/api.js`](js/api.js), [`js/data.js`](js/data.js), [`js/health-data-loader.js`](js/health-data-loader.js), [`js/markdown.js`](js/markdown.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
+- [`js/emf-model.js`](js/emf-model.js) → [`js/state.js`](js/state.js)
 - [`js/emf-runtime.js`](js/emf-runtime.js) → [`js/utils.js`](js/utils.js)
-- [`js/emf.js`](js/emf.js) → [`js/api.js`](js/api.js), [`js/caught-error.js`](js/caught-error.js), [`js/constants.js`](js/constants.js), [`js/context-card-editor-ui.js`](js/context-card-editor-ui.js), [`js/data.js`](js/data.js), [`js/emf-interpretation.js`](js/emf-interpretation.js), [`js/image-utils.js`](js/image-utils.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/pdf-import.js`](js/pdf-import.js), [`js/pii.js`](js/pii.js), [`js/recommendations.js`](js/recommendations.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
+- [`js/emf.js`](js/emf.js) → [`js/api.js`](js/api.js), [`js/caught-error.js`](js/caught-error.js), [`js/data.js`](js/data.js), [`js/emf-editor.js`](js/emf-editor.js), [`js/emf-interpretation.js`](js/emf-interpretation.js), [`js/emf-model.js`](js/emf-model.js), [`js/image-utils.js`](js/image-utils.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/pdf-import.js`](js/pdf-import.js), [`js/pii.js`](js/pii.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 
 </details>
 

--- a/js/emf-editor.js
+++ b/js/emf-editor.js
@@ -1,0 +1,665 @@
+// @ts-check
+// emf-editor.js — EMF assessment modal rendering and delegated interaction owner.
+
+import { SBM_2015_THRESHOLDS, getEMFSeverity } from './schema.js';
+import {
+  EMF_ROOM_PRESETS,
+  EMF_SOURCES,
+  EMF_MITIGATIONS,
+  EMF_METER_PRESETS,
+} from './constants.js';
+import { escapeHTML, escapeAttr, showNotification } from './utils.js';
+import { saveImportedData } from './data.js';
+import { toggleCtxTag } from './context-card-editor-ui.js';
+import { loadEMFCatalog, renderEMFMeterRecs, isProductRecsEnabled } from './recommendations.js';
+import { openModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
+import {
+  MEASUREMENT_TYPES,
+  SLEEPING_ROOMS,
+  ensureEMFAssessments,
+  safeEMFMediaType,
+} from './emf-model.js';
+
+/** @type {Record<string, any>} */
+const emfEditorDeps = {
+  addEMFAssessment: null,
+  addEMFPhotos: null,
+  addEMFRoom: null,
+  closeModal: null,
+  collectActiveAssessmentState: null,
+  deleteEMFAssessment: null,
+  handleEMFPDF: null,
+  handleEMFRoomDropdown: null,
+  hasAIProvider: () => false,
+  interpretEMFAssessment: null,
+  interpretEMFComparison: null,
+  removeEMFPhoto: null,
+  removeEMFRoom: null,
+  saveEMFExplicit: null,
+  selectEMFRoom: null,
+  toggleEMFAssessment: null,
+  toggleEMFCompare: null,
+  updateEMFField: null,
+  updateEMFMeasurement: null,
+  updateEMFMeter: null,
+  updateEMFRoom: null,
+  viewEMFPhoto: null,
+};
+
+export function configureEMFEditor(deps = {}) {
+  const previous = { ...emfEditorDeps };
+  for (const [key, value] of Object.entries(deps || {})) {
+    if (Object.hasOwn(emfEditorDeps, key) && (typeof value === 'function' || value === null)) {
+      emfEditorDeps[key] = value;
+    }
+  }
+  return previous;
+}
+
+export const emfEditorState = {
+  editingAssessmentId: /** @type {string | null} */ (null),
+  activeRoomIdx: 0,
+  compareMode: false,
+};
+
+let emfEditorDelegatesInstalled = false;
+
+function emfAttrString(attrs) {
+  return Object.entries(attrs)
+    .filter(([, value]) => value !== undefined && value !== null)
+    .map(([name, value]) => `${name}="${escapeAttr(String(value))}"`)
+    .join(' ');
+}
+
+function emfActionAttrs(action, attrs = {}) {
+  return emfAttrString({ 'data-emf-action': action, ...attrs });
+}
+
+function emfChangeAttrs(action, attrs = {}) {
+  return emfAttrString({ 'data-emf-change-action': action, ...attrs });
+}
+
+function isEMFEditorTarget(element) {
+  return !!element.closest('#detail-modal');
+}
+
+function removeEMFEditorDelegates() {
+  if (!emfEditorDelegatesInstalled) return;
+  emfEditorDelegatesInstalled = false;
+  document.removeEventListener('click', handleEMFEditorClick);
+  document.removeEventListener('change', handleEMFEditorChange);
+  document.removeEventListener('keydown', handleEMFEditorKeydown);
+}
+
+function closeEMFPreviewModal() {
+  removeEMFEditorDelegates();
+  emfEditorDeps.closeModal?.();
+}
+
+function closeEMFEditorModal() {
+  emfEditorDeps.collectActiveAssessmentState?.();
+  saveImportedData();
+  document.querySelectorAll('.emf-lightbox').forEach(element => removeModalOverlay(element));
+  removeEMFEditorDelegates();
+  emfEditorDeps.closeModal?.();
+}
+
+function emfNumberAttr(element, name, fallback = 0) {
+  const raw = element.dataset[name];
+  const value = Number(raw);
+  return Number.isFinite(value) ? value : fallback;
+}
+
+function handleEMFEditorClick(event) {
+  const target = event.target;
+  if (!(target instanceof Element)) return;
+  const actionElement = target.closest('[data-emf-action]');
+  if (!(actionElement instanceof HTMLElement) || !isEMFEditorTarget(actionElement)) return;
+
+  const action = actionElement.dataset.emfAction || '';
+  const assessmentId = actionElement.dataset.emfAssessmentId || '';
+  const roomIdx = emfNumberAttr(actionElement, 'emfRoomIdx');
+  const photoIdx = emfNumberAttr(actionElement, 'emfPhotoIdx');
+
+  if (actionElement.matches('button, a')) event.preventDefault();
+
+  if (action === 'close-editor') { closeEMFEditorModal(); return; }
+  if (action === 'close-preview') { closeEMFPreviewModal(); return; }
+  if (action === 'add-assessment') { emfEditorDeps.addEMFAssessment?.(); return; }
+  if (action === 'trigger-pdf-import') {
+    document.getElementById('emf-pdf-input')?.click();
+    return;
+  }
+  if (action === 'toggle-compare') { emfEditorDeps.toggleEMFCompare?.(); return; }
+  if (action === 'toggle-assessment') {
+    if (assessmentId) emfEditorDeps.toggleEMFAssessment?.(assessmentId);
+    return;
+  }
+  if (action === 'select-room') {
+    if (assessmentId) emfEditorDeps.selectEMFRoom?.(assessmentId, roomIdx);
+    return;
+  }
+  if (action === 'add-room') {
+    if (assessmentId) emfEditorDeps.addEMFRoom?.(assessmentId);
+    return;
+  }
+  if (action === 'remove-room') {
+    if (assessmentId) emfEditorDeps.removeEMFRoom?.(assessmentId, roomIdx);
+    return;
+  }
+  if (action === 'save') { emfEditorDeps.saveEMFExplicit?.(); return; }
+  if (action === 'interpret-assessment') {
+    if (assessmentId) emfEditorDeps.interpretEMFAssessment?.(assessmentId);
+    return;
+  }
+  if (action === 'delete-assessment') {
+    if (assessmentId) void emfEditorDeps.deleteEMFAssessment?.(assessmentId);
+    return;
+  }
+  if (action === 'toggle-tag') { toggleCtxTag(actionElement); return; }
+  if (action === 'view-photo') {
+    if (assessmentId) emfEditorDeps.viewEMFPhoto?.(assessmentId, roomIdx, photoIdx);
+    return;
+  }
+  if (action === 'remove-photo') {
+    if (assessmentId) emfEditorDeps.removeEMFPhoto?.(assessmentId, roomIdx, photoIdx);
+    return;
+  }
+  if (action === 'interpret-comparison') { emfEditorDeps.interpretEMFComparison?.(); }
+}
+
+function handleEMFEditorChange(event) {
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) return;
+  const actionElement = target.closest('[data-emf-change-action]');
+  if (!(actionElement instanceof HTMLElement) || !isEMFEditorTarget(actionElement)) return;
+
+  const action = actionElement.dataset.emfChangeAction || '';
+  const assessmentId = actionElement.dataset.emfAssessmentId || '';
+  const roomIdx = emfNumberAttr(actionElement, 'emfRoomIdx');
+
+  if (action === 'pdf-input') {
+    const input = actionElement instanceof HTMLInputElement ? actionElement : null;
+    const file = input?.files?.[0];
+    if (file) void emfEditorDeps.handleEMFPDF?.(file);
+    return;
+  }
+
+  if (!assessmentId) return;
+
+  if (action === 'field') {
+    const input = actionElement instanceof HTMLInputElement || actionElement instanceof HTMLTextAreaElement
+      ? actionElement
+      : null;
+    const field = actionElement.dataset.emfField || '';
+    if (input && field) emfEditorDeps.updateEMFField?.(assessmentId, field, input.value);
+    return;
+  }
+
+  if (action === 'room-dropdown') {
+    const select = actionElement instanceof HTMLSelectElement ? actionElement : null;
+    if (select) void emfEditorDeps.handleEMFRoomDropdown?.(assessmentId, roomIdx, select.value, select);
+    return;
+  }
+
+  if (action === 'room-field') {
+    const field = actionElement.dataset.emfRoomField || '';
+    let value;
+    if (actionElement instanceof HTMLInputElement && actionElement.type === 'checkbox') {
+      value = actionElement.checked;
+    } else if (actionElement instanceof HTMLInputElement || actionElement instanceof HTMLTextAreaElement) {
+      value = actionElement.value;
+    }
+    if (field && value !== undefined) emfEditorDeps.updateEMFRoom?.(assessmentId, roomIdx, field, value);
+    return;
+  }
+
+  if (action === 'measurement') {
+    const input = actionElement instanceof HTMLInputElement ? actionElement : null;
+    const type = actionElement.dataset.emfMeasurementType || '';
+    if (input && type) emfEditorDeps.updateEMFMeasurement?.(assessmentId, roomIdx, type, input.value);
+    return;
+  }
+
+  if (action === 'meter') {
+    const input = actionElement instanceof HTMLInputElement ? actionElement : null;
+    const type = actionElement.dataset.emfMeterType || '';
+    if (input && type) emfEditorDeps.updateEMFMeter?.(assessmentId, roomIdx, type, input.value);
+    return;
+  }
+
+  if (action === 'photos') {
+    const input = actionElement instanceof HTMLInputElement ? actionElement : null;
+    if (input?.files?.length) void emfEditorDeps.addEMFPhotos?.(assessmentId, roomIdx, input.files);
+  }
+}
+
+function handleEMFEditorKeydown(event) {
+  if (event.key !== 'Enter' && event.key !== ' ') return;
+  const target = event.target;
+  if (!(target instanceof Element)) return;
+  const actionElement = target.closest('[data-emf-action]');
+  if (!(actionElement instanceof HTMLElement) || !isEMFEditorTarget(actionElement)) return;
+  if (target.closest('input, textarea, select')) return;
+  if (actionElement.matches('button, a')) return;
+  event.preventDefault();
+  actionElement.click();
+}
+
+function installEMFEditorDelegates() {
+  if (emfEditorDelegatesInstalled) return;
+  emfEditorDelegatesInstalled = true;
+  document.addEventListener('click', handleEMFEditorClick);
+  document.addEventListener('change', handleEMFEditorChange);
+  document.addEventListener('keydown', handleEMFEditorKeydown);
+}
+
+export function openEMFAssessmentEditor() {
+  installEMFEditorDelegates();
+  const modal = document.getElementById('detail-modal');
+  const overlay = document.getElementById('modal-overlay');
+  emfEditorState.editingAssessmentId = null;
+  renderEMFEditor(modal);
+  openModalOverlay(overlay);
+}
+
+function getRoomWorstSeverity(room) {
+  let worst = null;
+  let worstIdx = -1;
+  const sleeping = room.sleeping !== false;
+  const tierOrder = ['green', 'yellow', 'orange', 'red'];
+  for (const [type, measurement] of Object.entries(room.measurements || {})) {
+    if (measurement && measurement.value != null) {
+      const severity = getEMFSeverity(type, measurement.value, sleeping);
+      if (severity) {
+        const index = tierOrder.indexOf(severity.color);
+        if (index > worstIdx) {
+          worst = severity;
+          worstIdx = index;
+        }
+      }
+    }
+  }
+  return worst;
+}
+
+function getWorstSeverity(assessment) {
+  let worst = null;
+  let worstIdx = -1;
+  const tierOrder = ['green', 'yellow', 'orange', 'red'];
+  for (const room of assessment.rooms) {
+    const severity = getRoomWorstSeverity(room);
+    if (severity) {
+      const index = tierOrder.indexOf(severity.color);
+      if (index > worstIdx) {
+        worst = severity;
+        worstIdx = index;
+      }
+    }
+  }
+  return worst;
+}
+
+function severityDot(type, value, sleeping = true) {
+  const severity = getEMFSeverity(type, value, sleeping);
+  if (!severity) return '';
+  return `<span class="emf-severity-dot" style="background:var(--${severity.color})" title="${severity.label}"></span>`;
+}
+
+function severityBadge(assessment) {
+  const worst = getWorstSeverity(assessment);
+  if (!worst) return '<span class="emf-badge emf-badge-none">No data</span>';
+  return `<span class="emf-badge emf-badge-${worst.color}">${worst.label}</span>`;
+}
+
+export function renderEMFEditor(modal) {
+  const assessments = ensureEMFAssessments();
+  const sorted = [...assessments].sort((a, b) => b.date.localeCompare(a.date));
+
+  let html = `<button type="button" class="modal-close" aria-label="Close" ${emfActionAttrs('close-editor')}>&times;</button>
+    <h3>Baubiologie EMF Assessment</h3>
+    <div class="modal-unit">Room-by-room electromagnetic field measurements rated against SBM-2015 sleeping area standards.</div>
+    <div class="emf-editor-actions">
+      <button type="button" class="import-btn import-btn-primary" ${emfActionAttrs('add-assessment')}>+ New Assessment</button>
+      ${emfEditorDeps.hasAIProvider() ? `<button type="button" class="import-btn import-btn-secondary" ${emfActionAttrs('trigger-pdf-import')}>Import PDF</button>
+      <input type="file" id="emf-pdf-input" accept=".pdf" style="display:none" ${emfChangeAttrs('pdf-input')}>` : ''}
+      <a href="data/emf-assessment-template.html" target="_blank" class="import-btn import-btn-secondary">Printable Template</a>
+      ${sorted.length >= 2 ? `<button type="button" class="import-btn import-btn-secondary" ${emfActionAttrs('toggle-compare')}>${emfEditorState.compareMode ? 'Exit Compare' : 'Compare'}</button>` : ''}
+    </div>`;
+
+  if (sorted.length === 0) {
+    emfEditorState.compareMode = false;
+    html += `<div class="emf-empty">No assessments yet. Add one manually or import a consultant's PDF report.</div>`;
+  } else if (emfEditorState.compareMode && sorted.length >= 2) {
+    html += renderComparisonView(sorted);
+  } else {
+    for (const assessment of sorted) {
+      const isExpanded = emfEditorState.editingAssessmentId === assessment.id;
+      const formattedDate = new Date(assessment.date + 'T00:00:00')
+        .toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+      html += `<div class="emf-assessment-card${isExpanded ? ' expanded' : ''}">
+        <div class="emf-assessment-header" role="button" tabindex="0" ${emfActionAttrs('toggle-assessment', { 'data-emf-assessment-id': assessment.id })}>
+          <div class="emf-assessment-info">
+            <span class="emf-assessment-date">${formattedDate}</span>
+            ${assessment.label ? `<span class="emf-assessment-label">${escapeHTML(assessment.label)}</span>` : ''}
+            ${assessment.consultant ? `<span class="emf-assessment-consultant">by ${escapeHTML(assessment.consultant)}</span>` : ''}
+          </div>
+          ${severityBadge(assessment)}
+        </div>`;
+
+      if (isExpanded) html += renderAssessmentDetail(assessment);
+      html += `</div>`;
+    }
+  }
+
+  html += `<div id="emf-meter-recs-slot"></div>`;
+  modal.innerHTML = html;
+
+  const meterSlot = document.getElementById('emf-meter-recs-slot');
+  if (meterSlot && isProductRecsEnabled()) {
+    loadEMFCatalog().then(catalog => {
+      if (catalog && document.getElementById('emf-meter-recs-slot') === meterSlot) {
+        meterSlot.innerHTML = renderEMFMeterRecs(catalog);
+      }
+    });
+  }
+}
+
+function renderAssessmentDetail(assessment) {
+  if (emfEditorState.activeRoomIdx >= assessment.rooms.length) emfEditorState.activeRoomIdx = 0;
+  const roomIdx = emfEditorState.activeRoomIdx;
+
+  let html = `<div class="emf-assessment-detail">
+    <div class="emf-meta-row">
+      <label>Date <input type="date" class="emf-input" data-emf-field="date" value="${escapeAttr(assessment.date)}" ${emfChangeAttrs('field', { 'data-emf-assessment-id': assessment.id })}></label>
+      <label>Label <input type="text" class="emf-input" data-emf-field="label" value="${escapeAttr(assessment.label)}" placeholder="e.g. Pre-mitigation" ${emfChangeAttrs('field', { 'data-emf-assessment-id': assessment.id })}></label>
+      <label>Consultant <input type="text" class="emf-input" data-emf-field="consultant" value="${escapeAttr(assessment.consultant)}" placeholder="Optional" ${emfChangeAttrs('field', { 'data-emf-assessment-id': assessment.id })}></label>
+    </div>`;
+
+  html += `<div class="emf-room-tabs">`;
+  for (let index = 0; index < assessment.rooms.length; index++) {
+    const room = assessment.rooms[index];
+    const worst = getRoomWorstSeverity(room);
+    const dot = worst ? `<span class="emf-severity-dot" style="background:var(--${worst.color})"></span>` : '';
+    html += `<button type="button" class="emf-room-tab${index === roomIdx ? ' active' : ''}" ${emfActionAttrs('select-room', { 'data-emf-assessment-id': assessment.id, 'data-emf-room-idx': index })}>${escapeHTML(room.name || 'Room ' + (index + 1))} ${dot}</button>`;
+  }
+  html += `<button type="button" class="emf-room-tab emf-room-tab-add" ${emfActionAttrs('add-room', { 'data-emf-assessment-id': assessment.id })} title="Add room">+</button>`;
+  html += `</div>`;
+
+  html += renderRoomContent(assessment.id, roomIdx, assessment.rooms[roomIdx], assessment.rooms.length);
+
+  html += `<div class="emf-meta-row" style="margin-top:12px">
+      <label style="flex:1">Notes <input type="text" class="emf-input" data-emf-field="note" value="${escapeAttr(assessment.note)}" placeholder="General assessment notes" ${emfChangeAttrs('field', { 'data-emf-assessment-id': assessment.id })}></label>
+    </div>
+    <div class="emf-assessment-footer">
+      <button type="button" class="import-btn import-btn-primary" ${emfActionAttrs('save')}>Save</button>
+      ${emfEditorDeps.hasAIProvider() ? `<button type="button" class="import-btn import-btn-secondary" ${emfActionAttrs('interpret-assessment', { 'data-emf-assessment-id': assessment.id })}>Interpret</button>` : ''}
+      <span style="flex:1"></span>
+      <button type="button" class="import-btn import-btn-secondary" style="color:var(--red);border-color:var(--red)" ${emfActionAttrs('delete-assessment', { 'data-emf-assessment-id': assessment.id })}>Delete Assessment</button>
+    </div>
+  </div>`;
+  return html;
+}
+
+function renderRoomContent(assessmentId, roomIdx, room, roomCount) {
+  const assessment = ensureEMFAssessments().find(candidate => candidate.id === assessmentId);
+  const existingNames = new Set(assessment ? assessment.rooms.map(candidate => candidate.name) : []);
+  const availablePresets = EMF_ROOM_PRESETS.filter(name => !existingNames.has(name));
+
+  let options = '';
+  if (!EMF_ROOM_PRESETS.includes(room.name) && room.name) {
+    options += `<option value="_current" selected>${escapeHTML(room.name)}</option>`;
+  }
+  for (let index = 0; index < (assessment ? assessment.rooms.length : 0); index++) {
+    const candidate = assessment.rooms[index];
+    const isCurrent = index === roomIdx;
+    options += `<option value="_room_${index}"${isCurrent ? ' selected' : ''}>${escapeHTML(candidate.name || 'Room ' + (index + 1))}${isCurrent ? '' : ' ↩'}</option>`;
+  }
+  if (availablePresets.length) {
+    options += `<option disabled>──────────</option>`;
+    for (const name of availablePresets) {
+      options += `<option value="_new_${escapeAttr(name)}">+ ${escapeHTML(name)}</option>`;
+    }
+  }
+  options += `<option value="_custom">+ Custom...</option>`;
+
+  let html = `<div class="emf-room-content">
+    <div class="emf-room-header">
+      <select class="emf-input emf-room-select" ${emfChangeAttrs('room-dropdown', { 'data-emf-assessment-id': assessmentId, 'data-emf-room-idx': roomIdx })}>
+        ${options}
+      </select>
+      <input type="text" class="emf-input emf-location" data-emf-room-field="location" value="${escapeAttr(room.location)}" placeholder="Location (e.g. bed pillow area)" ${emfChangeAttrs('room-field', { 'data-emf-assessment-id': assessmentId, 'data-emf-room-idx': roomIdx })}>
+      <label class="emf-sleeping-toggle" title="Sleeping areas use stricter SBM-2015 thresholds">
+        <input type="checkbox" data-emf-room-field="sleeping" ${room.sleeping !== false ? 'checked' : ''} ${emfChangeAttrs('room-field', { 'data-emf-assessment-id': assessmentId, 'data-emf-room-idx': roomIdx })}>
+        Sleeping area
+      </label>
+      ${roomCount > 1 ? `<button type="button" class="emf-remove-room" ${emfActionAttrs('remove-room', { 'data-emf-assessment-id': assessmentId, 'data-emf-room-idx': roomIdx })} title="Remove room">&times;</button>` : ''}
+    </div>
+    <div class="emf-measurements">`;
+
+  const sleeping = room.sleeping !== false;
+  for (const measurementType of MEASUREMENT_TYPES) {
+    const definition = SBM_2015_THRESHOLDS[measurementType.key];
+    const measurement = (room.measurements && room.measurements[measurementType.key]) || {};
+    const value = measurement.value != null ? measurement.value : '';
+    html += `<div class="emf-measurement-row">
+      <span class="emf-measurement-label">${measurementType.short}</span>
+      <input type="number" class="emf-input emf-value-input" value="${escapeAttr(String(value))}" step="any" placeholder="—"
+        data-emf-measurement-type="${measurementType.key}"
+        ${emfChangeAttrs('measurement', { 'data-emf-assessment-id': assessmentId, 'data-emf-room-idx': roomIdx })}>
+      <span class="emf-measurement-unit">${definition.unit}</span>
+      ${value !== '' ? severityDot(measurementType.key, parseFloat(value), sleeping) : '<span class="emf-severity-dot-placeholder"></span>'}
+      <input type="text" class="emf-input emf-meter-input" value="${escapeAttr(measurement.meter || '')}" placeholder="Meter"
+        list="emf-meters-${measurementType.key}"
+        data-emf-meter-type="${measurementType.key}"
+        ${emfChangeAttrs('meter', { 'data-emf-assessment-id': assessmentId, 'data-emf-room-idx': roomIdx })}>
+    </div>`;
+  }
+
+  html += `</div>`;
+
+  for (const measurementType of MEASUREMENT_TYPES) {
+    const meters = EMF_METER_PRESETS.filter(preset => preset.types.includes(measurementType.key));
+    html += `<datalist id="emf-meters-${measurementType.key}">${meters.map(preset => `<option value="${escapeHTML(preset.name)}">`).join('')}</datalist>`;
+  }
+
+  html += `<div class="emf-tags-section">
+    <label class="emf-tags-label">Sources identified</label>
+    <div class="ctx-tags" id="emf-sources-${assessmentId}-${roomIdx}">
+      ${EMF_SOURCES.map(source => `<button type="button" class="ctx-tag${(room.sources || []).includes(source) ? ' active' : ''}" ${emfActionAttrs('toggle-tag')}>${escapeHTML(source)}</button>`).join('')}
+    </div></div>`;
+
+  html += `<div class="emf-tags-section">
+    <label class="emf-tags-label">Mitigations applied</label>
+    <div class="ctx-tags" id="emf-mits-${assessmentId}-${roomIdx}">
+      ${EMF_MITIGATIONS.map(mitigation => `<button type="button" class="ctx-tag${(room.mitigations || []).includes(mitigation) ? ' active' : ''}" ${emfActionAttrs('toggle-tag')}>${escapeHTML(mitigation)}</button>`).join('')}
+    </div></div>`;
+
+  html += `<input type="text" class="emf-input emf-room-note" data-emf-room-field="note" value="${escapeAttr(room.note)}" placeholder="Room notes" ${emfChangeAttrs('room-field', { 'data-emf-assessment-id': assessmentId, 'data-emf-room-idx': roomIdx })}>`;
+
+  const photos = room.photos || [];
+  html += `<div class="emf-photos-section">
+    <label class="emf-tags-label">Photos</label>
+    <div class="emf-photos-grid">
+      ${photos.map((photo, photoIdx) => `<div class="emf-photo-thumb">
+        <img src="data:${safeEMFMediaType(photo.mediaType)};base64,${photo.base64}" alt="${escapeAttr(photo.name || 'Photo')}" role="button" tabindex="0" ${emfActionAttrs('view-photo', { 'data-emf-assessment-id': assessmentId, 'data-emf-room-idx': roomIdx, 'data-emf-photo-idx': photoIdx })}>
+        <button type="button" class="emf-photo-remove" ${emfActionAttrs('remove-photo', { 'data-emf-assessment-id': assessmentId, 'data-emf-room-idx': roomIdx, 'data-emf-photo-idx': photoIdx })} title="Remove">&times;</button>
+      </div>`).join('')}
+      <label class="emf-photo-add" title="Add photo">
+        <input type="file" accept="image/*" multiple style="display:none" ${emfChangeAttrs('photos', { 'data-emf-assessment-id': assessmentId, 'data-emf-room-idx': roomIdx })}>
+        +
+      </label>
+    </div>
+  </div>`;
+
+  html += `</div>`;
+  return html;
+}
+
+export function showEMFImportPreview(parsed) {
+  installEMFEditorDelegates();
+  const modal = document.getElementById('detail-modal');
+  const overlay = document.getElementById('modal-overlay');
+  if (!modal || !overlay) return;
+  const formattedDate = parsed.date
+    ? new Date(parsed.date + 'T00:00:00').toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    })
+    : 'Unknown date';
+
+  let html = `<button type="button" class="modal-close" aria-label="Close" ${emfActionAttrs('close-preview')}>&times;</button>
+    <h3>EMF Report Preview</h3>
+    <div class="modal-unit">${formattedDate}${parsed.consultant ? ' — by ' + escapeHTML(parsed.consultant) : ''}</div>`;
+
+  for (const room of parsed.rooms) {
+    html += `<div class="emf-room-card">
+      <div class="emf-room-header"><strong>${escapeHTML(room.name)}</strong>
+        ${room.location ? `<span style="color:var(--text-muted);font-size:12px">${escapeHTML(room.location)}</span>` : ''}
+      </div>
+      <div class="emf-measurements">`;
+    for (const measurementType of MEASUREMENT_TYPES) {
+      const measurement = (room.measurements || {})[measurementType.key];
+      if (!measurement) continue;
+      const definition = SBM_2015_THRESHOLDS[measurementType.key];
+      const sleeping = SLEEPING_ROOMS.has(room.name);
+      const severity = getEMFSeverity(measurementType.key, measurement.value, sleeping);
+      html += `<div class="emf-measurement-row">
+        <span class="emf-measurement-label">${measurementType.short}</span>
+        <span style="font-weight:600">${measurement.value}</span>
+        <span class="emf-measurement-unit">${definition.unit}</span>
+        ${severity ? `<span class="emf-severity-dot" style="background:var(--${severity.color})" title="${severity.label}"></span>
+        <span style="font-size:11px;color:var(--${severity.color})">${severity.label}</span>` : ''}
+      </div>`;
+    }
+    html += `</div>`;
+    if (room.sources && room.sources.length) {
+      html += `<div style="font-size:12px;color:var(--text-muted);margin-top:4px">Sources: ${room.sources.map(source => escapeHTML(source)).join(', ')}</div>`;
+    }
+    if (room.mitigations && room.mitigations.length) {
+      html += `<div style="font-size:12px;color:var(--text-muted)">Mitigations: ${room.mitigations.map(mitigation => escapeHTML(mitigation)).join(', ')}</div>`;
+    }
+    html += `</div>`;
+  }
+
+  html += `<div class="ctx-editor-actions">
+    <button type="button" class="import-btn import-btn-primary" id="emf-confirm-btn">Confirm Import</button>
+    <button type="button" class="import-btn import-btn-secondary" ${emfActionAttrs('close-preview')}>Cancel</button>
+  </div>`;
+
+  modal.innerHTML = html;
+  const confirmButton = modal.querySelector('#emf-confirm-btn');
+  if (!confirmButton) return;
+  openModalOverlay(overlay);
+
+  confirmButton.addEventListener('click', () => {
+    const assessments = ensureEMFAssessments();
+    const assessment = {
+      id: 'emf_' + Date.now(),
+      date: parsed.date || new Date().toISOString().slice(0, 10),
+      label: '',
+      consultant: parsed.consultant || '',
+      rooms: parsed.rooms.map(room => ({
+        name: room.name || 'Unknown',
+        location: room.location || '',
+        sleeping: SLEEPING_ROOMS.has(room.name || 'Unknown'),
+        measurements: room.measurements || {},
+        sources: room.sources || [],
+        mitigations: room.mitigations || [],
+        note: '',
+      })),
+      note: parsed.note || '',
+    };
+    for (const room of assessment.rooms) {
+      for (const [type, measurement] of Object.entries(room.measurements || {})) {
+        const definition = SBM_2015_THRESHOLDS[type];
+        if (definition && measurement) measurement.unit = definition.unit;
+      }
+    }
+    assessments.push(assessment);
+    saveImportedData();
+    showNotification('EMF assessment imported', 'success');
+    emfEditorState.editingAssessmentId = assessment.id;
+    renderEMFEditor(modal);
+  });
+}
+
+function renderComparisonView(sorted) {
+  const before = sorted[sorted.length > 1 ? 1 : 0];
+  const after = sorted[0];
+  const formatDate = date => new Date(date + 'T00:00:00')
+    .toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+  const roomNames = [...new Set([
+    ...before.rooms.map(room => room.name),
+    ...after.rooms.map(room => room.name),
+  ])];
+
+  let html = `<div class="emf-compare-header">
+    <span class="emf-compare-label">Before: ${formatDate(before.date)}${before.label ? ' — ' + escapeHTML(before.label) : ''}</span>
+    <span class="emf-compare-arrow">→</span>
+    <span class="emf-compare-label">After: ${formatDate(after.date)}${after.label ? ' — ' + escapeHTML(after.label) : ''}</span>
+  </div>`;
+
+  if (sorted.length > 2) {
+    html += `<div class="emf-compare-note">Comparing the two most recent assessments. ${sorted.length - 2} earlier assessment${sorted.length > 3 ? 's' : ''} not shown.</div>`;
+  }
+
+  html += `<div class="emf-compare-table"><table>
+    <thead><tr><th>Room</th>`;
+  for (const measurementType of MEASUREMENT_TYPES) {
+    html += `<th>${measurementType.short}</th>`;
+  }
+  html += `</tr></thead><tbody>`;
+
+  for (const name of roomNames) {
+    const beforeRoom = before.rooms.find(room => room.name === name);
+    const afterRoom = after.rooms.find(room => room.name === name);
+    const sleeping = (afterRoom || beforeRoom)?.sleeping !== false;
+
+    html += `<tr><td class="emf-compare-room">${escapeHTML(name)}</td>`;
+    for (const measurementType of MEASUREMENT_TYPES) {
+      const beforeValue = beforeRoom?.measurements?.[measurementType.key]?.value;
+      const afterValue = afterRoom?.measurements?.[measurementType.key]?.value;
+
+      if (beforeValue == null && afterValue == null) {
+        html += `<td class="emf-compare-cell">—</td>`;
+        continue;
+      }
+
+      const beforeSeverity = beforeValue != null
+        ? getEMFSeverity(measurementType.key, beforeValue, sleeping)
+        : null;
+      const afterSeverity = afterValue != null
+        ? getEMFSeverity(measurementType.key, afterValue, sleeping)
+        : null;
+
+      let cellHtml = '';
+      if (beforeValue != null && afterValue != null) {
+        const delta = afterValue - beforeValue;
+        const arrow = delta < 0 ? '↓' : delta > 0 ? '↑' : '=';
+        const arrowColor = delta < 0
+          ? 'var(--green)'
+          : delta > 0 ? 'var(--red)' : 'var(--text-muted)';
+        cellHtml = `<span style="color:var(--${beforeSeverity?.color || 'text-muted'})">${beforeValue}</span>
+          <span style="color:${arrowColor};font-weight:600">${arrow}</span>
+          <span style="color:var(--${afterSeverity?.color || 'text-muted'})">${afterValue}</span>`;
+      } else if (afterValue != null) {
+        cellHtml = `<span style="color:var(--text-muted)">—</span> → <span style="color:var(--${afterSeverity?.color || 'text-muted'})">${afterValue}</span>`;
+      } else {
+        cellHtml = `<span style="color:var(--${beforeSeverity?.color || 'text-muted'})">${beforeValue}</span> → <span style="color:var(--text-muted)">—</span>`;
+      }
+      html += `<td class="emf-compare-cell">${cellHtml}</td>`;
+    }
+    html += `</tr>`;
+  }
+
+  html += `</tbody></table></div>`;
+
+  if (emfEditorDeps.hasAIProvider()) {
+    html += `<div style="margin-top:12px">
+      <button type="button" class="import-btn import-btn-secondary" ${emfActionAttrs('interpret-comparison')}>Interpret Changes</button>
+    </div>`;
+  }
+  return html;
+}

--- a/js/emf-model.js
+++ b/js/emf-model.js
@@ -1,0 +1,27 @@
+// @ts-check
+// emf-model.js — Shared EMF assessment collection and display metadata.
+
+import { state } from './state.js';
+
+export const MEASUREMENT_TYPES = [
+  { key: 'acElectric',       short: 'AC Electric' },
+  { key: 'acMagnetic',       short: 'AC Magnetic' },
+  { key: 'rfMicrowave',      short: 'RF/Microwave' },
+  { key: 'dirtyElectricity', short: 'Dirty Elec.' },
+  { key: 'dcMagnetic',       short: 'DC Magnetic' },
+];
+
+export const SLEEPING_ROOMS = new Set(['Bedroom', 'Children\'s Room', 'Nursery']);
+
+export function ensureEMFAssessments() {
+  if (!state.importedData.emfAssessment) {
+    state.importedData.emfAssessment = { assessments: [] };
+  }
+  return state.importedData.emfAssessment.assessments;
+}
+
+const SAFE_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+
+export function safeEMFMediaType(type) {
+  return SAFE_IMAGE_TYPES.includes(type) ? type : 'image/png';
+}

--- a/js/emf.js
+++ b/js/emf.js
@@ -4,20 +4,33 @@
 
 import { getErrorMessage } from './caught-error.js';
 import { state } from './state.js';
-import { SBM_2015_THRESHOLDS, getEMFSeverity } from './schema.js';
-
-const SAFE_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
-function safeMediaType(t) { return SAFE_IMAGE_TYPES.includes(t) ? t : 'image/png'; }
-import { EMF_ROOM_PRESETS, EMF_SOURCES, EMF_MITIGATIONS, EMF_METER_PRESETS } from './constants.js';
-import { escapeHTML, escapeAttr, showNotification, showConfirmDialog, showPromptDialog, isPIIReviewEnabled } from './utils.js';
+import { SBM_2015_THRESHOLDS } from './schema.js';
+import {
+  escapeHTML,
+  showNotification,
+  showConfirmDialog,
+  showPromptDialog,
+  isPIIReviewEnabled,
+} from './utils.js';
 import { saveImportedData } from './data.js';
 import { resizeImage, isValidImageType } from './image-utils.js';
 import { callClaudeAPI, hasAIProvider } from './api.js';
-import { toggleCtxTag } from './context-card-editor-ui.js';
 import { extractPDFText } from './pdf-import.js';
 import { obfuscatePDFText, sanitizeWithOllama, sanitizeWithOllamaStreaming, checkOllamaPII, reviewPIIBeforeSend } from './pii.js';
-import { loadEMFCatalog, renderEMFMeterRecs, isProductRecsEnabled } from './recommendations.js';
 import { openModalOverlay, removeModalOverlay, trapModalFocus } from './modal-lifecycle.js';
+import {
+  configureEMFEditor,
+  emfEditorState,
+  openEMFAssessmentEditor,
+  renderEMFEditor,
+  showEMFImportPreview,
+} from './emf-editor.js';
+import {
+  MEASUREMENT_TYPES,
+  SLEEPING_ROOMS,
+  ensureEMFAssessments as ensureAssessments,
+  safeEMFMediaType as safeMediaType,
+} from './emf-model.js';
 import {
   closeEMFInterpretation,
   discussEMFInterpretation,
@@ -49,28 +62,7 @@ export function configureEMFRuntimeDeps(deps = {}) {
   return previous;
 }
 
-// ═══════════════════════════════════════════════
-// MEASUREMENT TYPES (display order)
-// ═══════════════════════════════════════════════
-const MEASUREMENT_TYPES = [
-  { key: 'acElectric',       short: 'AC Electric' },
-  { key: 'acMagnetic',       short: 'AC Magnetic' },
-  { key: 'rfMicrowave',      short: 'RF/Microwave' },
-  { key: 'dirtyElectricity', short: 'Dirty Elec.' },
-  { key: 'dcMagnetic',       short: 'DC Magnetic' },
-];
-
-// ═══════════════════════════════════════════════
-// DATA HELPERS
-// ═══════════════════════════════════════════════
-function ensureAssessments() {
-  if (!state.importedData.emfAssessment) {
-    state.importedData.emfAssessment = { assessments: [] };
-  }
-  return state.importedData.emfAssessment.assessments;
-}
-
-const SLEEPING_ROOMS = new Set(['Bedroom', 'Children\'s Room', 'Nursery']);
+export { openEMFAssessmentEditor };
 
 function newRoom(name) {
   return {
@@ -95,440 +87,6 @@ function newAssessment() {
   };
 }
 
-function getRoomWorstSeverity(room) {
-  let worst = null, worstIdx = -1;
-  const sleeping = room.sleeping !== false;
-  const tierOrder = ['green', 'yellow', 'orange', 'red'];
-  for (const [type, m] of Object.entries(room.measurements || {})) {
-    if (m && m.value != null) {
-      const sev = getEMFSeverity(type, m.value, sleeping);
-      if (sev) {
-        const idx = tierOrder.indexOf(sev.color);
-        if (idx > worstIdx) { worst = sev; worstIdx = idx; }
-      }
-    }
-  }
-  return worst;
-}
-
-/** Worst severity across all rooms in an assessment */
-function getWorstSeverity(assessment) {
-  let worst = null;
-  let worstIdx = -1;
-  const tierOrder = ['green', 'yellow', 'orange', 'red'];
-  for (const room of assessment.rooms) {
-    const sev = getRoomWorstSeverity(room);
-    if (sev) {
-      const idx = tierOrder.indexOf(sev.color);
-      if (idx > worstIdx) { worst = sev; worstIdx = idx; }
-    }
-  }
-  return worst;
-}
-
-// ═══════════════════════════════════════════════
-// SEVERITY DOT
-// ═══════════════════════════════════════════════
-function severityDot(type, value, sleeping = true) {
-  const sev = getEMFSeverity(type, value, sleeping);
-  if (!sev) return '';
-  return `<span class="emf-severity-dot" style="background:var(--${sev.color})" title="${sev.label}"></span>`;
-}
-
-function severityBadge(assessment) {
-  const worst = getWorstSeverity(assessment);
-  if (!worst) return '<span class="emf-badge emf-badge-none">No data</span>';
-  return `<span class="emf-badge emf-badge-${worst.color}">${worst.label}</span>`;
-}
-
-// ═══════════════════════════════════════════════
-// EDITOR UI
-// ═══════════════════════════════════════════════
-let _editingAssessmentId = null;
-let _activeRoomIdx = 0;
-let emfEditorDelegatesInstalled = false;
-
-function closeEMFModalRuntime() {
-  emfRuntimeDeps.closeModal?.();
-}
-
-/**
- * @param {string} message
- * @param {{ placeholder?: string, okLabel?: string }} [options]
- * @returns {Promise<string | null | undefined> | string | null | undefined}
- */
-function showEMFPromptRuntime(message, options) {
-  return showPromptDialog(message, options);
-}
-
-function emfAttrString(attrs) {
-  return Object.entries(attrs)
-    .filter(([, value]) => value !== undefined && value !== null)
-    .map(([name, value]) => `${name}="${escapeAttr(String(value))}"`)
-    .join(' ');
-}
-
-function emfActionAttrs(action, attrs = {}) {
-  return emfAttrString({ 'data-emf-action': action, ...attrs });
-}
-
-function emfChangeAttrs(action, attrs = {}) {
-  return emfAttrString({ 'data-emf-change-action': action, ...attrs });
-}
-
-function isEMFEditorTarget(el) {
-  return !!el.closest('#detail-modal');
-}
-
-function removeEMFEditorDelegates() {
-  if (!emfEditorDelegatesInstalled) return;
-  emfEditorDelegatesInstalled = false;
-  document.removeEventListener('click', _handleEMFEditorClick);
-  document.removeEventListener('change', _handleEMFEditorChange);
-  document.removeEventListener('keydown', _handleEMFEditorKeydown);
-}
-
-function closeEMFPreviewModal() {
-  removeEMFEditorDelegates();
-  closeEMFModalRuntime();
-}
-
-function closeEMFEditorModal() {
-  collectActiveAssessmentState();
-  saveImportedData();
-  document.querySelectorAll('.emf-lightbox').forEach(el => removeModalOverlay(el));
-  removeEMFEditorDelegates();
-  closeEMFModalRuntime();
-}
-
-function _emfNumberAttr(el, name, fallback = 0) {
-  const raw = el.dataset[name];
-  const value = Number(raw);
-  return Number.isFinite(value) ? value : fallback;
-}
-
-function _handleEMFEditorClick(event) {
-  const target = event.target;
-  if (!(target instanceof Element)) return;
-  const actionEl = target.closest('[data-emf-action]');
-  if (!(actionEl instanceof HTMLElement) || !isEMFEditorTarget(actionEl)) return;
-
-  const action = actionEl.dataset.emfAction || '';
-  const assessmentId = actionEl.dataset.emfAssessmentId || '';
-  const roomIdx = _emfNumberAttr(actionEl, 'emfRoomIdx');
-  const photoIdx = _emfNumberAttr(actionEl, 'emfPhotoIdx');
-
-  if (actionEl.matches('button, a')) event.preventDefault();
-
-  if (action === 'close-editor') { closeEMFEditorModal(); return; }
-  if (action === 'close-preview') { closeEMFPreviewModal(); return; }
-  if (action === 'add-assessment') { addEMFAssessment(); return; }
-  if (action === 'trigger-pdf-import') {
-    document.getElementById('emf-pdf-input')?.click();
-    return;
-  }
-  if (action === 'toggle-compare') { toggleEMFCompare(); return; }
-  if (action === 'toggle-assessment') { if (assessmentId) toggleEMFAssessment(assessmentId); return; }
-  if (action === 'select-room') { if (assessmentId) selectEMFRoom(assessmentId, roomIdx); return; }
-  if (action === 'add-room') { if (assessmentId) addEMFRoom(assessmentId); return; }
-  if (action === 'remove-room') { if (assessmentId) removeEMFRoom(assessmentId, roomIdx); return; }
-  if (action === 'save') { saveEMFExplicit(); return; }
-  if (action === 'interpret-assessment') { if (assessmentId) interpretEMFAssessment(assessmentId); return; }
-  if (action === 'delete-assessment') { if (assessmentId) void deleteEMFAssessment(assessmentId); return; }
-  if (action === 'toggle-tag') { toggleCtxTag(actionEl); return; }
-  if (action === 'view-photo') { if (assessmentId) viewEMFPhoto(assessmentId, roomIdx, photoIdx); return; }
-  if (action === 'remove-photo') { if (assessmentId) removeEMFPhoto(assessmentId, roomIdx, photoIdx); return; }
-  if (action === 'interpret-comparison') { interpretEMFComparison(); return; }
-}
-
-function _handleEMFEditorChange(event) {
-  const target = event.target;
-  if (!(target instanceof HTMLElement)) return;
-  const actionEl = target.closest('[data-emf-change-action]');
-  if (!(actionEl instanceof HTMLElement) || !isEMFEditorTarget(actionEl)) return;
-
-  const action = actionEl.dataset.emfChangeAction || '';
-  const assessmentId = actionEl.dataset.emfAssessmentId || '';
-  const roomIdx = _emfNumberAttr(actionEl, 'emfRoomIdx');
-
-  if (action === 'pdf-input') {
-    const input = actionEl instanceof HTMLInputElement ? actionEl : null;
-    const file = input?.files?.[0];
-    if (file) void handleEMFPDF(file);
-    return;
-  }
-
-  if (!assessmentId) return;
-
-  if (action === 'field') {
-    const input = actionEl instanceof HTMLInputElement || actionEl instanceof HTMLTextAreaElement ? actionEl : null;
-    const field = actionEl.dataset.emfField || '';
-    if (input && field) updateEMFField(assessmentId, field, input.value);
-    return;
-  }
-
-  if (action === 'room-dropdown') {
-    const select = actionEl instanceof HTMLSelectElement ? actionEl : null;
-    if (select) void handleEMFRoomDropdown(assessmentId, roomIdx, select.value, select);
-    return;
-  }
-
-  if (action === 'room-field') {
-    const field = actionEl.dataset.emfRoomField || '';
-    let value;
-    if (actionEl instanceof HTMLInputElement && actionEl.type === 'checkbox') value = actionEl.checked;
-    else if (actionEl instanceof HTMLInputElement || actionEl instanceof HTMLTextAreaElement) value = actionEl.value;
-    if (field && value !== undefined) updateEMFRoom(assessmentId, roomIdx, field, value);
-    return;
-  }
-
-  if (action === 'measurement') {
-    const input = actionEl instanceof HTMLInputElement ? actionEl : null;
-    const type = actionEl.dataset.emfMeasurementType || '';
-    if (input && type) updateEMFMeasurement(assessmentId, roomIdx, type, input.value);
-    return;
-  }
-
-  if (action === 'meter') {
-    const input = actionEl instanceof HTMLInputElement ? actionEl : null;
-    const type = actionEl.dataset.emfMeterType || '';
-    if (input && type) updateEMFMeter(assessmentId, roomIdx, type, input.value);
-    return;
-  }
-
-  if (action === 'photos') {
-    const input = actionEl instanceof HTMLInputElement ? actionEl : null;
-    if (input?.files?.length) void addEMFPhotos(assessmentId, roomIdx, input.files);
-  }
-}
-
-function _handleEMFEditorKeydown(event) {
-  if (event.key !== 'Enter' && event.key !== ' ') return;
-  const target = event.target;
-  if (!(target instanceof Element)) return;
-  const actionEl = target.closest('[data-emf-action]');
-  if (!(actionEl instanceof HTMLElement) || !isEMFEditorTarget(actionEl)) return;
-  if (target.closest('input, textarea, select')) return;
-  if (actionEl.matches('button, a')) return;
-  event.preventDefault();
-  actionEl.click();
-}
-
-function installEMFEditorDelegates() {
-  if (emfEditorDelegatesInstalled) return;
-  emfEditorDelegatesInstalled = true;
-  document.addEventListener('click', _handleEMFEditorClick);
-  document.addEventListener('change', _handleEMFEditorChange);
-  document.addEventListener('keydown', _handleEMFEditorKeydown);
-}
-
-export function openEMFAssessmentEditor() {
-  installEMFEditorDelegates();
-  const modal = document.getElementById('detail-modal');
-  const overlay = document.getElementById('modal-overlay');
-  _editingAssessmentId = null;
-  renderEMFEditor(modal);
-  openModalOverlay(overlay);
-}
-
-function renderEMFEditor(modal) {
-  const assessments = ensureAssessments();
-  const sorted = [...assessments].sort((a, b) => b.date.localeCompare(a.date));
-
-  let html = `<button type="button" class="modal-close" aria-label="Close" ${emfActionAttrs('close-editor')}>&times;</button>
-    <h3>Baubiologie EMF Assessment</h3>
-    <div class="modal-unit">Room-by-room electromagnetic field measurements rated against SBM-2015 sleeping area standards.</div>
-    <div class="emf-editor-actions">
-      <button type="button" class="import-btn import-btn-primary" ${emfActionAttrs('add-assessment')}>+ New Assessment</button>
-      ${emfAIDeps.hasAIProvider() ? `<button type="button" class="import-btn import-btn-secondary" ${emfActionAttrs('trigger-pdf-import')}>Import PDF</button>
-      <input type="file" id="emf-pdf-input" accept=".pdf" style="display:none" ${emfChangeAttrs('pdf-input')}>` : ''}
-      <a href="data/emf-assessment-template.html" target="_blank" class="import-btn import-btn-secondary">Printable Template</a>
-      ${sorted.length >= 2 ? `<button type="button" class="import-btn import-btn-secondary" ${emfActionAttrs('toggle-compare')}>${_compareMode ? 'Exit Compare' : 'Compare'}</button>` : ''}
-    </div>`;
-
-  if (sorted.length === 0) {
-    _compareMode = false;
-    html += `<div class="emf-empty">No assessments yet. Add one manually or import a consultant's PDF report.</div>`;
-  } else if (_compareMode && sorted.length >= 2) {
-    html += renderComparisonView(sorted);
-  } else {
-    for (const a of sorted) {
-      const isExpanded = _editingAssessmentId === a.id;
-      const fmtDate = new Date(a.date + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
-      html += `<div class="emf-assessment-card${isExpanded ? ' expanded' : ''}">
-        <div class="emf-assessment-header" role="button" tabindex="0" ${emfActionAttrs('toggle-assessment', { 'data-emf-assessment-id': a.id })}>
-          <div class="emf-assessment-info">
-            <span class="emf-assessment-date">${fmtDate}</span>
-            ${a.label ? `<span class="emf-assessment-label">${escapeHTML(a.label)}</span>` : ''}
-            ${a.consultant ? `<span class="emf-assessment-consultant">by ${escapeHTML(a.consultant)}</span>` : ''}
-          </div>
-          ${severityBadge(a)}
-        </div>`;
-
-      if (isExpanded) {
-        html += renderAssessmentDetail(a);
-      }
-      html += `</div>`;
-    }
-  }
-
-  // Meter recommendations always visible — empty state, list view, and compare view alike
-  html += `<div id="emf-meter-recs-slot"></div>`;
-
-  modal.innerHTML = html;
-
-  // Populate meter recommendations on the empty state — async, never blocks render
-  const meterSlot = document.getElementById('emf-meter-recs-slot');
-  if (meterSlot && isProductRecsEnabled()) {
-    loadEMFCatalog().then(cat => {
-      if (cat && document.getElementById('emf-meter-recs-slot') === meterSlot) {
-        meterSlot.innerHTML = renderEMFMeterRecs(cat);
-      }
-    });
-  }
-}
-
-function renderAssessmentDetail(a) {
-  if (_activeRoomIdx >= a.rooms.length) _activeRoomIdx = 0;
-  const ri = _activeRoomIdx;
-
-  let html = `<div class="emf-assessment-detail">
-    <div class="emf-meta-row">
-      <label>Date <input type="date" class="emf-input" data-emf-field="date" value="${escapeAttr(a.date)}" ${emfChangeAttrs('field', { 'data-emf-assessment-id': a.id })}></label>
-      <label>Label <input type="text" class="emf-input" data-emf-field="label" value="${escapeAttr(a.label)}" placeholder="e.g. Pre-mitigation" ${emfChangeAttrs('field', { 'data-emf-assessment-id': a.id })}></label>
-      <label>Consultant <input type="text" class="emf-input" data-emf-field="consultant" value="${escapeAttr(a.consultant)}" placeholder="Optional" ${emfChangeAttrs('field', { 'data-emf-assessment-id': a.id })}></label>
-    </div>`;
-
-  // Room tabs
-  html += `<div class="emf-room-tabs">`;
-  for (let i = 0; i < a.rooms.length; i++) {
-    const room = a.rooms[i];
-    const worst = getRoomWorstSeverity(room);
-    const dot = worst ? `<span class="emf-severity-dot" style="background:var(--${worst.color})"></span>` : '';
-    html += `<button type="button" class="emf-room-tab${i === ri ? ' active' : ''}" ${emfActionAttrs('select-room', { 'data-emf-assessment-id': a.id, 'data-emf-room-idx': i })}>${escapeHTML(room.name || 'Room ' + (i + 1))} ${dot}</button>`;
-  }
-  html += `<button type="button" class="emf-room-tab emf-room-tab-add" ${emfActionAttrs('add-room', { 'data-emf-assessment-id': a.id })} title="Add room">+</button>`;
-  html += `</div>`;
-
-  // Active room content
-  html += renderRoomContent(a.id, ri, a.rooms[ri], a.rooms.length);
-
-  html += `<div class="emf-meta-row" style="margin-top:12px">
-      <label style="flex:1">Notes <input type="text" class="emf-input" data-emf-field="note" value="${escapeAttr(a.note)}" placeholder="General assessment notes" ${emfChangeAttrs('field', { 'data-emf-assessment-id': a.id })}></label>
-    </div>
-    <div class="emf-assessment-footer">
-      <button type="button" class="import-btn import-btn-primary" ${emfActionAttrs('save')}>Save</button>
-      ${emfAIDeps.hasAIProvider() ? `<button type="button" class="import-btn import-btn-secondary" ${emfActionAttrs('interpret-assessment', { 'data-emf-assessment-id': a.id })}>Interpret</button>` : ''}
-      <span style="flex:1"></span>
-      <button type="button" class="import-btn import-btn-secondary" style="color:var(--red);border-color:var(--red)" ${emfActionAttrs('delete-assessment', { 'data-emf-assessment-id': a.id })}>Delete Assessment</button>
-    </div>
-  </div>`;
-  return html;
-}
-
-function renderRoomContent(assessmentId, roomIdx, room, roomCount) {
-  // Build dropdown: existing rooms as a group, then available presets
-  const a = ensureAssessments().find(x => x.id === assessmentId);
-  const existingNames = new Set(a ? a.rooms.map(r => r.name) : []);
-  const availablePresets = EMF_ROOM_PRESETS.filter(r => !existingNames.has(r));
-
-  let options = '';
-  // Current room's name is always selected
-  if (!EMF_ROOM_PRESETS.includes(room.name) && room.name) {
-    options += `<option value="_current" selected>${escapeHTML(room.name)}</option>`;
-  }
-  // Existing rooms (for switching)
-  for (let i = 0; i < (a ? a.rooms.length : 0); i++) {
-    const r = a.rooms[i];
-    const isCurrent = i === roomIdx;
-    options += `<option value="_room_${i}"${isCurrent ? ' selected' : ''}>${escapeHTML(r.name || 'Room ' + (i + 1))}${isCurrent ? '' : ' ↩'}</option>`;
-  }
-  // Available presets (for creating new rooms)
-  if (availablePresets.length) {
-    options += `<option disabled>──────────</option>`;
-    for (const r of availablePresets) {
-      options += `<option value="_new_${escapeAttr(r)}">+ ${escapeHTML(r)}</option>`;
-    }
-  }
-  options += `<option value="_custom">+ Custom...</option>`;
-
-  let html = `<div class="emf-room-content">
-    <div class="emf-room-header">
-      <select class="emf-input emf-room-select" ${emfChangeAttrs('room-dropdown', { 'data-emf-assessment-id': assessmentId, 'data-emf-room-idx': roomIdx })}>
-        ${options}
-      </select>
-      <input type="text" class="emf-input emf-location" data-emf-room-field="location" value="${escapeAttr(room.location)}" placeholder="Location (e.g. bed pillow area)" ${emfChangeAttrs('room-field', { 'data-emf-assessment-id': assessmentId, 'data-emf-room-idx': roomIdx })}>
-      <label class="emf-sleeping-toggle" title="Sleeping areas use stricter SBM-2015 thresholds">
-        <input type="checkbox" data-emf-room-field="sleeping" ${room.sleeping !== false ? 'checked' : ''} ${emfChangeAttrs('room-field', { 'data-emf-assessment-id': assessmentId, 'data-emf-room-idx': roomIdx })}>
-        Sleeping area
-      </label>
-      ${roomCount > 1 ? `<button type="button" class="emf-remove-room" ${emfActionAttrs('remove-room', { 'data-emf-assessment-id': assessmentId, 'data-emf-room-idx': roomIdx })} title="Remove room">&times;</button>` : ''}
-    </div>
-    <div class="emf-measurements">`;
-
-  const sleeping = room.sleeping !== false;
-  for (const mt of MEASUREMENT_TYPES) {
-    const def = SBM_2015_THRESHOLDS[mt.key];
-    const m = (room.measurements && room.measurements[mt.key]) || {};
-    const val = m.value != null ? m.value : '';
-    html += `<div class="emf-measurement-row">
-      <span class="emf-measurement-label">${mt.short}</span>
-      <input type="number" class="emf-input emf-value-input" value="${escapeAttr(String(val))}" step="any" placeholder="—"
-        data-emf-measurement-type="${mt.key}"
-        ${emfChangeAttrs('measurement', { 'data-emf-assessment-id': assessmentId, 'data-emf-room-idx': roomIdx })}>
-      <span class="emf-measurement-unit">${def.unit}</span>
-      ${val !== '' ? severityDot(mt.key, parseFloat(val), sleeping) : '<span class="emf-severity-dot-placeholder"></span>'}
-      <input type="text" class="emf-input emf-meter-input" value="${escapeAttr(m.meter || '')}" placeholder="Meter"
-        list="emf-meters-${mt.key}"
-        data-emf-meter-type="${mt.key}"
-        ${emfChangeAttrs('meter', { 'data-emf-assessment-id': assessmentId, 'data-emf-room-idx': roomIdx })}>
-    </div>`;
-  }
-
-  html += `</div>`;
-
-  // Meter datalists (one per measurement type, filtered to matching meters)
-  for (const mt of MEASUREMENT_TYPES) {
-    const meters = EMF_METER_PRESETS.filter(p => p.types.includes(mt.key));
-    html += `<datalist id="emf-meters-${mt.key}">${meters.map(p => `<option value="${escapeHTML(p.name)}">`).join('')}</datalist>`;
-  }
-
-  // Sources
-  html += `<div class="emf-tags-section">
-    <label class="emf-tags-label">Sources identified</label>
-    <div class="ctx-tags" id="emf-sources-${assessmentId}-${roomIdx}">
-      ${EMF_SOURCES.map(s => `<button type="button" class="ctx-tag${(room.sources || []).includes(s) ? ' active' : ''}" ${emfActionAttrs('toggle-tag')}>${escapeHTML(s)}</button>`).join('')}
-    </div></div>`;
-
-  // Mitigations
-  html += `<div class="emf-tags-section">
-    <label class="emf-tags-label">Mitigations applied</label>
-    <div class="ctx-tags" id="emf-mits-${assessmentId}-${roomIdx}">
-      ${EMF_MITIGATIONS.map(s => `<button type="button" class="ctx-tag${(room.mitigations || []).includes(s) ? ' active' : ''}" ${emfActionAttrs('toggle-tag')}>${escapeHTML(s)}</button>`).join('')}
-    </div></div>`;
-
-  html += `<input type="text" class="emf-input emf-room-note" data-emf-room-field="note" value="${escapeAttr(room.note)}" placeholder="Room notes" ${emfChangeAttrs('room-field', { 'data-emf-assessment-id': assessmentId, 'data-emf-room-idx': roomIdx })}>`;
-
-  // Photos
-  const photos = room.photos || [];
-  html += `<div class="emf-photos-section">
-    <label class="emf-tags-label">Photos</label>
-    <div class="emf-photos-grid">
-      ${photos.map((p, pi) => `<div class="emf-photo-thumb">
-        <img src="data:${safeMediaType(p.mediaType)};base64,${p.base64}" alt="${escapeAttr(p.name || 'Photo')}" role="button" tabindex="0" ${emfActionAttrs('view-photo', { 'data-emf-assessment-id': assessmentId, 'data-emf-room-idx': roomIdx, 'data-emf-photo-idx': pi })}>
-        <button type="button" class="emf-photo-remove" ${emfActionAttrs('remove-photo', { 'data-emf-assessment-id': assessmentId, 'data-emf-room-idx': roomIdx, 'data-emf-photo-idx': pi })} title="Remove">&times;</button>
-      </div>`).join('')}
-      <label class="emf-photo-add" title="Add photo">
-        <input type="file" accept="image/*" multiple style="display:none" ${emfChangeAttrs('photos', { 'data-emf-assessment-id': assessmentId, 'data-emf-room-idx': roomIdx })}>
-        +
-      </label>
-    </div>
-  </div>`;
-
-  html += `</div>`;
-  return html;
-}
-
 // ═══════════════════════════════════════════════
 // CRUD OPERATIONS
 // ═══════════════════════════════════════════════
@@ -536,22 +94,22 @@ export function addEMFAssessment() {
   const assessments = ensureAssessments();
   const a = newAssessment();
   assessments.push(a);
-  _editingAssessmentId = a.id;
+  emfEditorState.editingAssessmentId = a.id;
   renderEMFEditor(document.getElementById('detail-modal'));
 }
 
 export function toggleEMFAssessment(id) {
   collectActiveAssessmentState();
-  _editingAssessmentId = _editingAssessmentId === id ? null : id;
-  _activeRoomIdx = 0;
+  emfEditorState.editingAssessmentId = emfEditorState.editingAssessmentId === id ? null : id;
+  emfEditorState.activeRoomIdx = 0;
   renderEMFEditor(document.getElementById('detail-modal'));
 }
 
 export function selectEMFRoom(assessmentId, roomIdx) {
   // Ignore a stale delegated click after another assessment has become active.
-  if (_editingAssessmentId !== assessmentId) return;
+  if (emfEditorState.editingAssessmentId !== assessmentId) return;
   collectActiveAssessmentState();
-  _activeRoomIdx = roomIdx;
+  emfEditorState.activeRoomIdx = roomIdx;
   renderEMFEditor(document.getElementById('detail-modal'));
 }
 
@@ -571,14 +129,14 @@ export async function handleEMFRoomDropdown(assessmentId, currentRoomIdx, value,
     const a = assessments.find(x => x.id === assessmentId);
     if (!a) return;
     a.rooms.push(newRoom(name));
-    _activeRoomIdx = a.rooms.length - 1;
+    emfEditorState.activeRoomIdx = a.rooms.length - 1;
     saveImportedData();
     renderEMFEditor(document.getElementById('detail-modal'));
     return;
   }
   // Custom room
   if (value === '_custom') {
-    const name = await showEMFPromptRuntime('Room name:', {
+    const name = await showPromptDialog('Room name:', {
       placeholder: 'e.g. Master Bedroom',
       okLabel: 'Create',
     });
@@ -588,7 +146,7 @@ export async function handleEMFRoomDropdown(assessmentId, currentRoomIdx, value,
       const a = assessments.find(x => x.id === assessmentId);
       if (!a) return;
       a.rooms.push(newRoom(name));
-      _activeRoomIdx = a.rooms.length - 1;
+      emfEditorState.activeRoomIdx = a.rooms.length - 1;
       saveImportedData();
       renderEMFEditor(document.getElementById('detail-modal'));
     } else {
@@ -606,7 +164,7 @@ export function addEMFRoom(assessmentId) {
   const a = assessments.find(x => x.id === assessmentId);
   if (!a) return;
   a.rooms.push(newRoom(''));
-  _activeRoomIdx = a.rooms.length - 1;
+  emfEditorState.activeRoomIdx = a.rooms.length - 1;
   saveImportedData();
   renderEMFEditor(document.getElementById('detail-modal'));
 }
@@ -617,7 +175,9 @@ export function removeEMFRoom(assessmentId, roomIdx) {
   const a = assessments.find(x => x.id === assessmentId);
   if (!a || a.rooms.length <= 1) return;
   a.rooms.splice(roomIdx, 1);
-  if (_activeRoomIdx >= a.rooms.length) _activeRoomIdx = a.rooms.length - 1;
+  if (emfEditorState.activeRoomIdx >= a.rooms.length) {
+    emfEditorState.activeRoomIdx = a.rooms.length - 1;
+  }
   saveImportedData();
   renderEMFEditor(document.getElementById('detail-modal'));
 }
@@ -628,7 +188,7 @@ export async function deleteEMFAssessment(id) {
     const idx = assessments.findIndex(x => x.id === id);
     if (idx === -1) return;
     assessments.splice(idx, 1);
-    _editingAssessmentId = null;
+    emfEditorState.editingAssessmentId = null;
     if (assessments.length === 0) state.importedData.emfAssessment = null;
     saveImportedData();
     renderEMFEditor(document.getElementById('detail-modal'));
@@ -702,9 +262,9 @@ function applyEMFMeasurementValue(room, type, value) {
 }
 
 function collectActiveAssessmentInputs() {
-  if (!_editingAssessmentId) return;
+  if (!emfEditorState.editingAssessmentId) return;
   const assessments = ensureAssessments();
-  const a = assessments.find(x => x.id === _editingAssessmentId);
+  const a = assessments.find(x => x.id === emfEditorState.editingAssessmentId);
   const modal = document.getElementById('detail-modal');
   if (!a || !modal) return;
 
@@ -713,7 +273,7 @@ function collectActiveAssessmentInputs() {
     if (input) applyEMFField(a, field, input.value || '');
   }
 
-  const room = a.rooms?.[_activeRoomIdx];
+  const room = a.rooms?.[emfEditorState.activeRoomIdx];
   if (!room) return;
   const locationInput = /** @type {HTMLInputElement | null} */ (modal.querySelector('[data-emf-room-field="location"]'));
   if (locationInput) room.location = locationInput.value || '';
@@ -738,11 +298,11 @@ function collectActiveAssessmentState() {
 
 /** Collect tags from DOM for the active room */
 function collectTags() {
-  if (!_editingAssessmentId) return;
+  if (!emfEditorState.editingAssessmentId) return;
   const assessments = ensureAssessments();
-  const a = assessments.find(x => x.id === _editingAssessmentId);
+  const a = assessments.find(x => x.id === emfEditorState.editingAssessmentId);
   if (!a) return;
-  const ri = _activeRoomIdx;
+  const ri = emfEditorState.activeRoomIdx;
   const srcEl = document.getElementById(`emf-sources-${a.id}-${ri}`);
   if (srcEl) a.rooms[ri].sources = Array.from(srcEl.querySelectorAll('.ctx-tag.active')).map(b => b.textContent);
   const mitEl = document.getElementById(`emf-mits-${a.id}-${ri}`);
@@ -859,174 +419,11 @@ export async function handleEMFPDF(file) {
   }
 }
 
-function showEMFImportPreview(parsed) {
-  installEMFEditorDelegates();
-  const modal = document.getElementById('detail-modal');
-  const overlay = document.getElementById('modal-overlay');
-  if (!modal || !overlay) return;
-  const fmtDate = parsed.date ? new Date(parsed.date + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }) : 'Unknown date';
-
-  let html = `<button type="button" class="modal-close" aria-label="Close" ${emfActionAttrs('close-preview')}>&times;</button>
-    <h3>EMF Report Preview</h3>
-    <div class="modal-unit">${fmtDate}${parsed.consultant ? ' — by ' + escapeHTML(parsed.consultant) : ''}</div>`;
-
-  for (const room of parsed.rooms) {
-    html += `<div class="emf-room-card">
-      <div class="emf-room-header"><strong>${escapeHTML(room.name)}</strong>
-        ${room.location ? `<span style="color:var(--text-muted);font-size:12px">${escapeHTML(room.location)}</span>` : ''}
-      </div>
-      <div class="emf-measurements">`;
-    for (const mt of MEASUREMENT_TYPES) {
-      const m = (room.measurements || {})[mt.key];
-      if (!m) continue;
-      const def = SBM_2015_THRESHOLDS[mt.key];
-      const sleeping = SLEEPING_ROOMS.has(room.name);
-      const sev = getEMFSeverity(mt.key, m.value, sleeping);
-      html += `<div class="emf-measurement-row">
-        <span class="emf-measurement-label">${mt.short}</span>
-        <span style="font-weight:600">${m.value}</span>
-        <span class="emf-measurement-unit">${def.unit}</span>
-        ${sev ? `<span class="emf-severity-dot" style="background:var(--${sev.color})" title="${sev.label}"></span>
-        <span style="font-size:11px;color:var(--${sev.color})">${sev.label}</span>` : ''}
-      </div>`;
-    }
-    html += `</div>`;
-    if (room.sources && room.sources.length) {
-      html += `<div style="font-size:12px;color:var(--text-muted);margin-top:4px">Sources: ${room.sources.map(s => escapeHTML(s)).join(', ')}</div>`;
-    }
-    if (room.mitigations && room.mitigations.length) {
-      html += `<div style="font-size:12px;color:var(--text-muted)">Mitigations: ${room.mitigations.map(s => escapeHTML(s)).join(', ')}</div>`;
-    }
-    html += `</div>`;
-  }
-
-  html += `<div class="ctx-editor-actions">
-    <button type="button" class="import-btn import-btn-primary" id="emf-confirm-btn">Confirm Import</button>
-    <button type="button" class="import-btn import-btn-secondary" ${emfActionAttrs('close-preview')}>Cancel</button>
-  </div>`;
-
-  modal.innerHTML = html;
-  const confirmButton = modal.querySelector('#emf-confirm-btn');
-  if (!confirmButton) return;
-  openModalOverlay(overlay);
-
-  confirmButton.addEventListener('click', () => {
-    const assessments = ensureAssessments();
-    const assessment = {
-      id: 'emf_' + Date.now(),
-      date: parsed.date || new Date().toISOString().slice(0, 10),
-      label: '',
-      consultant: parsed.consultant || '',
-      rooms: parsed.rooms.map(r => ({
-        name: r.name || 'Unknown',
-        location: r.location || '',
-        sleeping: SLEEPING_ROOMS.has(r.name || 'Unknown'),
-        measurements: r.measurements || {},
-        sources: r.sources || [],
-        mitigations: r.mitigations || [],
-        note: ''
-      })),
-      note: parsed.note || ''
-    };
-    // Ensure units are set on measurements
-    for (const room of assessment.rooms) {
-      for (const [type, m] of Object.entries(room.measurements || {})) {
-        const def = SBM_2015_THRESHOLDS[type];
-        if (def && m) m.unit = def.unit;
-      }
-    }
-    assessments.push(assessment);
-    saveImportedData();
-    showNotification('EMF assessment imported', 'success');
-    _editingAssessmentId = assessment.id;
-    renderEMFEditor(modal);
-  });
-}
-
-// ═══════════════════════════════════════════════
-// BEFORE / AFTER COMPARISON
-// ═══════════════════════════════════════════════
-let _compareMode = false;
-
 export function toggleEMFCompare() {
   collectActiveAssessmentState();
-  _compareMode = !_compareMode;
-  _editingAssessmentId = null;
+  emfEditorState.compareMode = !emfEditorState.compareMode;
+  emfEditorState.editingAssessmentId = null;
   renderEMFEditor(document.getElementById('detail-modal'));
-}
-
-function renderComparisonView(sorted) {
-  // Pick two most recent by default
-  const a1 = sorted[sorted.length > 1 ? 1 : 0]; // older (Before)
-  const a2 = sorted[0]; // newer (After)
-  const fmtDate = d => new Date(d + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
-
-  // Collect all unique room names across both assessments
-  const roomNames = [...new Set([...a1.rooms.map(r => r.name), ...a2.rooms.map(r => r.name)])];
-
-  let html = `<div class="emf-compare-header">
-    <span class="emf-compare-label">Before: ${fmtDate(a1.date)}${a1.label ? ' — ' + escapeHTML(a1.label) : ''}</span>
-    <span class="emf-compare-arrow">→</span>
-    <span class="emf-compare-label">After: ${fmtDate(a2.date)}${a2.label ? ' — ' + escapeHTML(a2.label) : ''}</span>
-  </div>`;
-
-  if (sorted.length > 2) {
-    html += `<div class="emf-compare-note">Comparing the two most recent assessments. ${sorted.length - 2} earlier assessment${sorted.length > 3 ? 's' : ''} not shown.</div>`;
-  }
-
-  html += `<div class="emf-compare-table"><table>
-    <thead><tr><th>Room</th>`;
-  for (const mt of MEASUREMENT_TYPES) {
-    html += `<th>${mt.short}</th>`;
-  }
-  html += `</tr></thead><tbody>`;
-
-  for (const name of roomNames) {
-    const r1 = a1.rooms.find(r => r.name === name);
-    const r2 = a2.rooms.find(r => r.name === name);
-    const sleeping = (r2 || r1)?.sleeping !== false;
-
-    html += `<tr><td class="emf-compare-room">${escapeHTML(name)}</td>`;
-    for (const mt of MEASUREMENT_TYPES) {
-      const m1 = r1?.measurements?.[mt.key];
-      const m2 = r2?.measurements?.[mt.key];
-      const v1 = m1?.value;
-      const v2 = m2?.value;
-
-      if (v1 == null && v2 == null) {
-        html += `<td class="emf-compare-cell">—</td>`;
-        continue;
-      }
-
-      const sev1 = v1 != null ? getEMFSeverity(mt.key, v1, sleeping) : null;
-      const sev2 = v2 != null ? getEMFSeverity(mt.key, v2, sleeping) : null;
-
-      let cellHtml = '';
-      if (v1 != null && v2 != null) {
-        const delta = v2 - v1;
-        const arrow = delta < 0 ? '↓' : delta > 0 ? '↑' : '=';
-        const arrowColor = delta < 0 ? 'var(--green)' : delta > 0 ? 'var(--red)' : 'var(--text-muted)';
-        cellHtml = `<span style="color:var(--${sev1?.color || 'text-muted'})">${v1}</span>
-          <span style="color:${arrowColor};font-weight:600">${arrow}</span>
-          <span style="color:var(--${sev2?.color || 'text-muted'})">${v2}</span>`;
-      } else if (v2 != null) {
-        cellHtml = `<span style="color:var(--text-muted)">—</span> → <span style="color:var(--${sev2?.color || 'text-muted'})">${v2}</span>`;
-      } else {
-        cellHtml = `<span style="color:var(--${sev1?.color || 'text-muted'})">${v1}</span> → <span style="color:var(--text-muted)">—</span>`;
-      }
-      html += `<td class="emf-compare-cell">${cellHtml}</td>`;
-    }
-    html += `</tr>`;
-  }
-
-  html += `</tbody></table></div>`;
-
-  if (emfAIDeps.hasAIProvider()) {
-    html += `<div style="margin-top:12px">
-      <button type="button" class="import-btn import-btn-secondary" ${emfActionAttrs('interpret-comparison')}>Interpret Changes</button>
-    </div>`;
-  }
-  return html;
 }
 
 // ═══════════════════════════════════════════════
@@ -1104,3 +501,28 @@ export function saveEMFExplicit() {
   saveImportedData();
   showNotification('EMF assessment saved', 'success');
 }
+
+configureEMFEditor({
+  addEMFAssessment,
+  addEMFPhotos,
+  addEMFRoom,
+  closeModal: () => emfRuntimeDeps.closeModal?.(),
+  collectActiveAssessmentState,
+  deleteEMFAssessment,
+  handleEMFPDF,
+  handleEMFRoomDropdown,
+  hasAIProvider: () => emfAIDeps.hasAIProvider(),
+  interpretEMFAssessment,
+  interpretEMFComparison,
+  removeEMFPhoto,
+  removeEMFRoom,
+  saveEMFExplicit,
+  selectEMFRoom,
+  toggleEMFAssessment,
+  toggleEMFCompare,
+  updateEMFField,
+  updateEMFMeasurement,
+  updateEMFMeter,
+  updateEMFRoom,
+  viewEMFPhoto,
+});

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -7,6 +7,6 @@
   "viewRuntimeBridgeLookups": 0,
   "labStateAppFiles": 0,
   "labStateTestFiles": 0,
-  "largeJsFilesOver800Lines": 15,
+  "largeJsFilesOver800Lines": 14,
   "maxJsFileLines": 1168
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -193,6 +193,8 @@ const APP_SHELL = [
   '/js/onboarding-view.js',
   '/js/emf-runtime.js',
   '/js/emf.js',
+  '/js/emf-editor.js',
+  '/js/emf-model.js',
   '/js/emf-interpretation.js',
   '/js/image-utils.js',
   '/js/pdf-import.js',

--- a/tests/test-a11y-phase3.js
+++ b/tests/test-a11y-phase3.js
@@ -77,7 +77,7 @@ console.log('=== Phase 3 A11y Tests ===\n');
     suppSrc.includes('class="supp-bar-row" role="button" tabindex="0"'));
 
   // ─── 3. Modal close aria-labels ───
-  for (const f of ['/js/views.js', '/js/feedback.js', '/js/changelog-impl.js', '/js/emf.js', '/js/settings.js']) {
+  for (const f of ['/js/views.js', '/js/feedback.js', '/js/changelog-impl.js', '/js/emf-editor.js', '/js/settings.js']) {
     const src = read(f);
     const closeButtons = (src.match(/class="modal-close"/g) || []).length;
     const labelled = (src.match(/class="modal-close" aria-label="Close"/g) || []).length;

--- a/tests/test-emf-delegated-actions.js
+++ b/tests/test-emf-delegated-actions.js
@@ -8,6 +8,7 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
 const emfSrc = fs.readFileSync(path.join(root, 'js/emf.js'), 'utf8');
+const emfEditorSrc = fs.readFileSync(path.join(root, 'js/emf-editor.js'), 'utf8');
 const emfRuntimeSrc = fs.readFileSync(path.join(root, 'js/emf-runtime.js'), 'utf8');
 const emfInterpretationSrc = fs.readFileSync(path.join(root, 'js/emf-interpretation.js'), 'utf8');
 
@@ -24,15 +25,15 @@ function assert(name, condition, detail = '') {
   }
 }
 
-function section(start, end) {
-  const startIdx = emfSrc.indexOf(start);
-  const endIdx = emfSrc.indexOf(end, startIdx);
-  return startIdx >= 0 && endIdx > startIdx ? emfSrc.slice(startIdx, endIdx) : '';
+function section(source, start, end) {
+  const startIdx = source.indexOf(start);
+  const endIdx = source.indexOf(end, startIdx);
+  return startIdx >= 0 && endIdx > startIdx ? source.slice(startIdx, endIdx) : '';
 }
 
-const editorSrc = section('let _editingAssessmentId = null;', '// ═══════════════════════════════════════════════\n// CRUD OPERATIONS');
-const importPreviewSrc = section('function showEMFImportPreview(parsed)', '// ═══════════════════════════════════════════════\n// BEFORE / AFTER COMPARISON');
-const compareSrc = section('function renderComparisonView(sorted)', '// ═══════════════════════════════════════════════\n// AI INTERPRETATION');
+const editorSrc = section(emfEditorSrc, 'export const emfEditorState', 'export function showEMFImportPreview(parsed)');
+const importPreviewSrc = section(emfEditorSrc, 'export function showEMFImportPreview(parsed)', 'function renderComparisonView(sorted)');
+const compareSrc = section(emfEditorSrc, 'function renderComparisonView(sorted)', 'return html;\n}');
 function interpretationSection(start, end) {
   const startIdx = emfInterpretationSrc.indexOf(start);
   const endIdx = emfInterpretationSrc.indexOf(end, startIdx);
@@ -40,7 +41,7 @@ function interpretationSection(start, end) {
 }
 
 const interpretationSrc = interpretationSection('function _handleEMFInterpretationMouseDown', 'function _collectMitigationTags');
-const closePreviewSrc = section('function closeEMFPreviewModal()', 'function closeEMFEditorModal()');
+const closePreviewSrc = section(emfEditorSrc, 'function closeEMFPreviewModal()', 'function closeEMFEditorModal()');
 const migratedEditorSurface = `${editorSrc}\n${importPreviewSrc}\n${compareSrc}`;
 const inlineHandlerRe = /\bon(?:click|keydown|submit|change|input)=/;
 
@@ -51,35 +52,37 @@ assert('EMF editor migrated surface renders no inline event attributes',
 assert('EMF interpretation modal renders no inline event attributes',
   interpretationSrc.length > 0 && !inlineHandlerRe.test(interpretationSrc));
 assert('EMF editor imports shared tag toggle instead of inline global handler',
-  emfSrc.includes("import { toggleCtxTag } from './context-card-editor-ui.js';") &&
-    migratedEditorSurface.includes("if (action === 'toggle-tag') { toggleCtxTag(actionEl); return; }"));
+  emfEditorSrc.includes("import { toggleCtxTag } from './context-card-editor-ui.js';") &&
+    migratedEditorSurface.includes("if (action === 'toggle-tag') { toggleCtxTag(actionElement); return; }"));
 assert('EMF editor uses escaped data-action helpers',
-  emfSrc.includes('function emfActionAttrs') &&
-    emfSrc.includes('function emfChangeAttrs') &&
-    emfSrc.includes('escapeAttr(String(value))'));
+  emfEditorSrc.includes('function emfActionAttrs') &&
+    emfEditorSrc.includes('function emfChangeAttrs') &&
+    emfEditorSrc.includes('escapeAttr(String(value))'));
 assert('EMF editor installs idempotent click change and keydown delegates',
-  emfSrc.includes('let emfEditorDelegatesInstalled = false') &&
-    emfSrc.includes("document.addEventListener('click', _handleEMFEditorClick)") &&
-    emfSrc.includes("document.addEventListener('change', _handleEMFEditorChange)") &&
-    emfSrc.includes("document.addEventListener('keydown', _handleEMFEditorKeydown)") &&
-    emfSrc.includes('installEMFEditorDelegates();'));
+  emfEditorSrc.includes('let emfEditorDelegatesInstalled = false') &&
+    emfEditorSrc.includes("document.addEventListener('click', handleEMFEditorClick)") &&
+    emfEditorSrc.includes("document.addEventListener('change', handleEMFEditorChange)") &&
+    emfEditorSrc.includes("document.addEventListener('keydown', handleEMFEditorKeydown)") &&
+    emfEditorSrc.includes('installEMFEditorDelegates();'));
 assert('EMF editor delegates are scoped to #detail-modal',
-  emfSrc.includes("return !!el.closest('#detail-modal');") &&
-    emfSrc.includes('!isEMFEditorTarget(actionEl)'));
+  emfEditorSrc.includes("return !!element.closest('#detail-modal');") &&
+    emfEditorSrc.includes('!isEMFEditorTarget(actionElement)'));
 assert('EMF editor close path preserves save and lightbox cleanup',
-  emfSrc.includes('function closeEMFEditorModal()') &&
-    emfSrc.includes('collectActiveAssessmentState();') &&
-    emfSrc.includes("document.querySelectorAll('.emf-lightbox').forEach(el => removeModalOverlay(el));") &&
-    emfSrc.includes('removeEMFEditorDelegates();') &&
-    emfSrc.includes('closeEMFModalRuntime();'));
+  emfEditorSrc.includes('function closeEMFEditorModal()') &&
+    emfEditorSrc.includes('emfEditorDeps.collectActiveAssessmentState?.();') &&
+    emfEditorSrc.includes("document.querySelectorAll('.emf-lightbox').forEach(element => removeModalOverlay(element));") &&
+    emfEditorSrc.includes('removeEMFEditorDelegates();') &&
+    emfEditorSrc.includes('emfEditorDeps.closeModal?.();'));
 assert('EMF editor runtime hooks avoid counted direct window globals',
   !emfSrc.includes("from './views-runtime-bridge.js'") &&
+    !emfEditorSrc.includes("from './views-runtime-bridge.js'") &&
     !emfSrc.includes('getViewRuntimeFunction') &&
-    emfSrc.includes('emfRuntimeDeps.closeModal?.()') &&
+    !emfEditorSrc.includes('getViewRuntimeFunction') &&
+    emfSrc.includes('closeModal: () => emfRuntimeDeps.closeModal?.()') &&
     emfRuntimeSrc.includes('mod.configureEMFRuntimeDeps(emfRuntimeDeps);') &&
     !emfRuntimeSrc.includes("import('./emf.js')") &&
-    emfSrc.includes('return showPromptDialog(message, options);') &&
-    !/\bwindow(?:\.|\s*\[)/.test(emfSrc));
+    emfSrc.includes("showPromptDialog('Room name:'") &&
+    !/\bwindow(?:\.|\s*\[)/.test(`${emfSrc}\n${emfEditorSrc}`));
 assert('EMF interpretation runtime hooks avoid counted direct window globals',
   !emfInterpretationSrc.includes("from './views-runtime-bridge.js'") &&
     !emfInterpretationSrc.includes('getViewRuntimeFunction') &&
@@ -92,15 +95,15 @@ assert('EMF import preview close path does not persist editor state',
   closePreviewSrc.length > 0 &&
     !closePreviewSrc.includes('collectActiveAssessmentState') &&
     !closePreviewSrc.includes('saveImportedData') &&
-    emfSrc.includes("if (action === 'close-preview') { closeEMFPreviewModal(); return; }") &&
-    emfSrc.includes("${emfActionAttrs('close-preview')}>Cancel</button>"));
+    emfEditorSrc.includes("if (action === 'close-preview') { closeEMFPreviewModal(); return; }") &&
+    emfEditorSrc.includes("${emfActionAttrs('close-preview')}>Cancel</button>"));
 assert('EMF import preview X button uses non-saving close action',
   importPreviewSrc.includes('class="modal-close" aria-label="Close" ${emfActionAttrs(\'close-preview\')}'));
 assert('EMF editor delegates can be explicitly removed',
-  emfSrc.includes('function removeEMFEditorDelegates()') &&
-    emfSrc.includes("document.removeEventListener('click', _handleEMFEditorClick)") &&
-    emfSrc.includes("document.removeEventListener('change', _handleEMFEditorChange)") &&
-    emfSrc.includes("document.removeEventListener('keydown', _handleEMFEditorKeydown)"));
+  emfEditorSrc.includes('function removeEMFEditorDelegates()') &&
+    emfEditorSrc.includes("document.removeEventListener('click', handleEMFEditorClick)") &&
+    emfEditorSrc.includes("document.removeEventListener('change', handleEMFEditorChange)") &&
+    emfEditorSrc.includes("document.removeEventListener('keydown', handleEMFEditorKeydown)"));
 assert('EMF interpretation modal installs scoped action delegates',
   emfInterpretationSrc.includes('function emfInterpActionAttrs') &&
     interpretationSrc.includes('data-emf-interp-action') &&
@@ -133,7 +136,7 @@ assert('EMF interpretation streamed discuss button uses delegated action',
   'remove-photo',
   'interpret-comparison',
 ].forEach(action => {
-  assert(`EMF click action ${action} is handled`, emfSrc.includes(`action === '${action}'`));
+  assert(`EMF click action ${action} is handled`, emfEditorSrc.includes(`action === '${action}'`));
 });
 
 [
@@ -145,7 +148,7 @@ assert('EMF interpretation streamed discuss button uses delegated action',
   'meter',
   'photos',
 ].forEach(action => {
-  assert(`EMF change action ${action} is handled`, emfSrc.includes(`action === '${action}'`));
+  assert(`EMF change action ${action} is handled`, emfEditorSrc.includes(`action === '${action}'`));
 });
 
 console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);

--- a/tests/test-modal-lifecycle-integrations.js
+++ b/tests/test-modal-lifecycle-integrations.js
@@ -18,6 +18,7 @@ const dashboardAiSrc = fs.readFileSync(path.join(root, 'js/context-card-dashboar
 const dashboardWidgetControlsSrc = fs.readFileSync(path.join(root, 'js/dashboard-widget-controls.js'), 'utf8');
 const cycleSrc = fs.readFileSync(path.join(root, 'js/cycle.js'), 'utf8');
 const emfSrc = fs.readFileSync(path.join(root, 'js/emf.js'), 'utf8');
+const emfEditorSrc = fs.readFileSync(path.join(root, 'js/emf-editor.js'), 'utf8');
 const emfInterpretationSrc = fs.readFileSync(path.join(root, 'js/emf-interpretation.js'), 'utf8');
 const exportReportBuilderSrc = fs.readFileSync(path.join(root, 'js/export-report-builder.js'), 'utf8');
 const lensSrc = fs.readFileSync(path.join(root, 'js/lens.js'), 'utf8');
@@ -270,20 +271,24 @@ assert('light environment assessment uses shared overlay lifecycle before remova
 
 assert('EMF editor, interpretation, and photo overlays use shared lifecycle helpers',
   emfSrc.includes("import { openModalOverlay, removeModalOverlay, trapModalFocus } from './modal-lifecycle.js';") &&
+    emfEditorSrc.includes("import { openModalOverlay, removeModalOverlay } from './modal-lifecycle.js';") &&
     emfInterpretationSrc.includes("import { openModalOverlay, removeModalOverlay, trapModalFocus } from './modal-lifecycle.js';") &&
-    ((emfSrc.match(/openModalOverlay\(overlay\)/g) || []).length + (emfInterpretationSrc.match(/openModalOverlay\(overlay\)/g) || []).length) >= 4 &&
-    ((emfSrc.match(/removeModalOverlay\(overlay\)/g) || []).length + (emfInterpretationSrc.match(/removeModalOverlay\(overlay\)/g) || []).length) >= 2 &&
+    ((emfSrc.match(/openModalOverlay\(overlay\)/g) || []).length + (emfEditorSrc.match(/openModalOverlay\(overlay\)/g) || []).length + (emfInterpretationSrc.match(/openModalOverlay\(overlay\)/g) || []).length) >= 4 &&
+    ((emfSrc.match(/removeModalOverlay\(overlay\)/g) || []).length + (emfEditorSrc.match(/removeModalOverlay\(overlay\)/g) || []).length + (emfInterpretationSrc.match(/removeModalOverlay\(overlay\)/g) || []).length) >= 2 &&
     emfInterpretationSrc.includes('const wasConnected = overlay.isConnected;') &&
     emfInterpretationSrc.includes('if (!wasConnected) document.body.appendChild(overlay);') &&
     emfInterpretationSrc.includes("if (!wasConnected) try { trapModalFocus(overlay, { closeOnEscape: false }); } catch (_) {}") &&
     emfInterpretationSrc.includes("trapModalFocus(overlay, { closeOnEscape: false })") &&
     emfSrc.includes('trapModalFocus(overlay)') &&
-    emfSrc.includes("document.querySelectorAll('.emf-lightbox').forEach(el => removeModalOverlay(el))") &&
+    emfEditorSrc.includes("document.querySelectorAll('.emf-lightbox').forEach(element => removeModalOverlay(element))") &&
     !emfSrc.includes("overlay.classList.add('show')") &&
+    !emfEditorSrc.includes("overlay.classList.add('show')") &&
     !emfInterpretationSrc.includes("overlay.classList.add('show')") &&
     !emfSrc.includes("overlay.classList.remove('show')") &&
+    !emfEditorSrc.includes("overlay.classList.remove('show')") &&
     !emfInterpretationSrc.includes("overlay.classList.remove('show')") &&
     !emfSrc.includes('overlay.onclick = () => overlay.remove()') &&
+    !emfEditorSrc.includes('overlay.onclick = () => overlay.remove()') &&
     !emfInterpretationSrc.includes('overlay.onclick = () => overlay.remove()'));
 
 assert('light tool modals use shared overlay lifecycle helpers',

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -241,6 +241,8 @@ const domainUiCheckJsModules = [
   'js/crypto.js',
   'js/data.js',
   'js/emf.js',
+  'js/emf-editor.js',
+  'js/emf-model.js',
   'js/lab-context.js',
   'js/light-conditions-now.js',
   'js/light-env.js',

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -190,7 +190,7 @@ assert('App shell wires remaining Chat open consumers without window globals',
 assert('App shell injects the lazy EMF editor close callback without bridge lookups',
   !emfSrc.includes("from './views-runtime-bridge.js'")
     && !emfSrc.includes('getViewRuntimeFunction')
-    && emfSrc.includes('emfRuntimeDeps.closeModal?.();')
+    && emfSrc.includes('closeModal: () => emfRuntimeDeps.closeModal?.()')
     && emfRuntimeSrc.includes('mod.configureEMFRuntimeDeps(emfRuntimeDeps);')
     && !emfRuntimeSrc.includes("import('./emf.js')")
     && emfRuntimeSrc.includes('emfRuntimeDeps.loadModule()')

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -131,6 +131,8 @@
     "js/dna-runtime.js",
     "js/dna-runtime-bridge.js",
     "js/emf.js",
+    "js/emf-editor.js",
+    "js/emf-model.js",
     "js/export-report-builder.js",
     "js/export-report-html.js",
     "js/export-report.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -127,6 +127,8 @@
     "js/dna-runtime.js",
     "js/dna-runtime-bridge.js",
     "js/emf.js",
+    "js/emf-editor.js",
+    "js/emf-model.js",
     "js/emf-facade.js",
     "js/export-import.js",
     "js/export.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.461';
+self.APP_VERSION = '1.10.462';


### PR DESCRIPTION
## Summary
- extract EMF modal state, delegated actions, editor/import-preview rendering, and comparison rendering into `emf-editor.js`
- extract shared assessment access and display metadata into `emf-model.js`
- keep all 24 public `emf.js` functions unchanged while reducing the facade from 1,106 to 528 lines
- keep both new owners below the cap (`emf-editor.js` 665; `emf-model.js` 27)
- lower the large-JavaScript-module baseline from 15 to 14 and bump the app version to 1.10.462

## Verification
- `node tests/test-emf-flow.js` — 33/33
- `node tests/test-emf.js` — 217/217
- `node tests/test-emf-delegated-actions.js` — 38/38
- `node tests/test-modal-lifecycle-integrations.js` — 31/31
- `node tests/test-shell-delegated-actions.js` — 98/98
- `node tests/test-a11y-phase3.js` — 72/72
- `node tests/test-quality-guardrails.js` — 36/36
- `node tests/verify-modules.js` — 141/141
- `node tests/test-correctness-phase2.js` — 204/204
- focused production/service-worker/EMF-runtime Vitest specs — 32/32
- `npm run typecheck`
- `npx tsc -p tsconfig.checkjs.json --noEmit`
- `npm run typecheck:strict-null` — 0 diagnostics
- `npm run quality` — 14/14
- `npm run architecture:build && npm run architecture:check` — 507 modules, 0 cycles
- `PORT=8130 npx playwright test tests/playwright/emf-edge-browser-coverage.spec.js` — 1/1