### PR TITLE
Split lab context owners

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -9,8 +9,8 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 
 | Metric | Current |
 | --- | ---: |
-| Modules | 522 |
-| Internal import edges | 2328 |
+| Modules | 524 |
+| Internal import edges | 2339 |
 | Dynamic internal edges | 93 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -38,21 +38,21 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 
 | High fan-in | Dependants | High fan-out | Imports |
 | --- | ---: | --- | ---: |
-| [`js/utils.js`](js/utils.js) | 240 | [`js/app-shell-hooks.js`](js/app-shell-hooks.js) | 72 |
-| [`js/state.js`](js/state.js) | 165 | [`js/app-light-sun-modules.js`](js/app-light-sun-modules.js) | 36 |
-| [`js/data.js`](js/data.js) | 76 | [`js/sync-configure.js`](js/sync-configure.js) | 27 |
+| [`js/utils.js`](js/utils.js) | 241 | [`js/app-shell-hooks.js`](js/app-shell-hooks.js) | 72 |
+| [`js/state.js`](js/state.js) | 167 | [`js/app-light-sun-modules.js`](js/app-light-sun-modules.js) | 36 |
+| [`js/data.js`](js/data.js) | 77 | [`js/sync-configure.js`](js/sync-configure.js) | 27 |
 | [`js/caught-error.js`](js/caught-error.js) | 75 | [`js/settings.js`](js/settings.js) | 25 |
 | [`js/modal-lifecycle.js`](js/modal-lifecycle.js) | 69 | [`js/pdf-import.js`](js/pdf-import.js) | 24 |
 | [`js/api.js`](js/api.js) | 64 | [`js/chat-send.js`](js/chat-send.js) | 22 |
-| [`js/profile.js`](js/profile.js) | 45 | [`js/views.js`](js/views.js) | 22 |
+| [`js/profile.js`](js/profile.js) | 46 | [`js/views.js`](js/views.js) | 22 |
 | [`js/schema.js`](js/schema.js) | 33 | [`js/wearables-connect.js`](js/wearables-connect.js) | 21 |
 | [`js/crypto.js`](js/crypto.js) | 29 | [`js/dashboard-view-composition.js`](js/dashboard-view-composition.js) | 20 |
 | [`js/data-merge.js`](js/data-merge.js) | 29 | [`js/biology-scores.js`](js/biology-scores.js) | 19 |
 | [`js/constants.js`](js/constants.js) | 21 | [`js/export.js`](js/export.js) | 18 |
-| [`js/utils-runtime.js`](js/utils-runtime.js) | 20 | [`js/marker-detail-modal-impl.js`](js/marker-detail-modal-impl.js) | 17 |
-| [`js/marker-analysis.js`](js/marker-analysis.js) | 18 | [`js/sun.js`](js/sun.js) | 17 |
-| [`js/chat-runtime.js`](js/chat-runtime.js) | 17 | [`js/cycle-import.js`](js/cycle-import.js) | 15 |
-| [`js/context-cards-runtime.js`](js/context-cards-runtime.js) | 16 | [`js/lab-context.js`](js/lab-context.js) | 15 |
+| [`js/utils-runtime.js`](js/utils-runtime.js) | 20 | [`js/lab-context.js`](js/lab-context.js) | 17 |
+| [`js/marker-analysis.js`](js/marker-analysis.js) | 19 | [`js/marker-detail-modal-impl.js`](js/marker-detail-modal-impl.js) | 17 |
+| [`js/chat-runtime.js`](js/chat-runtime.js) | 17 | [`js/sun.js`](js/sun.js) | 17 |
+| [`js/context-cards-runtime.js`](js/context-cards-runtime.js) | 16 | [`js/cycle-import.js`](js/cycle-import.js) | 15 |
 
 ## Existing cyclic components
 
@@ -427,10 +427,12 @@ Native browser modules shipped with the static application.
 
 </details>
 
-<details><summary><code>lab</code> family — 5 modules</summary>
+<details><summary><code>lab</code> family — 7 modules</summary>
 
