### PR TITLE
Open marker cards on the first click after refresh

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -10,7 +10,7 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | Metric | Current |
 | --- | ---: |
 | Modules | 518 |
-| Internal import edges | 2320 |
+| Internal import edges | 2321 |
 | Dynamic internal edges | 93 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -557,7 +557,7 @@ Native browser modules shipped with the static application.
 - [`js/marker-detail-editing.js`](js/marker-detail-editing.js) → [`js/data.js`](js/data.js), [`js/marker-detail-actions.js`](js/marker-detail-actions.js), [`js/marker-detail-runtime.js`](js/marker-detail-runtime.js), [`js/marker-detail-store.js`](js/marker-detail-store.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/marker-detail-manual-entry.js`](js/marker-detail-manual-entry.js) → [`js/data.js`](js/data.js), [`js/marker-detail-actions.js`](js/marker-detail-actions.js), [`js/marker-detail-editing.js`](js/marker-detail-editing.js), [`js/marker-detail-runtime.js`](js/marker-detail-runtime.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/marker-detail-modal-impl.js`](js/marker-detail-modal-impl.js) → [`js/api.js`](js/api.js), [`js/charts.js`](js/charts.js), [`js/context-cards.js`](js/context-cards.js), [`js/data.js`](js/data.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/marker-analysis.js`](js/marker-analysis.js), [`js/marker-detail-actions.js`](js/marker-detail-actions.js), [`js/marker-detail-content.js`](js/marker-detail-content.js), [`js/marker-detail-custom-markers.js`](js/marker-detail-custom-markers.js), [`js/marker-detail-editing.js`](js/marker-detail-editing.js), [`js/marker-detail-manual-entry.js`](js/marker-detail-manual-entry.js), [`js/marker-detail-runtime.js`](js/marker-detail-runtime.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/modal-trigger-memory.js`](js/modal-trigger-memory.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
-- [`js/marker-detail-modal.js`](js/marker-detail-modal.js) → [`js/health-data-loader.js`](js/health-data-loader.js), [`js/marker-detail-modal-impl.js`](js/marker-detail-modal-impl.js) *(dynamic)*, [`js/marker-detail-runtime.js`](js/marker-detail-runtime.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/modal-trigger-memory.js`](js/modal-trigger-memory.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
+- [`js/marker-detail-modal.js`](js/marker-detail-modal.js) → [`js/health-data-loader.js`](js/health-data-loader.js), [`js/marker-detail-actions.js`](js/marker-detail-actions.js), [`js/marker-detail-modal-impl.js`](js/marker-detail-modal-impl.js) *(dynamic)*, [`js/marker-detail-runtime.js`](js/marker-detail-runtime.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/modal-trigger-memory.js`](js/modal-trigger-memory.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/marker-detail-runtime.js`](js/marker-detail-runtime.js) → [`js/dna-runtime-bridge.js`](js/dna-runtime-bridge.js), [`js/emf-runtime.js`](js/emf-runtime.js), [`js/recommendations-runtime.js`](js/recommendations-runtime.js), [`js/utils.js`](js/utils.js), [`js/wearables-runtime.js`](js/wearables-runtime.js)
 - [`js/marker-detail-store.js`](js/marker-detail-store.js) → [`js/data.js`](js/data.js), [`js/lab-entry-mutations.js`](js/lab-entry-mutations.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/state.js`](js/state.js)
 

--- a/js/marker-detail-actions.js
+++ b/js/marker-detail-actions.js
@@ -3,7 +3,7 @@
 
 import { escapeAttr } from './utils.js';
 
-const markerDetailActionDelegateRoots = new WeakSet();
+const markerDetailActionDelegates = new WeakMap();
 
 function dataAttrName(name) {
   return String(name).replace(/[A-Z]/g, char => `-${char.toLowerCase()}`);
@@ -138,9 +138,15 @@ function handleMarkerDetailChange(event, actions) {
 }
 
 export function installMarkerDetailActionDelegates(actions = {}, root = (typeof document !== 'undefined' ? document : null)) {
-  if (!root || markerDetailActionDelegateRoots.has(root)) return;
-  markerDetailActionDelegateRoots.add(root);
-  root.addEventListener('click', event => handleMarkerDetailClick(event, actions));
-  root.addEventListener('keydown', event => handleMarkerDetailKeydown(event, actions));
-  root.addEventListener('change', event => handleMarkerDetailChange(event, actions));
+  if (!root) return;
+  const installedActions = markerDetailActionDelegates.get(root);
+  if (installedActions) {
+    Object.assign(installedActions, actions);
+    return;
+  }
+  const delegatedActions = { ...actions };
+  markerDetailActionDelegates.set(root, delegatedActions);
+  root.addEventListener('click', event => handleMarkerDetailClick(event, delegatedActions));
+  root.addEventListener('keydown', event => handleMarkerDetailKeydown(event, delegatedActions));
+  root.addEventListener('change', event => handleMarkerDetailChange(event, delegatedActions));
 }

--- a/js/marker-detail-modal.js
+++ b/js/marker-detail-modal.js
@@ -3,6 +3,7 @@
 
 import { state } from './state.js';
 import { closeSuggestionsOnClickOutside } from './health-data-loader.js';
+import { installMarkerDetailActionDelegates } from './marker-detail-actions.js';
 import { closeModalOverlay } from './modal-lifecycle.js';
 import {
   closeEMFInterpretationRuntime,
@@ -119,6 +120,14 @@ export function fetchCustomMarkerDescription(...args) {
 export function showDetailModal(id, opts = {}) {
   if (!safeMarkerId(id)) return Promise.resolve(false);
   return runMarkerDetailAction('showDetailModal', [id, opts]);
+}
+
+// Category cards already render the shared delegated action contract while the
+// heavy modal implementation is still cold. Bridge their first click through
+// this facade; the implementation upgrades the same delegate with its complete
+// action set once the lazy import resolves.
+if (typeof document !== 'undefined') {
+  installMarkerDetailActionDelegates({ showDetailModal });
 }
 
 export function editRefRange(...args) {

--- a/tests/playwright/marker-detail-browser-coverage.spec.js
+++ b/tests/playwright/marker-detail-browser-coverage.spec.js
@@ -82,6 +82,83 @@ test('marker detail implementation loads on demand and single-flights', async ({
   expect(implementationRequests).toBe(1);
 });
 
+test('first delegated marker-card click loads and opens marker details', async ({ page }) => {
+  let implementationRequests = 0;
+  await page.route('**/js/marker-detail-modal-impl.js*', route => {
+    implementationRequests += 1;
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/javascript',
+      body: markerDetailFacadeStubBody(),
+    });
+  });
+  await openMarkerDetailLoaderPage(page, '/marker-detail-first-card-click-coverage');
+
+  const loadedBeforeClick = await page.evaluate(async ({ modalUrl }) => {
+    const modal = await import(modalUrl);
+    const card = document.createElement('button');
+    card.type = 'button';
+    card.dataset.markerDetailAction = 'show-detail-modal';
+    card.dataset.markerDetailId = 'proteins_albumin';
+    document.body.appendChild(card);
+    const loaded = modal.isMarkerDetailModuleLoaded();
+    card.click();
+    return loaded;
+  }, { modalUrl: moduleUrl('/js/marker-detail-modal.js') });
+
+  expect(loadedBeforeClick).toBe(false);
+  await expect.poll(() => page.evaluate(() => window.__markerDetailFacadeCalls || []))
+    .toEqual([['showDetailModal', 'proteins_albumin', {}]]);
+  expect(implementationRequests).toBe(1);
+});
+
+test('hard-refreshed category view opens a marker card before any Dashboard marker click', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('labcharts-default-tour', 'completed');
+  });
+  await page.goto('/app', { waitUntil: 'load' });
+  await page.reload({ waitUntil: 'load' });
+
+  const initial = await page.evaluate(async () => {
+    const [{ state }, dataModule, viewsModule, modalModule, tourModule] = await Promise.all([
+      import('/js/state.js'),
+      import('/js/data.js'),
+      import('/js/views.js'),
+      import('/js/marker-detail-modal.js'),
+      import('/js/tour.js'),
+    ]);
+    tourModule.endTour({ openEmptyChat: false });
+    localStorage.setItem(`labcharts-${state.currentProfile}-tour`, 'completed');
+    localStorage.setItem(`labcharts-${state.currentProfile}-emptyTour`, 'completed');
+    state.importedData = await fetch('/data/demo-male.json', { cache: 'no-store' }).then(response => response.json());
+    state.profileSex = 'male';
+    state.profileDob = '1987-11-22';
+    state.dateRangeFilter = 'all';
+    state.categoryView = 'charts';
+    await dataModule.saveImportedData();
+    viewsModule.showCategory('biochemistry');
+    return {
+      implementationLoaded: modalModule.isMarkerDetailModuleLoaded(),
+      markerCards: document.querySelectorAll(
+        '.chart-card-main[data-marker-detail-action="show-detail-modal"]',
+      ).length,
+    };
+  });
+
+  expect(initial.implementationLoaded).toBe(false);
+  expect(initial.markerCards).toBeGreaterThan(0);
+
+  const firstCard = page.locator(
+    '.chart-card-main[data-marker-detail-action="show-detail-modal"]',
+  ).first();
+  const markerId = await firstCard.getAttribute('data-marker-detail-id');
+  await firstCard.click();
+
+  await expect(page.locator('#modal-overlay')).toHaveClass(/show/);
+  await expect(page.locator('#detail-modal')).toHaveClass(/marker-detail-modal/);
+  await expect(page.locator('#detail-modal')).toHaveAttribute('data-sync-refresh-item-id', markerId);
+});
+
 test('marker detail lazy facade forwards its complete editing contract', async ({ page }) => {
   await page.route('**/js/marker-detail-modal-impl.js*', route => route.fulfill({
     status: 200,
@@ -871,7 +948,7 @@ test('marker detail delegated actions cover click key and data attribute contrac
     try {
       actionsModule.installMarkerDetailActionDelegates(actions, root);
       actionsModule.installMarkerDetailActionDelegates({
-        closeModal: () => calls.push(['duplicate-close']),
+        closeModal: () => calls.push(['upgraded-close']),
       }, root);
 
       clickAction('close-modal');
@@ -940,8 +1017,8 @@ test('marker detail delegated actions cover click key and data attribute contrac
         && escapedAttrs.includes('data-marker-detail-history-limit="0"');
 
       outcomes.clickDelegatesCallEveryRegisteredAction =
-        calls.some(call => call[0] === 'close')
-        && !calls.some(call => call[0] === 'duplicate-close')
+        calls.some(call => call[0] === 'upgraded-close')
+        && !calls.some(call => call[0] === 'close')
         && calls.some(call => call[0] === 'pin' && call[1] === 'proteins_albumin')
         && calls.some(call => call[0] === 'edit-ref' && call[2] === 'ref')
         && calls.some(call => call[0] === 'revert-ref' && call[2] === 'optimal')

--- a/tests/test-marker-detail-delegated-actions.js
+++ b/tests/test-marker-detail-delegated-actions.js
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
+const modalFacadeSrc = fs.readFileSync(path.join(root, 'js/marker-detail-modal.js'), 'utf8');
 const modalImplSrc = fs.readFileSync(path.join(root, 'js/marker-detail-modal-impl.js'), 'utf8');
 const manualEntrySrc = fs.readFileSync(path.join(root, 'js/marker-detail-manual-entry.js'), 'utf8');
 const customMarkersSrc = fs.readFileSync(path.join(root, 'js/marker-detail-custom-markers.js'), 'utf8');
@@ -53,10 +54,14 @@ assert('marker-detail-actions defines one shared action attribute helper',
     actionSrc.includes("replace(/[A-Z]/g, char => `-${char.toLowerCase()}`)") &&
     actionSrc.includes("value !== false"));
 assert('marker-detail-actions installs idempotent click and keyboard delegates',
-  actionSrc.includes('const markerDetailActionDelegateRoots = new WeakSet();') &&
-    actionSrc.includes("root.addEventListener('click', event => handleMarkerDetailClick(event, actions))") &&
-    actionSrc.includes("root.addEventListener('keydown', event => handleMarkerDetailKeydown(event, actions))") &&
-    actionSrc.includes("root.addEventListener('change', event => handleMarkerDetailChange(event, actions))"));
+  actionSrc.includes('const markerDetailActionDelegates = new WeakMap();') &&
+    actionSrc.includes('Object.assign(installedActions, actions)') &&
+    actionSrc.includes("root.addEventListener('click', event => handleMarkerDetailClick(event, delegatedActions))") &&
+    actionSrc.includes("root.addEventListener('keydown', event => handleMarkerDetailKeydown(event, delegatedActions))") &&
+    actionSrc.includes("root.addEventListener('change', event => handleMarkerDetailChange(event, delegatedActions))"));
+assert('marker-detail facade bridges delegated card clicks before the implementation loads',
+  modalFacadeSrc.includes("import { installMarkerDetailActionDelegates } from './marker-detail-actions.js'") &&
+    modalFacadeSrc.includes('installMarkerDetailActionDelegates({ showDetailModal });'));
 assert('marker-detail delegated actions are scoped to the installed root',
   actionSrc.includes("event.currentTarget.contains(actionEl)"));
 assert('marker-detail open manual entry action preserves optional prefill date',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.469';
+self.APP_VERSION = '1.10.470';


### PR DESCRIPTION
## What changed

- install the lightweight marker-detail click bridge from the public lazy facade, before the modal implementation is loaded
- retain one delegated listener per root while allowing the full implementation to upgrade its available actions after lazy loading
- add isolated and full-app Chromium regressions for the first category-card click, including an actual hard refresh and confirmation that no Dashboard marker click occurred first
- refresh the architecture map and bump the app cache version to 1.10.470

## Root cause

Category cards render `data-marker-detail-action="show-detail-modal"`, but the delegate that consumed that action lived inside the lazy marker-detail implementation. A Dashboard marker used a direct function call, which loaded the implementation and incidentally installed the missing delegate. That made category cards appear inert until a Dashboard marker had been opened once.

## User impact

A category marker card now opens its detail modal on the first click after a hard refresh while retaining the deferred modal implementation and stylesheet.

## Validation

- TypeScript, full check-js, and strict-null ratchet
- architecture: 518 modules, zero cycles
- quality guardrails: 7/7 large modules; 541 JavaScript files parsed
- production bundle and cold-load budgets
- marker delegate/runtime, modal lifecycle, manual-entry, audit, correctness, and module verification suites
- production/service-worker Vitest group: 35/35
- focused Chromium lazy-loader, delegate-upgrade, exact hard-refresh category click, and cold-load group: 6/6
- exact hard-refresh regression rerun: 1/1