### PR TITLE
Refactor DNA UI into a cohesive owner

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -9,8 +9,8 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 
 | Metric | Current |
 | --- | ---: |
-| Modules | 507 |
-| Internal import edges | 2289 |
+| Modules | 508 |
+| Internal import edges | 2296 |
 | Dynamic internal edges | 93 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -38,11 +38,11 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 
 | High fan-in | Dependants | High fan-out | Imports |
 | --- | ---: | --- | ---: |
-| [`js/utils.js`](js/utils.js) | 236 | [`js/app-shell-hooks.js`](js/app-shell-hooks.js) | 72 |
-| [`js/state.js`](js/state.js) | 162 | [`js/app-light-sun-modules.js`](js/app-light-sun-modules.js) | 36 |
+| [`js/utils.js`](js/utils.js) | 237 | [`js/app-shell-hooks.js`](js/app-shell-hooks.js) | 72 |
+| [`js/state.js`](js/state.js) | 163 | [`js/app-light-sun-modules.js`](js/app-light-sun-modules.js) | 36 |
 | [`js/data.js`](js/data.js) | 76 | [`js/sync-configure.js`](js/sync-configure.js) | 27 |
 | [`js/caught-error.js`](js/caught-error.js) | 73 | [`js/settings.js`](js/settings.js) | 25 |
-| [`js/modal-lifecycle.js`](js/modal-lifecycle.js) | 67 | [`js/pdf-import.js`](js/pdf-import.js) | 24 |
+| [`js/modal-lifecycle.js`](js/modal-lifecycle.js) | 68 | [`js/pdf-import.js`](js/pdf-import.js) | 24 |
 | [`js/api.js`](js/api.js) | 64 | [`js/chat-send.js`](js/chat-send.js) | 22 |
 | [`js/profile.js`](js/profile.js) | 45 | [`js/views.js`](js/views.js) | 22 |
 | [`js/schema.js`](js/schema.js) | 33 | [`js/wearables-connect.js`](js/wearables-connect.js) | 21 |
@@ -338,7 +338,7 @@ Native browser modules shipped with the static application.
 
 </details>
 
-<details><summary><code>dna</code> family — 8 modules</summary>
+<details><summary><code>dna</code> family — 9 modules</summary>
 
 - [`js/dna-actions.js`](js/dna-actions.js) → [`js/utils.js`](js/utils.js)
 - [`js/dna-file-detection.js`](js/dna-file-detection.js) → no in-scope imports
@@ -347,7 +347,8 @@ Native browser modules shipped with the static application.
 - [`js/dna-parser.js`](js/dna-parser.js) → [`js/dna-file-detection.js`](js/dna-file-detection.js), [`js/dna-genotype.js`](js/dna-genotype.js)
 - [`js/dna-runtime-bridge.js`](js/dna-runtime-bridge.js) → no in-scope imports
 - [`js/dna-runtime.js`](js/dna-runtime.js) → [`js/chat-runtime.js`](js/chat-runtime.js), [`js/context-cards-runtime.js`](js/context-cards-runtime.js), [`js/pdf-import-progress.js`](js/pdf-import-progress.js), [`js/profile.js`](js/profile.js), [`js/utils.js`](js/utils.js)