+- [`js/lab-context-output.js`](js/lab-context-output.js) → [`js/data.js`](js/data.js), [`js/lab-context-settings.js`](js/lab-context-settings.js), [`js/marker-analysis.js`](js/marker-analysis.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js)
+- [`js/lab-context-settings.js`](js/lab-context-settings.js) → [`js/context-source-registry.js`](js/context-source-registry.js), [`js/lab-context-wearables.js`](js/lab-context-wearables.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/lab-context-wearables.js`](js/lab-context-wearables.js) → [`js/context-source-registry.js`](js/context-source-registry.js), [`js/profile.js`](js/profile.js) *(dynamic)*, [`js/state.js`](js/state.js), [`js/wearable-adapters.js`](js/wearable-adapters.js), [`js/wearables-store.js`](js/wearables-store.js) *(dynamic)*
-- [`js/lab-context.js`](js/lab-context.js) → [`js/context-source-registry.js`](js/context-source-registry.js), [`js/cycle-runtime.js`](js/cycle-runtime.js), [`js/cycle-summary.js`](js/cycle-summary.js), [`js/data.js`](js/data.js), [`js/dna-runtime-bridge.js`](js/dna-runtime-bridge.js), [`js/food-contaminants.js`](js/food-contaminants.js), [`js/lab-context-wearables.js`](js/lab-context-wearables.js), [`js/marker-analysis.js`](js/marker-analysis.js), [`js/profile.js`](js/profile.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/supplement-impact.js`](js/supplement-impact.js), [`js/supplement-warnings.js`](js/supplement-warnings.js), [`js/theme.js`](js/theme.js), [`js/utils.js`](js/utils.js)
+- [`js/lab-context.js`](js/lab-context.js) → [`js/context-source-registry.js`](js/context-source-registry.js), [`js/cycle-runtime.js`](js/cycle-runtime.js), [`js/cycle-summary.js`](js/cycle-summary.js), [`js/data.js`](js/data.js), [`js/dna-runtime-bridge.js`](js/dna-runtime-bridge.js), [`js/food-contaminants.js`](js/food-contaminants.js), [`js/lab-context-output.js`](js/lab-context-output.js), [`js/lab-context-settings.js`](js/lab-context-settings.js), [`js/lab-context-wearables.js`](js/lab-context-wearables.js), [`js/marker-analysis.js`](js/marker-analysis.js), [`js/profile.js`](js/profile.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/supplement-impact.js`](js/supplement-impact.js), [`js/supplement-warnings.js`](js/supplement-warnings.js), [`js/theme.js`](js/theme.js), [`js/utils.js`](js/utils.js)
 - [`js/lab-date-range.js`](js/lab-date-range.js) → no in-scope imports
 - [`js/lab-entry-mutations.js`](js/lab-entry-mutations.js) → [`js/data-merge.js`](js/data-merge.js), [`js/lab-entry.js`](js/lab-entry.js)
 - [`js/lab-entry.js`](js/lab-entry.js) → no in-scope imports

--- a/js/lab-context-output.js
+++ b/js/lab-context-output.js
@@ -1,0 +1,191 @@
+// @ts-check
+// Lab-context summaries, change narration, and Lens prompt injection.
+
+import { state } from './state.js';
+import { getActiveData } from './data.js';
+import { getAllFlaggedMarkers } from './marker-analysis.js';
+import { getLatitudeFromLocation } from './profile.js';
+import {
+  isInsightContextCardsEnabled,
+  isLabMarkersContextEnabled,
+  isLightSunContextEnabled,
+  isSupplementsMedsContextEnabled,
+} from './lab-context-settings.js';
+
+export function summarizeChange(prev, curr) {
+  if (prev == null && curr == null) return null;
+  if (prev == null) return 'added';
+  if (curr == null) return 'cleared';
+  if (typeof curr === 'string' || typeof prev === 'string') {
+    const previous = (prev || '').toString().slice(0, 60);
+    const current = (curr || '').toString().slice(0, 60);
+    if (previous === current) return null;
+    return `changed${previous ? ' (was: "' + previous + (prev.length > 60 ? '…' : '') + '")' : ''}`;
+  }
+  if (Array.isArray(curr)) {
+    const previousLength = Array.isArray(prev) ? prev.length : 0;
+    if (curr.length > previousLength) {
+      const added = curr.slice(previousLength).map(goal => goal.text || JSON.stringify(goal)).join(', ');
+      return `added: ${added}`;
+    }
+    if (curr.length < previousLength) {
+      const removed = previousLength - curr.length;
+      return `removed ${removed} item${removed > 1 ? 's' : ''}`;
+    }
+    return 'updated';
+  }
+  const changes = [];
+  const allKeys = new Set([...Object.keys(prev || {}), ...Object.keys(curr || {})]);
+  for (const key of allKeys) {
+    if (key === 'note') continue;
+    const previousValue = prev?.[key];
+    const currentValue = curr?.[key];
+    if (JSON.stringify(previousValue) === JSON.stringify(currentValue)) continue;
+    if (previousValue == null || (Array.isArray(previousValue) && previousValue.length === 0)) {
+      const value = Array.isArray(currentValue) ? currentValue.join(', ') : currentValue;
+      changes.push(`${key}: ${value}`);
+    } else if (currentValue == null || (Array.isArray(currentValue) && currentValue.length === 0)) {
+      changes.push(`${key}: removed`);
+    } else {
+      const value = Array.isArray(currentValue) ? currentValue.join(', ') : currentValue;
+      const old = Array.isArray(previousValue) ? previousValue.join(', ') : previousValue;
+      changes.push(`${key}: ${old} → ${value}`);
+    }
+  }
+  return changes.length > 0
+    ? changes.slice(0, 5).join('; ') + (changes.length > 5 ? '; …' : '')
+    : null;
+}
+
+export function getContextSummary() {
+  const areas = [];
+  const data = getActiveData();
+  const includeInsightCards = isInsightContextCardsEnabled();
+  const includeSupplementsMeds = isSupplementsMedsContextEnabled();
+  const markerCount = Object.values(data.categories).reduce((sum, category) =>
+    sum + Object.values(category.markers).filter(marker =>
+      marker.values.some(value => value !== null)).length, 0);
+  if (isLabMarkersContextEnabled() && markerCount > 0) {
+    areas.push({ label: 'Lab values', detail: `${markerCount} markers` });
+  }
+  const diagnoses = state.importedData.diagnoses;
+  if (includeInsightCards && diagnoses && (
+    (diagnoses.conditions && diagnoses.conditions.length)
+    || diagnoses.note
+    || (Array.isArray(diagnoses.familyHistory) && diagnoses.familyHistory.length)
+  )) {
+    const conditionCount = (diagnoses.conditions && diagnoses.conditions.length) || 0;
+    const familyCount = (Array.isArray(diagnoses.familyHistory) && diagnoses.familyHistory.length) || 0;
+    const detail = conditionCount && familyCount
+      ? `${conditionCount} condition${conditionCount !== 1 ? 's' : ''}, ${familyCount} family entr${familyCount !== 1 ? 'ies' : 'y'}`
+      : conditionCount
+        ? `${conditionCount} condition${conditionCount !== 1 ? 's' : ''}`
+        : familyCount
+          ? `${familyCount} family entr${familyCount !== 1 ? 'ies' : 'y'}`
+          : 'notes';
+    areas.push({ label: 'Medical History', detail });
+  }
+  if (includeInsightCards && state.importedData.diet) {
+    areas.push({ label: 'Diet & Digestion', detail: state.importedData.diet.type || 'filled' });
+  }
+  if (includeInsightCards && state.importedData.exercise) {
+    areas.push({ label: 'Exercise', detail: state.importedData.exercise.frequency || 'filled' });
+  }
+  if (includeInsightCards && state.importedData.sleepRest) {
+    areas.push({ label: 'Sleep & Rest', detail: state.importedData.sleepRest.duration || 'filled' });
+  }
+  const lightCircadian = state.importedData.lightCircadian;
+  const autoLatitude = getLatitudeFromLocation();
+  if (isLightSunContextEnabled() && (lightCircadian || autoLatitude)) {
+    areas.push({ label: 'Light & Circadian', detail: autoLatitude ? `lat ${autoLatitude}` : 'filled' });
+  }
+  if (includeInsightCards && state.importedData.stress) {
+    areas.push({ label: 'Stress', detail: state.importedData.stress.level || 'filled' });
+  }
+  if (includeInsightCards && state.importedData.loveLife) {
+    areas.push({ label: 'Love Life', detail: 'filled' });
+  }
+  if (includeInsightCards && state.importedData.environment) {
+    areas.push({ label: 'Environment', detail: state.importedData.environment.setting || 'filled' });
+  }
+  const emfData = state.importedData.emfAssessment;
+  if (includeInsightCards && emfData?.assessments?.length > 0) {
+    areas.push({
+      label: 'EMF Assessment',
+      detail: `${emfData.assessments.length} assessment${emfData.assessments.length !== 1 ? 's' : ''}`,
+    });
+  }
+  const goals = state.importedData.healthGoals || [];
+  if (includeInsightCards && goals.length > 0) {
+    areas.push({ label: 'Health Goals', detail: `${goals.length} goal${goals.length !== 1 ? 's' : ''}` });
+  }
+  const lens = state.importedData.interpretiveLens || '';
+  if (lens.trim()) areas.push({ label: 'Interpretive Lens', detail: 'set' });
+  const contextNotes = state.importedData.contextNotes || '';
+  if (includeInsightCards && contextNotes.trim()) {
+    areas.push({ label: 'Context Notes', detail: 'set' });
+  }
+  const cycle = state.importedData.menstrualCycle;
+  if (includeInsightCards && cycle && state.profileSex === 'female') {
+    areas.push({ label: 'Menstrual Cycle', detail: `${cycle.cycleLength || 28}-day` });
+  }
+  const supplements = state.importedData.supplements || [];
+  if (includeSupplementsMeds && supplements.length > 0) {
+    areas.push({
+      label: 'Supplements',
+      detail: `${supplements.length} item${supplements.length !== 1 ? 's' : ''}`,
+    });
+  }
+  const notes = state.importedData.notes || [];
+  if (includeInsightCards && notes.length > 0) {
+    areas.push({ label: 'User Notes', detail: `${notes.length} note${notes.length !== 1 ? 's' : ''}` });
+  }
+  const flags = getAllFlaggedMarkers(data);
+  if (isLabMarkersContextEnabled() && flags.length > 0) {
+    areas.push({ label: 'Flagged Results', detail: `${flags.length} flagged` });
+  }
+  return areas;
+}
+
+const LENS_PROMPT_CHUNK_CHAR_LIMIT = 1800;
+const LENS_PROMPT_CHUNK_TOTAL_LIMIT = 8000;
+
+function trimLensTextForPrompt(text, remainingBudget) {
+  const raw = String(text || '').replace(/\s+/g, ' ').trim();
+  if (!raw) return '';
+  const limit = Math.max(0, Math.min(LENS_PROMPT_CHUNK_CHAR_LIMIT, remainingBudget));
+  if (limit === 0) return '';
+  if (raw.length <= limit) return raw;
+  const suffix = '... [trimmed]';
+  if (limit <= suffix.length) return raw.slice(0, limit);
+  return raw.slice(0, limit - suffix.length).trimEnd() + suffix;
+}
+
+export function injectLensChunks(context, lensResult) {
+  if (!lensResult || !Array.isArray(lensResult.chunks) || !lensResult.chunks.length) return context;
+  const snippet = formatLensChunks(lensResult);
+  const openTag = '[section:interpretiveLens]';
+  const closeTag = '[/section:interpretiveLens]';
+  const closeIndex = context.indexOf(closeTag);
+  if (closeIndex !== -1) {
+    return context.slice(0, closeIndex) + '\n\n' + snippet + '\n' + context.slice(closeIndex);
+  }
+  const block = `${openTag}\n## Interpretive Lens\n${snippet}\n${closeTag}\n\n`;
+  return block + context;
+}
+
+function formatLensChunks(result) {
+  const lines = [`### Retrieved from your knowledge source (${result.sourceName || 'Lens'}):`];
+  let remainingBudget = LENS_PROMPT_CHUNK_TOTAL_LIMIT;
+  let index = 1;
+  result.chunks.forEach(chunk => {
+    if (remainingBudget <= 0) return;
+    const text = trimLensTextForPrompt(chunk.text, remainingBudget);
+    if (!text) return;
+    remainingBudget -= text.length;
+    const citation = chunk.source ? ` - ${chunk.source}` : '';
+    lines.push(`${index++}. ${text}${citation}`);
+  });
+  lines.push('When your interpretation draws on these excerpts, cite the source. When it does not, say so.');
+  return lines.join('\n');
+}

