### PR TITLE
Split data merge lab entry owner

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -9,8 +9,8 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 
 | Metric | Current |
 | --- | ---: |
-| Modules | 519 |
-| Internal import edges | 2322 |
+| Modules | 520 |
+| Internal import edges | 2324 |
 | Dynamic internal edges | 93 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -331,9 +331,10 @@ Native browser modules shipped with the static application.
 
 </details>
 
-<details><summary><code>data</code> family — 3 modules</summary>
+<details><summary><code>data</code> family — 4 modules</summary>
 
-- [`js/data-merge.js`](js/data-merge.js) → [`js/lab-entry.js`](js/lab-entry.js), [`js/sync-delta-id.js`](js/sync-delta-id.js), [`js/sync-delta-surface-config.js`](js/sync-delta-surface-config.js)
+- [`js/data-merge-lab-entries.js`](js/data-merge-lab-entries.js) → [`js/lab-entry.js`](js/lab-entry.js)
+- [`js/data-merge.js`](js/data-merge.js) → [`js/data-merge-lab-entries.js`](js/data-merge-lab-entries.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/sync-delta-id.js`](js/sync-delta-id.js), [`js/sync-delta-surface-config.js`](js/sync-delta-surface-config.js)
 - [`js/data-wipe.js`](js/data-wipe.js) → no in-scope imports
 - [`js/data.js`](js/data.js) → [`js/crypto.js`](js/crypto.js), [`js/lab-date-range.js`](js/lab-date-range.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/marker-analysis.js`](js/marker-analysis.js), [`js/profile-context.js`](js/profile-context.js), [`js/profile.js`](js/profile.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/sync.js`](js/sync.js), [`js/utils-runtime.js`](js/utils-runtime.js), [`js/utils.js`](js/utils.js)
 

--- a/js/data-merge-lab-entries.js
+++ b/js/data-merge-lab-entries.js
@@ -1,0 +1,237 @@
+// @ts-check
+// data-merge-lab-entries.js — Lab-entry freshness and reconciliation.
+
+import {
+  LAB_ENTRY_MARKER_TOMBSTONES,
+  getLabEntryMarkerTombstoneAt,
+  getLabEntryMarkerTombstones,
+  getLabEntryMarkerValueTimestamp,
+  labEntryMarkerAffectsHOMAIR,
+  recalculateLabEntryHOMAIR,
+} from './lab-entry.js';
+
+export const FRESH_LOCAL_LAB_ENTRY_TTL_MS = 2 * 60 * 1000;
+
+const TIMESTAMP_FIELDS = [
+  'updatedAt',
+  'endedAt',
+  'startedAt',
+  'capturedAt',
+  'takenAt',
+  'savedAt',
+  'loggedAt',
+  'createdAt',
+  'importedAt',
+  'addedAt',
+  'at',
+];
+
+export function normalizeTimestamp(value) {
+  if (Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+// Pick a comparable timestamp for conflict resolution. Higher wins. Tries
+// the most recently-edited signal first, then creation/capture fields that
+// several synced array surfaces use. Returns 0 if nothing recognizable is
+// present so older/foreign records can still merge without throwing.
+export function pickTimestamp(rec) {
+  if (!rec || typeof rec !== 'object') return 0;
+  for (const field of TIMESTAMP_FIELDS) {
+    const ts = normalizeTimestamp(rec[field]);
+    if (ts !== null) return ts;
+  }
+  if (typeof rec.date === 'string') {
+    const parsed = Date.parse(rec.date);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}
+
+// Shared freshness ordering for id-keyed array records. Positive means `a`
+// is newer than `b`, negative means older, zero means no winner. Callers
+// intentionally treat zero as "keep the local/current record" so a stale
+// pull cannot undo a just-saved local edit when timestamps tie or are absent.
+export function compareRecordFreshness(a, b) {
+  const aTs = pickTimestamp(a);
+  const bTs = pickTimestamp(b);
+  if (aTs > bTs) return 1;
+  if (aTs < bTs) return -1;
+  return 0;
+}
+
+export function pickFresherRecord(current, candidate) {
+  return compareRecordFreshness(candidate, current) > 0 ? candidate : current;
+}
+
+export function hasExplicitTimestamp(rec) {
+  if (!rec || typeof rec !== 'object') return false;
+  return TIMESTAMP_FIELDS.some(field => normalizeTimestamp(rec[field]) !== null);
+}
+
+function mergeSourceFiles(a, b) {
+  const files = [];
+  for (const item of [a?.sourceFiles, a?.sourceFile, b?.sourceFiles, b?.sourceFile]) {
+    if (Array.isArray(item)) {
+      for (const file of item) if (file && !files.includes(file)) files.push(file);
+    } else if (item && !files.includes(item)) {
+      files.push(item);
+    }
+  }
+  return files;
+}
+
+export function mergeLabEntry(existing, incoming) {
+  if (!existing || typeof existing !== 'object') return incoming;
+  if (!incoming || typeof incoming !== 'object') return existing;
+  const existingTs = pickTimestamp(existing);
+  const incomingTs = pickTimestamp(incoming);
+  const incomingWins = incomingTs >= existingTs;
+  const base = incomingWins ? { ...existing, ...incoming } : { ...incoming, ...existing };
+  const markers = {};
+  const markerSources = {};
+  const markerTombstones = {};
+  const existingMarkers = existing.markers && typeof existing.markers === 'object' ? existing.markers : {};
+  const incomingMarkers = incoming.markers && typeof incoming.markers === 'object' ? incoming.markers : {};
+  const existingSources = existing.markerSources && typeof existing.markerSources === 'object' ? existing.markerSources : {};
+  const incomingSources = incoming.markerSources && typeof incoming.markerSources === 'object' ? incoming.markerSources : {};
+  const existingTombstones = getLabEntryMarkerTombstones(existing);
+  const incomingTombstones = getLabEntryMarkerTombstones(incoming);
+  const markerKeys = new Set([
+    ...Object.keys(existingMarkers),
+    ...Object.keys(incomingMarkers),
+    ...Object.keys(existingTombstones),
+    ...Object.keys(incomingTombstones),
+  ]);
+  let homaIRInputChanged = false;
+  let homaIRInputDeleted = false;
+  for (const key of markerKeys) {
+    const hasExisting = Object.prototype.hasOwnProperty.call(existingMarkers, key);
+    const hasIncoming = Object.prototype.hasOwnProperty.call(incomingMarkers, key);
+    const existingValueTs = hasExisting ? getLabEntryMarkerValueTimestamp(existing, key) : 0;
+    const incomingValueTs = hasIncoming ? getLabEntryMarkerValueTimestamp(incoming, key) : 0;
+    const deleteTs = Math.max(
+      getLabEntryMarkerTombstoneAt(existing, key),
+      getLabEntryMarkerTombstoneAt(incoming, key)
+    );
+    const valueTs = Math.max(existingValueTs, incomingValueTs);
+    if (deleteTs && deleteTs >= valueTs) {
+      markerTombstones[key] = deleteTs;
+      if (labEntryMarkerAffectsHOMAIR(key)) {
+        homaIRInputChanged = true;
+        homaIRInputDeleted = true;
+      }
+      continue;
+    }
+    if (hasExisting && hasIncoming) {
+      const markerIncomingWins = incomingValueTs > existingValueTs
+        || (incomingValueTs === existingValueTs && incomingWins);
+      markers[key] = markerIncomingWins ? incomingMarkers[key] : existingMarkers[key];
+      const sources = markerIncomingWins ? incomingSources : existingSources;
+      if (Object.prototype.hasOwnProperty.call(sources, key)) markerSources[key] = sources[key];
+      if (labEntryMarkerAffectsHOMAIR(key) && !Object.is(existingMarkers[key], incomingMarkers[key])) {
+        homaIRInputChanged = true;
+      }
+    } else if (hasIncoming) {
+      markers[key] = incomingMarkers[key];
+      if (incomingSources[key]) markerSources[key] = incomingSources[key];
+      if (labEntryMarkerAffectsHOMAIR(key)) homaIRInputChanged = true;
+    } else if (hasExisting) {
+      markers[key] = existingMarkers[key];
+      if (existingSources[key]) markerSources[key] = existingSources[key];
+      if (labEntryMarkerAffectsHOMAIR(key)) homaIRInputChanged = true;
+    }
+  }
+  base.markers = markers;
+  if (Object.keys(markerSources).length) base.markerSources = markerSources;
+  else delete base.markerSources;
+  if (Object.keys(markerTombstones).length) base[LAB_ENTRY_MARKER_TOMBSTONES] = markerTombstones;
+  else delete base[LAB_ENTRY_MARKER_TOMBSTONES];
+  const hasMergedHOMAIR = Object.prototype.hasOwnProperty.call(markers, 'diabetes.homaIR');
+  const hasMergedGlucose = Object.prototype.hasOwnProperty.call(markers, 'biochemistry.glucose');
+  const hasMergedInsulin = Object.prototype.hasOwnProperty.call(markers, 'hormones.insulin')
+    || Object.prototype.hasOwnProperty.call(markers, 'diabetes.insulin_d');
+  const wouldDeleteExistingHOMAIR = hasMergedHOMAIR && (!hasMergedGlucose || !hasMergedInsulin);
+  if (homaIRInputChanged && (!wouldDeleteExistingHOMAIR || homaIRInputDeleted)) recalculateLabEntryHOMAIR(base);
+  const sourceFiles = mergeSourceFiles(existing, incoming);
+  if (sourceFiles.length) {
+    base.sourceFiles = sourceFiles;
+    base.sourceFile = incomingWins
+      ? (incoming.sourceFile || existing.sourceFile || sourceFiles[sourceFiles.length - 1])
+      : (existing.sourceFile || incoming.sourceFile || sourceFiles[sourceFiles.length - 1]);
+  }
+  return base;
+}
+
+export function mergeLabEntriesByDate(localEntries, remoteEntries) {
+  const hasLocal = Array.isArray(localEntries);
+  const hasRemote = Array.isArray(remoteEntries);
+  if (!hasLocal && !hasRemote) return undefined;
+  const byDate = new Map();
+  const noDate = [];
+  function consume(entries) {
+    if (!Array.isArray(entries)) return;
+    for (const entry of entries) {
+      if (!entry || typeof entry !== 'object') continue;
+      if (typeof entry.date !== 'string' || !entry.date) {
+        noDate.push(entry);
+        continue;
+      }
+      const existing = byDate.get(entry.date);
+      byDate.set(entry.date, existing ? mergeLabEntry(existing, entry) : entry);
+    }
+  }
+  // Remote first, local second. Local wins timestamp ties so a just-imported
+  // unsynced lab entry cannot be wiped by a stale pull.
+  consume(remoteEntries);
+  consume(localEntries);
+  return [...byDate.values(), ...noDate].sort((a, b) => String(a.date || '').localeCompare(String(b.date || '')));
+}
+
+function isFreshLocalLabEntry(entry, now) {
+  if (!entry || typeof entry !== 'object') return false;
+  if (typeof entry.date !== 'string' || !entry.date) return false;
+  if (!Number.isFinite(entry.updatedAt)) return false;
+  return entry.updatedAt <= now + 1000 && now - entry.updatedAt <= FRESH_LOCAL_LAB_ENTRY_TTL_MS;
+}
+
+export function preserveFreshLocalLabEntries(merged, local, now = Date.now()) {
+  if (!merged || typeof merged !== 'object') return false;
+  if (!local || typeof local !== 'object' || !Array.isArray(local.entries)) return false;
+  const freshLocalEntries = local.entries.filter(entry => isFreshLocalLabEntry(entry, now));
+  if (!freshLocalEntries.length) return false;
+
+  if (!Array.isArray(merged.entries)) merged.entries = [];
+  const deletedEntryDates = new Set(Array.isArray(merged._deleted?.entries) ? merged._deleted.entries : []);
+  const byDate = new Map();
+  for (let i = 0; i < merged.entries.length; i++) {
+    const date = merged.entries[i]?.date;
+    if (typeof date === 'string' && date) byDate.set(date, i);
+  }
+
+  let changed = false;
+  for (const localEntry of freshLocalEntries) {
+    if (deletedEntryDates.has(localEntry.date)) continue;
+    const idx = byDate.get(localEntry.date);
+    if (idx === undefined) {
+      merged.entries.push(localEntry);
+      byDate.set(localEntry.date, merged.entries.length - 1);
+      changed = true;
+      continue;
+    }
+    const before = JSON.stringify(merged.entries[idx]);
+    const next = mergeLabEntry(merged.entries[idx], localEntry);
+    if (JSON.stringify(next) !== before) {
+      merged.entries[idx] = next;
+      changed = true;
+    }
+  }
+  if (changed) {
+    merged.entries.sort((a, b) => String(a.date || '').localeCompare(String(b.date || '')));
+  }
+  return changed;
+}

--- a/js/data-merge.js
+++ b/js/data-merge.js
@@ -3,14 +3,27 @@
 
 import { DELTA_ARRAY_CONFIG } from './sync-delta-surface-config.js';
 import { _isAllowlistSafeId } from './sync-delta-id.js';
+import { getLabEntryMarkerTombstones } from './lab-entry.js';
 import {
-  LAB_ENTRY_MARKER_TOMBSTONES,
-  getLabEntryMarkerTombstoneAt,
-  getLabEntryMarkerTombstones,
-  getLabEntryMarkerValueTimestamp,
-  labEntryMarkerAffectsHOMAIR,
-  recalculateLabEntryHOMAIR,
-} from './lab-entry.js';
+  FRESH_LOCAL_LAB_ENTRY_TTL_MS,
+  compareRecordFreshness,
+  hasExplicitTimestamp,
+  mergeLabEntriesByDate,
+  mergeLabEntry,
+  normalizeTimestamp,
+  pickFresherRecord,
+  pickTimestamp,
+  preserveFreshLocalLabEntries,
+} from './data-merge-lab-entries.js';
+
+export {
+  FRESH_LOCAL_LAB_ENTRY_TTL_MS,
+  compareRecordFreshness,
+  mergeLabEntry,
+  pickFresherRecord,
+  pickTimestamp,
+  preserveFreshLocalLabEntries,
+};
 //
 // Background: sync pushes the whole `importedData` blob and pull used to do
 // `localStorage.setItem(JSON.stringify(remote))`. With concurrent edits on
@@ -92,70 +105,8 @@ const LOCAL_WINS_MAP_FIELDS = [
   'manualValues',
 ];
 
-export const FRESH_LOCAL_LAB_ENTRY_TTL_MS = 2 * 60 * 1000;
 const TOMBSTONE_META_KEY = '_deletedAt';
 const TOMBSTONE_CLEAR_META_KEY = '_deletedClearedAt';
-
-const TIMESTAMP_FIELDS = [
-  'updatedAt',
-  'endedAt',
-  'startedAt',
-  'capturedAt',
-  'takenAt',
-  'savedAt',
-  'loggedAt',
-  'createdAt',
-  'importedAt',
-  'addedAt',
-  'at',
-];
-
-function normalizeTimestamp(value) {
-  if (Number.isFinite(value)) return value;
-  if (typeof value === 'string' && value.trim()) {
-    const parsed = Date.parse(value);
-    if (Number.isFinite(parsed)) return parsed;
-  }
-  return null;
-}
-
-// Pick a comparable timestamp for conflict resolution. Higher wins. Tries
-// the most recently-edited signal first, then creation/capture fields that
-// several synced array surfaces use. Returns 0 if nothing recognizable is
-// present so older/foreign records can still merge without throwing.
-export function pickTimestamp(rec) {
-  if (!rec || typeof rec !== 'object') return 0;
-  for (const field of TIMESTAMP_FIELDS) {
-    const ts = normalizeTimestamp(rec[field]);
-    if (ts !== null) return ts;
-  }
-  if (typeof rec.date === 'string') {
-    const parsed = Date.parse(rec.date);
-    return Number.isFinite(parsed) ? parsed : 0;
-  }
-  return 0;
-}
-
-// Shared freshness ordering for id-keyed array records. Positive means `a`
-// is newer than `b`, negative means older, zero means no winner. Callers
-// intentionally treat zero as "keep the local/current record" so a stale
-// pull cannot undo a just-saved local edit when timestamps tie or are absent.
-export function compareRecordFreshness(a, b) {
-  const aTs = pickTimestamp(a);
-  const bTs = pickTimestamp(b);
-  if (aTs > bTs) return 1;
-  if (aTs < bTs) return -1;
-  return 0;
-}
-
-export function pickFresherRecord(current, candidate) {
-  return compareRecordFreshness(candidate, current) > 0 ? candidate : current;
-}
-
-function hasExplicitTimestamp(rec) {
-  if (!rec || typeof rec !== 'object') return false;
-  return TIMESTAMP_FIELDS.some(field => normalizeTimestamp(rec[field]) !== null);
-}
 
 function mergePlainMap(localMap, remoteMap) {
   const hasLocal = localMap && typeof localMap === 'object' && !Array.isArray(localMap);
@@ -175,168 +126,6 @@ function preserveLocalGeneticsSnps(local, remote, out) {
   out.genetics = { ...out.genetics, snps: { ...localSnps } };
 }
 
-function mergeSourceFiles(a, b) {
-  const files = [];
-  for (const item of [a?.sourceFiles, a?.sourceFile, b?.sourceFiles, b?.sourceFile]) {
-    if (Array.isArray(item)) {
-      for (const file of item) if (file && !files.includes(file)) files.push(file);
-    } else if (item && !files.includes(item)) {
-      files.push(item);
-    }
-  }
-  return files;
-}
-
-export function mergeLabEntry(existing, incoming) {
-  if (!existing || typeof existing !== 'object') return incoming;
-  if (!incoming || typeof incoming !== 'object') return existing;
-  const existingTs = pickTimestamp(existing);
-  const incomingTs = pickTimestamp(incoming);
-  const incomingWins = incomingTs >= existingTs;
-  const base = incomingWins ? { ...existing, ...incoming } : { ...incoming, ...existing };
-  const markers = {};
-  const markerSources = {};
-  const markerTombstones = {};
-  const existingMarkers = existing.markers && typeof existing.markers === 'object' ? existing.markers : {};
-  const incomingMarkers = incoming.markers && typeof incoming.markers === 'object' ? incoming.markers : {};
-  const existingSources = existing.markerSources && typeof existing.markerSources === 'object' ? existing.markerSources : {};
-  const incomingSources = incoming.markerSources && typeof incoming.markerSources === 'object' ? incoming.markerSources : {};
-  const existingTombstones = getLabEntryMarkerTombstones(existing);
-  const incomingTombstones = getLabEntryMarkerTombstones(incoming);
-  const markerKeys = new Set([
-    ...Object.keys(existingMarkers),
-    ...Object.keys(incomingMarkers),
-    ...Object.keys(existingTombstones),
-    ...Object.keys(incomingTombstones),
-  ]);
-  let homaIRInputChanged = false;
-  let homaIRInputDeleted = false;
-  for (const key of markerKeys) {
-    const hasExisting = Object.prototype.hasOwnProperty.call(existingMarkers, key);
-    const hasIncoming = Object.prototype.hasOwnProperty.call(incomingMarkers, key);
-    const existingValueTs = hasExisting ? getLabEntryMarkerValueTimestamp(existing, key) : 0;
-    const incomingValueTs = hasIncoming ? getLabEntryMarkerValueTimestamp(incoming, key) : 0;
-    const deleteTs = Math.max(
-      getLabEntryMarkerTombstoneAt(existing, key),
-      getLabEntryMarkerTombstoneAt(incoming, key)
-    );
-    const valueTs = Math.max(existingValueTs, incomingValueTs);
-    if (deleteTs && deleteTs >= valueTs) {
-      markerTombstones[key] = deleteTs;
-      if (labEntryMarkerAffectsHOMAIR(key)) {
-        homaIRInputChanged = true;
-        homaIRInputDeleted = true;
-      }
-      continue;
-    }
-    if (hasExisting && hasIncoming) {
-      const markerIncomingWins = incomingValueTs > existingValueTs
-        || (incomingValueTs === existingValueTs && incomingWins);
-      markers[key] = markerIncomingWins ? incomingMarkers[key] : existingMarkers[key];
-      const sources = markerIncomingWins ? incomingSources : existingSources;
-      if (Object.prototype.hasOwnProperty.call(sources, key)) markerSources[key] = sources[key];
-      if (labEntryMarkerAffectsHOMAIR(key) && !Object.is(existingMarkers[key], incomingMarkers[key])) {
-        homaIRInputChanged = true;
-      }
-    } else if (hasIncoming) {
-      markers[key] = incomingMarkers[key];
-      if (incomingSources[key]) markerSources[key] = incomingSources[key];
-      if (labEntryMarkerAffectsHOMAIR(key)) homaIRInputChanged = true;
-    } else if (hasExisting) {
-      markers[key] = existingMarkers[key];
-      if (existingSources[key]) markerSources[key] = existingSources[key];
-      if (labEntryMarkerAffectsHOMAIR(key)) homaIRInputChanged = true;
-    }
-  }
-  base.markers = markers;
-  if (Object.keys(markerSources).length) base.markerSources = markerSources;
-  else delete base.markerSources;
-  if (Object.keys(markerTombstones).length) base[LAB_ENTRY_MARKER_TOMBSTONES] = markerTombstones;
-  else delete base[LAB_ENTRY_MARKER_TOMBSTONES];
-  const hasMergedHOMAIR = Object.prototype.hasOwnProperty.call(markers, 'diabetes.homaIR');
-  const hasMergedGlucose = Object.prototype.hasOwnProperty.call(markers, 'biochemistry.glucose');
-  const hasMergedInsulin = Object.prototype.hasOwnProperty.call(markers, 'hormones.insulin')
-    || Object.prototype.hasOwnProperty.call(markers, 'diabetes.insulin_d');
-  const wouldDeleteExistingHOMAIR = hasMergedHOMAIR && (!hasMergedGlucose || !hasMergedInsulin);
-  if (homaIRInputChanged && (!wouldDeleteExistingHOMAIR || homaIRInputDeleted)) recalculateLabEntryHOMAIR(base);
-  const sourceFiles = mergeSourceFiles(existing, incoming);
-  if (sourceFiles.length) {
-    base.sourceFiles = sourceFiles;
-    base.sourceFile = incomingWins
-      ? (incoming.sourceFile || existing.sourceFile || sourceFiles[sourceFiles.length - 1])
-      : (existing.sourceFile || incoming.sourceFile || sourceFiles[sourceFiles.length - 1]);
-  }
-  return base;
-}
-
-function mergeLabEntriesByDate(localEntries, remoteEntries) {
-  const hasLocal = Array.isArray(localEntries);
-  const hasRemote = Array.isArray(remoteEntries);
-  if (!hasLocal && !hasRemote) return undefined;
-  const byDate = new Map();
-  const noDate = [];
-  function consume(entries) {
-    if (!Array.isArray(entries)) return;
-    for (const entry of entries) {
-      if (!entry || typeof entry !== 'object') continue;
-      if (typeof entry.date !== 'string' || !entry.date) {
-        noDate.push(entry);
-        continue;
-      }
-      const existing = byDate.get(entry.date);
-      byDate.set(entry.date, existing ? mergeLabEntry(existing, entry) : entry);
-    }
-  }
-  // Remote first, local second. Local wins timestamp ties so a just-imported
-  // unsynced lab entry cannot be wiped by a stale pull.
-  consume(remoteEntries);
-  consume(localEntries);
-  return [...byDate.values(), ...noDate].sort((a, b) => String(a.date || '').localeCompare(String(b.date || '')));
-}
-
-function isFreshLocalLabEntry(entry, now) {
-  if (!entry || typeof entry !== 'object') return false;
-  if (typeof entry.date !== 'string' || !entry.date) return false;
-  if (!Number.isFinite(entry.updatedAt)) return false;
-  return entry.updatedAt <= now + 1000 && now - entry.updatedAt <= FRESH_LOCAL_LAB_ENTRY_TTL_MS;
-}
-
-export function preserveFreshLocalLabEntries(merged, local, now = Date.now()) {
-  if (!merged || typeof merged !== 'object') return false;
-  if (!local || typeof local !== 'object' || !Array.isArray(local.entries)) return false;
-  const freshLocalEntries = local.entries.filter(entry => isFreshLocalLabEntry(entry, now));
-  if (!freshLocalEntries.length) return false;
-
-  if (!Array.isArray(merged.entries)) merged.entries = [];
-  const deletedEntryDates = new Set(Array.isArray(merged._deleted?.entries) ? merged._deleted.entries : []);
-  const byDate = new Map();
-  for (let i = 0; i < merged.entries.length; i++) {
-    const date = merged.entries[i]?.date;
-    if (typeof date === 'string' && date) byDate.set(date, i);
-  }
-
-  let changed = false;
-  for (const localEntry of freshLocalEntries) {
-    if (deletedEntryDates.has(localEntry.date)) continue;
-    const idx = byDate.get(localEntry.date);
-    if (idx === undefined) {
-      merged.entries.push(localEntry);
-      byDate.set(localEntry.date, merged.entries.length - 1);
-      changed = true;
-      continue;
-    }
-    const before = JSON.stringify(merged.entries[idx]);
-    const next = mergeLabEntry(merged.entries[idx], localEntry);
-    if (JSON.stringify(next) !== before) {
-      merged.entries[idx] = next;
-      changed = true;
-    }
-  }
-  if (changed) {
-    merged.entries.sort((a, b) => String(a.date || '').localeCompare(String(b.date || '')));
-  }
-  return changed;
-}
 
 // Get/set helpers for the dotted path.
 // Exported so sync.js can plan deltas at nested paths (e.g.

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -7,6 +7,6 @@
   "viewRuntimeBridgeLookups": 0,
   "labStateAppFiles": 0,
   "labStateTestFiles": 0,
-  "largeJsFilesOver800Lines": 6,
+  "largeJsFilesOver800Lines": 5,
   "maxJsFileLines": 1168
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -157,6 +157,7 @@ const APP_SHELL = [
   '/js/local-ai-discovery.js',
   '/js/import-benchmarks.js',
   '/js/import-reference-benchmark.js',
+  '/js/data-merge-lab-entries.js',
   '/js/data-merge.js',
   '/js/pii-review.js',
   '/js/pii.js',

--- a/tests/test-correctness-phase2.js
+++ b/tests/test-correctness-phase2.js
@@ -123,6 +123,7 @@ const pwaAppShellAssets = [
   '/js/pdf-import-marker-normalization.js',
   '/js/pdf-import-persistence.js',
   '/js/blob-storage.js',
+  '/js/data-merge-lab-entries.js',
   '/js/data-merge.js',
   '/js/views-router.js',
   '/js/dashboard-view-composition.js',

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -242,6 +242,7 @@ assert('checkJs includes high-coupling browser modules',
 const domainUiCheckJsModules = [
   'js/crypto.js',
   'js/crypto-ui.js',
+  'js/data-merge-lab-entries.js',
   'js/data.js',
   'js/emf.js',
   'js/emf-editor.js',

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -92,6 +92,7 @@
     '/js/focus-card.js',
     '/js/onboarding-view-runtime.js',
     '/js/onboarding-view.js',
+    '/js/data-merge-lab-entries.js',
     '/js/pii-review.js',
     '/js/marker-detail-modal.js',
     '/js/marker-detail-modal-impl.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -124,6 +124,7 @@
     "js/dashboard-widget-controls.js",
     "js/dashboard-widget-renderers.js",
     "js/dashboard-widgets.js",
+    "js/data-merge-lab-entries.js",
     "js/data-merge.js",
     "js/data.js",
     "js/dna.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -122,6 +122,7 @@
     "js/dashboard-widget-controls.js",
     "js/dashboard-widget-renderers.js",
     "js/dashboard-widgets.js",
+    "js/data-merge-lab-entries.js",
     "js/data-merge.js",
     "js/data.js",
     "js/dna.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.471';
+self.APP_VERSION = '1.10.472';


### PR DESCRIPTION
## What changed

- extracted lab-entry freshness, timestamp ordering, same-date marker reconciliation, source-file merging, and fresh-local-entry preservation from `data-merge.js` into `data-merge-lab-entries.js`
- preserved the existing `data-merge.js` public API through named re-exports
- added the new static dependency to the service-worker app shell, TypeScript/checkJs scope, module verification, and architecture map
- bumped the app version and ratcheted the >=800-line JavaScript baseline from 6 to 5

## Why

`data-merge.js` mixed generic array/tombstone sync with the specialized rules required to reconcile lab entries and marker-level tombstones. The split gives lab-entry reconciliation one cohesive owner while leaving generic imported-data, array, and tombstone merging in the facade. The files are now 744 and 237 lines instead of one 955-line module.

## Impact

Behavior and existing import paths are unchanged. The service worker precaches the new static dependency, and the architecture remains cycle-free.

## Validation

- `node tests/test-data-merge.js` — 137 passed
- `node tests/test-sync.js` — 834 passed
- `npm test -- tests/service-worker-app-shell.test.js` — 4 passed
- `npm test -- tests/export-import-runtime.test.js` — 1 passed
- `node tests/test-correctness-phase2.js` — 215 passed
- `node tests/verify-modules.js` — 152 passed
- `node tests/test-quality-guardrails.js` — 36 passed
- `npx playwright test tests/playwright/data-merge-browser-coverage.spec.js --workers=1` — 2 passed
- `npx playwright test tests/playwright/cold-load-budget.spec.js --workers=1` — 5 passed; 270 requests / 985.3 KiB compressed
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run typecheck:strict-null`
- `npm run production:check`
- `npm run architecture:check` — 520 modules, zero cycles
- `npm run quality` — large-module baseline 5/5