-- [`js/dna.js`](js/dna.js) → [`js/caught-error.js`](js/caught-error.js), [`js/data.js`](js/data.js), [`js/dna-actions.js`](js/dna-actions.js), [`js/dna-genotype.js`](js/dna-genotype.js), [`js/dna-mtdna.js`](js/dna-mtdna.js), [`js/dna-parser.js`](js/dna-parser.js), [`js/dna-runtime-bridge.js`](js/dna-runtime-bridge.js), [`js/dna-runtime.js`](js/dna-runtime.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/pdf-import.js`](js/pdf-import.js) *(dynamic)*, [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
+- [`js/dna-ui.js`](js/dna-ui.js) → [`js/dna-actions.js`](js/dna-actions.js), [`js/dna-mtdna.js`](js/dna-mtdna.js), [`js/dna-runtime.js`](js/dna-runtime.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
+- [`js/dna.js`](js/dna.js) → [`js/caught-error.js`](js/caught-error.js), [`js/data.js`](js/data.js), [`js/dna-actions.js`](js/dna-actions.js), [`js/dna-genotype.js`](js/dna-genotype.js), [`js/dna-mtdna.js`](js/dna-mtdna.js), [`js/dna-parser.js`](js/dna-parser.js), [`js/dna-runtime-bridge.js`](js/dna-runtime-bridge.js), [`js/dna-runtime.js`](js/dna-runtime.js), [`js/dna-ui.js`](js/dna-ui.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/pdf-import.js`](js/pdf-import.js) *(dynamic)*, [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 
 </details>
 

--- a/js/dna-ui.js
+++ b/js/dna-ui.js
@@ -1,0 +1,505 @@
+// @ts-check
+// dna-ui.js — Genetics dashboard rendering and autosomal DNA modal owner.
+
+import { state } from './state.js';
+import { escapeAttr, escapeHTML } from './utils.js';
+import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
+import { dnaActionAttrs } from './dna-actions.js';
+import {
+  clearPendingDnaImport,
+  loadGeneticsStylesheetForAction,
+  navigateDnaRoute,
+  setPendingDnaImport,
+} from './dna-runtime.js';
+import { detectMtDNAMismatch } from './dna-mtdna.js';
+
+/** @type {Record<string, any>} */
+const dnaUiDeps = {
+  findGenotypeInfo: null,
+  geneticsStalenessHint: null,
+  getSnpCategoryLabel: category => String(category || 'Other'),
+  getSnpCategoryLabels: () => ({}),
+  getSnpTable: () => null,
+  handleDNAFile: null,
+  loadSnpTable: null,
+  resolveAPOE: null,
+  setImportRunning: null,
+};
+
+export function configureDnaUi(deps = {}) {
+  const previous = { ...dnaUiDeps };
+  for (const [key, value] of Object.entries(deps || {})) {
+    if (Object.hasOwn(dnaUiDeps, key) && typeof value === 'function') {
+      dnaUiDeps[key] = value;
+    }
+  }
+  return previous;
+}
+
+export function renderGeneticsSection() {
+  const genetics = state.importedData.genetics;
+  const hasSnps = genetics && genetics.snps && Object.keys(genetics.snps).length > 0;
+  const hasMtdna = genetics && genetics.mtdna;
+  if (!hasSnps && !hasMtdna) {
+    return `<div class="genetics-empty-stub" ${dnaActionAttrs('import-file')} role="button" tabindex="0" aria-label="Add DNA data">
+      <span class="genetics-empty-stub-icon" aria-hidden="true">&#129516;</span>
+      <span class="genetics-empty-stub-body">
+        <span class="genetics-empty-stub-title">Add your DNA data</span>
+        <span class="genetics-empty-stub-sub">Upload raw DNA, import a lab report PDF, or add one SNP manually. Files stay on this device.</span>
+        <span class="genetics-empty-actions">
+          <button type="button" class="genetics-action-link" ${dnaActionAttrs('import-file')}>Raw DNA file</button>
+          <button type="button" class="genetics-action-link" ${dnaActionAttrs('import-snp-report')}>Report PDF/text</button>
+          <button type="button" class="genetics-action-link" ${dnaActionAttrs('add-manual-snp')}>Add SNP manually</button>
+        </span>
+      </span>
+      <span class="genetics-empty-stub-arrow" aria-hidden="true">&rarr;</span>
+    </div>`;
+  }
+
+  const snpTable = dnaUiDeps.getSnpTable();
+  if (hasSnps && !snpTable) {
+    dnaUiDeps.loadSnpTable?.().then(() => navigateDnaRoute('dashboard'));
+    return '';
+  }
+
+  const snpCount = hasSnps ? Object.keys(genetics.snps).length : 0;
+  const apoe = genetics.apoe;
+  const collapsed = localStorage.getItem('labcharts-genetics-collapsed') === '1';
+
+  const primaryImpactFor = (effect, valence) => {
+    if (valence === 'protective') return true;
+    if (valence === 'neutral') return false;
+    return effect === 'significant' || effect === 'moderate' || effect === 'mild';
+  };
+
+  const byCat = {};
+  const otherByCat = {};
+  const apoeRsids = new Set(['rs429358', 'rs7412']);
+  for (const [rsid, stored] of Object.entries(genetics.snps || {})) {
+    if (apoe && apoeRsids.has(rsid)) continue;
+    const entry = snpTable?.[rsid];
+    if (!entry) continue;
+    const info = dnaUiDeps.findGenotypeInfo?.(entry, stored.genotype);
+    if (!info) continue;
+    const cat = entry.category || 'other';
+    const target = primaryImpactFor(info.effect, info.valence) ? byCat : otherByCat;
+    if (!target[cat]) target[cat] = [];
+    target[cat].push({
+      rsid,
+      gene: stored.gene || entry.gene,
+      variant: stored.variant || entry.variant,
+      genotype: stored.genotype,
+      effect: info.effect,
+      valence: info.valence || 'risk',
+      note: info.note,
+      references: entry.references || [],
+    });
+  }
+
+  const effectRank = { significant: 0, moderate: 1, mild: 2 };
+  const heaviest = findings => Math.min(...findings.map(finding => effectRank[finding.effect] ?? 3));
+  const catOrder = Object.entries(byCat).sort(([, a], [, b]) => heaviest(a) - heaviest(b));
+  const totalFindings = catOrder.reduce((count, [, findings]) => count + findings.length, 0);
+  const otherCatOrder = Object.entries(otherByCat).sort(([, a], [, b]) => heaviest(a) - heaviest(b));
+  const otherFindings = otherCatOrder.reduce((count, [, findings]) => count + findings.length, 0);
+
+  const dotFor = (effect, valence) => {
+    if (valence === 'protective') return '\uD83D\uDFE2';
+    if (valence === 'neutral') return '\u26AA';
+    if (effect === 'none') return '\u26AA';
+    if (effect === 'significant') return '\uD83D\uDD34';
+    if (effect === 'moderate') return '\uD83D\uDFE0';
+    if (effect === 'mild') return '\uD83D\uDFE1';
+    return '';
+  };
+  const impactFor = (effect, valence) => {
+    if (valence === 'protective') return { label: 'beneficial', tone: 'beneficial', rank: 3 };
+    if (valence === 'neutral') return { label: 'neutral', tone: 'informational', rank: 4 };
+    if (effect === 'significant') return { label: 'significant', tone: 'significant', rank: 0 };
+    if (effect === 'moderate') return { label: 'moderate', tone: 'moderate', rank: 1 };
+    if (effect === 'mild') return { label: 'mild', tone: 'mild', rank: 2 };
+    if (effect === 'none') return { label: 'normal', tone: 'normal', rank: 5 };
+    return { label: 'unclassified', tone: 'informational', rank: 6 };
+  };
+  const catLabels = dnaUiDeps.getSnpCategoryLabels();
+
+  const metaParts = [];
+  if (genetics.source) metaParts.push(escapeHTML(genetics.source));
+  if (hasSnps) metaParts.push(`${snpCount} SNPs`);
+  if (hasMtdna) metaParts.push(`mtDNA ${escapeHTML(genetics.mtdna.haplogroup)}`);
+  if (totalFindings > 0) metaParts.push(`${totalFindings} findings`);
+  const latestDate = [genetics.importDate, genetics.mtdna?.importDate].filter(Boolean).sort().pop();
+  if (latestDate) metaParts.push(latestDate);
+
+  let html = `<div class="dashboard-section genetics-section" id="genetics-section">
+    <div class="section-header" role="button" tabindex="0" aria-label="Expand or collapse genetics section" ${dnaActionAttrs('toggle-genetics-collapse')} style="cursor:pointer">
+      <span>\uD83E\uDDEC Genetics</span>
+      <span class="section-meta">${metaParts.join(' \u00B7 ')}
+        <span class="genetics-collapse-arrow${collapsed ? ' collapsed' : ''}">\u25BE</span></span>
+    </div>`;
+
+  html += `<div class="genetics-body${collapsed ? ' hidden' : ''}">`;
+
+  const overviewCards = [
+    {
+      label: 'Imported SNPs',
+      value: hasSnps ? snpCount.toLocaleString() : '0',
+      sub: genetics.source || 'Autosomal raw data',
+    },
+    {
+      label: 'Findings',
+      value: String(totalFindings),
+      sub: totalFindings ? 'Interpreted from known SNPs' : 'No interpreted findings',
+    },
+    apoe ? {
+      label: 'APOE',
+      value: apoe,
+      sub: 'Haplotype context',
+    } : null,
+    hasMtdna ? {
+      label: 'mtDNA',
+      value: genetics.mtdna.haplogroup,
+      sub: genetics.mtdna.coupling?.shortLabel || 'Maternal lineage',
+    } : null,
+  ].filter(card => card !== null);
+
+  html += '<div class="genetics-overview-grid">';
+  overviewCards.forEach(card => {
+    html += `<div class="genetics-overview-card">
+      <span class="genetics-overview-label">${escapeHTML(card.label)}</span>
+      <strong>${escapeHTML(card.value)}</strong>
+      <small>${escapeHTML(card.sub)}</small>
+    </div>`;
+  });
+  html += '</div>';
+
+  if (hasMtdna) {
+    const mt = genetics.mtdna;
+    const mismatch = detectMtDNAMismatch(genetics);
+    html += `<div class="genetics-mtdna">
+      <div class="genetics-mtdna-hg"><span class="genetics-mtdna-label">mtDNA Haplogroup:</span> <strong>${escapeHTML(mt.haplogroup)}</strong></div>`;
+    if (mt.coupling) {
+      html += `<div class="genetics-mtdna-coupling">${escapeHTML(mt.coupling.label)} \u2014 ${escapeHTML(mt.coupling.climate)}</div>`;
+    }
+    if (mismatch && mismatch.mismatch) {
+      html += `<div class="genetics-mtdna-mismatch mismatch-${mismatch.severity}">${escapeHTML(mismatch.message)}</div>`;
+    } else if (mismatch && !mismatch.mismatch) {
+      html += `<div class="genetics-mtdna-match">${escapeHTML(mismatch.message)}</div>`;
+    }
+    html += `<div class="genetics-mtdna-refs">Wallace 2015 (<a href="https://pubmed.ncbi.nlm.nih.gov/26406369/" target="_blank" rel="noopener">PMID: 26406369</a>)
+      \u00B7 <button type="button" ${dnaActionAttrs('delete-mtdna')}>remove</button></div>`;
+    html += `</div>`;
+  }
+
+  if (apoe) {
+    html += `<div class="genetics-apoe">APOE: <strong>${escapeHTML(apoe)}</strong></div>`;
+  }
+
+  if (totalFindings > 0) {
+    let shown = 0;
+    const INITIAL_LIMIT = 8;
+    html += `<div class="genetics-findings">`;
+    html += `<div class="genetics-legend" title="What the dots mean" aria-label="Genetics significance legend">
+      <span class="genetics-legend-item genetics-legend-significant"><span class="genetics-legend-dot">🔴</span> significant risk</span>
+      <span class="genetics-legend-item genetics-legend-moderate"><span class="genetics-legend-dot">🟠</span> moderate risk</span>
+      <span class="genetics-legend-item genetics-legend-mild"><span class="genetics-legend-dot">🟡</span> mild risk</span>
+      <span class="genetics-legend-item genetics-legend-beneficial"><span class="genetics-legend-dot">🟢</span> beneficial</span>
+      <span class="genetics-legend-item genetics-legend-informational"><span class="genetics-legend-dot">⚪</span> neutral</span>
+    </div>`;
+    for (const [cat, findings] of catOrder) {
+      findings.sort((a, b) => impactFor(a.effect, a.valence).rank - impactFor(b.effect, b.valence).rank);
+      const catLabel = catLabels[cat] || cat;
+      const startHidden = shown >= INITIAL_LIMIT;
+      html += `<div class="genetics-cat-group${startHidden ? ' genetics-extra' : ''}">`;
+      html += `<div class="genetics-cat-label">${escapeHTML(catLabel)}</div>`;
+      for (const finding of findings) {
+        const isExtra = shown >= INITIAL_LIMIT;
+        const impact = impactFor(finding.effect, finding.valence);
+        const primaryRef = (finding.references || []).find(ref => /^https?:\/\//i.test(String(ref || '')));
+        const refLink = primaryRef
+          ? ` <a href="${escapeAttr(primaryRef)}" target="_blank" rel="noopener" class="detail-genetics-ref" title="Primary study (PubMed)">primary study</a>`
+          : '';
+        const snpediaId = `${finding.rsid.charAt(0).toUpperCase()}${finding.rsid.slice(1)}`;
+        const snpediaLink = ` <a href="https://www.snpedia.com/index.php/${escapeAttr(encodeURIComponent(snpediaId))}" target="_blank" rel="noopener" class="detail-genetics-ref" title="All studies (SNPedia)">more studies</a>`;
+        const rowClasses = ['genetics-finding-row', `genetics-finding-${impact.tone}`];
+        if (isExtra && !startHidden) rowClasses.push('genetics-extra');
+        html += `<div class="${rowClasses.join(' ')}">
+          <span class="genetics-finding-dot">${dotFor(finding.effect, finding.valence)}</span>
+          <span class="genetics-finding-main">
+            <span class="genetics-finding-gene">${escapeHTML(finding.gene || finding.rsid)} ${escapeHTML(finding.variant || '')}</span>
+            <span class="genetics-finding-rsid">${escapeHTML(finding.rsid)} · ${escapeHTML(catLabel)}</span>
+          </span>
+          <span class="genetics-finding-impact genetics-impact-${impact.tone}">${escapeHTML(impact.label)}</span>
+          <span class="genetics-finding-genotype">${escapeHTML(finding.genotype)}</span>
+          <span class="genetics-finding-note">${escapeHTML(finding.note || 'Observed in your imported genotype.')}${refLink}${snpediaLink}</span>
+        </div>`;
+        shown++;
+      }
+      html += `</div>`;
+    }
+    if (totalFindings > INITIAL_LIMIT) {
+      html += `<button class="genetics-show-all" ${dnaActionAttrs('toggle-genetics-expand')}>${totalFindings - INITIAL_LIMIT} more findings</button>`;
+    }
+    html += `</div>`;
+  }
+
+  if (otherFindings > 0) {
+    html += `<details class="genetics-other-snps">
+      <summary>Other imported SNPs (${otherFindings})</summary>
+      <div class="genetics-other-snps-list">`;
+    for (const [cat, findings] of otherCatOrder) {
+      findings.sort((a, b) => impactFor(a.effect, a.valence).rank - impactFor(b.effect, b.valence).rank);
+      const catLabel = catLabels[cat] || cat;
+      html += `<div class="genetics-cat-group genetics-cat-group-secondary">
+        <div class="genetics-cat-label">${escapeHTML(catLabel)}</div>`;
+      for (const finding of findings) {
+        const impact = impactFor(finding.effect, finding.valence);
+        html += `<div class="genetics-finding-row genetics-finding-${impact.tone}">
+          <span class="genetics-finding-dot">${dotFor(finding.effect, finding.valence)}</span>
+          <span class="genetics-finding-main">
+            <span class="genetics-finding-gene">${escapeHTML(finding.gene || finding.rsid)} ${escapeHTML(finding.variant || '')}</span>
+            <span class="genetics-finding-rsid">${escapeHTML(finding.rsid)} · ${escapeHTML(catLabel)}</span>
+          </span>
+          <span class="genetics-finding-impact genetics-impact-${impact.tone}">${escapeHTML(impact.label)}</span>
+          <span class="genetics-finding-genotype">${escapeHTML(finding.genotype)}</span>
+          <span class="genetics-finding-note">${escapeHTML(finding.note || 'Observed in your imported genotype.')}</span>
+        </div>`;
+      }
+      html += `</div>`;
+    }
+    html += `</div></details>`;
+  }
+
+  const staleHint = dnaUiDeps.geneticsStalenessHint?.(genetics);
+  if (staleHint) {
+    html += `<div class="genetics-stale-hint">${escapeHTML(staleHint)}</div>`;
+  }
+
+  html += `<div class="genetics-actions">
+    <button type="button" class="genetics-action-link" ${dnaActionAttrs('add-manual-snp')}>Add SNP</button>
+    <button type="button" class="genetics-action-link" ${dnaActionAttrs('import-snp-report')}>Import report</button>
+    <button type="button" class="genetics-action-link" ${dnaActionAttrs('reimport-dna')}>Re-import raw DNA</button>
+    <button type="button" class="genetics-action-link genetics-action-delete" ${dnaActionAttrs('delete-dna')}>Delete</button>
+  </div>`;
+  html += `</div></div>`;
+
+  return html;
+}
+
+export function toggleGeneticsCollapse() {
+  const body = document.querySelector('.genetics-body');
+  const arrow = document.querySelector('.genetics-collapse-arrow');
+  if (!body) return;
+  const isHidden = body.classList.toggle('hidden');
+  arrow?.classList.toggle('collapsed', isHidden);
+  localStorage.setItem('labcharts-genetics-collapsed', isHidden ? '1' : '0');
+}
+
+export function toggleGeneticsExpand(button) {
+  const container = document.querySelector('.genetics-findings');
+  if (!container) return;
+  const isExpanded = container.classList.toggle('expanded');
+  if (!button.dataset.label) button.dataset.label = button.textContent;
+  button.textContent = isExpanded ? 'Show less' : button.dataset.label;
+}
+
+export function reimportDNA() {
+  const input = document.createElement('input');
+  input.type = 'file';
+  input.accept = '.txt,.csv';
+  input.onchange = () => {
+    const file = input.files?.[0];
+    if (file) void dnaUiDeps.handleDNAFile?.(file);
+  };
+  input.click();
+}
+
+let dnaModalEscapeBound = false;
+let dnaBackdropMouseDownInside = false;
+
+function nudgeDnaModal() {
+  const dialog = document.querySelector('#dna-modal-overlay .modal');
+  if (!(dialog instanceof HTMLElement)) return;
+  dialog.classList.remove('modal-nudge');
+  void dialog.offsetWidth;
+  dialog.classList.add('modal-nudge');
+  dialog.addEventListener('animationend', () => dialog.classList.remove('modal-nudge'), { once: true });
+}
+
+function handleDnaBackdropMouseDown(event) {
+  const target = event.target;
+  dnaBackdropMouseDownInside = target instanceof Element && !!target.closest('.modal');
+}
+
+function handleDnaBackdropClick(event) {
+  const target = event.target;
+  if (dnaBackdropMouseDownInside) {
+    dnaBackdropMouseDownInside = false;
+    return;
+  }
+  if (!(target instanceof Element) || target.id !== 'dna-modal-overlay') return;
+  event.preventDefault();
+  nudgeDnaModal();
+}
+
+function handleDnaModalEscape(event) {
+  const overlay = document.getElementById('dna-modal-overlay');
+  if (event.key !== 'Escape' || !overlay?.classList.contains('show')) return;
+  event.preventDefault();
+  closeDNAImportPreview();
+}
+
+function openDnaModalOverlay(overlay, initialFocus) {
+  if (!overlay.dataset.dnaBackdropNudgeWired) {
+    overlay.addEventListener('mousedown', handleDnaBackdropMouseDown);
+    overlay.addEventListener('click', handleDnaBackdropClick);
+    overlay.dataset.dnaBackdropNudgeWired = '1';
+  }
+  if (!dnaModalEscapeBound) {
+    document.addEventListener('keydown', handleDnaModalEscape);
+    dnaModalEscapeBound = true;
+  }
+  openModalOverlay(overlay, { initialFocus, focusDelay: 30, scrollLock: true });
+}
+
+export async function openManualSnpModal() {
+  if (!await loadGeneticsStylesheetForAction()) return false;
+  await dnaUiDeps.loadSnpTable?.();
+  clearPendingDnaImport();
+  const html = `<div class="dna-preview-header dna-manual-header">
+      <div>
+        <div class="dna-preview-title">Add SNPs manually</div>
+        <div class="dna-preview-stats">Paste one SNP or a whole small report table. Same path, no duplicate modes.</div>
+      </div>
+    </div>
+    <div class="dna-preview-body dna-manual-snp-body">
+      <div class="dna-manual-card dna-manual-card-bulk">
+        <div class="dna-manual-section-head">
+          <span>SNP calls</span>
+          <small>One per line: rsID + genotype. Notes after that are optional.</small>
+        </div>
+        <textarea id="manual-snp-bulk" class="dna-manual-textarea" rows="7" spellcheck="false" placeholder="rs1801133 CC&#10;rs1801131 AC&#10;rs429358 TT APOE report"></textarea>
+      </div>
+      <label class="dna-manual-field dna-manual-source">Source label
+        <input id="manual-snp-source" class="dna-manual-input" type="text" placeholder="Manual entry / lab report name" autocomplete="off">
+      </label>
+      <p class="dna-manual-help">Use a single line for one SNP, or paste a dozen lines. getbased validates each rsID, normalizes strand-aware genotypes, and merges accepted rows into existing genome data.</p>
+    </div>
+    <div class="dna-preview-actions">
+      <button type="button" class="import-btn import-btn-secondary" ${dnaActionAttrs('close-preview')}>Cancel</button>
+      <button type="button" class="import-btn import-btn-primary" ${dnaActionAttrs('save-manual-snp')}>Save SNPs</button>
+    </div>`;
+  let overlay = document.getElementById('dna-modal-overlay');
+  if (!overlay) {
+    overlay = document.createElement('div');
+    overlay.id = 'dna-modal-overlay';
+    overlay.className = 'modal-overlay';
+    document.body.appendChild(overlay);
+  }
+  overlay.innerHTML = `<div class="modal dna-preview-modal dna-manual-modal" role="dialog" aria-label="Add SNPs manually">${html}</div>`;
+  openDnaModalOverlay(overlay, '#manual-snp-bulk');
+  return true;
+}
+
+export function showDNAImportPreview(result) {
+  setPendingDnaImport(result);
+
+  const apoe = dnaUiDeps.resolveAPOE?.(result.matches);
+  const apoeRsids = apoe ? new Set(['rs429358', 'rs7412']) : new Set();
+  const significant = [];
+  const moderate = [];
+  const mild = [];
+  const beneficial = [];
+  const none = [];
+  for (const [rsid, match] of Object.entries(result.matches)) {
+    if (apoeRsids.has(rsid)) continue;
+    const item = {
+      rsid,
+      ...match,
+      impact: match.valence === 'protective' ? 'beneficial' : match.effect,
+    };
+    if (item.impact === 'beneficial') beneficial.push(item);
+    else if (match.effect === 'significant') significant.push(item);
+    else if (match.effect === 'moderate') moderate.push(item);
+    else if (match.effect === 'mild') mild.push(item);
+    else none.push(item);
+  }
+
+  const effectIcon = {
+    significant: '\uD83D\uDD34',
+    moderate: '\uD83D\uDFE0',
+    mild: '\uD83D\uDFE1',
+    beneficial: '\uD83D\uDFE2',
+    none: '\u26AA',
+  };
+
+  function renderGroup(items, label) {
+    if (items.length === 0) return '';
+    return `<div class="dna-preview-group">
+      <div class="dna-preview-group-title">${label} (${items.length})</div>
+      ${items.map(match => `<div class="dna-preview-row">
+        <span class="dna-preview-icon">${effectIcon[match.impact || match.effect] || '\u2753'}</span>
+        <span class="dna-preview-gene">${escapeHTML(match.gene)} <span class="dna-preview-variant">${escapeHTML(match.variant)}</span> <span class="dna-preview-category">${escapeHTML(dnaUiDeps.getSnpCategoryLabel(match.category))}</span></span>
+        <span class="dna-preview-genotype">${escapeHTML(match.genotype)}</span>
+      </div>
+      <div class="dna-preview-note">${escapeHTML(match.note)}</div>`).join('')}
+    </div>`;
+  }
+
+  function renderCollapsedGroup(items, label) {
+    if (items.length === 0) return '';
+    return `<div class="dna-preview-group">
+      <div class="dna-preview-group-title dna-preview-collapsible" role="button" tabindex="0" ${dnaActionAttrs('toggle-preview-group')}>
+        ${label} (${items.length}) <span class="dna-preview-expand-hint">show</span>
+      </div>
+      <div class="dna-preview-collapsed-items">
+        ${items.map(match => `<div class="dna-preview-row">
+          <span class="dna-preview-icon">${effectIcon[match.impact || match.effect] || '\u2753'}</span>
+          <span class="dna-preview-gene">${escapeHTML(match.gene)} <span class="dna-preview-variant">${escapeHTML(match.variant)}</span> <span class="dna-preview-category">${escapeHTML(dnaUiDeps.getSnpCategoryLabel(match.category))}</span></span>
+          <span class="dna-preview-genotype">${escapeHTML(match.genotype)}</span>
+        </div>`).join('')}
+      </div>
+    </div>`;
+  }
+
+  const html = `
+    <div class="dna-preview-header">
+      <div class="dna-preview-title">DNA Import \u2014 ${escapeHTML(result.source)}</div>
+      <div class="dna-preview-stats">${result.totalLines.toLocaleString()} SNPs scanned \u00B7 ${result.coverage.found} of ${result.coverage.total} health-relevant SNPs found</div>
+      ${apoe ? `<div class="dna-preview-apoe">APOE Haplotype: <strong>${escapeHTML(apoe)}</strong></div>` : ''}
+    </div>
+    <div class="dna-preview-body">
+      ${renderGroup(significant, '\uD83D\uDD34 Significant findings')}
+      ${renderGroup(moderate, '\uD83D\uDFE0 Moderate findings')}
+      ${renderGroup(mild, '\uD83D\uDFE1 Mild findings')}
+      ${renderGroup(beneficial, '\uD83D\uDFE2 Beneficial findings')}
+      ${renderCollapsedGroup(none, '\u26AA Other imported SNPs')}
+    </div>
+    <div class="dna-preview-disclaimer">
+      Processed locally \u2014 your DNA file was never transmitted. Only matched SNPs are stored.
+    </div>
+    <div class="dna-preview-actions">
+      <button class="import-btn import-btn-secondary" ${dnaActionAttrs('close-preview')}>Cancel</button>
+      <button class="import-btn import-btn-primary" ${dnaActionAttrs('confirm-import')}>Import ${result.coverage.found} SNPs</button>
+    </div>`;
+
+  let overlay = document.getElementById('dna-modal-overlay');
+  if (!overlay) {
+    overlay = document.createElement('div');
+    overlay.id = 'dna-modal-overlay';
+    overlay.className = 'modal-overlay';
+    document.body.appendChild(overlay);
+  }
+  overlay.innerHTML = `<div class="modal dna-preview-modal" role="dialog">${html}</div>`;
+  openDnaModalOverlay(overlay, '.import-btn-primary');
+}
+
+export function closeDNAImportPreview() {
+  clearPendingDnaImport();
+  dnaUiDeps.setImportRunning?.(false);
+  closeModalOverlay('dna-modal-overlay');
+  if (dnaModalEscapeBound) {
+    document.removeEventListener('keydown', handleDnaModalEscape);
+    dnaModalEscapeBound = false;
+  }
+}

--- a/js/dna.js
+++ b/js/dna.js
@@ -2,11 +2,21 @@
 // dna.js — DNA storage, context assembly, and UI orchestration
 import { getErrorMessage } from './caught-error.js';
 import { state } from './state.js';
-import { escapeAttr, escapeHTML, hashString, showNotification } from './utils.js';
+import { escapeHTML, hashString, showNotification } from './utils.js';
 import { saveImportedData } from './data.js';
-import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
-import { dnaActionAttrs, initDnaActionDelegates } from './dna-actions.js';
+import { closeModalOverlay } from './modal-lifecycle.js';
+import { initDnaActionDelegates } from './dna-actions.js';
 import { configureDnaModuleBridge } from './dna-runtime-bridge.js';
+import {
+  closeDNAImportPreview,
+  configureDnaUi,
+  openManualSnpModal,
+  reimportDNA,
+  renderGeneticsSection,
+  showDNAImportPreview,
+  toggleGeneticsCollapse,
+  toggleGeneticsExpand,
+} from './dna-ui.js';
 import { findGenotypeInfo as findGenotypeInfoImpl, findGenotypeMatch, findSnpHint as findSnpHintImpl, sortAlleles } from './dna-genotype.js';
 import {
   detectDNAFile,
@@ -21,7 +31,7 @@ import {
   isDnaLabImportRunning, logDnaDebugError, logDnaDebugWarn,
   loadGeneticsStylesheetForAction,
   navigateDnaRoute, refreshDnaShell,
-  refreshDnaSidebar, setPendingDnaImport,
+  refreshDnaSidebar,
   triggerDnaFilePicker, updateDnaChatNudge,
 } from './dna-runtime.js';
 import {
@@ -38,6 +48,14 @@ import {
   setManualHaplogroup,
 } from './dna-mtdna.js';
 export { detectDNAFile, isDNAFile, isDNAFileByContent };
+export {
+  closeDNAImportPreview,
+  openManualSnpModal,
+  reimportDNA,
+  renderGeneticsSection,
+  toggleGeneticsCollapse,
+  toggleGeneticsExpand,
+};
 // ═══════════════════════════════════════════════
 // PARSE DNA FILE
 // ═══════════════════════════════════════════════
@@ -383,370 +401,8 @@ export function buildFullGeneticsContext(genetics) {
 }
 
 // ═══════════════════════════════════════════════
-// DASHBOARD SECTION
+// MANUAL / REPORT SNP IMPORT
 // ═══════════════════════════════════════════════
-
-export function renderGeneticsSection() {
-  const genetics = state.importedData.genetics;
-  const hasSnps = genetics && genetics.snps && Object.keys(genetics.snps).length > 0;
-  const hasMtdna = genetics && genetics.mtdna;
-  // Empty-state CTA: lives in the natural conceptual slot (where genetics
-  // would render) so users who skipped the chat onboarding DNA step have a
-  // path back. Below the fold on first paint but appears after supplements/charts.
-  if (!hasSnps && !hasMtdna) {
-    return `<div class="genetics-empty-stub" ${dnaActionAttrs('import-file')} role="button" tabindex="0" aria-label="Add DNA data">
-      <span class="genetics-empty-stub-icon" aria-hidden="true">&#129516;</span>
-      <span class="genetics-empty-stub-body">
-        <span class="genetics-empty-stub-title">Add your DNA data</span>
-        <span class="genetics-empty-stub-sub">Upload raw DNA, import a lab report PDF, or add one SNP manually. Files stay on this device.</span>
-        <span class="genetics-empty-actions">
-          <button type="button" class="genetics-action-link" ${dnaActionAttrs('import-file')}>Raw DNA file</button>
-          <button type="button" class="genetics-action-link" ${dnaActionAttrs('import-snp-report')}>Report PDF/text</button>
-          <button type="button" class="genetics-action-link" ${dnaActionAttrs('add-manual-snp')}>Add SNP manually</button>
-        </span>
-      </span>
-      <span class="genetics-empty-stub-arrow" aria-hidden="true">&rarr;</span>
-    </div>`;
-  }
-  if (hasSnps && !_snpTable) {
-    loadSNPTable().then(() => navigateDnaRoute('dashboard'));
-    return '';
-  }
-  const snpTable = _snpTable;
-  const snpCount = hasSnps ? Object.keys(genetics.snps).length : 0;
-  const apoe = genetics.apoe;
-  const collapsed = localStorage.getItem('labcharts-genetics-collapsed') === '1';
-
-  const primaryImpactFor = (effect, valence) => {
-    if (valence === 'protective') return true;
-    if (valence === 'neutral') return false;
-    return effect === 'significant' || effect === 'moderate' || effect === 'mild';
-  };
-
-  // Group findings by category. Only meaningful impact tiers are shown up
-  // front; normal / neutral rows stay available in a collapsed group.
-  const byCat = {};
-  const otherByCat = {};
-  const apoeRsids = new Set(['rs429358', 'rs7412']);
-  for (const [rsid, stored] of Object.entries(genetics.snps || {})) {
-    if (apoe && apoeRsids.has(rsid)) continue;
-    const entry = snpTable?.[rsid];
-    if (!entry) continue;
-    const info = findGenotypeInfo(entry, stored.genotype);
-    if (!info) continue;
-    const cat = entry.category || 'other';
-    const target = primaryImpactFor(info.effect, info.valence) ? byCat : otherByCat;
-    if (!target[cat]) target[cat] = [];
-    target[cat].push({ rsid, gene: stored.gene || entry.gene, variant: stored.variant || entry.variant, genotype: stored.genotype, effect: info.effect, valence: info.valence || 'risk', note: info.note, references: entry.references || [] });
-  }
-
-  // Sort categories by the weight of the heaviest finding in each — significant
-  // categories first, then moderate-only, then mild-only. Before there were
-  // only two non-none tiers the binary "has significant?" sort sufficed, but
-  // with three tiers a category of moderates was tying with a category of
-  // milds, hiding clinical priority in arrival order.
-  const _effectRank = { significant: 0, moderate: 1, mild: 2 };
-  const _heaviest = (findings) => Math.min(...findings.map(f => _effectRank[f.effect] ?? 3));
-  const catOrder = Object.entries(byCat).sort(([, a], [, b]) => _heaviest(a) - _heaviest(b));
-  const totalFindings = catOrder.reduce((n, [, fs]) => n + fs.length, 0);
-  const otherCatOrder = Object.entries(otherByCat).sort(([, a], [, b]) => _heaviest(a) - _heaviest(b));
-  const otherFindings = otherCatOrder.reduce((n, [, fs]) => n + fs.length, 0);
-
-  // Two-axis dot: severity x valence. Protective = green regardless of magnitude;
-  // neutral = white circle (lab-artifact / neutral, neither bad nor good).
-  // Risk severity scales by warmth (significant -> red, moderate -> orange, mild -> yellow).
-  const dotFor = (effect, valence) => {
-    if (valence === 'protective') return '\uD83D\uDFE2';
-    if (valence === 'neutral') return '\u26AA';
-    if (effect === 'none') return '\u26AA';
-    if (effect === 'significant') return '\uD83D\uDD34';
-    if (effect === 'moderate') return '\uD83D\uDFE0';
-    if (effect === 'mild') return '\uD83D\uDFE1';
-    return '';
-  };
-  const impactFor = (effect, valence) => {
-    if (valence === 'protective') return { label: 'beneficial', tone: 'beneficial', rank: 3 };
-    if (valence === 'neutral') return { label: 'neutral', tone: 'informational', rank: 4 };
-    if (effect === 'significant') return { label: 'significant', tone: 'significant', rank: 0 };
-    if (effect === 'moderate') return { label: 'moderate', tone: 'moderate', rank: 1 };
-    if (effect === 'mild') return { label: 'mild', tone: 'mild', rank: 2 };
-    if (effect === 'none') return { label: 'normal', tone: 'normal', rank: 5 };
-    return { label: 'unclassified', tone: 'informational', rank: 6 };
-  };
-  const catLabels = SNP_CATEGORY_LABELS;
-
-  const metaParts = [];
-  if (genetics.source) metaParts.push(escapeHTML(genetics.source));
-  if (hasSnps) metaParts.push(`${snpCount} SNPs`);
-  if (hasMtdna) metaParts.push(`mtDNA ${escapeHTML(genetics.mtdna.haplogroup)}`);
-  if (totalFindings > 0) metaParts.push(`${totalFindings} findings`);
-  const latestDate = [genetics.importDate, genetics.mtdna?.importDate].filter(Boolean).sort().pop();
-  if (latestDate) metaParts.push(latestDate);
-
-  let html = `<div class="dashboard-section genetics-section" id="genetics-section">
-    <div class="section-header" role="button" tabindex="0" aria-label="Expand or collapse genetics section" ${dnaActionAttrs('toggle-genetics-collapse')} style="cursor:pointer">
-      <span>\uD83E\uDDEC Genetics</span>
-      <span class="section-meta">${metaParts.join(' \u00B7 ')}
-        <span class="genetics-collapse-arrow${collapsed ? ' collapsed' : ''}">\u25BE</span></span>
-    </div>`;
-
-  html += `<div class="genetics-body${collapsed ? ' hidden' : ''}">`;
-
-  const overviewCards = [
-    {
-      label: 'Imported SNPs',
-      value: hasSnps ? snpCount.toLocaleString() : '0',
-      sub: genetics.source || 'Autosomal raw data'
-    },
-    {
-      label: 'Findings',
-      value: String(totalFindings),
-      sub: totalFindings ? 'Interpreted from known SNPs' : 'No interpreted findings'
-    },
-    apoe ? {
-      label: 'APOE',
-      value: apoe,
-      sub: 'Haplotype context'
-    } : null,
-    hasMtdna ? {
-      label: 'mtDNA',
-      value: genetics.mtdna.haplogroup,
-      sub: genetics.mtdna.coupling?.shortLabel || 'Maternal lineage'
-    } : null
-  ].filter(card => card !== null);
-
-  html += '<div class="genetics-overview-grid">';
-  overviewCards.forEach(card => {
-    html += `<div class="genetics-overview-card">
-      <span class="genetics-overview-label">${escapeHTML(card.label)}</span>
-      <strong>${escapeHTML(card.value)}</strong>
-      <small>${escapeHTML(card.sub)}</small>
-    </div>`;
-  });
-  html += '</div>';
-
-  // mtDNA Haplogroup — prominent display
-  if (hasMtdna) {
-    const mt = genetics.mtdna;
-    const mismatch = detectMtDNAMismatch(genetics);
-    html += `<div class="genetics-mtdna">
-      <div class="genetics-mtdna-hg"><span class="genetics-mtdna-label">mtDNA Haplogroup:</span> <strong>${escapeHTML(mt.haplogroup)}</strong></div>`;
-    if (mt.coupling) {
-      html += `<div class="genetics-mtdna-coupling">${escapeHTML(mt.coupling.label)} \u2014 ${escapeHTML(mt.coupling.climate)}</div>`;
-    }
-    if (mismatch && mismatch.mismatch) {
-      html += `<div class="genetics-mtdna-mismatch mismatch-${mismatch.severity}">${escapeHTML(mismatch.message)}</div>`;
-    } else if (mismatch && !mismatch.mismatch) {
-      html += `<div class="genetics-mtdna-match">${escapeHTML(mismatch.message)}</div>`;
-    }
-    html += `<div class="genetics-mtdna-refs">Wallace 2015 (<a href="https://pubmed.ncbi.nlm.nih.gov/26406369/" target="_blank" rel="noopener">PMID: 26406369</a>)
-      \u00B7 <button type="button" ${dnaActionAttrs('delete-mtdna')}>remove</button></div>`;
-    html += `</div>`;
-  }
-
-  if (apoe) {
-    html += `<div class="genetics-apoe">APOE: <strong>${escapeHTML(apoe)}</strong></div>`;
-  }
-
-  if (totalFindings > 0) {
-    // Initially show first 8 findings, rest hidden behind "show all"
-    let shown = 0;
-    const INITIAL_LIMIT = 8;
-    html += `<div class="genetics-findings">`;
-    // Legend — explain the dot scheme so users can read severity AND valence at a glance.
-    html += `<div class="genetics-legend" title="What the dots mean" aria-label="Genetics significance legend">
-      <span class="genetics-legend-item genetics-legend-significant"><span class="genetics-legend-dot">🔴</span> significant risk</span>
-      <span class="genetics-legend-item genetics-legend-moderate"><span class="genetics-legend-dot">🟠</span> moderate risk</span>
-      <span class="genetics-legend-item genetics-legend-mild"><span class="genetics-legend-dot">🟡</span> mild risk</span>
-      <span class="genetics-legend-item genetics-legend-beneficial"><span class="genetics-legend-dot">🟢</span> beneficial</span>
-      <span class="genetics-legend-item genetics-legend-informational"><span class="genetics-legend-dot">⚪</span> neutral</span>
-    </div>`;
-    for (const [cat, findings] of catOrder) {
-      // Within-category: severity descending, with beneficial and neutral
-      // entries still visible so the desktop section matches the mobile summary.
-      findings.sort((a, b) => impactFor(a.effect, a.valence).rank - impactFor(b.effect, b.valence).rank);
-      const catLabel = catLabels[cat] || cat;
-      const startHidden = shown >= INITIAL_LIMIT;
-      html += `<div class="genetics-cat-group${startHidden ? ' genetics-extra' : ''}">`;
-      html += `<div class="genetics-cat-label">${escapeHTML(catLabel)}</div>`;
-      for (const f of findings) {
-        const isExtra = shown >= INITIAL_LIMIT;
-        const impact = impactFor(f.effect, f.valence);
-        const primaryRef = (f.references || []).find(ref => /^https?:\/\//i.test(String(ref || '')));
-        const refLink = primaryRef ? ` <a href="${escapeAttr(primaryRef)}" target="_blank" rel="noopener" class="detail-genetics-ref" title="Primary study (PubMed)">primary study</a>` : '';
-        const snpediaId = `${f.rsid.charAt(0).toUpperCase()}${f.rsid.slice(1)}`;
-        const snpediaLink = ` <a href="https://www.snpedia.com/index.php/${escapeAttr(encodeURIComponent(snpediaId))}" target="_blank" rel="noopener" class="detail-genetics-ref" title="All studies (SNPedia)">more studies</a>`;
-        const rowClasses = ['genetics-finding-row', `genetics-finding-${impact.tone}`];
-        if (isExtra && !startHidden) rowClasses.push('genetics-extra');
-        html += `<div class="${rowClasses.join(' ')}">
-          <span class="genetics-finding-dot">${dotFor(f.effect, f.valence)}</span>
-          <span class="genetics-finding-main">
-            <span class="genetics-finding-gene">${escapeHTML(f.gene || f.rsid)} ${escapeHTML(f.variant || '')}</span>
-            <span class="genetics-finding-rsid">${escapeHTML(f.rsid)} · ${escapeHTML(catLabel)}</span>
-          </span>
-          <span class="genetics-finding-impact genetics-impact-${impact.tone}">${escapeHTML(impact.label)}</span>
-          <span class="genetics-finding-genotype">${escapeHTML(f.genotype)}</span>
-          <span class="genetics-finding-note">${escapeHTML(f.note || 'Observed in your imported genotype.')}${refLink}${snpediaLink}</span>
-        </div>`;
-        shown++;
-      }
-      html += `</div>`;
-    }
-    if (totalFindings > INITIAL_LIMIT) {
-      html += `<button class="genetics-show-all" ${dnaActionAttrs('toggle-genetics-expand')}>${totalFindings - INITIAL_LIMIT} more findings</button>`;
-    }
-    html += `</div>`;
-  }
-
-  if (otherFindings > 0) {
-    html += `<details class="genetics-other-snps">
-      <summary>Other imported SNPs (${otherFindings})</summary>
-      <div class="genetics-other-snps-list">`;
-    for (const [cat, findings] of otherCatOrder) {
-      findings.sort((a, b) => impactFor(a.effect, a.valence).rank - impactFor(b.effect, b.valence).rank);
-      const catLabel = catLabels[cat] || cat;
-      html += `<div class="genetics-cat-group genetics-cat-group-secondary">
-        <div class="genetics-cat-label">${escapeHTML(catLabel)}</div>`;
-      for (const f of findings) {
-        const impact = impactFor(f.effect, f.valence);
-        html += `<div class="genetics-finding-row genetics-finding-${impact.tone}">
-          <span class="genetics-finding-dot">${dotFor(f.effect, f.valence)}</span>
-          <span class="genetics-finding-main">
-            <span class="genetics-finding-gene">${escapeHTML(f.gene || f.rsid)} ${escapeHTML(f.variant || '')}</span>
-            <span class="genetics-finding-rsid">${escapeHTML(f.rsid)} · ${escapeHTML(catLabel)}</span>
-          </span>
-          <span class="genetics-finding-impact genetics-impact-${impact.tone}">${escapeHTML(impact.label)}</span>
-          <span class="genetics-finding-genotype">${escapeHTML(f.genotype)}</span>
-          <span class="genetics-finding-note">${escapeHTML(f.note || 'Observed in your imported genotype.')}</span>
-        </div>`;
-      }
-      html += `</div>`;
-    }
-    html += `</div></details>`;
-  }
-
-  const _staleHint = _geneticsStalenessHint(genetics);
-  if (_staleHint) {
-    html += `<div class="genetics-stale-hint">${escapeHTML(_staleHint)}</div>`;
-  }
-
-  html += `<div class="genetics-actions">
-    <button type="button" class="genetics-action-link" ${dnaActionAttrs('add-manual-snp')}>Add SNP</button>
-    <button type="button" class="genetics-action-link" ${dnaActionAttrs('import-snp-report')}>Import report</button>
-    <button type="button" class="genetics-action-link" ${dnaActionAttrs('reimport-dna')}>Re-import raw DNA</button>
-    <button type="button" class="genetics-action-link genetics-action-delete" ${dnaActionAttrs('delete-dna')}>Delete</button>
-  </div>`;
-  html += `</div></div>`;
-
-  return html;
-}
-
-export function toggleGeneticsCollapse() {
-  const body = document.querySelector('.genetics-body');
-  const arrow = document.querySelector('.genetics-collapse-arrow');
-  if (!body) return;
-  const isHidden = body.classList.toggle('hidden');
-  arrow?.classList.toggle('collapsed', isHidden);
-  localStorage.setItem('labcharts-genetics-collapsed', isHidden ? '1' : '0');
-}
-
-export function toggleGeneticsExpand(btn) {
-  const container = document.querySelector('.genetics-findings');
-  if (!container) return;
-  const isExpanded = container.classList.toggle('expanded');
-  if (!btn.dataset.label) btn.dataset.label = btn.textContent;
-  btn.textContent = isExpanded ? 'Show less' : btn.dataset.label;
-}
-
-export function reimportDNA() {
-  const input = document.createElement('input');
-  input.type = 'file';
-  input.accept = '.txt,.csv';
-  input.onchange = () => {
-    const file = input.files?.[0];
-    if (file) void handleDNAFile(file);
-  };
-  input.click();
-}
-
-let _dnaModalEscapeBound = false, _dnaBackdropMouseDownInside = false;
-
-function nudgeDnaModal() {
-  const dialog = document.querySelector('#dna-modal-overlay .modal');
-  if (!(dialog instanceof HTMLElement)) return;
-  dialog.classList.remove('modal-nudge'); void dialog.offsetWidth;
-  dialog.classList.add('modal-nudge');
-  dialog.addEventListener('animationend', () => dialog.classList.remove('modal-nudge'), { once: true });
-}
-
-function handleDnaBackdropMouseDown(event) {
-  const target = event.target;
-  _dnaBackdropMouseDownInside = target instanceof Element && !!target.closest('.modal');
-}
-
-function handleDnaBackdropClick(event) {
-  const target = event.target;
-  if (_dnaBackdropMouseDownInside) { _dnaBackdropMouseDownInside = false; return; }
-  if (!(target instanceof Element) || target.id !== 'dna-modal-overlay') return;
-  event.preventDefault();
-  nudgeDnaModal();
-}
-
-function handleDnaModalEscape(event) {
-  const overlay = document.getElementById('dna-modal-overlay');
-  if (event.key !== 'Escape' || !overlay?.classList.contains('show')) return;
-  event.preventDefault();
-  closeDNAImportPreview();
-}
-
-function openDnaModalOverlay(overlay, initialFocus) {
-  if (!overlay.dataset.dnaBackdropNudgeWired) {
-    overlay.addEventListener('mousedown', handleDnaBackdropMouseDown);
-    overlay.addEventListener('click', handleDnaBackdropClick);
-    overlay.dataset.dnaBackdropNudgeWired = '1';
-  }
-  if (!_dnaModalEscapeBound) { document.addEventListener('keydown', handleDnaModalEscape); _dnaModalEscapeBound = true; }
-  openModalOverlay(overlay, { initialFocus, focusDelay: 30, scrollLock: true });
-}
-
-export async function openManualSnpModal() {
-  if (!await loadGeneticsStylesheetForAction()) return false;
-  await loadSNPTable();
-  clearPendingDnaImport();
-  const html = `<div class="dna-preview-header dna-manual-header">
-      <div>
-        <div class="dna-preview-title">Add SNPs manually</div>
-        <div class="dna-preview-stats">Paste one SNP or a whole small report table. Same path, no duplicate modes.</div>
-      </div>
-    </div>
-    <div class="dna-preview-body dna-manual-snp-body">
-      <div class="dna-manual-card dna-manual-card-bulk">
-        <div class="dna-manual-section-head">
-          <span>SNP calls</span>
-          <small>One per line: rsID + genotype. Notes after that are optional.</small>
-        </div>
-        <textarea id="manual-snp-bulk" class="dna-manual-textarea" rows="7" spellcheck="false" placeholder="rs1801133 CC&#10;rs1801131 AC&#10;rs429358 TT APOE report"></textarea>
-      </div>
-      <label class="dna-manual-field dna-manual-source">Source label
-        <input id="manual-snp-source" class="dna-manual-input" type="text" placeholder="Manual entry / lab report name" autocomplete="off">
-      </label>
-      <p class="dna-manual-help">Use a single line for one SNP, or paste a dozen lines. getbased validates each rsID, normalizes strand-aware genotypes, and merges accepted rows into existing genome data.</p>
-    </div>
-    <div class="dna-preview-actions">
-      <button type="button" class="import-btn import-btn-secondary" ${dnaActionAttrs('close-preview')}>Cancel</button>
-      <button type="button" class="import-btn import-btn-primary" ${dnaActionAttrs('save-manual-snp')}>Save SNPs</button>
-    </div>`;
-  let overlay = document.getElementById('dna-modal-overlay');
-  if (!overlay) {
-    overlay = document.createElement('div');
-    overlay.id = 'dna-modal-overlay';
-    overlay.className = 'modal-overlay';
-    document.body.appendChild(overlay);
-  }
-  overlay.innerHTML = `<div class="modal dna-preview-modal dna-manual-modal" role="dialog" aria-label="Add SNPs manually">${html}</div>`;
-  openDnaModalOverlay(overlay, '#manual-snp-bulk');
-  return true;
-}
 
 export function parseManualSnpRows(singleRsid, singleGenotype, bulkText) {
   const rows = [];
@@ -864,100 +520,6 @@ export async function handleDNAFile(file) {
   }
 }
 
-function showDNAImportPreview(result) {
-  setPendingDnaImport(result);
-
-  // Categorize matches by effect — skip raw APOE components when haplotype resolved
-  const apoe = resolveAPOE(result.matches);
-  const apoeRsids = apoe ? new Set(['rs429358', 'rs7412']) : new Set();
-  // parseDNAFile already filtered out SNPs whose raw call doesn't resolve to
-  // any catalog genotype (Low-pass WGS imputation noise: garbage allele calls
-  // that aren't valid variants for the locus), so every entry here has a
-  // curated effect tier \u2014 significant / moderate / mild / none. No "unknown"
-  // bucket: surfacing those as "Genotype not in lookup" was misleading because
-  // the rsID *is* curated, only the specific allele call was bad data.
-  const significant = [], moderate = [], mild = [], beneficial = [], none = [];
-  for (const [rsid, m] of Object.entries(result.matches)) {
-    if (apoeRsids.has(rsid)) continue;
-    const item = { rsid, ...m, impact: m.valence === 'protective' ? 'beneficial' : m.effect };
-    if (item.impact === 'beneficial') beneficial.push(item);
-    else if (m.effect === 'significant') significant.push(item);
-    else if (m.effect === 'moderate') moderate.push(item);
-    else if (m.effect === 'mild') mild.push(item);
-    else none.push(item);
-  }
-
-  const effectIcon = { significant: '\uD83D\uDD34', moderate: '\uD83D\uDFE0', mild: '\uD83D\uDFE1', beneficial: '\uD83D\uDFE2', none: '\u26AA' };
-
-  function renderGroup(items, label) {
-    if (items.length === 0) return '';
-    return `<div class="dna-preview-group">
-      <div class="dna-preview-group-title">${label} (${items.length})</div>
-      ${items.map(m => `<div class="dna-preview-row">
-        <span class="dna-preview-icon">${effectIcon[m.impact || m.effect] || '\u2753'}</span>
-        <span class="dna-preview-gene">${escapeHTML(m.gene)} <span class="dna-preview-variant">${escapeHTML(m.variant)}</span> <span class="dna-preview-category">${escapeHTML(getSnpCategoryLabel(m.category))}</span></span>
-        <span class="dna-preview-genotype">${escapeHTML(m.genotype)}</span>
-      </div>
-      <div class="dna-preview-note">${escapeHTML(m.note)}</div>`).join('')}
-    </div>`;
-  }
-
-  function renderCollapsedGroup(items, label) {
-    if (items.length === 0) return '';
-    return `<div class="dna-preview-group">
-      <div class="dna-preview-group-title dna-preview-collapsible" role="button" tabindex="0" ${dnaActionAttrs('toggle-preview-group')}>
-        ${label} (${items.length}) <span class="dna-preview-expand-hint">show</span>
-      </div>
-      <div class="dna-preview-collapsed-items">
-        ${items.map(m => `<div class="dna-preview-row">
-          <span class="dna-preview-icon">${effectIcon[m.impact || m.effect] || '\u2753'}</span>
-          <span class="dna-preview-gene">${escapeHTML(m.gene)} <span class="dna-preview-variant">${escapeHTML(m.variant)}</span> <span class="dna-preview-category">${escapeHTML(getSnpCategoryLabel(m.category))}</span></span>
-          <span class="dna-preview-genotype">${escapeHTML(m.genotype)}</span>
-        </div>`).join('')}
-      </div>
-    </div>`;
-  }
-
-  const html = `
-    <div class="dna-preview-header">
-      <div class="dna-preview-title">DNA Import \u2014 ${escapeHTML(result.source)}</div>
-      <div class="dna-preview-stats">${result.totalLines.toLocaleString()} SNPs scanned \u00B7 ${result.coverage.found} of ${result.coverage.total} health-relevant SNPs found</div>
-      ${apoe ? `<div class="dna-preview-apoe">APOE Haplotype: <strong>${escapeHTML(apoe)}</strong></div>` : ''}
-    </div>
-    <div class="dna-preview-body">
-      ${renderGroup(significant, '\uD83D\uDD34 Significant findings')}
-      ${renderGroup(moderate, '\uD83D\uDFE0 Moderate findings')}
-      ${renderGroup(mild, '\uD83D\uDFE1 Mild findings')}
-      ${renderGroup(beneficial, '\uD83D\uDFE2 Beneficial findings')}
-      ${renderCollapsedGroup(none, '\u26AA Other imported SNPs')}
-    </div>
-    <div class="dna-preview-disclaimer">
-      Processed locally \u2014 your DNA file was never transmitted. Only matched SNPs are stored.
-    </div>
-    <div class="dna-preview-actions">
-      <button class="import-btn import-btn-secondary" ${dnaActionAttrs('close-preview')}>Cancel</button>
-      <button class="import-btn import-btn-primary" ${dnaActionAttrs('confirm-import')}>Import ${result.coverage.found} SNPs</button>
-    </div>`;
-
-  // Use a dedicated overlay — don't clobber the PDF import modal
-  let overlay = document.getElementById('dna-modal-overlay');
-  if (!overlay) {
-    overlay = document.createElement('div');
-    overlay.id = 'dna-modal-overlay';
-    overlay.className = 'modal-overlay';
-    document.body.appendChild(overlay);
-  }
-  overlay.innerHTML = `<div class="modal dna-preview-modal" role="dialog">${html}</div>`;
-  openDnaModalOverlay(overlay, '.import-btn-primary');
-}
-
-export function closeDNAImportPreview() {
-  clearPendingDnaImport();
-  _dnaImportRunning = false;
-  closeModalOverlay('dna-modal-overlay');
-  if (_dnaModalEscapeBound) { document.removeEventListener('keydown', handleDnaModalEscape); _dnaModalEscapeBound = false; }
-}
-
 export async function confirmDNAImport() {
   const result = getPendingDnaImport();
   if (!result) return;
@@ -1072,6 +634,18 @@ export async function confirmDeleteDNA() {
     refreshDnaShell('dashboard');
   }
 }
+
+configureDnaUi({
+  findGenotypeInfo,
+  geneticsStalenessHint: _geneticsStalenessHint,
+  getSnpCategoryLabel,
+  getSnpCategoryLabels: () => SNP_CATEGORY_LABELS,
+  getSnpTable: () => _snpTable,
+  handleDNAFile,
+  loadSnpTable: loadSNPTable,
+  resolveAPOE,
+  setImportRunning: running => { _dnaImportRunning = !!running; },
+});
 
 initDnaActionDelegates({ triggerDNAFilePicker: triggerDnaFilePicker, closeDNAImportPreview, closeMtDNAPreview, confirmDeleteDNA, confirmDNAImport, confirmMtDNAImport, deleteMtDNAData, importSnpReport, openManualSnpModal, reimportDNA, saveManualSnpFromModal, toggleGeneticsCollapse, toggleGeneticsExpand });
 

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -7,6 +7,6 @@
   "viewRuntimeBridgeLookups": 0,
   "labStateAppFiles": 0,
   "labStateTestFiles": 0,
-  "largeJsFilesOver800Lines": 14,
+  "largeJsFilesOver800Lines": 13,
   "maxJsFileLines": 1168
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -375,6 +375,7 @@ const APP_SHELL = [
   '/js/dna-genotype.js',
   '/js/dna-parser.js',
   '/js/dna.js',
+  '/js/dna-ui.js',
   '/js/dna-runtime.js',
   '/js/dna-runtime-bridge.js',
   '/js/dna-mtdna.js',

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -127,6 +127,7 @@ assert('SW APP_SHELL includes lens URL helper module', swAuditSrc.includes("'/js
 assert('SW APP_SHELL includes lens local store helper module', swAuditSrc.includes("'/js/lens-local-store.js'"));
 assert('SW APP_SHELL includes DNA action delegates module', swAuditSrc.includes("'/js/dna-actions.js'"));
 assert('SW APP_SHELL includes DNA genotype helper module', swAuditSrc.includes("'/js/dna-genotype.js'"));
+assert('SW APP_SHELL includes DNA UI owner module', swAuditSrc.includes("'/js/dna-ui.js'"));
 assert('SW APP_SHELL includes DNA mtDNA helper module', swAuditSrc.includes("'/js/dna-mtdna.js'"));
 assert('SW APP_SHELL includes service worker update module', swAuditSrc.includes("'/js/service-worker-update.js'"));
 assert('index loads app shell CSS bundle', indexSrc.includes('href="css/app-shell.css"'));
@@ -526,6 +527,8 @@ const markerDetailCssAuditSrc = read('css/marker-detail-modal.css');
 const contextProfileCssAuditSrc = read('css/context-profile.css');
 const contextEditorCssAuditSrc = read('css/context-editor.css');
 const dnaSrc = read('js/dna.js');
+const dnaUiSrc = read('js/dna-ui.js');
+const dnaSurfaceSrc = `${dnaSrc}\n${dnaUiSrc}`;
 assert('Trend alert name escaped', dashboardLabRenderersSrc.includes('escapeHTML(alert.name)'));
 assert('Trend alert category escaped', dashboardLabRenderersSrc.includes('escapeHTML(alert.category)'));
 assert('Flagged marker name escaped', /escapeHTML\(f\.name\)/.test(dashboardLabRenderersSrc));
@@ -539,7 +542,7 @@ assert('Correlation option names escaped', /escapeHTML\(marker\.name\)/.test(com
 assert('Light channel device names escaped before next-move HTML',
   /const dev = matchingDevice \? escapeHTML\(`\$\{matchingDevice\.brand\} \$\{matchingDevice\.model\}`\) : ''/.test(lightChannelViewSrc));
 assert('Genome genetics refs keep shared unscoped CSS',
-  dnaSrc.includes('class="detail-genetics-ref"') && /\.detail-genetics-ref\s*\{/.test(geneticsCssAuditSrc));
+  dnaUiSrc.includes('class="detail-genetics-ref"') && /\.detail-genetics-ref\s*\{/.test(geneticsCssAuditSrc));
 assert('Marker detail bundle does not own shared genetics refs',
   !/\.marker-detail-modal\s+\.detail-genetics(?:-ref)?/.test(markerDetailCssAuditSrc));
 
@@ -640,11 +643,11 @@ assert('Lens page controls use delegated shell actions',
     && lensPageShellSrc.includes('open-privacy-settings')
     && !/\son(?:click|change|input)\s*=/.test(lensPagesSrc));
 assert('DNA controls use delegated actions',
-  dnaSrc.includes("from './dna-actions.js'")
+  dnaSurfaceSrc.includes("from './dna-actions.js'")
     && dnaActionsSrc.includes('function handleDnaActionClick')
     && dnaActionsSrc.includes('function handleDnaActionKeydown')
     && dnaActionsSrc.includes('export function dnaActionAttrs')
-    && !/\son(?:click|keydown|change|input)\s*=/.test(dnaSrc));
+    && !/\son(?:click|keydown|change|input)\s*=/.test(dnaSurfaceSrc));
 
 const _SANITIZER_RE = /(escapeHTML|safeMarkerId|escapeAttr|applyInlineMarkdown|renderMarkdown)\s*\(/;
 const _SAFE_HELPERS = new Set([

--- a/tests/test-dna.js
+++ b/tests/test-dna.js
@@ -491,11 +491,13 @@ assert('Genome lens header keeps affiliate link on its own row',
   stylesSrc.includes('flex-basis: 100%'));
 
 const dnaSrc = await fetchWithRetry('js/dna.js');
+const dnaUiSrc = await fetchWithRetry('js/dna-ui.js');
+const dnaSurfaceSrc = `${dnaSrc}\n${dnaUiSrc}`;
 const dnaRuntimeSrc = await fetchWithRetry('js/dna-runtime.js');
 const dnaMtDnaSrc = await fetchWithRetry('js/dna-mtdna.js');
 assert('dna.js delegates browser runtime hooks to dna-runtime',
   dnaSrc.includes("from './dna-runtime.js'") &&
-    !/\bwindow\b/.test(dnaSrc));
+    !/\bwindow\b/.test(dnaSurfaceSrc));
 assert('dna-runtime owns DNA transient runtime state and shell integration',
   dnaRuntimeSrc.includes('_pendingDNAImport') &&
     dnaRuntimeSrc.includes('_pendingMtDNA') &&
@@ -511,23 +513,23 @@ assert('dna-mtdna delegates browser runtime hooks to dna-runtime',
     dnaMtDnaSrc.includes('getDnaProfileLatitudeBand') &&
     dnaMtDnaSrc.includes('refreshDnaShell') &&
     !/\bwindow(?:\.|\s*\[)/.test(dnaMtDnaSrc));
-assert('genetics section collapses non-priority SNP calls', dnaSrc.includes('genetics-other-snps') && dnaSrc.includes('Other imported SNPs'));
+assert('genetics section collapses non-priority SNP calls', dnaUiSrc.includes('genetics-other-snps') && dnaUiSrc.includes('Other imported SNPs'));
 assert('genetics actions expose manual SNP and report import escape hatches',
-  dnaSrc.includes("dnaActionAttrs('add-manual-snp')") &&
-  dnaSrc.includes("dnaActionAttrs('import-snp-report')") &&
+  dnaUiSrc.includes("dnaActionAttrs('add-manual-snp')") &&
+  dnaUiSrc.includes("dnaActionAttrs('import-snp-report')") &&
   dnaSrc.includes("accept = '.pdf,.txt,.csv,.text'") &&
-  dnaSrc.includes('manual-snp-bulk') &&
-  dnaSrc.includes('Save SNPs') &&
-  dnaSrc.includes('Same path, no duplicate modes'));
+  dnaUiSrc.includes('manual-snp-bulk') &&
+  dnaUiSrc.includes('Save SNPs') &&
+  dnaUiSrc.includes('Same path, no duplicate modes'));
 assert('manual SNP UI uses one paste surface instead of duplicate single/bulk mechanisms',
-  dnaSrc.includes('<textarea id="manual-snp-bulk"') &&
-  !dnaSrc.includes('id="manual-snp-rsid"') &&
-  !dnaSrc.includes('id="manual-snp-genotype"') &&
-  !dnaSrc.includes('Single SNP'));
+  dnaUiSrc.includes('<textarea id="manual-snp-bulk"') &&
+  !dnaUiSrc.includes('id="manual-snp-rsid"') &&
+  !dnaUiSrc.includes('id="manual-snp-genotype"') &&
+  !dnaUiSrc.includes('Single SNP'));
 assert('manual SNP modal uses genetics-styled controls instead of generic form-input fields',
-  dnaSrc.includes('dna-manual-input') &&
-  dnaSrc.includes('dna-manual-textarea') &&
-  !dnaSrc.includes('id="manual-snp-rsid" class="form-input"'));
+  dnaUiSrc.includes('dna-manual-input') &&
+  dnaUiSrc.includes('dna-manual-textarea') &&
+  !dnaUiSrc.includes('id="manual-snp-rsid" class="form-input"'));
 assert('manual SNP CSS gives inputs app-native surfaces and focus rings',
   stylesSrc.includes('.dna-manual-input') &&
   stylesSrc.includes('background: var(--bg-primary)') &&
@@ -540,19 +542,20 @@ assert('manual/report SNP imports stage changes in a draft and restore memory on
   dnaSrc.includes('state.importedData = originalData'));
 assert('manual/report SNP imports merge through upsert instead of replacing genetics',
   dnaSrc.includes('result.mergeSnps') && dnaSrc.includes('upsertGeneticsSnp(draftData'));
-assert('DNA import preview separates beneficial findings', dnaSrc.includes('Beneficial findings') && dnaSrc.includes("impact: m.valence === 'protective' ? 'beneficial' : m.effect"));
+assert('DNA import preview separates beneficial findings', dnaUiSrc.includes('Beneficial findings') && dnaUiSrc.includes("impact: match.valence === 'protective' ? 'beneficial' : match.effect"));
 assert('DNA preview modal uses shared overlay lifecycle helpers and backdrop nudge',
-  dnaSrc.includes("from './modal-lifecycle.js'") &&
-    dnaSrc.includes('nudgeDnaModal') &&
-    dnaSrc.includes("classList.add('modal-nudge')") &&
-    dnaSrc.includes('handleDnaBackdropClick') &&
-    dnaSrc.includes("target.id !== 'dna-modal-overlay'") &&
-    dnaSrc.includes('handleDnaModalEscape') &&
-    dnaSrc.includes("event.key !== 'Escape'") &&
+  dnaUiSrc.includes("from './modal-lifecycle.js'") &&
+    dnaUiSrc.includes('nudgeDnaModal') &&
+    dnaUiSrc.includes("classList.add('modal-nudge')") &&
+    dnaUiSrc.includes('handleDnaBackdropClick') &&
+    dnaUiSrc.includes("target.id !== 'dna-modal-overlay'") &&
+    dnaUiSrc.includes('handleDnaModalEscape') &&
+    dnaUiSrc.includes("event.key !== 'Escape'") &&
     dnaMtDnaSrc.includes("from './modal-lifecycle.js'") &&
-    dnaSrc.includes('openDnaModalOverlay(overlay') &&
+    dnaUiSrc.includes('openDnaModalOverlay(overlay') &&
     dnaMtDnaSrc.includes('openModalOverlay(overlay)') &&
     ((dnaSrc.match(/closeModalOverlay\('dna-modal-overlay'\)/g) || []).length
+      + (dnaUiSrc.match(/closeModalOverlay\('dna-modal-overlay'\)/g) || []).length
       + (dnaMtDnaSrc.match(/closeModalOverlay\('dna-modal-overlay'\)/g) || []).length) === 4);
 assert('DNA import success waits for persistence',
   /async function confirmDNAImport\(\)[\s\S]{0,900}await saveImportedData\(\)/.test(dnaSrc));
@@ -565,8 +568,8 @@ assert('mtDNA save paths wait for persistence',
   /export async function confirmMtDNAImport\(\)[\s\S]{0,1200}await saveImportedData\(\)/.test(dnaMtDnaSrc) &&
   /export async function deleteMtDNAData\(\)[\s\S]{0,180}await saveImportedData\(\)/.test(dnaMtDnaSrc));
 assert('DNA reference links use attribute escaping instead of quote-only replacement',
-  dnaSrc.includes('escapeAttr(primaryRef)') &&
-  !dnaSrc.includes("f.references[0].replace(/\\\"/g, '&quot;')"));
+  dnaUiSrc.includes('escapeAttr(primaryRef)') &&
+  !dnaSurfaceSrc.includes("f.references[0].replace(/\\\"/g, '&quot;')"));
 
 const labCtxSrc = await fetchWithRetry('js/lab-context.js');
 assert('lab-context.js uses the DNA module bridge for genetics context',

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -198,6 +198,7 @@ const highValueCheckJsModules = [
   'js/dashboard-lab-widget-renderers.js',
   'js/dashboard-widget-renderers.js',
   'js/dna.js',
+  'js/dna-ui.js',
   'js/dna-runtime.js',
   'js/export-import.js',
   'js/export.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -126,6 +126,7 @@
     "js/data-merge.js",
     "js/data.js",
     "js/dna.js",
+    "js/dna-ui.js",
     "js/dna-file-detection.js",
     "js/dna-parser.js",
     "js/dna-runtime.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -124,6 +124,7 @@
     "js/data-merge.js",
     "js/data.js",
     "js/dna.js",
+    "js/dna-ui.js",
     "js/dna-runtime.js",
     "js/dna-runtime-bridge.js",
     "js/emf.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.462';
+self.APP_VERSION = '1.10.463';


### PR DESCRIPTION
## Summary
- move genetics dashboard rendering and autosomal DNA modal lifecycle into `dna-ui.js`
- keep parsing, storage, import confirmation, and the public `dna.js` facade stable through injected dependencies
- register the new offline/typechecked module and reduce the >=800-line JavaScript baseline from 14 to 13

## Verification
- DNA adapter: 186/186
- DNA Illumina/valence: 134/134
- mtDNA subclades: 105/105
- DNA recommendations/runtime/empty-state: 86/86
- pre-release audit: 366/366
- focused production/service-worker Vitest: 30/30
- focused DNA Playwright: 4/4
- typecheck, checkjs, strict-null, quality, production, architecture, module verification, correctness, and a11y gates passed