### PR TITLE
Refactor Crypto UI into a cohesive owner

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -9,8 +9,8 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 
 | Metric | Current |
 | --- | ---: |
-| Modules | 508 |
-| Internal import edges | 2296 |
+| Modules | 509 |
+| Internal import edges | 2300 |
 | Dynamic internal edges | 93 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -41,8 +41,8 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 | [`js/utils.js`](js/utils.js) | 237 | [`js/app-shell-hooks.js`](js/app-shell-hooks.js) | 72 |
 | [`js/state.js`](js/state.js) | 163 | [`js/app-light-sun-modules.js`](js/app-light-sun-modules.js) | 36 |
 | [`js/data.js`](js/data.js) | 76 | [`js/sync-configure.js`](js/sync-configure.js) | 27 |
-| [`js/caught-error.js`](js/caught-error.js) | 73 | [`js/settings.js`](js/settings.js) | 25 |
-| [`js/modal-lifecycle.js`](js/modal-lifecycle.js) | 68 | [`js/pdf-import.js`](js/pdf-import.js) | 24 |
+| [`js/caught-error.js`](js/caught-error.js) | 74 | [`js/settings.js`](js/settings.js) | 25 |
+| [`js/modal-lifecycle.js`](js/modal-lifecycle.js) | 69 | [`js/pdf-import.js`](js/pdf-import.js) | 24 |
 | [`js/api.js`](js/api.js) | 64 | [`js/chat-send.js`](js/chat-send.js) | 22 |
 | [`js/profile.js`](js/profile.js) | 45 | [`js/views.js`](js/views.js) | 22 |
 | [`js/schema.js`](js/schema.js) | 33 | [`js/wearables-connect.js`](js/wearables-connect.js) | 21 |
@@ -297,10 +297,11 @@ Native browser modules shipped with the static application.
 
 </details>
 
-<details><summary><code>crypto</code> family — 2 modules</summary>
+<details><summary><code>crypto</code> family — 3 modules</summary>
 
 - [`js/crypto-key-cache.js`](js/crypto-key-cache.js) → no in-scope imports