--- a/js/lab-context-output.js
+++ b/js/lab-context-output.js
@@ -109,10 +109,11 @@ export function getContextSummary() {
     areas.push({ label: 'Environment', detail: state.importedData.environment.setting || 'filled' });
   }
   const emfData = state.importedData.emfAssessment;
-  if (includeInsightCards && emfData?.assessments?.length > 0) {
+  const emfAssessments = emfData?.assessments;
+  if (includeInsightCards && emfAssessments && emfAssessments.length > 0) {
     areas.push({
       label: 'EMF Assessment',
-      detail: `${emfData.assessments.length} assessment${emfData.assessments.length !== 1 ? 's' : ''}`,
+      detail: `${emfAssessments.length} assessment${emfAssessments.length !== 1 ? 's' : ''}`,
     });
   }
   const goals = state.importedData.healthGoals || [];

--- a/js/lab-context-settings.js
+++ b/js/lab-context-settings.js
@@ -1,0 +1,192 @@
+// @ts-check
+// AI context-source preferences, cache fingerprinting, and invalidation.
+
+import { state } from './state.js';
+import { hashString } from './utils.js';
+import {
+  CONTEXT_SOURCE_IDS,
+  getLabGroupContextSourceSlug,
+  isContextSourceEnabled,
+  setContextSourceEnabled,
+} from './context-source-registry.js';
+import {
+  isWearableContextEnabled,
+  setWearableContextEnabledState,
+} from './lab-context-wearables.js';
+
+/** @type {{ fingerprint: string | null, context: string | null }} */
+let labContextCache = { fingerprint: null, context: null };
+
+function getActiveContextProfileId() {
+  try { return localStorage.getItem('labcharts-active-profile') || state.currentProfile || 'default'; }
+  catch { return state.currentProfile || 'default'; }
+}
+
+function getStoredContextPreferencePart(profileId) {
+  const stored = [];
+  try {
+    const scopedPrefix = `labcharts-${profileId}-ai-ctx-`;
+    const legacyPrefix = 'labcharts-ai-ctx-';
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (!key || (!key.startsWith(scopedPrefix) && !key.startsWith(legacyPrefix))) continue;
+      stored.push(`${key}=${localStorage.getItem(key) || ''}`);
+    }
+  } catch {}
+  return stored.sort().join(',');
+}
+
+function getContextPreferencePart() {
+  const profileId = getActiveContextProfileId();
+  return [
+    `activeProfile:${profileId}`,
+    `stateProfile:${state.currentProfile || ''}`,
+    `sources:${[
+      `${CONTEXT_SOURCE_IDS.INSIGHT_CARDS}:${isInsightContextCardsEnabled() ? 'on' : 'off'}`,
+      `${CONTEXT_SOURCE_IDS.SUPPLEMENTS_MEDS}:${isSupplementsMedsContextEnabled() ? 'on' : 'off'}`,
+      `${CONTEXT_SOURCE_IDS.LAB_MARKERS}:${isLabMarkersContextEnabled() ? 'on' : 'off'}`,
+      `${CONTEXT_SOURCE_IDS.GENOME_SUMMARY}:${isGeneticsSummaryInAIContext() ? 'on' : 'off'}`,
+      `${CONTEXT_SOURCE_IDS.GENOME_PRIORITY}:${isGeneticsPriorityInAIContext() ? 'on' : 'off'}`,
+      `${CONTEXT_SOURCE_IDS.GENOME_INVENTORY}:${isGeneticsInventoryInAIContext() ? 'on' : 'off'}`,
+      `${CONTEXT_SOURCE_IDS.LIGHT_SUN}:${isLightSunContextEnabled() ? 'on' : 'off'}`,
+      `${CONTEXT_SOURCE_IDS.WEARABLES}:${isWearableContextEnabled() ? 'on' : 'off'}`,
+    ].join(',')}`,
+    `stored:${getStoredContextPreferencePart(profileId)}`,
+  ].join('|');
+}
+
+export function getLabContextFingerprint() {
+  const data = state.importedData;
+  const entryPart = (data.entries || []).map(entry =>
+    entry.date + ':' + Object.keys(entry.markers || {}).length).join(',');
+  const cardPart = ['healthGoals', 'diagnoses', 'supplements', 'biometrics', 'genetics',
+    'menstrualCycle', 'diet', 'exercise', 'sleepRest', 'lightCircadian', 'stress',
+    'loveLife', 'environment', 'emfAssessment', 'changeHistory', 'wearableSummary'
+  ].map(key => hashString(JSON.stringify(data[key] || ''))).join(',');
+  return hashString([
+    entryPart, cardPart,
+    state.profileSex || '', state.profileDob || '',
+    state.unitSystem || '', state.rangeMode || '',
+    data.interpretiveLens || '', data.contextNotes || '',
+    JSON.stringify(data.notes || []), JSON.stringify(data.markerNotes || {}),
+    JSON.stringify(data.contextSourceSettings || {}),
+    JSON.stringify(data.biologyScoreContextSettings || {}),
+    JSON.stringify(data.refOverrides || {}), JSON.stringify(data.categoryLabels || {}),
+    JSON.stringify(data.markerLabels || {}),
+    getContextPreferencePart(),
+  ].join('|'));
+}
+
+export function getCachedLabContext(fingerprint) {
+  return labContextCache.fingerprint === fingerprint && labContextCache.context
+    ? labContextCache.context
+    : null;
+}
+
+export function setCachedLabContext(fingerprint, context) {
+  labContextCache = { fingerprint, context };
+}
+
+export function invalidateLabContextCache() {
+  labContextCache = { fingerprint: null, context: null };
+}
+
+function groupContextLegacyKey(groupName) {
+  const group = String(groupName || '').replace(/[\u0000-\u001F\u007F]/g, ' ').trim();
+  return group ? `labcharts-ai-ctx-${group}` : null;
+}
+
+export function isGroupInAIContext(groupName) {
+  const slug = getLabGroupContextSourceSlug(groupName);
+  if (!slug) return true;
+  return isContextSourceEnabled(slug, {
+    defaultValue: true,
+    legacyKey: groupContextLegacyKey(groupName),
+  });
+}
+
+export function setGroupInAIContext(groupName, val) {
+  const slug = getLabGroupContextSourceSlug(groupName);
+  if (!slug) return;
+  setContextSourceEnabled(slug, !!val, { legacyKey: groupContextLegacyKey(groupName) });
+  invalidateLabContextCache();
+}
+
+export function isGeneticsInventoryInAIContext() {
+  return isContextSourceEnabled(CONTEXT_SOURCE_IDS.GENOME_INVENTORY);
+}
+
+export function setGeneticsInventoryInAIContext(on) {
+  setContextSourceEnabled(CONTEXT_SOURCE_IDS.GENOME_INVENTORY, on);
+  invalidateLabContextCache();
+}
+
+function biologyScoreContextSettings() {
+  const imported = /** @type {any} */ (state.importedData || {});
+  if (!imported.biologyScoreContextSettings || typeof imported.biologyScoreContextSettings !== 'object') {
+    imported.biologyScoreContextSettings = {};
+  }
+  return imported.biologyScoreContextSettings;
+}
+
+function setProfileContextEnabled(slug, on, legacyKey = null) {
+  setContextSourceEnabled(slug, on, { legacyKey });
+  invalidateLabContextCache();
+}
+
+export function isInsightContextCardsEnabled() {
+  return isContextSourceEnabled(CONTEXT_SOURCE_IDS.INSIGHT_CARDS);
+}
+
+export function setInsightContextCardsEnabled(on) {
+  setProfileContextEnabled(CONTEXT_SOURCE_IDS.INSIGHT_CARDS, on);
+}
+
+export function isSupplementsMedsContextEnabled() {
+  return isContextSourceEnabled(CONTEXT_SOURCE_IDS.SUPPLEMENTS_MEDS);
+}
+
+export function setSupplementsMedsContextEnabled(on) {
+  setProfileContextEnabled(CONTEXT_SOURCE_IDS.SUPPLEMENTS_MEDS, on);
+}
+
+export function isLabMarkersContextEnabled() {
+  return isContextSourceEnabled(CONTEXT_SOURCE_IDS.LAB_MARKERS);
+}
+
+export function setLabMarkersContextEnabled(on) {
+  setProfileContextEnabled(CONTEXT_SOURCE_IDS.LAB_MARKERS, on);
+}
+
+export function isGeneticsSummaryInAIContext() {
+  return isContextSourceEnabled(CONTEXT_SOURCE_IDS.GENOME_SUMMARY);
+}
+
+export function setGeneticsSummaryInAIContext(on) {
+  setProfileContextEnabled(CONTEXT_SOURCE_IDS.GENOME_SUMMARY, on);
+}
+
+export function isGeneticsPriorityInAIContext() {
+  return isContextSourceEnabled(CONTEXT_SOURCE_IDS.GENOME_PRIORITY);
+}
+
+export function setGeneticsPriorityInAIContext(on) {
+  setProfileContextEnabled(CONTEXT_SOURCE_IDS.GENOME_PRIORITY, on);
+}
+
+export function isLightSunContextEnabled() {
+  return isContextSourceEnabled(CONTEXT_SOURCE_IDS.LIGHT_SUN, {
+    defaultValue: state.importedData?.biologyScoreContextSettings?.includeLightContext !== false,
+  });
+}
+
+export function setLightSunContextEnabled(on) {
+  setContextSourceEnabled(CONTEXT_SOURCE_IDS.LIGHT_SUN, on);
+  biologyScoreContextSettings().includeLightContext = !!on;
+  invalidateLabContextCache();
+}
+
+export function setWearableContextEnabled(on) {
+  setWearableContextEnabledState(on);
+  invalidateLabContextCache();
+}