-- [`js/crypto.js`](js/crypto.js) → [`js/backup.js`](js/backup.js), [`js/blob-storage.js`](js/blob-storage.js), [`js/cashu-wallet-store.js`](js/cashu-wallet-store.js) *(dynamic)*, [`js/caught-error.js`](js/caught-error.js), [`js/crypto-key-cache.js`](js/crypto-key-cache.js), [`js/cycle-store.js`](js/cycle-store.js), [`js/data-merge.js`](js/data-merge.js), [`js/data-wipe.js`](js/data-wipe.js) *(dynamic)*, [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/profile-storage-key.js`](js/profile-storage-key.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js), [`js/wearables-store.js`](js/wearables-store.js)
+- [`js/crypto-ui.js`](js/crypto-ui.js) → [`js/backup.js`](js/backup.js), [`js/caught-error.js`](js/caught-error.js), [`js/data-wipe.js`](js/data-wipe.js) *(dynamic)*, [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/utils.js`](js/utils.js)
+- [`js/crypto.js`](js/crypto.js) → [`js/backup.js`](js/backup.js), [`js/blob-storage.js`](js/blob-storage.js), [`js/cashu-wallet-store.js`](js/cashu-wallet-store.js) *(dynamic)*, [`js/caught-error.js`](js/caught-error.js), [`js/crypto-key-cache.js`](js/crypto-key-cache.js), [`js/crypto-ui.js`](js/crypto-ui.js), [`js/cycle-store.js`](js/cycle-store.js), [`js/data-merge.js`](js/data-merge.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/profile-storage-key.js`](js/profile-storage-key.js), [`js/state.js`](js/state.js), [`js/wearables-store.js`](js/wearables-store.js)
 
 </details>
 

--- a/js/crypto-ui.js
+++ b/js/crypto-ui.js
@@ -1,0 +1,649 @@
+// @ts-check
+// crypto-ui.js — Encryption dialogs, nudges, delegates, and settings UI owner.
+
+import { getErrorMessage } from './caught-error.js';
+import { escapeAttr, escapeHTML, showConfirmDialog, showNotification } from './utils.js';
+import {
+  isDataProtectionStylesheetLoaded,
+  loadDataProtectionStylesheetForAction,
+} from './modal-lifecycle.js';
+import {
+  exportEncryptedBackup,
+  getAutoBackupSnapshots,
+  getFolderBackupState,
+  importEncryptedBackup,
+  MAX_SNAPSHOTS,
+  renderFolderBackupSection,
+  restoreAutoBackup,
+} from './backup.js';
+
+/** @type {Record<string, any>} */
+const cryptoUiDeps = {
+  changeEncryptionPassphrase: null,
+  clearEncryptionSession: null,
+  disableEncryptionStorage: null,
+  getEncryptionEnabled: () => false,
+  migrateEncryptionStorage: null,
+  prepareEncryption: null,
+  unlockEncryption: null,
+};
+
+export function configureCryptoUi(deps = {}) {
+  const previous = { ...cryptoUiDeps };
+  for (const [key, value] of Object.entries(deps || {})) {
+    if (Object.hasOwn(cryptoUiDeps, key) && typeof value === 'function') {
+      cryptoUiDeps[key] = value;
+    }
+  }
+  return previous;
+}
+
+const needsDataProtectionStylesheet = () => typeof document !== 'undefined'
+  && !!document.querySelector('[data-data-protection-stylesheet-anchor]')
+  && !isDataProtectionStylesheetLoaded();
+
+function runWithDataProtectionStylesheet(action) {
+  if (!needsDataProtectionStylesheet()) return action();
+  return loadDataProtectionStylesheetForAction().then(loaded => {
+    if (loaded) return action();
+    showNotification('Data protection controls could not be loaded. Try again.', 'error');
+    return false;
+  });
+}
+
+const cryptoActionDelegateRoots = new WeakSet();
+const CRYPTO_ACTION_DELEGATE_KEY = Symbol.for('getbased.cryptoActionDelegatesInstalled');
+const CRYPTO_ACTION_ATTR = 'data-crypto-action';
+const CRYPTO_ACTION_SELECTOR = `[${CRYPTO_ACTION_ATTR}]`;
+
+function cryptoActionAttrs(action, attrs = {}) {
+  let html = `${CRYPTO_ACTION_ATTR}="${escapeAttr(action)}"`;
+  for (const [key, value] of Object.entries(attrs)) {
+    if (value == null) continue;
+    const attr = key.replace(/[A-Z]/g, character => '-' + character.toLowerCase());
+    html += ` data-crypto-${attr}="${escapeAttr(String(value))}"`;
+  }
+  return html;
+}
+
+function closestCryptoAction(target) {
+  return /** @type {HTMLElement | null} */ (
+    target && typeof target.closest === 'function'
+      ? target.closest(CRYPTO_ACTION_SELECTOR)
+      : null
+  );
+}
+
+function readSnapshotActionId(actionElement) {
+  const raw = actionElement.dataset.cryptoSnapshotId;
+  if (raw == null) return null;
+  if (actionElement.dataset.cryptoSnapshotIdType === 'number') {
+    const id = Number(raw);
+    return Number.isFinite(id) ? id : null;
+  }
+  return raw;
+}
+
+function handleCryptoActionClick(event) {
+  const actionElement = closestCryptoAction(event.target);
+  if (!actionElement || !event.currentTarget?.contains?.(actionElement)) return;
+  const action = actionElement.getAttribute(CRYPTO_ACTION_ATTR);
+  if (action === 'change-passphrase') changePassphrase();
+  else if (action === 'disable-encryption') disableEncryption();
+  else if (action === 'enable-encryption') showEnableEncryptionModal();
+  else if (action === 'export-backup') exportEncryptedBackup();
+  else if (action === 'toggle-backup-snapshots') toggleBackupSnapshots();
+  else if (action === 'restore-auto-backup') {
+    const id = readSnapshotActionId(actionElement);
+    if (id == null) return;
+    restoreAutoBackup(id);
+  } else {
+    return;
+  }
+  event.preventDefault();
+  event.stopPropagation();
+}
+
+function handleCryptoActionKeydown(event) {
+  if (event.key !== 'Enter' && event.key !== ' ') return;
+  const actionElement = closestCryptoAction(event.target);
+  if (!actionElement || actionElement.getAttribute('role') !== 'button') return;
+  if (event.target?.closest?.('button, a, input, textarea, select')) return;
+  handleCryptoActionClick(event);
+}
+
+function handleCryptoActionChange(event) {
+  const actionElement = closestCryptoAction(event.target);
+  if (!actionElement || !event.currentTarget?.contains?.(actionElement)) return;
+  if (actionElement.getAttribute(CRYPTO_ACTION_ATTR) !== 'import-backup') return;
+  const fileInput = /** @type {HTMLInputElement} */ (actionElement);
+  const file = fileInput.files && fileInput.files[0];
+  if (!file) return;
+  importEncryptedBackup(file);
+  fileInput.value = '';
+  event.stopPropagation();
+}
+
+export function installCryptoActionDelegates(root = typeof document !== 'undefined' ? document : null) {
+  if (!root || cryptoActionDelegateRoots.has(root) || root[CRYPTO_ACTION_DELEGATE_KEY]) return;
+  cryptoActionDelegateRoots.add(root);
+  Object.defineProperty(root, CRYPTO_ACTION_DELEGATE_KEY, { value: true, configurable: true });
+  root.addEventListener('click', handleCryptoActionClick);
+  root.addEventListener('keydown', handleCryptoActionKeydown);
+  root.addEventListener('change', handleCryptoActionChange);
+}
+
+if (typeof document !== 'undefined') installCryptoActionDelegates();
+
+let failCount = 0;
+
+export function showPassphraseModal(onSuccess) {
+  let overlay = document.getElementById('passphrase-overlay');
+  if (!overlay) {
+    overlay = document.createElement('div');
+    overlay.id = 'passphrase-overlay';
+    overlay.className = 'passphrase-overlay';
+    document.body.appendChild(overlay);
+  }
+  failCount = 0;
+  renderPassphraseForm(overlay, onSuccess);
+}
+
+function renderPassphraseForm(overlay, onSuccess) {
+  overlay.innerHTML = `
+    <div class="passphrase-dialog" role="dialog" aria-modal="true" aria-label="Enter passphrase">
+      <div class="passphrase-icon">&#128274;</div>
+      <h3 class="passphrase-title">Unlock getbased</h3>
+      <p class="passphrase-desc">Your data is encrypted. Enter your passphrase to continue.</p>
+      <input type="password" class="passphrase-input" id="passphrase-unlock-input" placeholder="Passphrase" autocomplete="current-password" autofocus>
+      <div class="passphrase-error" id="passphrase-error"></div>
+      <button class="passphrase-btn passphrase-btn-primary" id="passphrase-unlock-btn">Unlock</button>
+      <button class="passphrase-btn passphrase-btn-link" id="passphrase-forgot-btn">Forgot passphrase?</button>
+    </div>`;
+  const input = /** @type {HTMLInputElement | null} */ (document.getElementById('passphrase-unlock-input'));
+  const button = /** @type {HTMLButtonElement | null} */ (document.getElementById('passphrase-unlock-btn'));
+  const errorElement = document.getElementById('passphrase-error');
+  const forgotButton = /** @type {HTMLButtonElement | null} */ (document.getElementById('passphrase-forgot-btn'));
+  if (!input || !button || !errorElement || !forgotButton) return;
+  overlay.style.display = 'flex';
+
+  const attemptUnlock = async () => {
+    const passphrase = input.value;
+    if (!passphrase) { errorElement.textContent = 'Please enter your passphrase'; return; }
+    button.disabled = true;
+    button.textContent = 'Decrypting...';
+    errorElement.textContent = '';
+
+    if (failCount >= 3) {
+      errorElement.textContent = 'Too many attempts. Please wait...';
+      await new Promise(resolve => setTimeout(resolve, 5000));
+      errorElement.textContent = '';
+    }
+
+    try {
+      await cryptoUiDeps.unlockEncryption?.(passphrase);
+      overlay.style.display = 'none';
+      overlay.innerHTML = '';
+      onSuccess();
+    } catch {
+      failCount++;
+      input.value = '';
+      errorElement.textContent = `Wrong passphrase (attempt ${failCount})`;
+      button.disabled = false;
+      button.textContent = 'Unlock';
+      input.focus();
+    }
+  };
+
+  button.addEventListener('click', attemptUnlock);
+  input.addEventListener('keydown', event => {
+    if (event.key === 'Enter') attemptUnlock();
+  });
+
+  forgotButton.addEventListener('click', () => {
+    // Inline confirm inside the passphrase overlay (can't use showConfirmDialog — it's behind this z-index)
+    const dialog = /** @type {HTMLElement | null} */ (overlay.querySelector('.passphrase-dialog'));
+    if (!dialog) return;
+    dialog.innerHTML = `
+      <div class="passphrase-icon">&#9888;&#65039;</div>
+      <h3 class="passphrase-title">Erase All Data?</h3>
+      <p class="passphrase-desc">If you forgot your passphrase, the only option is to <strong>erase all data</strong> and start fresh. This cannot be undone.</p>
+      <div style="display:flex;gap:8px;margin-top:12px">
+        <button class="passphrase-btn passphrase-btn-secondary" id="passphrase-forgot-cancel">Go Back</button>
+        <button class="passphrase-btn passphrase-btn-primary" id="passphrase-forgot-confirm" style="background:var(--red)">Erase Everything</button>
+      </div>`;
+    document.getElementById('passphrase-forgot-cancel')?.addEventListener('click', () => {
+      renderPassphraseForm(overlay, onSuccess);
+    });
+    document.getElementById('passphrase-forgot-confirm')?.addEventListener('click', async () => {
+      try {
+        const { eraseAllLocalAppData } = await import('./data-wipe.js');
+        await eraseAllLocalAppData();
+      } catch {
+        const keysToRemove = [];
+        for (let index = 0; index < localStorage.length; index++) {
+          const key = localStorage.key(index);
+          if (key && key.startsWith('labcharts')) keysToRemove.push(key);
+        }
+        keysToRemove.forEach(key => localStorage.removeItem(key));
+      }
+      cryptoUiDeps.clearEncryptionSession?.();
+      overlay.style.display = 'none';
+      overlay.innerHTML = '';
+      location.reload();
+    });
+  });
+
+  setTimeout(() => input.focus(), 50);
+}
+
+function validatePassphrase(passphrase) {
+  if (passphrase.length < 8) return { valid: false, message: 'At least 8 characters' };
+  if (!/[a-z]/.test(passphrase)) return { valid: false, message: 'At least 1 lowercase letter' };
+  if (!/[A-Z]/.test(passphrase)) return { valid: false, message: 'At least 1 uppercase letter' };
+  if (!/[!@#$%^&*()\-_=+\[\]{};:'",.<>?/\\|`~]/.test(passphrase)) return { valid: false, message: 'At least 1 special character' };
+  return { valid: true, message: '' };
+}
+
+function getPassphraseStrength(passphrase) {
+  let score = 0;
+  if (passphrase.length >= 8) score++;
+  if (/[a-z]/.test(passphrase)) score++;
+  if (/[A-Z]/.test(passphrase)) score++;
+  if (/[!@#$%^&*()\-_=+\[\]{};:'",.<>?/\\|`~]/.test(passphrase)) score++;
+  return score;
+}
+
+export function showEnableEncryptionModal() {
+  if (needsDataProtectionStylesheet()) {
+    return runWithDataProtectionStylesheet(() => showEnableEncryptionModal());
+  }
+  let overlay = document.getElementById('passphrase-overlay');
+  if (!overlay) {
+    overlay = document.createElement('div');
+    overlay.id = 'passphrase-overlay';
+    overlay.className = 'passphrase-overlay';
+    document.body.appendChild(overlay);
+  }
+  overlay.innerHTML = `
+    <div class="passphrase-dialog" role="dialog" aria-modal="true" aria-label="Set encryption passphrase">
+      <div class="passphrase-icon">&#128274;</div>
+      <h3 class="passphrase-title">Enable Encryption</h3>
+      <p class="passphrase-desc">Set a passphrase to encrypt your medical data at rest. <strong>If you forget this passphrase, your data cannot be recovered.</strong></p>
+      <input type="password" class="passphrase-input" id="passphrase-set-input" placeholder="Enter passphrase" autocomplete="new-password" autofocus>
+      <input type="password" class="passphrase-input" id="passphrase-confirm-input" placeholder="Confirm passphrase" autocomplete="new-password">
+      <div class="passphrase-strength" id="passphrase-strength">
+        <div class="passphrase-strength-bars">
+          <div class="passphrase-strength-bar" data-index="0"></div>
+          <div class="passphrase-strength-bar" data-index="1"></div>
+          <div class="passphrase-strength-bar" data-index="2"></div>
+          <div class="passphrase-strength-bar" data-index="3"></div>
+        </div>
+        <ul class="passphrase-rules" id="passphrase-rules">
+          <li data-rule="length">At least 8 characters</li>
+          <li data-rule="lower">At least 1 lowercase letter</li>
+          <li data-rule="upper">At least 1 uppercase letter</li>
+          <li data-rule="special">At least 1 special character</li>
+        </ul>
+      </div>
+      <div class="passphrase-error" id="passphrase-set-error"></div>
+      <div style="display:flex;gap:8px;margin-top:8px">
+        <button class="passphrase-btn passphrase-btn-secondary" id="passphrase-set-cancel">Cancel</button>
+        <button class="passphrase-btn passphrase-btn-primary" id="passphrase-set-btn">Enable Encryption</button>
+      </div>
+    </div>`;
+  const passphraseInput = /** @type {HTMLInputElement | null} */ (document.getElementById('passphrase-set-input'));
+  const confirmInput = /** @type {HTMLInputElement | null} */ (document.getElementById('passphrase-confirm-input'));
+  const button = /** @type {HTMLButtonElement | null} */ (document.getElementById('passphrase-set-btn'));
+  const cancelButton = /** @type {HTMLButtonElement | null} */ (document.getElementById('passphrase-set-cancel'));
+  const errorElement = document.getElementById('passphrase-set-error');
+  if (!passphraseInput || !confirmInput || !button || !cancelButton || !errorElement) return;
+  overlay.style.display = 'flex';
+
+  const strengthBars = /** @type {NodeListOf<HTMLElement>} */ (overlay.querySelectorAll('.passphrase-strength-bar'));
+  const ruleItems = overlay.querySelectorAll('.passphrase-rules li');
+  const barColors = ['var(--red)', 'var(--orange)', 'var(--yellow)', 'var(--green)'];
+  let migrationStarted = false;
+
+  const updateStrengthMeter = () => {
+    const passphrase = passphraseInput.value;
+    const score = getPassphraseStrength(passphrase);
+    strengthBars.forEach((bar, index) => {
+      bar.style.background = index < score ? barColors[score - 1] : 'var(--border)';
+    });
+    const checks = [
+      passphrase.length >= 8,
+      /[a-z]/.test(passphrase),
+      /[A-Z]/.test(passphrase),
+      /[!@#$%^&*()\-_=+\[\]{};:'",.<>?/\\|`~]/.test(passphrase),
+    ];
+    ruleItems.forEach((item, index) => item.classList.toggle('met', checks[index]));
+  };
+  passphraseInput.addEventListener('input', updateStrengthMeter);
+
+  cancelButton.addEventListener('click', () => {
+    overlay.style.display = 'none';
+    overlay.innerHTML = '';
+  });
+
+  button.addEventListener('click', async () => {
+    const passphrase = passphraseInput.value;
+    const confirmation = confirmInput.value;
+    if (!passphrase) { errorElement.textContent = 'Please enter a passphrase'; return; }
+    const validation = validatePassphrase(passphrase);
+    if (!validation.valid) { errorElement.textContent = validation.message; return; }
+    if (passphrase !== confirmation) { errorElement.textContent = 'Passphrases do not match'; return; }
+
+    button.disabled = true;
+    button.textContent = 'Encrypting...';
+    errorElement.textContent = '';
+
+    try {
+      if (!migrationStarted) {
+        await cryptoUiDeps.prepareEncryption?.(passphrase);
+        migrationStarted = true;
+      }
+      await cryptoUiDeps.migrateEncryptionStorage?.();
+      overlay.style.display = 'none';
+      overlay.innerHTML = '';
+      showNotification('Encryption enabled \u2014 keep your passphrase safe', 'success');
+      const section = document.getElementById('encryption-section');
+      if (section) section.innerHTML = renderEncryptionSection();
+    } catch (error) {
+      errorElement.textContent = 'Encryption failed: ' + getErrorMessage(error);
+      button.disabled = false;
+      button.textContent = migrationStarted ? 'Retry Encryption' : 'Enable Encryption';
+    }
+  });
+
+  confirmInput.addEventListener('keydown', event => {
+    if (event.key === 'Enter') button.click();
+  });
+
+  setTimeout(() => passphraseInput.focus(), 50);
+}
+
+export function maybeShowEncryptionNudge() {
+  if (cryptoUiDeps.getEncryptionEnabled()) return;
+  if (localStorage.getItem('labcharts-encryption-nudge-dismissed')) return;
+  if (needsDataProtectionStylesheet()) {
+    return void runWithDataProtectionStylesheet(() => maybeShowEncryptionNudge());
+  }
+  setTimeout(() => {
+    let overlay = document.getElementById('passphrase-overlay');
+    if (!overlay) {
+      overlay = document.createElement('div');
+      overlay.id = 'passphrase-overlay';
+      overlay.className = 'passphrase-overlay';
+      document.body.appendChild(overlay);
+    }
+    overlay.innerHTML = `
+      <div class="passphrase-dialog" role="dialog" aria-modal="true" aria-label="Enable encryption">
+        <div class="passphrase-icon">&#128274;</div>
+        <h3 class="passphrase-title">Protect Your Data</h3>
+        <p class="passphrase-desc">Your lab results are stored in your browser's local storage, where browser extensions and anyone with filesystem access can read them. Set a passphrase to encrypt your data at rest.</p>
+        <div style="display:flex;gap:8px;margin-top:12px">
+          <button class="passphrase-btn passphrase-btn-secondary" id="encryption-nudge-dismiss">Not Now</button>
+          <button class="passphrase-btn passphrase-btn-primary" id="encryption-nudge-enable">Enable Encryption</button>
+        </div>
+      </div>`;
+    overlay.style.display = 'flex';
+    const dismissButton = document.getElementById('encryption-nudge-dismiss');
+    const enableButton = document.getElementById('encryption-nudge-enable');
+    if (!dismissButton || !enableButton) return;
+    dismissButton.addEventListener('click', () => {
+      localStorage.setItem('labcharts-encryption-nudge-dismissed', 'true');
+      overlay.style.display = 'none';
+      overlay.innerHTML = '';
+    });
+    enableButton.addEventListener('click', () => {
+      overlay.style.display = 'none';
+      overlay.innerHTML = '';
+      showEnableEncryptionModal();
+    });
+  }, 800);
+}
+
+export function maybeShowBackupNudge() {
+  if (document.getElementById('tour-overlay')) return;
+
+  const profiles = localStorage.getItem('labcharts-profiles');
+  if (!profiles) return;
+  let profileList;
+  try {
+    profileList = JSON.parse(profiles);
+    if (profileList.length === 0) return;
+  } catch {
+    return;
+  }
+  const hasAnyData = profileList.some(profile => {
+    try {
+      const data = JSON.parse(localStorage.getItem(`labcharts-${profile.id}-imported`) || '{}');
+      return data.entries && data.entries.length > 0;
+    } catch {
+      return false;
+    }
+  });
+  if (!hasAnyData) return;
+
+  const folderBackupState = getFolderBackupState();
+  if (folderBackupState?.folderName && !folderBackupState?.permissionLost) return;
+  const snoozedUntil = localStorage.getItem('labcharts-backup-nudge-snoozed-until');
+  if (snoozedUntil && Date.now() < Number(snoozedUntil)) return;
+
+  const THIRTY_DAYS = 30 * 24 * 60 * 60 * 1000;
+  const lastManual = localStorage.getItem('labcharts-last-manual-backup');
+  const lastFolder = localStorage.getItem('labcharts-folder-backup-last');
+  const mostRecent = Math.max(
+    lastManual ? new Date(lastManual).getTime() : 0,
+    lastFolder ? new Date(lastFolder).getTime() : 0,
+  );
+  if (mostRecent > 0 && (Date.now() - mostRecent) < THIRTY_DAYS) return;
+
+  const overlay = document.getElementById('passphrase-overlay');
+  if (overlay && overlay.style.display === 'flex') return;
+  if (needsDataProtectionStylesheet()) {
+    void runWithDataProtectionStylesheet(() => maybeShowBackupNudge());
+    return;
+  }
+
+  setTimeout(() => {
+    const visibleOverlay = document.getElementById('passphrase-overlay');
+    if (visibleOverlay && visibleOverlay.style.display === 'flex') return;
+
+    let nudgeOverlay = document.getElementById('passphrase-overlay');
+    if (!nudgeOverlay) {
+      nudgeOverlay = document.createElement('div');
+      nudgeOverlay.id = 'passphrase-overlay';
+      nudgeOverlay.className = 'passphrase-overlay';
+      document.body.appendChild(nudgeOverlay);
+    }
+    nudgeOverlay.innerHTML = `
+      <div class="passphrase-dialog" role="dialog" aria-modal="true" aria-label="Backup reminder">
+        <div class="passphrase-icon">&#128190;</div>
+        <h3 class="passphrase-title">Back Up Your Data</h3>
+        <p class="passphrase-desc">Your lab results only exist in this browser. Download a backup to protect against data loss.</p>
+        <div style="display:flex;gap:8px;margin-top:12px">
+          <button class="passphrase-btn passphrase-btn-secondary" id="backup-nudge-snooze">Not Now</button>
+          <button class="passphrase-btn passphrase-btn-primary" id="backup-nudge-download">Download Now</button>
+        </div>
+      </div>`;
+    nudgeOverlay.style.display = 'flex';
+    const snoozeButton = document.getElementById('backup-nudge-snooze');
+    const downloadButton = document.getElementById('backup-nudge-download');
+    if (!snoozeButton || !downloadButton) return;
+    snoozeButton.addEventListener('click', () => {
+      localStorage.setItem('labcharts-backup-nudge-snoozed-until', String(Date.now() + THIRTY_DAYS));
+      nudgeOverlay.style.display = 'none';
+      nudgeOverlay.innerHTML = '';
+    });
+    downloadButton.addEventListener('click', () => {
+      nudgeOverlay.style.display = 'none';
+      nudgeOverlay.innerHTML = '';
+      exportEncryptedBackup();
+    });
+  }, 500);
+}
+
+export async function disableEncryption() {
+  if (!await showConfirmDialog('Disable encryption? Your data will be stored in plaintext.')) return;
+  try {
+    await cryptoUiDeps.disableEncryptionStorage?.();
+    showNotification('Encryption disabled', 'info');
+    const section = document.getElementById('encryption-section');
+    if (section) section.innerHTML = renderEncryptionSection();
+  } catch (error) {
+    showNotification('Failed to disable encryption: ' + getErrorMessage(error), 'error');
+  }
+}
+
+export async function changePassphrase() {
+  if (needsDataProtectionStylesheet()) {
+    return runWithDataProtectionStylesheet(() => changePassphrase());
+  }
+  let overlay = document.getElementById('passphrase-overlay');
+  if (!overlay) {
+    overlay = document.createElement('div');
+    overlay.id = 'passphrase-overlay';
+    overlay.className = 'passphrase-overlay';
+    document.body.appendChild(overlay);
+  }
+  overlay.innerHTML = `
+    <div class="passphrase-dialog" role="dialog" aria-modal="true" aria-label="Change passphrase">
+      <div class="passphrase-icon">&#128274;</div>
+      <h3 class="passphrase-title">Change Passphrase</h3>
+      <input type="password" class="passphrase-input" id="passphrase-old-input" placeholder="Current passphrase" autocomplete="current-password" autofocus>
+      <input type="password" class="passphrase-input" id="passphrase-new1-input" placeholder="New passphrase" autocomplete="new-password">
+      <input type="password" class="passphrase-input" id="passphrase-new2-input" placeholder="Confirm new passphrase" autocomplete="new-password">
+      <div class="passphrase-error" id="passphrase-change-error"></div>
+      <div style="display:flex;gap:8px;margin-top:8px">
+        <button class="passphrase-btn passphrase-btn-secondary" id="passphrase-change-cancel">Cancel</button>
+        <button class="passphrase-btn passphrase-btn-primary" id="passphrase-change-btn">Change Passphrase</button>
+      </div>
+    </div>`;
+  const oldInput = /** @type {HTMLInputElement | null} */ (document.getElementById('passphrase-old-input'));
+  const newInput = /** @type {HTMLInputElement | null} */ (document.getElementById('passphrase-new1-input'));
+  const confirmationInput = /** @type {HTMLInputElement | null} */ (document.getElementById('passphrase-new2-input'));
+  const button = /** @type {HTMLButtonElement | null} */ (document.getElementById('passphrase-change-btn'));
+  const cancelButton = /** @type {HTMLButtonElement | null} */ (document.getElementById('passphrase-change-cancel'));
+  const errorElement = document.getElementById('passphrase-change-error');
+  if (!oldInput || !newInput || !confirmationInput || !button || !cancelButton || !errorElement) return;
+  overlay.style.display = 'flex';
+
+  cancelButton.addEventListener('click', () => {
+    overlay.style.display = 'none';
+    overlay.innerHTML = '';
+  });
+
+  button.addEventListener('click', async () => {
+    const oldPassphrase = oldInput.value;
+    const newPassphrase = newInput.value;
+    const confirmation = confirmationInput.value;
+    if (!oldPassphrase) { errorElement.textContent = 'Enter current passphrase'; return; }
+    const validation = validatePassphrase(newPassphrase);
+    if (!validation.valid) { errorElement.textContent = validation.message; return; }
+    if (newPassphrase !== confirmation) { errorElement.textContent = 'New passphrases do not match'; return; }
+
+    button.disabled = true;
+    button.textContent = 'Changing...';
+    errorElement.textContent = '';
+
+    try {
+      await cryptoUiDeps.changeEncryptionPassphrase?.(oldPassphrase, newPassphrase);
+      overlay.style.display = 'none';
+      overlay.innerHTML = '';
+      showNotification('Passphrase changed successfully', 'success');
+    } catch {
+      errorElement.textContent = 'Current passphrase is incorrect';
+      button.disabled = false;
+      button.textContent = 'Change Passphrase';
+    }
+  });
+
+  setTimeout(() => oldInput.focus(), 50);
+}
+
+export function renderEncryptionSection() {
+  const enabled = cryptoUiDeps.getEncryptionEnabled();
+  if (enabled) {
+    return `<div class="encryption-status-card encryption-status-on">
+      <div class="encryption-status-icon">&#128274;</div>
+      <div class="encryption-status-body">
+        <div class="encryption-status-title">Encryption is ON</div>
+        <div class="encryption-status-detail">Your medical data, chat history, wearable history, and API keys are encrypted with AES-256-GCM. Display preferences remain unencrypted.</div>
+      </div>
+    </div>
+    <div style="display:flex;gap:8px;margin-top:12px;flex-wrap:wrap">
+      <button class="import-btn import-btn-secondary" ${cryptoActionAttrs('change-passphrase')}>Change Passphrase</button>
+      <button class="import-btn import-btn-secondary" ${cryptoActionAttrs('disable-encryption')}>Disable Encryption</button>
+    </div>`;
+  }
+  return `<div class="encryption-status-card encryption-status-off">
+    <div class="encryption-status-icon">&#128275;</div>
+    <div class="encryption-status-body">
+      <div class="encryption-status-title">Encryption is OFF</div>
+      <div class="encryption-status-detail">Your data is stored as plaintext in localStorage. Browser extensions and anyone with filesystem access can read it.</div>
+    </div>
+  </div>
+  <button class="import-btn import-btn-primary" style="margin-top:12px" ${cryptoActionAttrs('enable-encryption')}>Enable Encryption</button>`;
+}
+
+export function renderBackupSection() {
+  const lastAuto = localStorage.getItem('labcharts-last-autobackup');
+  const autoStatus = lastAuto
+    ? `Last auto-backup: ${new Date(lastAuto).toLocaleString()}`
+    : 'No auto-backups yet';
+  return `<div class="ai-provider-desc" style="margin-bottom:10px">Create a full backup of all profiles, data, and chat history. ${cryptoUiDeps.getEncryptionEnabled() ? 'Backups inherit encryption \u2014 same passphrase required to restore.' : 'Backups are unencrypted unless encryption is enabled.'}</div>
+  <div style="display:flex;gap:8px;flex-wrap:wrap">
+    <button class="import-btn import-btn-primary" ${cryptoActionAttrs('export-backup')}>Download Backup</button>
+    <label class="import-btn import-btn-secondary" style="cursor:pointer;display:inline-flex;align-items:center">
+      Restore Backup
+      <input type="file" accept=".json" style="display:none" ${cryptoActionAttrs('import-backup')}>
+    </label>
+  </div>
+  <div class="backup-auto-status">${escapeHTML(autoStatus)}</div>
+  <div class="backup-snapshots-toggle" ${cryptoActionAttrs('toggle-backup-snapshots')} id="backup-snapshots-toggle" role="button" tabindex="0" style="display:none">
+    <span class="privacy-configure-arrow" id="backup-snapshots-arrow">&#9654;</span>
+    Recent snapshots
+  </div>
+  <div class="backup-snapshot-list" id="backup-snapshot-list" style="display:none"></div>
+  <div id="backup-folder-section">${renderFolderBackupSection()}</div>`;
+}
+
+export async function loadBackupSnapshots() {
+  const list = document.getElementById('backup-snapshot-list');
+  const toggle = document.getElementById('backup-snapshots-toggle');
+  if (!list) return;
+  const snapshots = await getAutoBackupSnapshots();
+  if (snapshots.length === 0) {
+    if (toggle) toggle.style.display = 'none';
+    list.style.display = 'none';
+    return;
+  }
+  if (toggle) toggle.style.display = '';
+  const shown = snapshots.slice(0, MAX_SNAPSHOTS);
+  list.innerHTML = shown.map(snapshot => {
+    const date = new Date(snapshot.createdAt).toLocaleString();
+    const profileCount = snapshot.snapshot?.profiles ? snapshot.snapshot.profiles.length : '?';
+    const actionAttrs = cryptoActionAttrs('restore-auto-backup', {
+      snapshotId: snapshot.id,
+      snapshotIdType: typeof snapshot.id === 'number' ? 'number' : 'string',
+    });
+    return `<div class="backup-snapshot-item">
+      <div class="backup-snapshot-info">
+        <span class="backup-snapshot-date">${escapeHTML(date)}</span>
+        <span class="backup-snapshot-meta">${profileCount} profile(s)${snapshot.encrypted ? ' \u2022 encrypted' : ''}</span>
+      </div>
+      <button class="import-btn import-btn-secondary" style="padding:4px 10px;font-size:12px" ${actionAttrs}>Restore</button>
+    </div>`;
+  }).join('');
+}
+
+export function toggleBackupSnapshots() {
+  const list = document.getElementById('backup-snapshot-list');
+  const arrow = document.getElementById('backup-snapshots-arrow');
+  if (!list) return;
+  const open = list.style.display !== 'none';
+  list.style.display = open ? 'none' : 'flex';
+  if (arrow) arrow.innerHTML = open ? '&#9654;' : '&#9660;';
+}

--- a/js/crypto.js
+++ b/js/crypto.js
@@ -3,7 +3,6 @@
 
 import { getErrorMessage } from './caught-error.js';
 import { state } from './state.js';
-import { showNotification, showConfirmDialog, escapeAttr, escapeHTML } from './utils.js';
 import { profileStorageKey } from './profile-storage-key.js';
 import { getBlob, setBlob, deleteBlob, shouldUseBlob } from './blob-storage.js';
 import { ensureImportedArray } from './data-merge.js';
@@ -11,22 +10,40 @@ import { clearKeyCache, updateKeyCache } from './crypto-key-cache.js';
 import { configureCycleStoreCrypto } from './cycle-store.js';
 import { configureWearablesStoreCrypto } from './wearables-store.js';
 import { isDataProtectionStylesheetLoaded, loadDataProtectionStylesheetForAction } from './modal-lifecycle.js';
+import {
+  changePassphrase,
+  configureCryptoUi,
+  disableEncryption,
+  installCryptoActionDelegates,
+  loadBackupSnapshots,
+  maybeShowBackupNudge,
+  maybeShowEncryptionNudge,
+  renderBackupSection,
+  renderEncryptionSection,
+  showEnableEncryptionModal,
+  showPassphraseModal,
+  toggleBackupSnapshots,
+} from './crypto-ui.js';
 
 export { getCachedKey, updateKeyCache } from './crypto-key-cache.js';
+export {
+  changePassphrase,
+  disableEncryption,
+  installCryptoActionDelegates,
+  loadBackupSnapshots,
+  maybeShowBackupNudge,
+  maybeShowEncryptionNudge,
+  renderBackupSection,
+  renderEncryptionSection,
+  showEnableEncryptionModal,
+  toggleBackupSnapshots,
+};
 
 const appWindow = /** @type {Window & typeof globalThis & {
   __WEARABLES_TEST?: boolean,
 }} */ (typeof window !== 'undefined' ? window : {});
 
 const needsDataProtectionStylesheet = () => typeof document !== 'undefined' && !!document.querySelector('[data-data-protection-stylesheet-anchor]') && !isDataProtectionStylesheetLoaded();
-function runWithDataProtectionStylesheet(action) {
-  if (!needsDataProtectionStylesheet()) return action();
-  return loadDataProtectionStylesheetForAction().then(loaded => {
-    if (loaded) return action();
-    showNotification('Data protection controls could not be loaded. Try again.', 'error');
-    return false;
-  });
-}
 /**
  * @typedef {{
  *   buildSidebar: null | (() => void),
@@ -64,89 +81,6 @@ export function configureCryptoProfileDeps(deps = {}) {
   }
   return previous;
 }
-const cryptoActionDelegateRoots = new WeakSet();
-const CRYPTO_ACTION_DELEGATE_KEY = Symbol.for('getbased.cryptoActionDelegatesInstalled');
-const CRYPTO_ACTION_ATTR = 'data-crypto-action';
-const CRYPTO_ACTION_SELECTOR = `[${CRYPTO_ACTION_ATTR}]`;
-
-function cryptoActionAttrs(action, attrs = {}) {
-  let html = `${CRYPTO_ACTION_ATTR}="${escapeAttr(action)}"`;
-  for (const [key, value] of Object.entries(attrs)) {
-    if (value == null) continue;
-    const attr = key.replace(/[A-Z]/g, c => '-' + c.toLowerCase());
-    html += ` data-crypto-${attr}="${escapeAttr(String(value))}"`;
-  }
-  return html;
-}
-
-function closestCryptoAction(target) {
-  return /** @type {HTMLElement | null} */ (
-    target && typeof target.closest === 'function'
-      ? target.closest(CRYPTO_ACTION_SELECTOR)
-      : null
-  );
-}
-
-function readSnapshotActionId(actionEl) {
-  const raw = actionEl.dataset.cryptoSnapshotId;
-  if (raw == null) return null;
-  if (actionEl.dataset.cryptoSnapshotIdType === 'number') {
-    const id = Number(raw);
-    return Number.isFinite(id) ? id : null;
-  }
-  return raw;
-}
-
-function handleCryptoActionClick(event) {
-  const actionEl = closestCryptoAction(event.target);
-  if (!actionEl || !event.currentTarget?.contains?.(actionEl)) return;
-  const action = actionEl.getAttribute(CRYPTO_ACTION_ATTR);
-  if (action === 'change-passphrase') changePassphrase();
-  else if (action === 'disable-encryption') disableEncryption();
-  else if (action === 'enable-encryption') showEnableEncryptionModal();
-  else if (action === 'export-backup') exportEncryptedBackup();
-  else if (action === 'toggle-backup-snapshots') toggleBackupSnapshots();
-  else if (action === 'restore-auto-backup') {
-    const id = readSnapshotActionId(actionEl);
-    if (id == null) return;
-    restoreAutoBackup(id);
-  } else {
-    return;
-  }
-  event.preventDefault();
-  event.stopPropagation();
-}
-
-function handleCryptoActionKeydown(event) {
-  if (event.key !== 'Enter' && event.key !== ' ') return;
-  const actionEl = closestCryptoAction(event.target);
-  if (!actionEl || actionEl.getAttribute('role') !== 'button') return;
-  if (event.target?.closest?.('button, a, input, textarea, select')) return;
-  handleCryptoActionClick(event);
-}
-
-function handleCryptoActionChange(event) {
-  const actionEl = closestCryptoAction(event.target);
-  if (!actionEl || !event.currentTarget?.contains?.(actionEl)) return;
-  if (actionEl.getAttribute(CRYPTO_ACTION_ATTR) !== 'import-backup') return;
-  const fileInput = /** @type {HTMLInputElement} */ (actionEl);
-  const file = fileInput.files && fileInput.files[0];
-  if (!file) return;
-  importEncryptedBackup(file);
-  fileInput.value = '';
-  event.stopPropagation();
-}
-
-export function installCryptoActionDelegates(root = typeof document !== 'undefined' ? document : null) {
-  if (!root || cryptoActionDelegateRoots.has(root) || root[CRYPTO_ACTION_DELEGATE_KEY]) return;
-  cryptoActionDelegateRoots.add(root);
-  Object.defineProperty(root, CRYPTO_ACTION_DELEGATE_KEY, { value: true, configurable: true });
-  root.addEventListener('click', handleCryptoActionClick);
-  root.addEventListener('keydown', handleCryptoActionKeydown);
-  root.addEventListener('change', handleCryptoActionChange);
-}
-
-if (typeof document !== 'undefined') installCryptoActionDelegates();
 
 // ═══════════════════════════════════════════════
 // SENSITIVE KEY PATTERNS
@@ -446,369 +380,6 @@ export async function initEncryption() {
   await decryptKeyCache();
 }
 
-let _failCount = 0;
-
-function showPassphraseModal(onSuccess) {
-  let overlay = document.getElementById('passphrase-overlay');
-  if (!overlay) {
-    overlay = document.createElement('div');
-    overlay.id = 'passphrase-overlay';
-    overlay.className = 'passphrase-overlay';
-    document.body.appendChild(overlay);
-  }
-  _failCount = 0;
-  renderPassphraseForm(overlay, onSuccess);
-}
-
-function renderPassphraseForm(overlay, onSuccess) {
-  overlay.innerHTML = `
-    <div class="passphrase-dialog" role="dialog" aria-modal="true" aria-label="Enter passphrase">
-      <div class="passphrase-icon">&#128274;</div>
-      <h3 class="passphrase-title">Unlock getbased</h3>
-      <p class="passphrase-desc">Your data is encrypted. Enter your passphrase to continue.</p>
-      <input type="password" class="passphrase-input" id="passphrase-unlock-input" placeholder="Passphrase" autocomplete="current-password" autofocus>
-      <div class="passphrase-error" id="passphrase-error"></div>
-      <button class="passphrase-btn passphrase-btn-primary" id="passphrase-unlock-btn">Unlock</button>
-      <button class="passphrase-btn passphrase-btn-link" id="passphrase-forgot-btn">Forgot passphrase?</button>
-    </div>`;
-  const input = /** @type {HTMLInputElement | null} */ (document.getElementById('passphrase-unlock-input'));
-  const btn = /** @type {HTMLButtonElement | null} */ (document.getElementById('passphrase-unlock-btn'));
-  const errorEl = document.getElementById('passphrase-error');
-  const forgotBtn = /** @type {HTMLButtonElement | null} */ (document.getElementById('passphrase-forgot-btn'));
-  if (!input || !btn || !errorEl || !forgotBtn) return;
-  overlay.style.display = 'flex';
-
-  const attemptUnlock = async () => {
-    const passphrase = input.value;
-    if (!passphrase) { errorEl.textContent = 'Please enter your passphrase'; return; }
-    btn.disabled = true;
-    btn.textContent = 'Decrypting...';
-    errorEl.textContent = '';
-
-    // Rate limit after 3 failures
-    if (_failCount >= 3) {
-      errorEl.textContent = 'Too many attempts. Please wait...';
-      await new Promise(r => setTimeout(r, 5000));
-      errorEl.textContent = '';
-    }
-
-    try {
-      const saltHex = localStorage.getItem('labcharts-encryption-salt');
-      if (!saltHex) throw new Error('No encryption salt found');
-      const salt = fromBase64(saltHex);
-      const key = await deriveKey(passphrase, salt);
-
-      // Verify by trying to decrypt profiles
-      const profilesRaw = localStorage.getItem('labcharts-profiles');
-      if (profilesRaw && isEncryptedValue(profilesRaw)) {
-        const parsed = parseEncryptedValue(profilesRaw);
-        if (parsed) await decrypt(key, parsed.iv, parsed.ciphertext);
-      }
-
-      _sessionKey = key;
-      overlay.style.display = 'none';
-      overlay.innerHTML = '';
-      onSuccess();
-    } catch {
-      _failCount++;
-      input.value = '';
-      errorEl.textContent = `Wrong passphrase (attempt ${_failCount})`;
-      btn.disabled = false;
-      btn.textContent = 'Unlock';
-      input.focus();
-    }
-  };
-
-  btn.addEventListener('click', attemptUnlock);
-  input.addEventListener('keydown', (e) => {
-    if (e.key === 'Enter') attemptUnlock();
-  });
-
-  forgotBtn.addEventListener('click', () => {
-    // Inline confirm inside the passphrase overlay (can't use showConfirmDialog — it's behind this z-index)
-    const dialog = /** @type {HTMLElement | null} */ (overlay.querySelector('.passphrase-dialog'));
-    if (!dialog) return;
-    dialog.innerHTML = `
-      <div class="passphrase-icon">&#9888;&#65039;</div>
-      <h3 class="passphrase-title">Erase All Data?</h3>
-      <p class="passphrase-desc">If you forgot your passphrase, the only option is to <strong>erase all data</strong> and start fresh. This cannot be undone.</p>
-      <div style="display:flex;gap:8px;margin-top:12px">
-        <button class="passphrase-btn passphrase-btn-secondary" id="passphrase-forgot-cancel">Go Back</button>
-        <button class="passphrase-btn passphrase-btn-primary" id="passphrase-forgot-confirm" style="background:var(--red)">Erase Everything</button>
-      </div>`;
-    document.getElementById('passphrase-forgot-cancel')?.addEventListener('click', () => {
-      renderPassphraseForm(overlay, onSuccess);
-    });
-    document.getElementById('passphrase-forgot-confirm')?.addEventListener('click', async () => {
-      try {
-        const { eraseAllLocalAppData } = await import('./data-wipe.js');
-        await eraseAllLocalAppData();
-      } catch {
-        const keysToRemove = [];
-        for (let i = 0; i < localStorage.length; i++) {
-          const k = localStorage.key(i);
-          if (k && k.startsWith('labcharts')) keysToRemove.push(k);
-        }
-        keysToRemove.forEach(k => localStorage.removeItem(k));
-      }
-      _sessionKey = null;
-      overlay.style.display = 'none';
-      overlay.innerHTML = '';
-      location.reload();
-    });
-  });
-
-  setTimeout(() => input.focus(), 50);
-}
-
-// ═══════════════════════════════════════════════
-// PASSPHRASE VALIDATION
-// ═══════════════════════════════════════════════
-function validatePassphrase(p) {
-  if (p.length < 8) return { valid: false, message: 'At least 8 characters' };
-  if (!/[a-z]/.test(p)) return { valid: false, message: 'At least 1 lowercase letter' };
-  if (!/[A-Z]/.test(p)) return { valid: false, message: 'At least 1 uppercase letter' };
-  if (!/[!@#$%^&*()\-_=+\[\]{};:'",.<>?/\\|`~]/.test(p)) return { valid: false, message: 'At least 1 special character' };
-  return { valid: true, message: '' };
-}
-
-function getPassphraseStrength(p) {
-  let score = 0;
-  if (p.length >= 8) score++;
-  if (/[a-z]/.test(p)) score++;
-  if (/[A-Z]/.test(p)) score++;
-  if (/[!@#$%^&*()\-_=+\[\]{};:'",.<>?/\\|`~]/.test(p)) score++;
-  return score; // 0–4
-}
-
-// ═══════════════════════════════════════════════
-// ENABLE / DISABLE ENCRYPTION
-// ═══════════════════════════════════════════════
-export function showEnableEncryptionModal() {
-  if (needsDataProtectionStylesheet()) return runWithDataProtectionStylesheet(() => showEnableEncryptionModal());
-  let overlay = document.getElementById('passphrase-overlay');
-  if (!overlay) {
-    overlay = document.createElement('div');
-    overlay.id = 'passphrase-overlay';
-    overlay.className = 'passphrase-overlay';
-    document.body.appendChild(overlay);
-  }
-  overlay.innerHTML = `
-    <div class="passphrase-dialog" role="dialog" aria-modal="true" aria-label="Set encryption passphrase">
-      <div class="passphrase-icon">&#128274;</div>
-      <h3 class="passphrase-title">Enable Encryption</h3>
-      <p class="passphrase-desc">Set a passphrase to encrypt your medical data at rest. <strong>If you forget this passphrase, your data cannot be recovered.</strong></p>
-      <input type="password" class="passphrase-input" id="passphrase-set-input" placeholder="Enter passphrase" autocomplete="new-password" autofocus>
-      <input type="password" class="passphrase-input" id="passphrase-confirm-input" placeholder="Confirm passphrase" autocomplete="new-password">
-      <div class="passphrase-strength" id="passphrase-strength">
-        <div class="passphrase-strength-bars">
-          <div class="passphrase-strength-bar" data-index="0"></div>
-          <div class="passphrase-strength-bar" data-index="1"></div>
-          <div class="passphrase-strength-bar" data-index="2"></div>
-          <div class="passphrase-strength-bar" data-index="3"></div>
-        </div>
-        <ul class="passphrase-rules" id="passphrase-rules">
-          <li data-rule="length">At least 8 characters</li>
-          <li data-rule="lower">At least 1 lowercase letter</li>
-          <li data-rule="upper">At least 1 uppercase letter</li>
-          <li data-rule="special">At least 1 special character</li>
-        </ul>
-      </div>
-      <div class="passphrase-error" id="passphrase-set-error"></div>
-      <div style="display:flex;gap:8px;margin-top:8px">
-        <button class="passphrase-btn passphrase-btn-secondary" id="passphrase-set-cancel">Cancel</button>
-        <button class="passphrase-btn passphrase-btn-primary" id="passphrase-set-btn">Enable Encryption</button>
-      </div>
-    </div>`;
-  const input1 = /** @type {HTMLInputElement | null} */ (document.getElementById('passphrase-set-input'));
-  const input2 = /** @type {HTMLInputElement | null} */ (document.getElementById('passphrase-confirm-input'));
-  const btn = /** @type {HTMLButtonElement | null} */ (document.getElementById('passphrase-set-btn'));
-  const cancelBtn = /** @type {HTMLButtonElement | null} */ (document.getElementById('passphrase-set-cancel'));
-  const errorEl = document.getElementById('passphrase-set-error');
-  if (!input1 || !input2 || !btn || !cancelBtn || !errorEl) return;
-  overlay.style.display = 'flex';
-
-  // Live strength meter
-  const strengthBars = /** @type {NodeListOf<HTMLElement>} */ (overlay.querySelectorAll('.passphrase-strength-bar'));
-  const ruleItems = overlay.querySelectorAll('.passphrase-rules li');
-  const barColors = ['var(--red)', 'var(--orange)', 'var(--yellow)', 'var(--green)'];
-  let migrationStarted = false;
-
-  const updateStrengthMeter = () => {
-    const p = input1.value;
-    const score = getPassphraseStrength(p);
-    strengthBars.forEach((bar, i) => {
-      bar.style.background = i < score ? barColors[score - 1] : 'var(--border)';
-    });
-    // Update checklist
-    const checks = [p.length >= 8, /[a-z]/.test(p), /[A-Z]/.test(p), /[!@#$%^&*()\-_=+\[\]{};:'",.<>?/\\|`~]/.test(p)];
-    ruleItems.forEach((li, i) => li.classList.toggle('met', checks[i]));
-  };
-  input1.addEventListener('input', updateStrengthMeter);
-
-  cancelBtn.addEventListener('click', () => {
-    overlay.style.display = 'none';
-    overlay.innerHTML = '';
-  });
-
-  btn.addEventListener('click', async () => {
-    const p1 = input1.value;
-    const p2 = input2.value;
-    if (!p1) { errorEl.textContent = 'Please enter a passphrase'; return; }
-    const validation = validatePassphrase(p1);
-    if (!validation.valid) { errorEl.textContent = validation.message; return; }
-    if (p1 !== p2) { errorEl.textContent = 'Passphrases do not match'; return; }
-
-    btn.disabled = true;
-    btn.textContent = 'Encrypting...';
-    errorEl.textContent = '';
-
-    try {
-      if (!migrationStarted) {
-        const salt = crypto.getRandomValues(new Uint8Array(16));
-        localStorage.setItem('labcharts-encryption-salt', toBase64(salt));
-        _sessionKey = await deriveKey(p1, salt);
-        localStorage.setItem('labcharts-encryption-enabled', 'true');
-        migrationStarted = true;
-      }
-      await migrateSensitiveKeys();
-      await migrateLocalIDB('encrypted');
-      await decryptKeyCache();
-
-      overlay.style.display = 'none';
-      overlay.innerHTML = '';
-      showNotification('Encryption enabled \u2014 keep your passphrase safe', 'success');
-      const section = document.getElementById('encryption-section');
-      if (section) section.innerHTML = renderEncryptionSection();
-    } catch (err) {
-      errorEl.textContent = 'Encryption failed: ' + getErrorMessage(err);
-      btn.disabled = false;
-      btn.textContent = migrationStarted ? 'Retry Encryption' : 'Enable Encryption';
-    }
-  });
-
-  input2.addEventListener('keydown', (e) => {
-    if (e.key === 'Enter') btn.click();
-  });
-
-  setTimeout(() => input1.focus(), 50);
-}
-
-export function maybeShowEncryptionNudge() {
-  if (getEncryptionEnabled()) return;
-  if (localStorage.getItem('labcharts-encryption-nudge-dismissed')) return;
-  if (needsDataProtectionStylesheet()) return void runWithDataProtectionStylesheet(() => maybeShowEncryptionNudge());
-  setTimeout(() => {
-    let overlay = document.getElementById('passphrase-overlay');
-    if (!overlay) {
-      overlay = document.createElement('div');
-      overlay.id = 'passphrase-overlay';
-      overlay.className = 'passphrase-overlay';
-      document.body.appendChild(overlay);
-    }
-    overlay.innerHTML = `
-      <div class="passphrase-dialog" role="dialog" aria-modal="true" aria-label="Enable encryption">
-        <div class="passphrase-icon">&#128274;</div>
-        <h3 class="passphrase-title">Protect Your Data</h3>
-        <p class="passphrase-desc">Your lab results are stored in your browser's local storage, where browser extensions and anyone with filesystem access can read them. Set a passphrase to encrypt your data at rest.</p>
-        <div style="display:flex;gap:8px;margin-top:12px">
-          <button class="passphrase-btn passphrase-btn-secondary" id="encryption-nudge-dismiss">Not Now</button>
-          <button class="passphrase-btn passphrase-btn-primary" id="encryption-nudge-enable">Enable Encryption</button>
-        </div>
-      </div>`;
-    overlay.style.display = 'flex';
-    const dismissBtn = document.getElementById('encryption-nudge-dismiss'), enableBtn = document.getElementById('encryption-nudge-enable');
-    if (!dismissBtn || !enableBtn) return;
-    dismissBtn.addEventListener('click', () => {
-      localStorage.setItem('labcharts-encryption-nudge-dismissed', 'true');
-      overlay.style.display = 'none';
-      overlay.innerHTML = '';
-    });
-    enableBtn.addEventListener('click', () => {
-      overlay.style.display = 'none';
-      overlay.innerHTML = '';
-      showEnableEncryptionModal();
-    });
-  }, 800);
-}
-
-export function maybeShowBackupNudge() {
-  // Don't compete with the guided tour. First-time users see the welcome
-  // tour right after their first demo import; firing the backup nudge
-  // behind it (or stealing focus) is an unwelcome interruption. The nudge
-  // will re-evaluate on next app load anyway.
-  if (document.getElementById('tour-overlay')) return;
-
-  // Skip if no profiles or no actual data to back up
-  const profiles = localStorage.getItem('labcharts-profiles');
-  if (!profiles) return;
-  let profileList;
-  try { profileList = JSON.parse(profiles); if (profileList.length === 0) return; } catch { return; }
-  const hasAnyData = profileList.some(p => {
-    try { const d = JSON.parse(localStorage.getItem(`labcharts-${p.id}-imported`) || '{}'); return d.entries && d.entries.length > 0; } catch { return false; }
-  });
-  if (!hasAnyData) return;
-  // Skip if folder backup is active and healthy
-  const _fbState = getFolderBackupState();
-  if (_fbState?.folderName && !_fbState?.permissionLost) return;
-  // Skip if snoozed
-  const snoozedUntil = localStorage.getItem('labcharts-backup-nudge-snoozed-until');
-  if (snoozedUntil && Date.now() < Number(snoozedUntil)) return;
-  // Skip if backed up within 30 days (manual download or folder backup)
-  const THIRTY_DAYS = 30 * 24 * 60 * 60 * 1000;
-  const lastManual = localStorage.getItem('labcharts-last-manual-backup');
-  const lastFolder = localStorage.getItem('labcharts-folder-backup-last');
-  const mostRecent = Math.max(
-    lastManual ? new Date(lastManual).getTime() : 0,
-    lastFolder ? new Date(lastFolder).getTime() : 0
-  );
-  if (mostRecent > 0 && (Date.now() - mostRecent) < THIRTY_DAYS) return;
-  // Skip if another overlay is already showing
-  const overlay = document.getElementById('passphrase-overlay');
-  if (overlay && overlay.style.display === 'flex') return;
-  if (needsDataProtectionStylesheet()) {
-    void runWithDataProtectionStylesheet(() => maybeShowBackupNudge());
-    return;
-  }
-
-  setTimeout(() => {
-    // Re-check overlay (encryption nudge may have appeared during delay)
-    const ov = document.getElementById('passphrase-overlay');
-    if (ov && ov.style.display === 'flex') return;
-
-    let el = document.getElementById('passphrase-overlay');
-    if (!el) {
-      el = document.createElement('div');
-      el.id = 'passphrase-overlay';
-      el.className = 'passphrase-overlay';
-      document.body.appendChild(el);
-    }
-    el.innerHTML = `
-      <div class="passphrase-dialog" role="dialog" aria-modal="true" aria-label="Backup reminder">
-        <div class="passphrase-icon">&#128190;</div>
-        <h3 class="passphrase-title">Back Up Your Data</h3>
-        <p class="passphrase-desc">Your lab results only exist in this browser. Download a backup to protect against data loss.</p>
-        <div style="display:flex;gap:8px;margin-top:12px">
-          <button class="passphrase-btn passphrase-btn-secondary" id="backup-nudge-snooze">Not Now</button>
-          <button class="passphrase-btn passphrase-btn-primary" id="backup-nudge-download">Download Now</button>
-        </div>
-      </div>`;
-    el.style.display = 'flex';
-    const snoozeBtn = document.getElementById('backup-nudge-snooze'),
-      downloadBtn = document.getElementById('backup-nudge-download');
-    if (!snoozeBtn || !downloadBtn) return;
-    snoozeBtn.addEventListener('click', () => {
-      localStorage.setItem('labcharts-backup-nudge-snoozed-until', String(Date.now() + THIRTY_DAYS));
-      el.style.display = 'none';
-      el.innerHTML = '';
-    });
-    downloadBtn.addEventListener('click', () => {
-      el.style.display = 'none';
-      el.innerHTML = '';
-      exportEncryptedBackup();
-    });
-  }, 500);
-}
 
 async function migrationProfileIds() {
   const ids = new Set();
@@ -926,121 +497,84 @@ async function migrateLocalIDB(mode) {
   return migrated;
 }
 
-export async function disableEncryption() {
-  if (await showConfirmDialog('Disable encryption? Your data will be stored in plaintext.')) {
-    try {
-      // Decrypt every storage backend before dropping the only in-memory key.
-      await migrateLocalIDB('plain');
-      await decryptAllSensitiveKeys();
-      localStorage.removeItem('labcharts-encryption-enabled');
-      localStorage.removeItem('labcharts-encryption-salt');
-      _sessionKey = null;
-      clearKeyCache();
-      showNotification('Encryption disabled', 'info');
-      const section = document.getElementById('encryption-section');
-      if (section) section.innerHTML = renderEncryptionSection();
-    } catch (err) {
-      showNotification('Failed to disable encryption: ' + getErrorMessage(err), 'error');
-    }
+async function unlockEncryption(passphrase) {
+  const saltHex = localStorage.getItem('labcharts-encryption-salt');
+  if (!saltHex) throw new Error('No encryption salt found');
+  const salt = fromBase64(saltHex);
+  const key = await deriveKey(passphrase, salt);
+
+  const profilesRaw = localStorage.getItem('labcharts-profiles');
+  if (profilesRaw && isEncryptedValue(profilesRaw)) {
+    const parsed = parseEncryptedValue(profilesRaw);
+    if (parsed) await decrypt(key, parsed.iv, parsed.ciphertext);
   }
+  _sessionKey = key;
 }
 
-export async function changePassphrase() {
-  if (needsDataProtectionStylesheet()) {
-    return runWithDataProtectionStylesheet(() => changePassphrase());
-  }
-  let overlay = document.getElementById('passphrase-overlay');
-  if (!overlay) {
-    overlay = document.createElement('div');
-    overlay.id = 'passphrase-overlay';
-    overlay.className = 'passphrase-overlay';
-    document.body.appendChild(overlay);
-  }
-  overlay.innerHTML = `
-    <div class="passphrase-dialog" role="dialog" aria-modal="true" aria-label="Change passphrase">
-      <div class="passphrase-icon">&#128274;</div>
-      <h3 class="passphrase-title">Change Passphrase</h3>
-      <input type="password" class="passphrase-input" id="passphrase-old-input" placeholder="Current passphrase" autocomplete="current-password" autofocus>
-      <input type="password" class="passphrase-input" id="passphrase-new1-input" placeholder="New passphrase" autocomplete="new-password">
-      <input type="password" class="passphrase-input" id="passphrase-new2-input" placeholder="Confirm new passphrase" autocomplete="new-password">
-      <div class="passphrase-error" id="passphrase-change-error"></div>
-      <div style="display:flex;gap:8px;margin-top:8px">
-        <button class="passphrase-btn passphrase-btn-secondary" id="passphrase-change-cancel">Cancel</button>
-        <button class="passphrase-btn passphrase-btn-primary" id="passphrase-change-btn">Change Passphrase</button>
-      </div>
-    </div>`;
-  const oldInput = /** @type {HTMLInputElement | null} */ (document.getElementById('passphrase-old-input'));
-  const new1Input = /** @type {HTMLInputElement | null} */ (document.getElementById('passphrase-new1-input'));
-  const new2Input = /** @type {HTMLInputElement | null} */ (document.getElementById('passphrase-new2-input'));
-  const btn = /** @type {HTMLButtonElement | null} */ (document.getElementById('passphrase-change-btn'));
-  const cancelBtn = /** @type {HTMLButtonElement | null} */ (document.getElementById('passphrase-change-cancel'));
-  const errorEl = document.getElementById('passphrase-change-error');
-  if (!oldInput || !new1Input || !new2Input || !btn || !cancelBtn || !errorEl) return;
-  overlay.style.display = 'flex';
-
-  cancelBtn.addEventListener('click', () => {
-    overlay.style.display = 'none';
-    overlay.innerHTML = '';
-  });
-
-  btn.addEventListener('click', async () => {
-    const oldP = oldInput.value;
-    const newP = new1Input.value;
-    const newP2 = new2Input.value;
-    if (!oldP) { errorEl.textContent = 'Enter current passphrase'; return; }
-    const validation = validatePassphrase(newP);
-    if (!validation.valid) { errorEl.textContent = validation.message; return; }
-    if (newP !== newP2) { errorEl.textContent = 'New passphrases do not match'; return; }
-
-    btn.disabled = true;
-    btn.textContent = 'Changing...';
-    errorEl.textContent = '';
-
-    try {
-      // Verify old passphrase
-      const oldSalt = fromBase64(localStorage.getItem('labcharts-encryption-salt'));
-      const oldKey = await deriveKey(oldP, oldSalt);
-
-      // Test decryption with old key
-      const profilesRaw = localStorage.getItem('labcharts-profiles');
-      if (profilesRaw && isEncryptedValue(profilesRaw)) {
-        const parsed = parseEncryptedValue(profilesRaw);
-        if (parsed) await decrypt(oldKey, parsed.iv, parsed.ciphertext);
-      }
-
-      // Decrypt every backend under the old key before replacing it.
-      _sessionKey = oldKey;
-      await migrateLocalIDB('plain');
-      await decryptAllSensitiveKeys();
-
-      // Re-encrypt localStorage, blob storage, and raw local databases.
-      const newSalt = crypto.getRandomValues(new Uint8Array(16));
-      localStorage.setItem('labcharts-encryption-salt', toBase64(newSalt));
-      const newKey = await deriveKey(newP, newSalt);
-      _sessionKey = newKey;
-      await migrateSensitiveKeys();
-      await migrateLocalIDB('encrypted');
-      await decryptKeyCache();
-
-      overlay.style.display = 'none';
-      overlay.innerHTML = '';
-      showNotification('Passphrase changed successfully', 'success');
-    } catch {
-      errorEl.textContent = 'Current passphrase is incorrect';
-      btn.disabled = false;
-      btn.textContent = 'Change Passphrase';
-    }
-  });
-
-  setTimeout(() => oldInput.focus(), 50);
+async function prepareEncryption(passphrase) {
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  localStorage.setItem('labcharts-encryption-salt', toBase64(salt));
+  _sessionKey = await deriveKey(passphrase, salt);
+  localStorage.setItem('labcharts-encryption-enabled', 'true');
 }
+
+async function migrateEncryptionStorage() {
+  await migrateSensitiveKeys();
+  await migrateLocalIDB('encrypted');
+  await decryptKeyCache();
+}
+
+async function disableEncryptionStorage() {
+  // Decrypt every storage backend before dropping the only in-memory key.
+  await migrateLocalIDB('plain');
+  await decryptAllSensitiveKeys();
+  localStorage.removeItem('labcharts-encryption-enabled');
+  localStorage.removeItem('labcharts-encryption-salt');
+  _sessionKey = null;
+  clearKeyCache();
+}
+
+async function changeEncryptionPassphrase(oldPassphrase, newPassphrase) {
+  const oldSalt = fromBase64(localStorage.getItem('labcharts-encryption-salt'));
+  const oldKey = await deriveKey(oldPassphrase, oldSalt);
+
+  const profilesRaw = localStorage.getItem('labcharts-profiles');
+  if (profilesRaw && isEncryptedValue(profilesRaw)) {
+    const parsed = parseEncryptedValue(profilesRaw);
+    if (parsed) await decrypt(oldKey, parsed.iv, parsed.ciphertext);
+  }
+
+  // Decrypt every backend under the old key before replacing it.
+  _sessionKey = oldKey;
+  await migrateLocalIDB('plain');
+  await decryptAllSensitiveKeys();
+
+  // Re-encrypt localStorage, blob storage, and raw local databases.
+  const newSalt = crypto.getRandomValues(new Uint8Array(16));
+  localStorage.setItem('labcharts-encryption-salt', toBase64(newSalt));
+  const newKey = await deriveKey(newPassphrase, newSalt);
+  _sessionKey = newKey;
+  await migrateSensitiveKeys();
+  await migrateLocalIDB('encrypted');
+  await decryptKeyCache();
+}
+
 
 // ═══════════════════════════════════════════════
 // Backup/restore, auto-backup, folder backup extracted to js/backup.js
-import { buildBackupSnapshot, configureBackupRuntimeDeps, exportEncryptedBackup, importEncryptedBackup, scheduleAutoBackup, getAutoBackupSnapshots, restoreAutoBackup, openBackupDB, initFolderBackup, getFolderBackupState, renderFolderBackupSection, MAX_SNAPSHOTS } from './backup.js';
+import { buildBackupSnapshot, configureBackupRuntimeDeps, scheduleAutoBackup, openBackupDB, initFolderBackup } from './backup.js';
 export { buildBackupSnapshot, scheduleAutoBackup, openBackupDB, initFolderBackup };
 
 configureBackupRuntimeDeps({ encryptedGetItem, getEncryptionEnabled });
+configureCryptoUi({
+  changeEncryptionPassphrase,
+  clearEncryptionSession: () => { _sessionKey = null; },
+  disableEncryptionStorage,
+  getEncryptionEnabled,
+  migrateEncryptionStorage,
+  prepareEncryption,
+  unlockEncryption,
+});
 
 // ═══════════════════════════════════════════════
 // CROSS-TAB SYNC (BroadcastChannel)
@@ -1076,92 +610,4 @@ export function broadcastDataChanged(profileId) {
   if (_bc) {
     _bc.postMessage({ type: 'data-changed', profileId });
   }
-}
-
-// ═══════════════════════════════════════════════
-// SETTINGS UI — SECURITY SECTION
-// ═══════════════════════════════════════════════
-export function renderEncryptionSection() {
-  const enabled = getEncryptionEnabled();
-  if (enabled) {
-    return `<div class="encryption-status-card encryption-status-on">
-      <div class="encryption-status-icon">&#128274;</div>
-      <div class="encryption-status-body">
-        <div class="encryption-status-title">Encryption is ON</div>
-        <div class="encryption-status-detail">Your medical data, chat history, wearable history, and API keys are encrypted with AES-256-GCM. Display preferences remain unencrypted.</div>
-      </div>
-    </div>
-    <div style="display:flex;gap:8px;margin-top:12px;flex-wrap:wrap">
-      <button class="import-btn import-btn-secondary" ${cryptoActionAttrs('change-passphrase')}>Change Passphrase</button>
-      <button class="import-btn import-btn-secondary" ${cryptoActionAttrs('disable-encryption')}>Disable Encryption</button>
-    </div>`;
-  }
-  return `<div class="encryption-status-card encryption-status-off">
-    <div class="encryption-status-icon">&#128275;</div>
-    <div class="encryption-status-body">
-      <div class="encryption-status-title">Encryption is OFF</div>
-      <div class="encryption-status-detail">Your data is stored as plaintext in localStorage. Browser extensions and anyone with filesystem access can read it.</div>
-    </div>
-  </div>
-  <button class="import-btn import-btn-primary" style="margin-top:12px" ${cryptoActionAttrs('enable-encryption')}>Enable Encryption</button>`;
-}
-
-export function renderBackupSection() {
-  const lastAuto = localStorage.getItem('labcharts-last-autobackup');
-  const autoStatus = lastAuto
-    ? `Last auto-backup: ${new Date(lastAuto).toLocaleString()}`
-    : 'No auto-backups yet';
-  return `<div class="ai-provider-desc" style="margin-bottom:10px">Create a full backup of all profiles, data, and chat history. ${getEncryptionEnabled() ? 'Backups inherit encryption \u2014 same passphrase required to restore.' : 'Backups are unencrypted unless encryption is enabled.'}</div>
-  <div style="display:flex;gap:8px;flex-wrap:wrap">
-    <button class="import-btn import-btn-primary" ${cryptoActionAttrs('export-backup')}>Download Backup</button>
-    <label class="import-btn import-btn-secondary" style="cursor:pointer;display:inline-flex;align-items:center">
-      Restore Backup
-      <input type="file" accept=".json" style="display:none" ${cryptoActionAttrs('import-backup')}>
-    </label>
-  </div>
-  <div class="backup-auto-status">${escapeHTML(autoStatus)}</div>
-  <div class="backup-snapshots-toggle" ${cryptoActionAttrs('toggle-backup-snapshots')} id="backup-snapshots-toggle" role="button" tabindex="0" style="display:none">
-    <span class="privacy-configure-arrow" id="backup-snapshots-arrow">&#9654;</span>
-    Recent snapshots
-  </div>
-  <div class="backup-snapshot-list" id="backup-snapshot-list" style="display:none"></div>
-  <div id="backup-folder-section">${renderFolderBackupSection()}</div>`;
-}
-
-export async function loadBackupSnapshots() {
-  const list = document.getElementById('backup-snapshot-list');
-  const toggle = document.getElementById('backup-snapshots-toggle');
-  if (!list) return;
-  const snapshots = await getAutoBackupSnapshots();
-  if (snapshots.length === 0) {
-    if (toggle) toggle.style.display = 'none';
-    list.style.display = 'none';
-    return;
-  }
-  if (toggle) toggle.style.display = '';
-  const shown = snapshots.slice(0, MAX_SNAPSHOTS);
-  list.innerHTML = shown.map(s => {
-    const date = new Date(s.createdAt).toLocaleString();
-    const profileCount = (s.snapshot && s.snapshot.profiles) ? s.snapshot.profiles.length : '?';
-    const actionAttrs = cryptoActionAttrs('restore-auto-backup', {
-      snapshotId: s.id,
-      snapshotIdType: typeof s.id === 'number' ? 'number' : 'string',
-    });
-    return `<div class="backup-snapshot-item">
-      <div class="backup-snapshot-info">
-        <span class="backup-snapshot-date">${escapeHTML(date)}</span>
-        <span class="backup-snapshot-meta">${profileCount} profile(s)${s.encrypted ? ' \u2022 encrypted' : ''}</span>
-      </div>
-      <button class="import-btn import-btn-secondary" style="padding:4px 10px;font-size:12px" ${actionAttrs}>Restore</button>
-    </div>`;
-  }).join('');
-}
-
-export function toggleBackupSnapshots() {
-  const list = document.getElementById('backup-snapshot-list');
-  const arrow = document.getElementById('backup-snapshots-arrow');
-  if (!list) return;
-  const open = list.style.display !== 'none';
-  list.style.display = open ? 'none' : 'flex';
-  if (arrow) arrow.innerHTML = open ? '&#9654;' : '&#9660;';
 }

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -7,6 +7,6 @@
   "viewRuntimeBridgeLookups": 0,
   "labStateAppFiles": 0,
   "labStateTestFiles": 0,
-  "largeJsFilesOver800Lines": 13,
+  "largeJsFilesOver800Lines": 12,
   "maxJsFileLines": 1168
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -348,6 +348,7 @@ const APP_SHELL = [
   '/js/recommendations.js',
   '/js/recommendations-region.js',
   '/js/crypto.js',
+  '/js/crypto-ui.js',
   '/js/data-wipe.js',
   '/js/backup-cycle.js',
   '/js/backup-serialization.js',

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -247,7 +247,7 @@ assert('genetics CSS lazy-load anchor preserves the original cascade position',
 assert('SW APP_SHELL includes genetics CSS bundle', swAuditSrc.includes("'/css/genetics.css'"));
 const dataProtectionLifecycleAuditSrc = read('js/modal-lifecycle.js');
 const settingsLoaderAuditSrc = read('js/settings-loader.js');
-const cryptoAuditSrc = read('js/crypto.js');
+const cryptoUiAuditSrc = read('js/crypto-ui.js');
 const piiAuditSrc = read('js/pii.js');
 assert('index defers data protection CSS behind its ordered lazy-load anchor',
   !indexSrc.includes('href="css/data-protection.css"') &&
@@ -257,7 +257,7 @@ assert('index defers data protection CSS behind its ordered lazy-load anchor',
 assert('data protection presentation joins every owning first-open boundary',
   importLoaderAuditSrc.includes('loadDataProtectionStylesheet()') &&
   settingsLoaderAuditSrc.includes('loadDataProtectionStylesheet()') &&
-  cryptoAuditSrc.includes('runWithDataProtectionStylesheet') &&
+  cryptoUiAuditSrc.includes('runWithDataProtectionStylesheet') &&
   piiAuditSrc.includes('loadDataProtectionStylesheetForAction'));
 assert('SW APP_SHELL includes data protection CSS bundle', swAuditSrc.includes("'/css/data-protection.css'"));
 assert('index defers settings CSS behind its ordered lazy-load anchor',

--- a/tests/test-crypto.js
+++ b/tests/test-crypto.js
@@ -58,6 +58,7 @@ await import('../js/utils.js');
 const backupModule = await import('../js/backup.js');
 const backupSrc = read('js/backup.js');
 const cryptoStoreSrc = read('js/crypto.js');
+const cryptoUiSrc = read('js/crypto-ui.js');
 const cycleStoreSrc = read('js/cycle-store.js');
 const profileStorageKeySrc = read('js/profile-storage-key.js');
 
@@ -251,6 +252,7 @@ console.log('8. Service worker');
 try {
   const swText = read('service-worker.js');
   assert('Service worker contains /js/crypto.js', swText.includes('/js/crypto.js'));
+  assert('Service worker contains /js/crypto-ui.js', swText.includes('/js/crypto-ui.js'));
   assert('Service worker contains /js/data-wipe.js', swText.includes('/js/data-wipe.js'));
   assert('SW uses importScripts for version', swText.includes("importScripts('/version.js')"));
   assert('SW CACHE_NAME uses semver', swText.includes('`labcharts-v${self.APP_VERSION}`'));
@@ -397,19 +399,21 @@ try {
 console.log('14. crypto.js source inspection');
 try {
   const src = await fetchWithRetry('js/crypto.js');
+  const uiSrc = await fetchWithRetry('js/crypto-ui.js');
+  const surfaceSrc = `${src}\n${uiSrc}`;
   assert('crypto.js uses PBKDF2', src.includes('PBKDF2'));
   assert('crypto.js uses AES-GCM', src.includes('AES-GCM'));
   assert('crypto.js has 600000 iterations', src.includes('600000'));
   assert('crypto.js uses 12-byte IV', src.includes('Uint8Array(12)'));
   assert('crypto.js uses 16-byte salt', src.includes('Uint8Array(16)'));
   assert('crypto.js has BroadcastChannel', src.includes('BroadcastChannel'));
-  assert('crypto.js has backup format', src.includes('labcharts-backup'));
+  assert('crypto surface has backup format', surfaceSrc.includes('labcharts-backup'));
   assert('crypto.js has v1: prefix', src.includes("'v1:'") || src.includes('`v1:'));
-  assert('crypto.js never stores passphrase', !src.includes('localStorage') || (!src.includes('setItem') && !src.includes('passphrase')) || !src.match(/localStorage\.setItem\([^)]*passphrase/));
-  assert('Forgot passphrase does NOT use showConfirmDialog', !src.includes("forgotBtn.addEventListener('click', () => {\n    showConfirmDialog"));
-  assert('Forgot passphrase has inline confirm UI', src.includes('passphrase-forgot-confirm'));
-  assert('Forgot passphrase has Go Back button', src.includes('passphrase-forgot-cancel'));
-  assert('Forgot passphrase wipes IndexedDB-backed app data', src.includes("import('./data-wipe.js'") && src.includes('eraseAllLocalAppData'));
+  assert('crypto surface never stores passphrase', !surfaceSrc.match(/localStorage\.setItem\([^)]*passphrase/));
+  assert('Forgot passphrase does NOT use showConfirmDialog', !uiSrc.includes("forgotButton.addEventListener('click', () => {\n    showConfirmDialog"));
+  assert('Forgot passphrase has inline confirm UI', uiSrc.includes('passphrase-forgot-confirm'));
+  assert('Forgot passphrase has Go Back button', uiSrc.includes('passphrase-forgot-cancel'));
+  assert('Forgot passphrase wipes IndexedDB-backed app data', uiSrc.includes("import('./data-wipe.js'") && uiSrc.includes('eraseAllLocalAppData'));
   const bkSrc0 = await fetchWithRetry('js/backup.js');
   assert('Backup includes encryptionSalt field', bkSrc0.includes('encryptionSalt'));
   assert('Restore sets labcharts-encryption-enabled', bkSrc0.includes("localStorage.setItem('labcharts-encryption-enabled'"));
@@ -631,8 +635,7 @@ try {
   assert('backup.js has restoreAutoBackup function', bkSrc.includes('async function restoreAutoBackup'));
   assert('backup.js has MAX_SNAPSHOTS = 5', bkSrc.includes('MAX_SNAPSHOTS = 5'));
   assert('backup.js has AUTO_BACKUP_COOLDOWN = 300000', bkSrc.includes('AUTO_BACKUP_COOLDOWN = 300000'));
-  const cryptoSrc = await fetchWithRetry('js/crypto.js');
-  assert('crypto.js has labcharts-last-autobackup', cryptoSrc.includes('labcharts-last-autobackup'));
+  assert('crypto UI has labcharts-last-autobackup', cryptoUiSrc.includes('labcharts-last-autobackup'));
 } catch (e) {
   assert('buildBackupSnapshot prefs check', false, e.message);
 }

--- a/tests/test-folder-backup.js
+++ b/tests/test-folder-backup.js
@@ -139,9 +139,11 @@ const exportModule = await import('../js/export.js');
   try {
     const backupSrc2 = read('/js/backup.js');
     const cryptoSrc = read('/js/crypto.js');
+    const cryptoUiSrc = read('/js/crypto-ui.js');
+    const cryptoSurfaceSrc = `${cryptoSrc}\n${cryptoUiSrc}`;
     assert('labcharts-last-manual-backup in backup.js', backupSrc2.includes('labcharts-last-manual-backup'));
-    assert('crypto.js has backup-nudge-snoozed-until', cryptoSrc.includes('backup-nudge-snoozed-until'));
-    assert('crypto.js has maybeShowBackupNudge function', cryptoSrc.includes('function maybeShowBackupNudge'));
+    assert('crypto surface has backup-nudge-snoozed-until', cryptoSurfaceSrc.includes('backup-nudge-snoozed-until'));
+    assert('crypto UI has maybeShowBackupNudge function', cryptoUiSrc.includes('function maybeShowBackupNudge'));
   } catch (e) {
     assert('backup nudge source inspection', false, e.message);
   }

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -240,6 +240,7 @@ assert('checkJs includes high-coupling browser modules',
   missingHighValueCheckJsModules.length ? `missing: ${missingHighValueCheckJsModules.join(', ')}` : '');
 const domainUiCheckJsModules = [
   'js/crypto.js',
+  'js/crypto-ui.js',
   'js/data.js',
   'js/emf.js',
   'js/emf-editor.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -115,6 +115,7 @@
     "js/context-cards.js",
     "js/crypto-key-cache.js",
     "js/crypto.js",
+    "js/crypto-ui.js",
     "js/dashboard-page-view.js",
     "js/dashboard-lab-widget-renderers.js",
     "js/dashboard-recommendation-widget.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -112,6 +112,7 @@
     "js/context-card-summaries.js",
     "js/context-cards.js",
     "js/crypto.js",
+    "js/crypto-ui.js",
     "js/cycle.js",
     "js/dashboard-page-view.js",
     "js/dashboard-lab-widget-renderers.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.463';
+self.APP_VERSION = '1.10.464';


### PR DESCRIPTION
## What changed

- extracted encryption dialogs, nudges, delegated actions, and settings rendering from `js/crypto.js` into `js/crypto-ui.js`
- retained cryptographic key handling, PBKDF2/AES-GCM operations, storage migrations, backup runtime wiring, and cross-tab synchronization in the `crypto.js` facade
- connected the two owners with injected callbacks so existing imports continue to use the same public `crypto.js` API without a back-import cycle
- added the new owner to service-worker precaching and both JavaScript typecheck configurations
- updated focused source-ownership assertions, the generated module map, app version, and the oversized-module baseline from 13 to 12

## Why

`js/crypto.js` mixed security-critical storage operations with DOM-heavy settings behavior and exceeded the 800-line maintainability cap. The split gives the UI a cohesive owner while keeping compatibility at the existing facade and leaving both resulting modules below the cap (`crypto.js`: 613 lines; `crypto-ui.js`: 649 lines).

## Impact

This is intended to be behavior-preserving. Existing consumers keep importing the same APIs from `crypto.js`; end-user encryption, passphrase, backup, nudge, and restore behavior is unchanged.

## Validation

- `node tests/test-crypto.js` (299/299)
- `node tests/test-folder-backup.js` (47/47)
- `node tests/test-wearables.js` (588/588)
- `node tests/test-audit.js` (366/366)
- `node tests/test-cashu-wallet.js` (254/254)
- `node tests/test-blob-storage.js` (20/20)
- `node tests/test-custom-api.js` (134/134)
- `node tests/test-custom-lens.js` (188/188)
- `node tests/verify-modules.js` (141/141)
- `node tests/test-correctness-phase2.js` (204/204)
- `node tests/test-a11y-phase3.js` (72/72)
- `node tests/test-shell-delegated-actions.js` (98/98)
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run typecheck:strict-null`
- `node tests/test-quality-guardrails.js` (36/36)
- `npm run quality`
- `npm run architecture:check`
- focused production/service-worker Vitest coverage (30/30)
- `npx playwright test tests/playwright/crypto-browser-coverage.spec.js` (3/3)
- `npx playwright test tests/playwright/data-protection-stylesheet-browser-coverage.spec.js` (3/3)
- `npm run production:check`