--- a/js/lab-context.js
+++ b/js/lab-context.js
@@ -3,7 +3,7 @@
 
 import { state } from './state.js';
 import { SBM_2015_THRESHOLDS, getEMFSeverity } from './schema.js';
-import { getStatus, hasCardContent, hashString, isDebugMode } from './utils.js';
+import { getStatus, hasCardContent, isDebugMode } from './utils.js';
 import { formatTime } from './theme.js';
 import { getActiveData } from './data.js';
 import { getDnaModuleFunction } from './dna-runtime-bridge.js';
@@ -19,23 +19,25 @@ import { isHormonalContraception, recentCyclePeriods, upgradeMenstrualCycleProfi
 import { scanSupplementsForWarnings, humanizeEffect } from './supplement-warnings.js';
 import { scanDietForContaminants } from './food-contaminants.js';
 import { ingredientDailyTotal, effectiveTimesPerDay } from './supplement-impact.js';
-import {
-  CONTEXT_SOURCE_IDS,
-  INSIGHT_CONTEXT_CHANGE_FIELDS,
-  getLabGroupContextSourceSlug,
-  isContextSourceEnabled,
-  setContextSourceEnabled,
-} from './context-source-registry.js';
+import { INSIGHT_CONTEXT_CHANGE_FIELDS } from './context-source-registry.js';
 import {
   buildWearableContext,
-  buildWearableSeriesSection,
-  getAgentWearableSeriesDays,
-  isAgentWearableSeriesEnabled,
   isWearableContextEnabled,
-  setAgentWearableSeriesDays,
-  setAgentWearableSeriesEnabled,
-  setWearableContextEnabledState,
 } from './lab-context-wearables.js';
+import {
+  getCachedLabContext,
+  getLabContextFingerprint,
+  isGeneticsInventoryInAIContext,
+  isGeneticsPriorityInAIContext,
+  isGeneticsSummaryInAIContext,
+  isGroupInAIContext,
+  isInsightContextCardsEnabled,
+  isLabMarkersContextEnabled,
+  isLightSunContextEnabled,
+  isSupplementsMedsContextEnabled,
+  setCachedLabContext,
+} from './lab-context-settings.js';
+import { summarizeChange } from './lab-context-output.js';
 
 /**
  * @typedef {{ skipGroupFilter?: boolean, ignoreContextToggles?: boolean }} LabContextOptions
@@ -65,233 +67,21 @@ export function configureLabContext(deps = {}) {
   return previous;
 }
 
-// ═══════════════════════════════════════════════
-// LAB CONTEXT MEMOIZATION
-// ═══════════════════════════════════════════════
-/** @type {{ fingerprint: string | null, context: string | null }} */
-let _labContextCache = { fingerprint: null, context: null };
-
-function _getActiveContextProfileId() {
-  try { return localStorage.getItem('labcharts-active-profile') || state.currentProfile || 'default'; }
-  catch { return state.currentProfile || 'default'; }
-}
-
-function _getStoredContextPreferencePart(profileId) {
-  const stored = [];
-  try {
-    const scopedPrefix = `labcharts-${profileId}-ai-ctx-`;
-    const legacyPrefix = 'labcharts-ai-ctx-';
-    for (let i = 0; i < localStorage.length; i++) {
-      const key = localStorage.key(i);
-      if (!key || (!key.startsWith(scopedPrefix) && !key.startsWith(legacyPrefix))) continue;
-      stored.push(`${key}=${localStorage.getItem(key) || ''}`);
-    }
-  } catch {}
-  return stored.sort().join(',');
-}
-
-function _getContextPreferencePart() {
-  const profileId = _getActiveContextProfileId();
-  return [
-    `activeProfile:${profileId}`,
-    `stateProfile:${state.currentProfile || ''}`,
-    `sources:${[
-      `${CONTEXT_SOURCE_IDS.INSIGHT_CARDS}:${isInsightContextCardsEnabled() ? 'on' : 'off'}`,
-      `${CONTEXT_SOURCE_IDS.SUPPLEMENTS_MEDS}:${isSupplementsMedsContextEnabled() ? 'on' : 'off'}`,
-      `${CONTEXT_SOURCE_IDS.LAB_MARKERS}:${isLabMarkersContextEnabled() ? 'on' : 'off'}`,
-      `${CONTEXT_SOURCE_IDS.GENOME_SUMMARY}:${isGeneticsSummaryInAIContext() ? 'on' : 'off'}`,
-      `${CONTEXT_SOURCE_IDS.GENOME_PRIORITY}:${isGeneticsPriorityInAIContext() ? 'on' : 'off'}`,
-      `${CONTEXT_SOURCE_IDS.GENOME_INVENTORY}:${isGeneticsInventoryInAIContext() ? 'on' : 'off'}`,
-      `${CONTEXT_SOURCE_IDS.LIGHT_SUN}:${isLightSunContextEnabled() ? 'on' : 'off'}`,
-      `${CONTEXT_SOURCE_IDS.WEARABLES}:${isWearableContextEnabled() ? 'on' : 'off'}`,
-    ].join(',')}`,
-    `stored:${_getStoredContextPreferencePart(profileId)}`,
-  ].join('|');
-}
-
-function _getLabContextFingerprint() {
-  const d = state.importedData;
-  // Lightweight fingerprint: entry dates + marker counts, profile fields, card JSON
-  const entryPart = (d.entries || []).map(e => e.date + ':' + Object.keys(e.markers || {}).length).join(',');
-  const cardPart = ['healthGoals', 'diagnoses', 'supplements', 'biometrics', 'genetics',
-    'menstrualCycle', 'diet', 'exercise', 'sleepRest', 'lightCircadian', 'stress',
-    'loveLife', 'environment', 'emfAssessment', 'changeHistory', 'wearableSummary'
-  ].map(k => hashString(JSON.stringify(d[k] || ''))).join(',');
-  return hashString([
-    entryPart, cardPart,
-    state.profileSex || '', state.profileDob || '',
-    state.unitSystem || '', state.rangeMode || '',
-    d.interpretiveLens || '', d.contextNotes || '',
-    JSON.stringify(d.notes || []), JSON.stringify(d.markerNotes || {}),
-    JSON.stringify(d.contextSourceSettings || {}),
-    JSON.stringify(d.biologyScoreContextSettings || {}),
-    JSON.stringify(d.refOverrides || {}), JSON.stringify(d.categoryLabels || {}),
-    JSON.stringify(d.markerLabels || {}),
-    _getContextPreferencePart()
-  ].join('|'));
-}
-
-export function invalidateLabContextCache() { _labContextCache = { fingerprint: null, context: null }; }
-
-// ═══════════════════════════════════════════════
-// SPECIALTY LABS IN AI CONTEXT (per-group)
-// ═══════════════════════════════════════════════
-function _groupContextSlug(groupName) {
-  return getLabGroupContextSourceSlug(groupName);
-}
-
-function _groupContextLegacyKey(groupName) {
-  const group = String(groupName || '').replace(/[\u0000-\u001F\u007F]/g, ' ').trim();
-  return group ? `labcharts-ai-ctx-${group}` : null;
-}
-
-export function isGroupInAIContext(groupName) {
-  const slug = _groupContextSlug(groupName);
-  if (!slug) return true;
-  return isContextSourceEnabled(slug, { defaultValue: true, legacyKey: _groupContextLegacyKey(groupName) });
-}
-
-export function setGroupInAIContext(groupName, val) {
-  const slug = _groupContextSlug(groupName);
-  if (!slug) return;
-  setContextSourceEnabled(slug, !!val, { legacyKey: _groupContextLegacyKey(groupName) });
-  invalidateLabContextCache();
-}
-
-export function isGeneticsInventoryInAIContext() {
-  return isContextSourceEnabled(CONTEXT_SOURCE_IDS.GENOME_INVENTORY);
-}
-
-export function setGeneticsInventoryInAIContext(on) {
-  setContextSourceEnabled(CONTEXT_SOURCE_IDS.GENOME_INVENTORY, on);
-  invalidateLabContextCache();
-}
-
-function _biologyScoreContextSettings() {
-  const imported = /** @type {any} */ (state.importedData || {});
-  if (!imported.biologyScoreContextSettings || typeof imported.biologyScoreContextSettings !== 'object') {
-    imported.biologyScoreContextSettings = {};
-  }
-  return imported.biologyScoreContextSettings;
-}
-
-function _setProfileContextEnabled(slug, on, legacyKey = null) {
-  setContextSourceEnabled(slug, on, { legacyKey });
-  invalidateLabContextCache();
-}
-
-export function isInsightContextCardsEnabled() {
-  return isContextSourceEnabled(CONTEXT_SOURCE_IDS.INSIGHT_CARDS);
-}
-
-export function setInsightContextCardsEnabled(on) {
-  _setProfileContextEnabled(CONTEXT_SOURCE_IDS.INSIGHT_CARDS, on);
-}
-
-export function isSupplementsMedsContextEnabled() {
-  return isContextSourceEnabled(CONTEXT_SOURCE_IDS.SUPPLEMENTS_MEDS);
-}
-
-export function setSupplementsMedsContextEnabled(on) {
-  _setProfileContextEnabled(CONTEXT_SOURCE_IDS.SUPPLEMENTS_MEDS, on);
-}
-
-export function isLabMarkersContextEnabled() {
-  return isContextSourceEnabled(CONTEXT_SOURCE_IDS.LAB_MARKERS);
-}
-
-export function setLabMarkersContextEnabled(on) {
-  _setProfileContextEnabled(CONTEXT_SOURCE_IDS.LAB_MARKERS, on);
-}
-
-export function isGeneticsSummaryInAIContext() {
-  return isContextSourceEnabled(CONTEXT_SOURCE_IDS.GENOME_SUMMARY);
-}
-
-export function setGeneticsSummaryInAIContext(on) {
-  _setProfileContextEnabled(CONTEXT_SOURCE_IDS.GENOME_SUMMARY, on);
-}
-
-export function isGeneticsPriorityInAIContext() {
-  return isContextSourceEnabled(CONTEXT_SOURCE_IDS.GENOME_PRIORITY);
-}
-
-export function setGeneticsPriorityInAIContext(on) {
-  _setProfileContextEnabled(CONTEXT_SOURCE_IDS.GENOME_PRIORITY, on);
-}
-
-export function isLightSunContextEnabled() {
-  return isContextSourceEnabled(CONTEXT_SOURCE_IDS.LIGHT_SUN, {
-    defaultValue: state.importedData?.biologyScoreContextSettings?.includeLightContext !== false,
-  });
-}
-
-export function setLightSunContextEnabled(on) {
-  setContextSourceEnabled(CONTEXT_SOURCE_IDS.LIGHT_SUN, on);
-  _biologyScoreContextSettings().includeLightContext = !!on;
-  invalidateLabContextCache();
-}
-
-export function setWearableContextEnabled(on) {
-  setWearableContextEnabledState(on);
-  invalidateLabContextCache();
-}
-
 export {
-  buildWearableContext,
-  buildWearableSeriesSection,
-  getAgentWearableSeriesDays,
-  isAgentWearableSeriesEnabled,
-  isWearableContextEnabled,
-  setAgentWearableSeriesDays,
+  buildWearableContext, buildWearableSeriesSection, getAgentWearableSeriesDays,
+  isAgentWearableSeriesEnabled, isWearableContextEnabled, setAgentWearableSeriesDays,
   setAgentWearableSeriesEnabled,
-};
-
-// ═══════════════════════════════════════════════
-// CHANGE SUMMARY HELPER
-// ═══════════════════════════════════════════════
-function summarizeChange(prev, curr) {
-  if (prev == null && curr == null) return null;
-  if (prev == null) return 'added';
-  if (curr == null) return 'cleared';
-  // String fields (interpretiveLens, contextNotes)
-  if (typeof curr === 'string' || typeof prev === 'string') {
-    const p = (prev || '').toString().slice(0, 60);
-    const c = (curr || '').toString().slice(0, 60);
-    if (p === c) return null;
-    return `changed${p ? ' (was: "' + p + (prev.length > 60 ? '…' : '') + '")' : ''}`;
-  }
-  // Arrays (healthGoals)
-  if (Array.isArray(curr)) {
-    const pLen = Array.isArray(prev) ? prev.length : 0;
-    if (curr.length > pLen) {
-      const added = curr.slice(pLen).map(g => g.text || JSON.stringify(g)).join(', ');
-      return `added: ${added}`;
-    }
-    if (curr.length < pLen) return `removed ${pLen - curr.length} item${pLen - curr.length > 1 ? 's' : ''}`;
-    return 'updated';
-  }
-  // Objects (context cards, diagnoses, menstrualCycle)
-  const changes = [];
-  const allKeys = new Set([...Object.keys(prev || {}), ...Object.keys(curr || {})]);
-  for (const k of allKeys) {
-    if (k === 'note') continue; // skip free-text notes for brevity
-    const pv = prev?.[k], cv = curr?.[k];
-    const pvStr = JSON.stringify(pv), cvStr = JSON.stringify(cv);
-    if (pvStr === cvStr) continue;
-    if (pv == null || (Array.isArray(pv) && pv.length === 0)) {
-      const val = Array.isArray(cv) ? cv.join(', ') : cv;
-      changes.push(`${k}: ${val}`);
-    } else if (cv == null || (Array.isArray(cv) && cv.length === 0)) {
-      changes.push(`${k}: removed`);
-    } else {
-      const val = Array.isArray(cv) ? cv.join(', ') : cv;
-      const old = Array.isArray(pv) ? pv.join(', ') : pv;
-      changes.push(`${k}: ${old} → ${val}`);
-    }
-  }
-  return changes.length > 0 ? changes.slice(0, 5).join('; ') + (changes.length > 5 ? '; …' : '') : null;
-}
+} from './lab-context-wearables.js';
+export {
+  invalidateLabContextCache, isGeneticsInventoryInAIContext, isGeneticsPriorityInAIContext,
+  isGeneticsSummaryInAIContext, isGroupInAIContext, isInsightContextCardsEnabled,
+  isLabMarkersContextEnabled, isLightSunContextEnabled, isSupplementsMedsContextEnabled,
+  setGeneticsInventoryInAIContext, setGeneticsPriorityInAIContext,
+  setGeneticsSummaryInAIContext, setGroupInAIContext, setInsightContextCardsEnabled,
+  setLabMarkersContextEnabled, setLightSunContextEnabled, setSupplementsMedsContextEnabled,
+  setWearableContextEnabled,
+} from './lab-context-settings.js';
+export { getContextSummary, injectLensChunks } from './lab-context-output.js';
 
 // ═══════════════════════════════════════════════
 // LAB CONTEXT
@@ -315,14 +105,15 @@ function summarizeChange(prev, curr) {
 export function buildLabContext(/** @type {LabContextOptions} */ { skipGroupFilter, ignoreContextToggles } = {}) {
   // skipGroupFilter: true → include all specialty groups regardless of AI toggle
   // ignoreContextToggles: true → Agent Access permission already granted; assemble full context
-  const fp = _getLabContextFingerprint() + (skipGroupFilter ? ':all' : '') + (ignoreContextToggles ? ':ignore-context-toggles' : '');
-  if (_labContextCache.fingerprint === fp && _labContextCache.context) {
+  const fp = getLabContextFingerprint() + (skipGroupFilter ? ':all' : '') + (ignoreContextToggles ? ':ignore-context-toggles' : '');
+  const cached = getCachedLabContext(fp);
+  if (cached) {
     if (isDebugMode()) console.log('[AI] Lab context cache hit');
-    return _labContextCache.context;
+    return cached;
   }
   if (isDebugMode()) console.log('[AI] Lab context cache miss — rebuilding');
   const ctx = _buildLabContextInner({ skipGroupFilter, ignoreContextToggles });
-  _labContextCache = { fingerprint: fp, context: ctx };
+  setCachedLabContext(fp, ctx);
   return ctx;
 }
 
@@ -1000,103 +791,4 @@ function _buildLabContextInner(/** @type {LabContextOptions} */ { skipGroupFilte
   }
 
   return ctx;
-}
-
-// ═══════════════════════════════════════════════
-// CONTEXT SUMMARY (snapshot what data areas were sent)
-// ═══════════════════════════════════════════════
-export function getContextSummary() {
-  const areas = [];
-  const data = getActiveData();
-  const includeInsightCards = isInsightContextCardsEnabled();
-  const includeSupplementsMeds = isSupplementsMedsContextEnabled();
-  // Lab values
-  const markerCount = Object.values(data.categories).reduce((sum, cat) =>
-    sum + Object.values(cat.markers).filter(m => m.values.some(v => v !== null)).length, 0);
-  if (isLabMarkersContextEnabled() && markerCount > 0) areas.push({ label: 'Lab values', detail: `${markerCount} markers` });
-  // Context cards
-  const diag = state.importedData.diagnoses;
-  if (includeInsightCards && diag && ((diag.conditions && diag.conditions.length) || diag.note || (Array.isArray(diag.familyHistory) && diag.familyHistory.length))) {
-    const cN = (diag.conditions && diag.conditions.length) || 0;
-    const fN = (Array.isArray(diag.familyHistory) && diag.familyHistory.length) || 0;
-    const detail = cN && fN ? `${cN} condition${cN !== 1 ? 's' : ''}, ${fN} family entr${fN !== 1 ? 'ies' : 'y'}` : cN ? `${cN} condition${cN !== 1 ? 's' : ''}` : fN ? `${fN} family entr${fN !== 1 ? 'ies' : 'y'}` : 'notes';
-    areas.push({ label: 'Medical History', detail });
-  }
-  if (includeInsightCards && state.importedData.diet) areas.push({ label: 'Diet & Digestion', detail: state.importedData.diet.type || 'filled' });
-  if (includeInsightCards && state.importedData.exercise) areas.push({ label: 'Exercise', detail: state.importedData.exercise.frequency || 'filled' });
-  if (includeInsightCards && state.importedData.sleepRest) areas.push({ label: 'Sleep & Rest', detail: state.importedData.sleepRest.duration || 'filled' });
-  const lc = state.importedData.lightCircadian;
-  const autoLat = getLatitudeFromLocation();
-  if (isLightSunContextEnabled() && (lc || autoLat)) areas.push({ label: 'Light & Circadian', detail: autoLat ? `lat ${autoLat}` : 'filled' });
-  if (includeInsightCards && state.importedData.stress) areas.push({ label: 'Stress', detail: state.importedData.stress.level || 'filled' });
-  if (includeInsightCards && state.importedData.loveLife) areas.push({ label: 'Love Life', detail: 'filled' });
-  if (includeInsightCards && state.importedData.environment) areas.push({ label: 'Environment', detail: state.importedData.environment.setting || 'filled' });
-  const emfData = state.importedData.emfAssessment;
-  if (includeInsightCards && emfData && emfData.assessments && emfData.assessments.length > 0) areas.push({ label: 'EMF Assessment', detail: `${emfData.assessments.length} assessment${emfData.assessments.length !== 1 ? 's' : ''}` });
-  // Goals, lens, notes
-  const goals = state.importedData.healthGoals || [];
-  if (includeInsightCards && goals.length > 0) areas.push({ label: 'Health Goals', detail: `${goals.length} goal${goals.length !== 1 ? 's' : ''}` });
-  const lens = state.importedData.interpretiveLens || '';
-  if (lens.trim()) areas.push({ label: 'Interpretive Lens', detail: 'set' });
-  const ctxNotes = state.importedData.contextNotes || '';
-  if (includeInsightCards && ctxNotes.trim()) areas.push({ label: 'Context Notes', detail: 'set' });
-  // Cycle
-  const mc = state.importedData.menstrualCycle;
-  if (includeInsightCards && mc && state.profileSex === 'female') areas.push({ label: 'Menstrual Cycle', detail: `${mc.cycleLength || 28}-day` });
-  // Supplements
-  const supps = state.importedData.supplements || [];
-  if (includeSupplementsMeds && supps.length > 0) areas.push({ label: 'Supplements', detail: `${supps.length} item${supps.length !== 1 ? 's' : ''}` });
-  // Notes
-  const notes = state.importedData.notes || [];
-  if (includeInsightCards && notes.length > 0) areas.push({ label: 'User Notes', detail: `${notes.length} note${notes.length !== 1 ? 's' : ''}` });
-  // Flagged
-  const flags = getAllFlaggedMarkers(data);
-  if (isLabMarkersContextEnabled() && flags.length > 0) areas.push({ label: 'Flagged Results', detail: `${flags.length} flagged` });
-  return areas;
-}
-
-// ═══════════════════════════════════════════════
-// LENS INJECTION — fold retrieved chunks into the Interpretive Lens block
-// ═══════════════════════════════════════════════
-const LENS_PROMPT_CHUNK_CHAR_LIMIT = 1800;
-const LENS_PROMPT_CHUNK_TOTAL_LIMIT = 8000;
-
-function _trimLensTextForPrompt(text, remainingBudget) {
-  const raw = String(text || '').replace(/\s+/g, ' ').trim();
-  if (!raw) return '';
-  const limit = Math.max(0, Math.min(LENS_PROMPT_CHUNK_CHAR_LIMIT, remainingBudget));
-  if (limit === 0) return '';
-  if (raw.length <= limit) return raw;
-  const suffix = '... [trimmed]';
-  if (limit <= suffix.length) return raw.slice(0, limit);
-  return raw.slice(0, limit - suffix.length).trimEnd() + suffix;
-}
-
-export function injectLensChunks(ctx, lensResult) {
-  if (!lensResult || !Array.isArray(lensResult.chunks) || !lensResult.chunks.length) return ctx;
-  const snippet = _formatLensChunks(lensResult);
-  const openTag = '[section:interpretiveLens]';
-  const closeTag = '[/section:interpretiveLens]';
-  const closeIdx = ctx.indexOf(closeTag);
-  if (closeIdx !== -1) {
-    return ctx.slice(0, closeIdx) + '\n\n' + snippet + '\n' + ctx.slice(closeIdx);
-  }
-  const block = `${openTag}\n## Interpretive Lens\n${snippet}\n${closeTag}\n\n`;
-  return block + ctx;
-}
-
-function _formatLensChunks(result) {
-  const lines = [`### Retrieved from your knowledge source (${result.sourceName || 'Lens'}):`];
-  let remainingBudget = LENS_PROMPT_CHUNK_TOTAL_LIMIT;
-  let n = 1;
-  result.chunks.forEach(c => {
-    if (remainingBudget <= 0) return;
-    const text = _trimLensTextForPrompt(c.text, remainingBudget);
-    if (!text) return;
-    remainingBudget -= text.length;
-    const cite = c.source ? ` - ${c.source}` : '';
-    lines.push(`${n++}. ${text}${cite}`);
-  });
-  lines.push('When your interpretation draws on these excerpts, cite the source. When it does not, say so.');
-  return lines.join('\n');
 }

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -7,6 +7,6 @@
   "viewRuntimeBridgeLookups": 0,
   "labStateAppFiles": 0,
   "labStateTestFiles": 0,
-  "largeJsFilesOver800Lines": 4,
-  "maxJsFileLines": 1103
+  "largeJsFilesOver800Lines": 3,
+  "maxJsFileLines": 1095
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -359,6 +359,8 @@ const APP_SHELL = [
   '/js/backup-serialization.js',
   '/js/backup.js',
   '/js/lab-context.js',
+  '/js/lab-context-output.js',
+  '/js/lab-context-settings.js',
   '/js/lab-context-wearables.js',
   '/js/markdown.js',
   '/js/provider-qr.js',

--- a/tests/test-change-history.js
+++ b/tests/test-change-history.js
@@ -173,9 +173,10 @@ const contextCards = await import('../js/context-cards.js');
   console.log('14. AI Context');
 
   const labCtxSrc = read('js/lab-context.js');
+  const labCtxOutputSrc = read('js/lab-context-output.js');
   assert('buildLabContext reads changeHistory', labCtxSrc.includes('changeHistory'));
   assert('Context Change Timeline section', labCtxSrc.includes('Context Change Timeline'));
-  assert('summarizeChange helper exists', labCtxSrc.includes('function summarizeChange'));
+  assert('summarizeChange helper exists', labCtxOutputSrc.includes('function summarizeChange'));
 
   // ═══════════════════════════════════════
   // 15. saveAndRefresh accepts field param

--- a/tests/test-chat-actions.js
+++ b/tests/test-chat-actions.js
@@ -381,7 +381,10 @@ const appUiShellModulesSrc = read('js/app-ui-shell-modules.js');
 const chatRenderSrc = read('js/chat-render.js');
 const chatSendSrc = read('js/chat-send.js');
 const labCtxSrc = read('js/lab-context.js');
-assert('lab-context.js has getContextSummary', labCtxSrc.includes('function getContextSummary'), 'found');
+const labCtxOutputSrc = read('js/lab-context-output.js');
+assert('lab-context.js exposes getContextSummary from its output owner',
+  labCtxSrc.includes('getContextSummary') && labCtxOutputSrc.includes('function getContextSummary'),
+  'found');
 assert('chat.js loads window bindings entry', chatSrc.includes("import './chat-window-bindings.js'"), 'found');
 assert('chat.js imports action helpers', chatSrc.includes("from './chat-actions.js'"), 'found');
 assert('chat-actions.js exports buildActionBar', chatActionsSrc.includes('export function buildActionBar'), 'found');

--- a/tests/test-correctness-phase2.js
+++ b/tests/test-correctness-phase2.js
@@ -45,8 +45,9 @@ assert('sync-lifecycle.js clears save and pull timers on disable',
 // ─── 2. Lab-context fingerprint includes wearableSummary ───
 console.log('\n2. Lab-context cache fingerprint');
 const lcSrc = read('js/lab-context.js');
+const lcSettingsSrc = read('js/lab-context-settings.js');
 assert('lab-context fingerprint covers wearableSummary',
-  lcSrc.includes("'wearableSummary'") && lcSrc.match(/cardPart\s*=.*wearableSummary/s),
+  lcSettingsSrc.includes("'wearableSummary'") && lcSettingsSrc.match(/cardPart\s*=.*wearableSummary/s),
   'AI context replayed stale wearable data after sync without this');
 
 // ─── 3. Lens LRU cache bumps on hit ───
@@ -151,6 +152,8 @@ const pwaAppShellAssets = [
   '/js/supplement-impact.js',
   '/js/commit-hash.js',
   '/js/focus-card.js',
+  '/js/lab-context-output.js',
+  '/js/lab-context-settings.js',
   '/js/onboarding-view.js',
   '/js/emf-runtime.js',
   '/js/pii-review.js',

--- a/tests/test-custom-lens.js
+++ b/tests/test-custom-lens.js
@@ -303,11 +303,15 @@ assert('focus card calls hasLens', /if \(hasLens\(\)\) \{[\s\S]{0,800}await quer
 // ─── 11. Wiring: lab-context.js helper ───
 console.log('\n11. lab-context.js helper');
 const lcSrc = read('js/lab-context.js');
-assert('exports injectLensChunks', lcSrc.includes('export function injectLensChunks('));
-assert('injectLensChunks handles close tag', lcSrc.includes('[/section:interpretiveLens]'));
-assert('injectLensChunks caps prompt chunk length', lcSrc.includes('LENS_PROMPT_CHUNK_CHAR_LIMIT'));
-assert('injectLensChunks caps total prompt text', lcSrc.includes('LENS_PROMPT_CHUNK_TOTAL_LIMIT'));
-assert('lab-context keeps injectLensChunks module-only', !lcSrc.includes('Object.assign(window, { injectLensChunks'));
+const lcOutputSrc = read('js/lab-context-output.js');
+assert('exports injectLensChunks',
+  lcSrc.includes('injectLensChunks') && lcOutputSrc.includes('export function injectLensChunks('));
+assert('injectLensChunks handles close tag', lcOutputSrc.includes('[/section:interpretiveLens]'));
+assert('injectLensChunks caps prompt chunk length', lcOutputSrc.includes('LENS_PROMPT_CHUNK_CHAR_LIMIT'));
+assert('injectLensChunks caps total prompt text', lcOutputSrc.includes('LENS_PROMPT_CHUNK_TOTAL_LIMIT'));
+assert('lab-context keeps injectLensChunks module-only',
+  !lcSrc.includes('Object.assign(window, { injectLensChunks')
+    && !lcOutputSrc.includes('Object.assign(window, { injectLensChunks'));
 
 // ─── 12. Wiring: sync.js registration ───
 console.log('\n12. sync.js registration');

--- a/tests/test-family-history.js
+++ b/tests/test-family-history.js
@@ -155,6 +155,7 @@ assert('Summary joins your-conditions + family with " — "',
 console.log('6. AI context family history');
 
 const labCtxSrc = await fetch('js/lab-context.js').then(r => r.text());
+const labCtxOutputSrc = await fetch('js/lab-context-output.js').then(r => r.text());
 assert('Family history block emitted within [section:diagnoses]',
   /\[section:diagnoses\][\s\S]{0,1500}### Family history \(heritable\/environmental risk signal\)/.test(labCtxSrc));
 assert('Family history block iterates diag.familyHistory',
@@ -168,8 +169,8 @@ assert('Family history line format includes relative, condition, optional onset 
 console.log('7. Active areas list');
 
 assert('Active-areas list counts both conditions and family entries',
-  /label: 'Medical History', detail \}\)/.test(labCtxSrc) &&
-  /family entr/.test(labCtxSrc));
+  /label: 'Medical History', detail \}\)/.test(labCtxOutputSrc) &&
+  /family entr/.test(labCtxOutputSrc));
 
 // ═══════════════════════════════════════
 // 8. "Medical History" rename — verifying user-facing strings

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -248,6 +248,8 @@ const domainUiCheckJsModules = [
   'js/emf-editor.js',
   'js/emf-model.js',
   'js/lab-context.js',
+  'js/lab-context-output.js',
+  'js/lab-context-settings.js',
   'js/light-conditions-interpretation.js',
   'js/light-conditions-renderer.js',
   'js/light-conditions-now.js',

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -92,6 +92,8 @@
     '/js/nav-runtime.js',
     '/js/views-router-runtime.js',
     '/js/focus-card.js',
+    '/js/lab-context-output.js',
+    '/js/lab-context-settings.js',
     '/js/onboarding-view-runtime.js',
     '/js/onboarding-view.js',
     '/js/data-merge-lab-entries.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -151,6 +151,8 @@
     "js/import-review-draft.js",
     "js/import-review-row-actions.js",
     "js/lab-context.js",
+    "js/lab-context-output.js",
+    "js/lab-context-settings.js",
     "js/lab-context-wearables.js",
     "js/lab-date-range.js",
     "js/lens-actions.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -149,6 +149,8 @@
     "js/lab-entry.js",
     "js/lab-entry-mutations.js",
     "js/lab-context.js",
+    "js/lab-context-output.js",
+    "js/lab-context-settings.js",
     "js/lab-context-wearables.js",
     "js/legal-consent-bootstrap.js",
     "js/lens-page-shell.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.473';
+self.APP_VERSION = '1.10.474';


### PR DESCRIPTION
## What changed

- extracted context-source preferences, cache fingerprinting, and invalidation into `lab-context-settings.js`
- extracted context summaries, change narration, and Lens prompt injection into `lab-context-output.js`
- kept `lab-context.js` as the public facade and retained the clinical/profile assembly order in place
- added the new owners to offline caching, check-js coverage, architecture metadata, and source-level contracts
- ratcheted the oversized-JavaScript baseline from 4 files to 3 and bumped the app version to 1.10.474

## Why

`lab-context.js` exceeded the 800-line maintainability guardrail because it combined assembly, preferences/cache state, and output formatting. Moving the two cohesive lower-risk responsibilities reduces the facade to 795 logical lines without changing its public API or the high-risk assembly sequence.

## Validation

- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run architecture:check`
- `npm run quality`
- `npm run production:check`
- `npx vitest run tests/sync-runtime.test.js tests/service-worker-app-shell.test.js`
- focused Node suites for correctness, chat actions, Lens, pre-lab, audit, change history, biometrics, Biology Scores, Sun context, and wearables
- `PORT=8179 npx playwright test tests/playwright/lab-context-browser-coverage.spec.js --workers=1`