### PR TITLE
Split data view controls

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -9,8 +9,8 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 
 | Metric | Current |
 | --- | ---: |
-| Modules | 524 |
-| Internal import edges | 2339 |
+| Modules | 525 |
+| Internal import edges | 2343 |
 | Dynamic internal edges | 93 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -38,13 +38,13 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 
 | High fan-in | Dependants | High fan-out | Imports |
 | --- | ---: | --- | ---: |
-| [`js/utils.js`](js/utils.js) | 241 | [`js/app-shell-hooks.js`](js/app-shell-hooks.js) | 72 |
-| [`js/state.js`](js/state.js) | 167 | [`js/app-light-sun-modules.js`](js/app-light-sun-modules.js) | 36 |
+| [`js/utils.js`](js/utils.js) | 242 | [`js/app-shell-hooks.js`](js/app-shell-hooks.js) | 72 |
+| [`js/state.js`](js/state.js) | 168 | [`js/app-light-sun-modules.js`](js/app-light-sun-modules.js) | 36 |
 | [`js/data.js`](js/data.js) | 77 | [`js/sync-configure.js`](js/sync-configure.js) | 27 |
 | [`js/caught-error.js`](js/caught-error.js) | 75 | [`js/settings.js`](js/settings.js) | 25 |
 | [`js/modal-lifecycle.js`](js/modal-lifecycle.js) | 69 | [`js/pdf-import.js`](js/pdf-import.js) | 24 |
 | [`js/api.js`](js/api.js) | 64 | [`js/chat-send.js`](js/chat-send.js) | 22 |
-| [`js/profile.js`](js/profile.js) | 46 | [`js/views.js`](js/views.js) | 22 |
+| [`js/profile.js`](js/profile.js) | 47 | [`js/views.js`](js/views.js) | 22 |
 | [`js/schema.js`](js/schema.js) | 33 | [`js/wearables-connect.js`](js/wearables-connect.js) | 21 |
 | [`js/crypto.js`](js/crypto.js) | 29 | [`js/dashboard-view-composition.js`](js/dashboard-view-composition.js) | 20 |
 | [`js/data-merge.js`](js/data-merge.js) | 29 | [`js/biology-scores.js`](js/biology-scores.js) | 19 |
@@ -331,12 +331,13 @@ Native browser modules shipped with the static application.
 
 </details>
 
-<details><summary><code>data</code> family — 4 modules</summary>
+<details><summary><code>data</code> family — 5 modules</summary>
 
 - [`js/data-merge-lab-entries.js`](js/data-merge-lab-entries.js) → [`js/lab-entry.js`](js/lab-entry.js)
 - [`js/data-merge.js`](js/data-merge.js) → [`js/data-merge-lab-entries.js`](js/data-merge-lab-entries.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/sync-delta-id.js`](js/sync-delta-id.js), [`js/sync-delta-surface-config.js`](js/sync-delta-surface-config.js)
+- [`js/data-view-controls.js`](js/data-view-controls.js) → [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils-runtime.js`](js/utils-runtime.js), [`js/utils.js`](js/utils.js)
 - [`js/data-wipe.js`](js/data-wipe.js) → no in-scope imports
-- [`js/data.js`](js/data.js) → [`js/crypto.js`](js/crypto.js), [`js/lab-date-range.js`](js/lab-date-range.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/marker-analysis.js`](js/marker-analysis.js), [`js/profile-context.js`](js/profile-context.js), [`js/profile.js`](js/profile.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/sync.js`](js/sync.js), [`js/utils-runtime.js`](js/utils-runtime.js), [`js/utils.js`](js/utils.js)
+- [`js/data.js`](js/data.js) → [`js/crypto.js`](js/crypto.js), [`js/data-view-controls.js`](js/data-view-controls.js), [`js/lab-date-range.js`](js/lab-date-range.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/marker-analysis.js`](js/marker-analysis.js), [`js/profile-context.js`](js/profile-context.js), [`js/profile.js`](js/profile.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/sync.js`](js/sync.js), [`js/utils.js`](js/utils.js)
 
 </details>
 

--- a/js/data-view-controls.js
+++ b/js/data-view-controls.js
@@ -1,0 +1,383 @@
+// @ts-check
+// Browser controls for data views, chart layers, and display preferences.
+
+import { state } from './state.js';
+import { escapeAttr } from './utils.js';
+import { profileStorageKey } from './profile.js';
+import { scheduleUtilsAfterNextPaint } from './utils-runtime.js';
+
+/**
+ * @typedef {import('../types/app-state.js').ProfileData} ImportedDataRecord
+ * @typedef {{
+ *   buildSidebar: null | ((data?: ImportedDataRecord) => void),
+ *   navigate: null | ((route?: string, data?: unknown) => void),
+ *   showDetailModal: null | ((id: string) => void),
+ * }} DataRuntimeDeps
+ * @typedef {{
+ *   getActiveData: null | (() => any),
+ *   invalidateActiveDataCache: null | (() => void),
+ * }} DataViewCoreDeps
+ */
+
+/** @type {DataRuntimeDeps} */
+const dataRuntimeDeps = {
+  buildSidebar: null,
+  navigate: null,
+  showDetailModal: null,
+};
+
+/** @type {DataViewCoreDeps} */
+const dataViewCoreDeps = {
+  getActiveData: null,
+  invalidateActiveDataCache: null,
+};
+
+/** @param {Partial<DataRuntimeDeps>} [deps] */
+export function configureDataRuntimeDeps(deps = {}) {
+  const previous = { ...dataRuntimeDeps };
+  if (Object.hasOwn(deps, 'buildSidebar') && (deps.buildSidebar === null || typeof deps.buildSidebar === 'function')) {
+    dataRuntimeDeps.buildSidebar = deps.buildSidebar;
+  }
+  if (Object.hasOwn(deps, 'navigate') && (deps.navigate === null || typeof deps.navigate === 'function')) {
+    dataRuntimeDeps.navigate = deps.navigate;
+  }
+  if (Object.hasOwn(deps, 'showDetailModal') && (deps.showDetailModal === null || typeof deps.showDetailModal === 'function')) {
+    dataRuntimeDeps.showDetailModal = deps.showDetailModal;
+  }
+  return previous;
+}
+
+/** @param {Partial<DataViewCoreDeps>} [deps] */
+export function configureDataViewCoreDependencies(deps = {}) {
+  const previous = { ...dataViewCoreDeps };
+  if (Object.hasOwn(deps, 'getActiveData')
+    && (deps.getActiveData === null || typeof deps.getActiveData === 'function')) {
+    dataViewCoreDeps.getActiveData = deps.getActiveData;
+  }
+  if (Object.hasOwn(deps, 'invalidateActiveDataCache')
+    && (deps.invalidateActiveDataCache === null || typeof deps.invalidateActiveDataCache === 'function')) {
+    dataViewCoreDeps.invalidateActiveDataCache = deps.invalidateActiveDataCache;
+  }
+  return previous;
+}
+
+function getActiveData() {
+  if (typeof dataViewCoreDeps.getActiveData !== 'function') {
+    throw new Error('Data view controls require getActiveData');
+  }
+  return dataViewCoreDeps.getActiveData();
+}
+
+function invalidateActiveDataCache() {
+  dataViewCoreDeps.invalidateActiveDataCache?.();
+}
+
+function navigateDataView(route, data) {
+  dataRuntimeDeps.navigate?.(route, data);
+}
+
+function buildDataSidebar(data) {
+  dataRuntimeDeps.buildSidebar?.(data);
+}
+
+const DATA_ACTION_ATTR = 'data-lab-data-action';
+const DATA_CHANGE_ATTR = 'data-lab-data-change';
+const DATA_RANGE_ATTR = 'data-lab-data-range';
+const DATA_ACTION_SELECTOR = `[${DATA_ACTION_ATTR}]`;
+const DATA_CHANGE_SELECTOR = `[${DATA_CHANGE_ATTR}]`;
+const dataActionDelegateRoots = new WeakSet();
+
+function dataAttrName(name) {
+  return String(name).replace(/[A-Z]/g, char => `-${char.toLowerCase()}`);
+}
+
+function dataControlAttrs(kind, action, attrs = {}) {
+  let html = `data-lab-data-${kind}="${escapeAttr(action)}"`;
+  for (const [name, value] of Object.entries(attrs)) {
+    if (value === undefined || value === null || value === false) continue;
+    html += ` data-lab-data-${escapeAttr(dataAttrName(name))}="${escapeAttr(String(value))}"`;
+  }
+  return html;
+}
+
+export function dataActionAttrs(action, attrs = {}) {
+  return dataControlAttrs('action', action, attrs);
+}
+
+export function dataChangeAttrs(action, attrs = {}) {
+  return dataControlAttrs('change', action, attrs);
+}
+
+function closestDataElement(target, selector) {
+  return /** @type {HTMLElement | null} */ (
+    target && typeof target.closest === 'function' ? target.closest(selector) : null
+  );
+}
+
+function rootContains(root, el) {
+  return !!(root && typeof root.contains === 'function' && root.contains(el));
+}
+
+function containChartLayersClick(event) {
+  event.stopPropagation();
+  if (typeof event.stopImmediatePropagation === 'function') event.stopImmediatePropagation();
+}
+
+function handleDataClick(event) {
+  const actionEl = closestDataElement(event.target, DATA_ACTION_SELECTOR);
+  if (!actionEl || !rootContains(event.currentTarget, actionEl)) return;
+  const action = actionEl.getAttribute(DATA_ACTION_ATTR);
+  if (action === 'chart-layers-row') {
+    containChartLayersClick(event);
+    return;
+  }
+  if (action === 'set-date-range') {
+    event.preventDefault();
+    setDateRange(actionEl.getAttribute(DATA_RANGE_ATTR) || 'all');
+    return;
+  }
+  if (action === 'toggle-chart-layers') {
+    event.preventDefault();
+    toggleChartLayersDropdown(event);
+    if (typeof event.stopImmediatePropagation === 'function') event.stopImmediatePropagation();
+    return;
+  }
+  if (action === 'switch-range-mode') {
+    event.preventDefault();
+    switchRangeMode(actionEl.getAttribute(DATA_RANGE_ATTR) || 'optimal');
+    return;
+  }
+}
+
+function handleDataChange(event) {
+  const actionEl = closestDataElement(event.target, DATA_CHANGE_SELECTOR);
+  if (!actionEl || !rootContains(event.currentTarget, actionEl)) return;
+  const action = actionEl.getAttribute(DATA_CHANGE_ATTR);
+  const checked = /** @type {{ checked?: boolean }} */ (event.target || {}).checked === true;
+  const mode = checked ? 'on' : 'off';
+  if (action === 'set-note-overlay') {
+    setNoteOverlay(mode);
+  } else if (action === 'set-supp-overlay') {
+    setSuppOverlay(mode);
+  } else if (action === 'set-phase-overlay') {
+    setPhaseOverlay(mode);
+  }
+}
+
+export function installDataActionDelegates(root = typeof document !== 'undefined' ? document : null) {
+  if (!root || dataActionDelegateRoots.has(root)) return;
+  dataActionDelegateRoots.add(root);
+  root.addEventListener('click', handleDataClick);
+  root.addEventListener('change', handleDataChange);
+}
+
+installDataActionDelegates();
+
+export function renderDateRangeFilter() {
+  const ranges = [
+    { key: '3m', label: '3M' },
+    { key: '6m', label: '6M' },
+    { key: '1y', label: '1Y' },
+    { key: 'all', label: 'All' }
+  ];
+  return `<div class="date-range-filter">${ranges.map(r =>
+    `<button class="range-btn${state.dateRangeFilter === r.key ? ' active' : ''}" type="button" ${dataActionAttrs('set-date-range', { range: r.key })}>${r.label}</button>`
+  ).join('')}</div>`;
+}
+
+export function setDateRange(range) {
+  state.dateRangeFilter = range;
+  buildDataSidebar();
+  navigateDataView(state.currentView || 'dashboard');
+}
+
+export function renderChartLayersDropdown() {
+  const hasNotes = (state.importedData.notes || []).length > 0;
+  const hasSupps = (state.importedData.supplements || []).length > 0;
+  const hasCycle = state.profileSex === 'female' && state.importedData.menstrualCycle?.periods?.length > 0;
+  if (!hasNotes && !hasSupps && !hasCycle) return '';
+  return `<div class="chart-layers-wrapper">
+    <button class="view-btn chart-layers-trigger" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="chart-layers-dropdown" ${dataActionAttrs('toggle-chart-layers')}>Layers \u25BE</button>
+    <div class="chart-layers-dropdown" id="chart-layers-dropdown" role="menu">
+      ${hasNotes ? `<label class="chart-layers-row" ${dataActionAttrs('chart-layers-row')}>
+        <input type="checkbox" ${state.noteOverlayMode === 'on' ? 'checked' : ''} ${dataChangeAttrs('set-note-overlay')}>
+        <span>\uD83D\uDCDD Notes</span>
+      </label>` : ''}
+      ${hasSupps ? `<label class="chart-layers-row" ${dataActionAttrs('chart-layers-row')}>
+        <input type="checkbox" ${state.suppOverlayMode === 'on' ? 'checked' : ''} ${dataChangeAttrs('set-supp-overlay')}>
+        <span>\uD83D\uDC8A Supplements</span>
+      </label>` : ''}
+      ${hasCycle ? `<label class="chart-layers-row" ${dataActionAttrs('chart-layers-row')}>
+        <input type="checkbox" ${state.phaseOverlayMode === 'on' ? 'checked' : ''} ${dataChangeAttrs('set-phase-overlay')}>
+        <span>\uD83D\uDD34 Cycle Phases</span>
+      </label>` : ''}
+    </div>
+  </div>`;
+}
+
+function _getActiveNavCategory() {
+  const activeNav = /** @type {HTMLElement | null} */ (document.querySelector('.nav-item.active'));
+  return activeNav?.dataset.category || 'dashboard';
+}
+
+export function toggleChartLayersDropdown(e) {
+  // Direct callers still rely on this; delegated clicks add
+  // stopImmediatePropagation() at document level after this returns.
+  e.stopPropagation();
+  const dd = document.getElementById('chart-layers-dropdown');
+  if (!dd) return;
+  const trigger = /** @type {HTMLButtonElement | null} */ (
+    dd.parentElement?.querySelector('.chart-layers-trigger') || null
+  );
+  const isOpen = dd.classList.contains('open');
+  dd.classList.toggle('open', !isOpen);
+  if (trigger) trigger.setAttribute('aria-expanded', String(!isOpen));
+  if (!isOpen) {
+    const close = (ev) => {
+      // Allow keyboard close (Escape) without requiring an event target
+      if (!ev || !ev.target || !ev.target.closest || !ev.target.closest('.chart-layers-wrapper')) {
+        dd.classList.remove('open');
+        if (trigger) trigger.setAttribute('aria-expanded', 'false');
+        document.removeEventListener('click', close);
+        document.removeEventListener('keydown', closeOnEsc);
+      }
+    };
+    const closeOnEsc = (ev) => {
+      if (ev.key === 'Escape') {
+        dd.classList.remove('open');
+        if (trigger) trigger.setAttribute('aria-expanded', 'false');
+        if (trigger) trigger.focus();
+        document.removeEventListener('click', close);
+        document.removeEventListener('keydown', closeOnEsc);
+      }
+    };
+    setTimeout(() => {
+      document.addEventListener('click', close);
+      document.addEventListener('keydown', closeOnEsc);
+    }, 0);
+  }
+}
+
+export function setSuppOverlay(mode) {
+  state.suppOverlayMode = mode === 'off' ? 'off' : 'on';
+  localStorage.setItem(profileStorageKey(state.currentProfile, 'suppOverlay'), state.suppOverlayMode);
+  const activeCat = _getActiveNavCategory();
+  navigateDataView(activeCat);
+}
+
+export function setNoteOverlay(mode) {
+  state.noteOverlayMode = mode === 'off' ? 'off' : 'on';
+  localStorage.setItem(profileStorageKey(state.currentProfile, 'noteOverlay'), state.noteOverlayMode);
+  const activeCat = _getActiveNavCategory();
+  navigateDataView(activeCat);
+}
+
+export function setPhaseOverlay(mode) {
+  state.phaseOverlayMode = mode === 'off' ? 'off' : 'on';
+  localStorage.setItem(profileStorageKey(state.currentProfile, 'phaseOverlay'), state.phaseOverlayMode);
+  const activeCat = _getActiveNavCategory();
+  navigateDataView(activeCat);
+}
+
+export function destroyAllCharts() {
+  for (const c of Object.values(state.chartInstances)) c.destroy();
+  state.chartInstances = {};
+}
+
+export function switchUnitSystem(system) {
+  invalidateActiveDataCache();
+  state.unitSystem = system;
+  localStorage.setItem(profileStorageKey(state.currentProfile, 'units'), system);
+  const openId = state._activeDetailMarkerId;
+  const data = getActiveData();
+  buildDataSidebar(data);
+  updateHeaderDates(data);
+  navigateDataView(state.currentView || 'dashboard', data);
+  if (openId) dataRuntimeDeps.showDetailModal?.(openId);
+}
+
+export function toggleAltUnits(force) {
+  const next = (force === true || force === false) ? force : !state.showAltUnits;
+  if (next === state.showAltUnits) return;
+  state.showAltUnits = next;
+  localStorage.setItem(profileStorageKey(state.currentProfile, 'showAltUnits'), next ? 'on' : 'off');
+  const openId = state._activeDetailMarkerId;
+  if (openId) dataRuntimeDeps.showDetailModal?.(openId);
+}
+
+let _rangeModeRefreshToken = 0;
+
+function _captureCategoryCardOrderForRangeRefresh(route) {
+  if (typeof document === 'undefined' || !route) return null;
+  const grid = document.querySelector('#view-content .charts-grid');
+  if (!grid) return null;
+  const prefix = `${route}_`;
+  const markerKeys = Array.from(grid.querySelectorAll('canvas[id^="chart-"]'))
+    .map(canvas => String(canvas.id || '').slice('chart-'.length))
+    .filter(id => id.startsWith(prefix))
+    .map(id => id.slice(prefix.length))
+    .filter(Boolean);
+  return markerKeys.length ? { categoryKey: route, markerKeys } : null;
+}
+
+function _afterNextPaint(fn) {
+  scheduleUtilsAfterNextPaint(fn);
+}
+
+export function switchRangeMode(mode) {
+  const nextMode = mode === 'reference' ? 'reference' : mode === 'both' ? 'both' : 'optimal';
+  if (state.rangeMode === nextMode) return;
+  state.rangeMode = nextMode;
+  localStorage.setItem(profileStorageKey(state.currentProfile, 'rangeMode'), nextMode);
+  updateHeaderRangeToggle();
+  const openId = state._activeDetailMarkerId;
+  const preservedOrder = _captureCategoryCardOrderForRangeRefresh(state.currentView);
+  if (preservedOrder) state._preserveCategoryCardOrder = preservedOrder;
+  else delete state._preserveCategoryCardOrder;
+  const token = ++_rangeModeRefreshToken;
+  _afterNextPaint(() => {
+    if (token !== _rangeModeRefreshToken || state.rangeMode !== nextMode) return;
+    const data = getActiveData();
+    buildDataSidebar(data);
+    navigateDataView(state.currentView || 'dashboard', data);
+    if (openId && state._activeDetailMarkerId === openId) {
+      dataRuntimeDeps.showDetailModal?.(openId);
+    }
+  });
+}
+
+export function updateHeaderDates(data) {
+  if (!data) data = getActiveData();
+  const el = document.getElementById("header-dates");
+  if (el) {
+    if (data.dateLabels.length > 0) {
+      const labels = data.dateLabels;
+      const dateText = labels.length === 1 ? labels[0] : `${labels[0]} – ${labels[labels.length - 1]}`;
+      el.innerHTML = `<span class="label">Dates:</span> ${dateText}`;
+      el.style.display = '';
+    } else {
+      el.style.display = 'none';
+    }
+  }
+}
+
+export function updateHeaderRangeToggle() {
+  const el = document.getElementById('header-range-toggle');
+  if (!el) return;
+  const modes = ['optimal', 'reference', 'both'];
+  const buttons = /** @type {HTMLButtonElement[]} */ (
+    Array.from(el.querySelectorAll('.range-toggle-btn'))
+  );
+  const canPatch = buttons.length === modes.length && modes.every(m => buttons.some(btn => btn.dataset.range === m));
+  if (!canPatch) {
+    el.innerHTML = modes.map(m =>
+      `<button class="range-toggle-btn${state.rangeMode === m ? ' active' : ''}" type="button" data-range="${m}" aria-pressed="${state.rangeMode === m ? 'true' : 'false'}" ${dataActionAttrs('switch-range-mode', { range: m })}>${m.charAt(0).toUpperCase() + m.slice(1)}</button>`
+    ).join('');
+    return;
+  }
+  for (const btn of buttons) {
+    const active = btn.dataset.range === state.rangeMode;
+    btn.classList.toggle('active', active);
+    btn.setAttribute('aria-pressed', active ? 'true' : 'false');
+  }
+}

--- a/js/data.js
+++ b/js/data.js
@@ -4,16 +4,16 @@
 import { state } from './state.js';
 import { getBiologyProfileContext } from './profile-context.js';
 import { MARKER_SCHEMA, UNIT_CONVERSIONS, OPTIMAL_RANGES, PHASE_RANGES } from './schema.js';
-import { escapeAttr, hashString, isDebugMode, showNotification } from './utils.js';
+import { hashString, isDebugMode, showNotification } from './utils.js';
 import { profileStorageKey, touchProfileTimestamp, migrateProfileData } from './profile.js';
 import { encryptedSetItem, broadcastDataChanged, scheduleAutoBackup } from './crypto.js';
 import { onDataSaved } from './sync.js';
 import { recalculateLabEntryHOMAIR } from './lab-entry.js';
-import { scheduleUtilsAfterNextPaint } from './utils-runtime.js';
 import { getLabDateRangeBounds } from './lab-date-range.js';
 import {
   getAllFlaggedMarkers as getAllFlaggedMarkersForData,
 } from './marker-analysis.js';
+import { configureDataViewCoreDependencies } from './data-view-controls.js';
 
 export {
   countFlagged,
@@ -25,47 +25,31 @@ export {
   getPhaseRefEnvelope,
   statusIcon,
 } from './marker-analysis.js';
+export {
+  configureDataRuntimeDeps,
+  dataActionAttrs,
+  dataChangeAttrs,
+  destroyAllCharts,
+  installDataActionDelegates,
+  renderChartLayersDropdown,
+  renderDateRangeFilter,
+  setDateRange,
+  setNoteOverlay,
+  setPhaseOverlay,
+  setSuppOverlay,
+  switchRangeMode,
+  switchUnitSystem,
+  toggleAltUnits,
+  toggleChartLayersDropdown,
+  updateHeaderDates,
+  updateHeaderRangeToggle,
+} from './data-view-controls.js';
 
 /**
  * @typedef {import('../types/app-state.js').ProfileData} ImportedDataRecord
  * @typedef {() => Array<number | null | undefined> | undefined} MarkerValueGetter
  * @typedef {[MarkerValueGetter | 'age' | 'crp', number, number, boolean, number | null, 'ceil' | 'floor' | null, (number | undefined)?]} BortzFeature
- * @typedef {{
- *   buildSidebar: null | ((data?: ImportedDataRecord) => void),
- *   navigate: null | ((route?: string, data?: unknown) => void),
- *   showDetailModal: null | ((id: string) => void),
- * }} DataRuntimeDeps
  */
-
-/** @type {DataRuntimeDeps} */
-const dataRuntimeDeps = {
-  buildSidebar: null,
-  navigate: null,
-  showDetailModal: null,
-};
-
-/** @param {Partial<DataRuntimeDeps>} [deps] */
-export function configureDataRuntimeDeps(deps = {}) {
-  const previous = { ...dataRuntimeDeps };
-  if (Object.hasOwn(deps, 'buildSidebar') && (deps.buildSidebar === null || typeof deps.buildSidebar === 'function')) {
-    dataRuntimeDeps.buildSidebar = deps.buildSidebar;
-  }
-  if (Object.hasOwn(deps, 'navigate') && (deps.navigate === null || typeof deps.navigate === 'function')) {
-    dataRuntimeDeps.navigate = deps.navigate;
-  }
-  if (Object.hasOwn(deps, 'showDetailModal') && (deps.showDetailModal === null || typeof deps.showDetailModal === 'function')) {
-    dataRuntimeDeps.showDetailModal = deps.showDetailModal;
-  }
-  return previous;
-}
-
-function navigateDataView(route, data) {
-  dataRuntimeDeps.navigate?.(route, data);
-}
-
-function buildDataSidebar(data) {
-  dataRuntimeDeps.buildSidebar?.(data);
-}
 
 /** @type {{ invalidateLabContextCache: (() => void) | null }} */
 const dataContextDeps = {
@@ -80,98 +64,6 @@ export function configureDataContextDependencies(deps = {}) {
   return previous;
 }
 
-const DATA_ACTION_ATTR = 'data-lab-data-action';
-const DATA_CHANGE_ATTR = 'data-lab-data-change';
-const DATA_RANGE_ATTR = 'data-lab-data-range';
-const DATA_ACTION_SELECTOR = `[${DATA_ACTION_ATTR}]`;
-const DATA_CHANGE_SELECTOR = `[${DATA_CHANGE_ATTR}]`;
-const dataActionDelegateRoots = new WeakSet();
-
-function dataAttrName(name) {
-  return String(name).replace(/[A-Z]/g, char => `-${char.toLowerCase()}`);
-}
-
-function dataControlAttrs(kind, action, attrs = {}) {
-  let html = `data-lab-data-${kind}="${escapeAttr(action)}"`;
-  for (const [name, value] of Object.entries(attrs)) {
-    if (value === undefined || value === null || value === false) continue;
-    html += ` data-lab-data-${escapeAttr(dataAttrName(name))}="${escapeAttr(String(value))}"`;
-  }
-  return html;
-}
-
-export function dataActionAttrs(action, attrs = {}) {
-  return dataControlAttrs('action', action, attrs);
-}
-
-export function dataChangeAttrs(action, attrs = {}) {
-  return dataControlAttrs('change', action, attrs);
-}
-
-function closestDataElement(target, selector) {
-  return /** @type {HTMLElement | null} */ (
-    target && typeof target.closest === 'function' ? target.closest(selector) : null
-  );
-}
-
-function rootContains(root, el) {
-  return !!(root && typeof root.contains === 'function' && root.contains(el));
-}
-
-function containChartLayersClick(event) {
-  event.stopPropagation();
-  if (typeof event.stopImmediatePropagation === 'function') event.stopImmediatePropagation();
-}
-
-function handleDataClick(event) {
-  const actionEl = closestDataElement(event.target, DATA_ACTION_SELECTOR);
-  if (!actionEl || !rootContains(event.currentTarget, actionEl)) return;
-  const action = actionEl.getAttribute(DATA_ACTION_ATTR);
-  if (action === 'chart-layers-row') {
-    containChartLayersClick(event);
-    return;
-  }
-  if (action === 'set-date-range') {
-    event.preventDefault();
-    setDateRange(actionEl.getAttribute(DATA_RANGE_ATTR) || 'all');
-    return;
-  }
-  if (action === 'toggle-chart-layers') {
-    event.preventDefault();
-    toggleChartLayersDropdown(event);
-    if (typeof event.stopImmediatePropagation === 'function') event.stopImmediatePropagation();
-    return;
-  }
-  if (action === 'switch-range-mode') {
-    event.preventDefault();
-    switchRangeMode(actionEl.getAttribute(DATA_RANGE_ATTR) || 'optimal');
-    return;
-  }
-}
-
-function handleDataChange(event) {
-  const actionEl = closestDataElement(event.target, DATA_CHANGE_SELECTOR);
-  if (!actionEl || !rootContains(event.currentTarget, actionEl)) return;
-  const action = actionEl.getAttribute(DATA_CHANGE_ATTR);
-  const checked = /** @type {{ checked?: boolean }} */ (event.target || {}).checked === true;
-  const mode = checked ? 'on' : 'off';
-  if (action === 'set-note-overlay') {
-    setNoteOverlay(mode);
-  } else if (action === 'set-supp-overlay') {
-    setSuppOverlay(mode);
-  } else if (action === 'set-phase-overlay') {
-    setPhaseOverlay(mode);
-  }
-}
-
-export function installDataActionDelegates(root = typeof document !== 'undefined' ? document : null) {
-  if (!root || dataActionDelegateRoots.has(root)) return;
-  dataActionDelegateRoots.add(root);
-  root.addEventListener('click', handleDataClick);
-  root.addEventListener('change', handleDataChange);
-}
-
-installDataActionDelegates();
 
 // ═══════════════════════════════════════════════
 // PRIVATE CYCLE PHASE HELPER (avoids circular dep with cycle.js)
@@ -848,247 +740,12 @@ export function filterDatesByRange(data, options = {}) {
   return filtered;
 }
 
-export function renderDateRangeFilter() {
-  const ranges = [
-    { key: '3m', label: '3M' },
-    { key: '6m', label: '6M' },
-    { key: '1y', label: '1Y' },
-    { key: 'all', label: 'All' }
-  ];
-  return `<div class="date-range-filter">${ranges.map(r =>
-    `<button class="range-btn${state.dateRangeFilter === r.key ? ' active' : ''}" type="button" ${dataActionAttrs('set-date-range', { range: r.key })}>${r.label}</button>`
-  ).join('')}</div>`;
-}
-
-export function setDateRange(range) {
-  state.dateRangeFilter = range;
-  // Order matters: buildSidebar() resets the .active class to Dashboard
-  // by default. If we navigate first then buildSidebar, the next
-  // range-button click reads .nav-item.active as Dashboard and bounces
-  // the user there. Rebuild the sidebar first, then navigate — navigate
-  // re-applies the correct active class. Source the target view from
-  // state.currentView (set by navigate) rather than the DOM, since the
-  // DOM's active class has just been clobbered by buildSidebar.
-  buildDataSidebar();
-  navigateDataView(state.currentView || 'dashboard');
-}
-
-export function renderChartLayersDropdown() {
-  const hasNotes = (state.importedData.notes || []).length > 0;
-  const hasSupps = (state.importedData.supplements || []).length > 0;
-  const hasCycle = state.profileSex === 'female' && state.importedData.menstrualCycle?.periods?.length > 0;
-  if (!hasNotes && !hasSupps && !hasCycle) return '';
-  return `<div class="chart-layers-wrapper">
-    <button class="view-btn chart-layers-trigger" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="chart-layers-dropdown" ${dataActionAttrs('toggle-chart-layers')}>Layers \u25BE</button>
-    <div class="chart-layers-dropdown" id="chart-layers-dropdown" role="menu">
-      ${hasNotes ? `<label class="chart-layers-row" ${dataActionAttrs('chart-layers-row')}>
-        <input type="checkbox" ${state.noteOverlayMode === 'on' ? 'checked' : ''} ${dataChangeAttrs('set-note-overlay')}>
-        <span>\uD83D\uDCDD Notes</span>
-      </label>` : ''}
-      ${hasSupps ? `<label class="chart-layers-row" ${dataActionAttrs('chart-layers-row')}>
-        <input type="checkbox" ${state.suppOverlayMode === 'on' ? 'checked' : ''} ${dataChangeAttrs('set-supp-overlay')}>
-        <span>\uD83D\uDC8A Supplements</span>
-      </label>` : ''}
-      ${hasCycle ? `<label class="chart-layers-row" ${dataActionAttrs('chart-layers-row')}>
-        <input type="checkbox" ${state.phaseOverlayMode === 'on' ? 'checked' : ''} ${dataChangeAttrs('set-phase-overlay')}>
-        <span>\uD83D\uDD34 Cycle Phases</span>
-      </label>` : ''}
-    </div>
-  </div>`;
-}
-
-function _getActiveNavCategory() {
-  const activeNav = /** @type {HTMLElement | null} */ (document.querySelector('.nav-item.active'));
-  return activeNav?.dataset.category || 'dashboard';
-}
-
-export function toggleChartLayersDropdown(e) {
-  // Direct callers still rely on this; delegated clicks add
-  // stopImmediatePropagation() at document level after this returns.
-  e.stopPropagation();
-  const dd = document.getElementById('chart-layers-dropdown');
-  if (!dd) return;
-  const trigger = /** @type {HTMLButtonElement | null} */ (dd.parentElement?.querySelector('.chart-layers-trigger') || null);
-  const isOpen = dd.classList.contains('open');
-  dd.classList.toggle('open', !isOpen);
-  if (trigger) trigger.setAttribute('aria-expanded', String(!isOpen));
-  if (!isOpen) {
-    const close = (ev) => {
-      // Allow keyboard close (Escape) without requiring an event target
-      if (!ev || !ev.target || !ev.target.closest || !ev.target.closest('.chart-layers-wrapper')) {
-        dd.classList.remove('open');
-        if (trigger) trigger.setAttribute('aria-expanded', 'false');
-        document.removeEventListener('click', close);
-        document.removeEventListener('keydown', closeOnEsc);
-      }
-    };
-    const closeOnEsc = (ev) => {
-      if (ev.key === 'Escape') {
-        dd.classList.remove('open');
-        if (trigger) trigger.setAttribute('aria-expanded', 'false');
-        if (trigger) trigger.focus();
-        document.removeEventListener('click', close);
-        document.removeEventListener('keydown', closeOnEsc);
-      }
-    };
-    setTimeout(() => {
-      document.addEventListener('click', close);
-      document.addEventListener('keydown', closeOnEsc);
-    }, 0);
-  }
-}
-
-export function setSuppOverlay(mode) {
-  state.suppOverlayMode = mode === 'off' ? 'off' : 'on';
-  localStorage.setItem(profileStorageKey(state.currentProfile, 'suppOverlay'), state.suppOverlayMode);
-  const activeCat = _getActiveNavCategory();
-  navigateDataView(activeCat);
-}
-
-export function setNoteOverlay(mode) {
-  state.noteOverlayMode = mode === 'off' ? 'off' : 'on';
-  localStorage.setItem(profileStorageKey(state.currentProfile, 'noteOverlay'), state.noteOverlayMode);
-  const activeCat = _getActiveNavCategory();
-  navigateDataView(activeCat);
-}
-
-export function setPhaseOverlay(mode) {
-  state.phaseOverlayMode = mode === 'off' ? 'off' : 'on';
-  localStorage.setItem(profileStorageKey(state.currentProfile, 'phaseOverlay'), state.phaseOverlayMode);
-  const activeCat = _getActiveNavCategory();
-  navigateDataView(activeCat);
-}
-
 export function recalculateHOMAIR(entry) {
   recalculateLabEntryHOMAIR(entry);
-}
-
-// ═══════════════════════════════════════════════
-// CHART LIFECYCLE
-// ═══════════════════════════════════════════════
-export function destroyAllCharts() {
-  for (const c of Object.values(state.chartInstances)) c.destroy();
-  state.chartInstances = {};
 }
 
 export function getAllFlaggedMarkers(data) {
   return getAllFlaggedMarkersForData(data || getActiveData());
 }
 
-// ═══════════════════════════════════════════════
-// UNIT TOGGLE
-// ═══════════════════════════════════════════════
-export function switchUnitSystem(system) {
-  invalidateActiveDataCache();
-  state.unitSystem = system;
-  localStorage.setItem(profileStorageKey(state.currentProfile, 'units'), system);
-  // Capture the open detail-modal marker BEFORE the rebuild — navigate()
-  // doesn't close the modal overlay, so without re-rendering it the user
-  // would see stale pre-conversion values behind their unit-toggle action.
-  // Matches the pattern in toggleAltUnits().
-  const openId = state._activeDetailMarkerId;
-  const data = getActiveData();
-  buildDataSidebar(data);
-  updateHeaderDates(data);
-  navigateDataView(state.currentView || 'dashboard', data);
-  if (openId) {
-    dataRuntimeDeps.showDetailModal?.(openId);
-  }
-}
-
-// Per-profile preference: when on, the detail modal renders a secondary
-// "≈ value altUnit" line for markers with a UNIT_CONVERSIONS entry. Default
-// off keeps the modal uncluttered for single-locale users. Lives in
-// Settings → Display alongside Unit System / Range Display.
-//   toggleAltUnits()      — flip (used internally / by tests)
-//   toggleAltUnits(true)  — force on (used by Settings on-button onclick)
-//   toggleAltUnits(false) — force off (used by Settings off-button onclick)
-export function toggleAltUnits(force) {
-  const next = (force === true || force === false) ? force : !state.showAltUnits;
-  if (next === state.showAltUnits) return;
-  state.showAltUnits = next;
-  localStorage.setItem(profileStorageKey(state.currentProfile, 'showAltUnits'), next ? 'on' : 'off');
-  // Refresh the currently-visible detail modal so the alt-unit lines update
-  // without a full navigate (the modal lives outside the page rebuild).
-  const openId = state._activeDetailMarkerId;
-  if (openId) {
-    dataRuntimeDeps.showDetailModal?.(openId);
-  }
-}
-
-let _rangeModeRefreshToken = 0;
-
-function _captureCategoryCardOrderForRangeRefresh(route) {
-  if (typeof document === 'undefined' || !route) return null;
-  const grid = document.querySelector('#view-content .charts-grid');
-  if (!grid) return null;
-  const prefix = `${route}_`;
-  const markerKeys = Array.from(grid.querySelectorAll('canvas[id^="chart-"]'))
-    .map(canvas => String(canvas.id || '').slice('chart-'.length))
-    .filter(id => id.startsWith(prefix))
-    .map(id => id.slice(prefix.length))
-    .filter(Boolean);
-  return markerKeys.length ? { categoryKey: route, markerKeys } : null;
-}
-
-function _afterNextPaint(fn) {
-  scheduleUtilsAfterNextPaint(fn);
-}
-
-export function switchRangeMode(mode) {
-  const nextMode = mode === 'reference' ? 'reference' : mode === 'both' ? 'both' : 'optimal';
-  if (state.rangeMode === nextMode) return;
-  state.rangeMode = nextMode;
-  localStorage.setItem(profileStorageKey(state.currentProfile, 'rangeMode'), nextMode);
-  updateHeaderRangeToggle();
-  // Capture before the view refresh: an open detail modal would otherwise
-  // keep stale range bands behind the unchanged overlay.
-  const openId = state._activeDetailMarkerId;
-  const preservedOrder = _captureCategoryCardOrderForRangeRefresh(state.currentView);
-  if (preservedOrder) state._preserveCategoryCardOrder = preservedOrder;
-  else delete state._preserveCategoryCardOrder;
-  const token = ++_rangeModeRefreshToken;
-  _afterNextPaint(() => {
-    if (token !== _rangeModeRefreshToken || state.rangeMode !== nextMode) return;
-    const data = getActiveData();
-    buildDataSidebar(data);
-    navigateDataView(state.currentView || 'dashboard', data);
-    if (openId && state._activeDetailMarkerId === openId) {
-      dataRuntimeDeps.showDetailModal?.(openId);
-    }
-  });
-}
-
-export function updateHeaderDates(data) {
-  if (!data) data = getActiveData();
-  const el = document.getElementById("header-dates");
-  if (el) {
-    if (data.dateLabels.length > 0) {
-      const labels = data.dateLabels;
-      const dateText = labels.length === 1 ? labels[0] : `${labels[0]} – ${labels[labels.length - 1]}`;
-      el.innerHTML = `<span class="label">Dates:</span> ${dateText}`;
-      el.style.display = '';
-    } else {
-      el.style.display = 'none';
-    }
-  }
-}
-
-export function updateHeaderRangeToggle() {
-  const el = document.getElementById('header-range-toggle');
-  if (!el) return;
-  const modes = ['optimal', 'reference', 'both'];
-  const buttons = /** @type {HTMLButtonElement[]} */ (Array.from(el.querySelectorAll('.range-toggle-btn')));
-  const canPatch = buttons.length === modes.length && modes.every(m => buttons.some(btn => btn.dataset.range === m));
-  if (!canPatch) {
-    el.innerHTML = modes.map(m =>
-      `<button class="range-toggle-btn${state.rangeMode === m ? ' active' : ''}" type="button" data-range="${m}" aria-pressed="${state.rangeMode === m ? 'true' : 'false'}" ${dataActionAttrs('switch-range-mode', { range: m })}>${m.charAt(0).toUpperCase() + m.slice(1)}</button>`
-    ).join('');
-    return;
-  }
-  for (const btn of buttons) {
-    const active = btn.dataset.range === state.rangeMode;
-    btn.classList.toggle('active', active);
-    btn.setAttribute('aria-pressed', active ? 'true' : 'false');
-  }
-}
+configureDataViewCoreDependencies({ getActiveData, invalidateActiveDataCache });

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -7,6 +7,6 @@
   "viewRuntimeBridgeLookups": 0,
   "labStateAppFiles": 0,
   "labStateTestFiles": 0,
-  "largeJsFilesOver800Lines": 3,
-  "maxJsFileLines": 1095
+  "largeJsFilesOver800Lines": 2,
+  "maxJsFileLines": 1087
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -150,6 +150,7 @@ const APP_SHELL = [
   '/js/profile-runtime.js',
   '/js/profile-share.js',
   '/js/data.js',
+  '/js/data-view-controls.js',
   '/js/lab-entry.js',
   '/js/lab-entry-mutations.js',
   '/js/marker-analysis.js',

--- a/tests/test-a11y-phase3.js
+++ b/tests/test-a11y-phase3.js
@@ -124,7 +124,7 @@ console.log('=== Phase 3 A11y Tests ===\n');
     categoryPageViewSrc.includes('class="view-toggle" role="tablist"'));
 
   // ─── 6. Chart layers dropdown ARIA ───
-  const dataSrc = read('/js/data.js');
+  const dataSrc = read('/js/data-view-controls.js');
   assert('chart-layers-trigger has aria-haspopup + aria-controls',
     /<button class="view-btn chart-layers-trigger"[\s\S]{0,220}aria-haspopup="true"[\s\S]{0,220}aria-expanded="false"[\s\S]{0,220}aria-controls="chart-layers-dropdown"/.test(dataSrc));
   assert('chart-layers-dropdown has role=menu',

--- a/tests/test-correctness-phase2.js
+++ b/tests/test-correctness-phase2.js
@@ -126,6 +126,7 @@ const pwaAppShellAssets = [
   '/js/blob-storage.js',
   '/js/data-merge-lab-entries.js',
   '/js/data-merge.js',
+  '/js/data-view-controls.js',
   '/js/views-router.js',
   '/js/dashboard-view-composition.js',
   '/js/dashboard-page-view.js',

--- a/tests/test-cycle-improvements.js
+++ b/tests/test-cycle-improvements.js
@@ -99,7 +99,7 @@ const { phaseBandPlugin } = await import('../js/charts.js');
   {
     assert('setPhaseOverlay is a module API', typeof dataModule.setPhaseOverlay === 'function');
     assert('setPhaseOverlay stays off window', !('setPhaseOverlay' in window));
-    const src = read('js/data.js');
+    const src = read('js/data-view-controls.js');
     assert('setPhaseOverlay sets phaseOverlayMode', src.includes("state.phaseOverlayMode = mode === 'off' ? 'off' : 'on'"));
     assert('setPhaseOverlay persists to localStorage', src.includes("'phaseOverlay'") && src.includes('setPhaseOverlay'));
   }
@@ -131,7 +131,7 @@ const { phaseBandPlugin } = await import('../js/charts.js');
   // ── Section 9: renderChartLayersDropdown includes cycle phases ──
   console.log('Section 9: renderChartLayersDropdown');
   {
-    const src = read('js/data.js');
+    const src = read('js/data-view-controls.js');
     assert('Layers dropdown checks for cycle data', src.includes('hasCycle'));
     assert('Layers dropdown delegates setPhaseOverlay changes',
       src.includes("dataChangeAttrs('set-phase-overlay')") && src.includes('setPhaseOverlay(mode)'));

--- a/tests/test-data-delegated-actions.js
+++ b/tests/test-data-delegated-actions.js
@@ -21,17 +21,18 @@ function assert(name, condition) {
   }
 }
 
-const dataSrc = read('js/data.js');
+const dataFacadeSrc = read('js/data.js');
+const dataSrc = read('js/data-view-controls.js');
 const appShellHooksSrc = read('js/app-shell-hooks.js');
 const eventNames = ['click', 'keydown', 'change', 'input', 'submit', 'blur', 'toggle'];
 const inlineEventPattern = new RegExp(`\\bon(?:${eventNames.join('|')})=["']`);
 
 console.log('=== Data Delegated Actions Tests ===');
 
-assert('data.js renderer emits no inline event attributes',
+assert('data view controls renderer emits no inline event attributes',
   !inlineEventPattern.test(dataSrc));
 
-assert('data.js imports escapeAttr for delegated data attributes',
+assert('data view controls import escapeAttr for delegated data attributes',
   /import\s*\{[^}]*\bescapeAttr\b[^}]*\}\s*from\s*['"]\.\/utils\.js['"]/.test(dataSrc));
 
 assert('data view callbacks use shell injection instead of bridge or window lookups',
@@ -41,6 +42,7 @@ assert('data view callbacks use shell injection instead of bridge or window look
   && dataSrc.includes('dataRuntimeDeps.navigate?.(route, data);')
   && dataSrc.includes('dataRuntimeDeps.buildSidebar?.(data);')
   && dataSrc.includes('dataRuntimeDeps.showDetailModal?.(openId);')
+  && dataFacadeSrc.includes("from './data-view-controls.js'")
   && /import\s*\{[^}]*\bconfigureDataRuntimeDeps\b[^}]*\}\s*from\s*['"]\.\/data\.js['"]/.test(appShellHooksSrc)
   && appShellHooksSrc.includes('configureDataRuntimeDeps({ buildSidebar, navigate, showDetailModal });'));
 

--- a/tests/test-integration-batch2.js
+++ b/tests/test-integration-batch2.js
@@ -189,10 +189,10 @@ console.log('=== Integration Tests — Batch 2 Fixes ===\n');
   assert('buildSidebar imports filterDatesByRange', navSrc.includes('filterDatesByRange'));
   assert('buildSidebar calls filterDatesByRange', navSrc.includes('filterDatesByRange(data)'));
 
-  const dataSrc = read('/js/data.js');
+  const dataSrc = read('/js/data-view-controls.js');
   const setDateIdx = dataSrc.indexOf('function setDateRange');
   const setDateBlock = dataSrc.substring(setDateIdx, dataSrc.indexOf('\n}', setDateIdx));
-  assert('setDateRange rebuilds sidebar', setDateBlock.includes('buildSidebar'));
+  assert('setDateRange rebuilds sidebar', setDateBlock.includes('buildDataSidebar'));
 
   // ═══════════════════════════════════════
   // 11. Context card state preservation

--- a/tests/test-manual-entry-flow.js
+++ b/tests/test-manual-entry-flow.js
@@ -217,7 +217,7 @@ console.log('=== Manual Entry Flow Tests ===\n');
   // ═══════════════════════════════════════
   console.log('%c 10. activeNav sweep ', 'font-weight:bold;color:#f59e0b');
 
-  const dataSrc = read('js/data.js');
+  const dataSrc = read('js/data-view-controls.js');
   assert('switchUnitSystem uses state.currentView (no .nav-item.active query)',
     /switchUnitSystem[\s\S]{0,800}navigateDataView\(state\.currentView \|\| 'dashboard'/.test(dataSrc) &&
     !/switchUnitSystem[\s\S]{0,800}document\.querySelector\(".nav-item\.active"\)/.test(dataSrc));

--- a/tests/test-multi-unit.js
+++ b/tests/test-multi-unit.js
@@ -229,6 +229,7 @@ console.log('\n-- source-shape pins (UI wiring) --');
     fs.readFileSync(new URL('../js/settings-display-panel.js', import.meta.url), 'utf8'),
   ].join('\n');
   const data = fs.readFileSync(new URL('../js/data.js', import.meta.url), 'utf8');
+  const dataViewControls = fs.readFileSync(new URL('../js/data-view-controls.js', import.meta.url), 'utf8');
   const state = fs.readFileSync(new URL('../js/state.js', import.meta.url), 'utf8');
   const profile = fs.readFileSync(new URL('../js/profile.js', import.meta.url), 'utf8');
 
@@ -267,15 +268,16 @@ console.log('\n-- source-shape pins (UI wiring) --');
   assert('settings.js unit-toggle scope is narrowed to [data-unit] (so alt-units buttons aren\'t deactivated)',
     /unit-toggle-btn\[data-unit\]/.test(settings));
 
-  // data.js: toggleAltUnits accepts force arg, persists, refreshes detail modal
-  assert('data.js toggleAltUnits accepts force arg',
-    /export function toggleAltUnits\(force\)/.test(data));
-  assert('data.js toggleAltUnits persists to localStorage',
-    /localStorage\.setItem\(profileStorageKey\(state\.currentProfile, 'showAltUnits'\)/.test(data));
-  assert('data.js toggleAltUnits refreshes open detail modal via state._activeDetailMarkerId',
-    /state\._activeDetailMarkerId[\s\S]{0,200}dataRuntimeDeps\.showDetailModal\?\.\(openId\)/.test(data));
+  // Data view controls: toggleAltUnits accepts force arg, persists, refreshes detail modal
+  assert('data view controls toggleAltUnits accepts force arg',
+    /export function toggleAltUnits\(force\)/.test(dataViewControls));
+  assert('data view controls toggleAltUnits persists to localStorage',
+    /localStorage\.setItem\(profileStorageKey\(state\.currentProfile, 'showAltUnits'\)/.test(dataViewControls));
+  assert('data view controls toggleAltUnits refreshes open detail modal via state._activeDetailMarkerId',
+    /state\._activeDetailMarkerId[\s\S]{0,200}dataRuntimeDeps\.showDetailModal\?\.\(openId\)/.test(dataViewControls));
   assert('data.js keeps toggleAltUnits module-only',
-    /export function toggleAltUnits\(force\)/.test(data) && !data.includes('Object.assign(window'));
+    /export\s*\{[\s\S]*\btoggleAltUnits\b[\s\S]*\}\s*from\s*['"]\.\/data-view-controls\.js['"]/.test(data)
+      && !dataViewControls.includes('Object.assign(window'));
 
   // state.js: showAltUnits default off
   assert('state.js declares showAltUnits: false',

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -244,6 +244,7 @@ const domainUiCheckJsModules = [
   'js/crypto-ui.js',
   'js/data-merge-lab-entries.js',
   'js/data.js',
+  'js/data-view-controls.js',
   'js/emf.js',
   'js/emf-editor.js',
   'js/emf-model.js',

--- a/tests/test-v1-6-shipped.js
+++ b/tests/test-v1-6-shipped.js
@@ -576,6 +576,7 @@ const _origProfileSex = state ? state.profileSex : null;
     const compareCorrelationsSrc = fetchSrc('js/compare-correlations.js');
     const markerDetailSrc = fetchSrc('js/marker-detail-modal-impl.js');
     const dataSrc = fetchSrc('js/data.js');
+    const dataViewControlsSrc = fetchSrc('js/data-view-controls.js');
     const cssSrc = fetchCssSrc();
     assert('category-view-renderers.js: marker cards render latest-value summary before chart',
       /chart-card-snapshot/.test(categoryViewRenderersSrc)
@@ -599,21 +600,21 @@ const _origProfileSex = state ? state.profileSex : null;
       /const modalOpen\s*=\s*!!document\.querySelector\('\.modal-overlay\.show'\)/.test(chartCardRecsSrc)
       && /recLinks\.length > 0 && !modalOpen/.test(chartCardRecsSrc));
     assert('data.js: range mode switch paints the active pill before view refresh',
-      /function _afterNextPaint\(fn\)/.test(dataSrc)
-      && dataSrc.includes("import { scheduleUtilsAfterNextPaint } from './utils-runtime.js';")
-      && /scheduleUtilsAfterNextPaint\(fn\)/.test(dataSrc)
-      && /const token\s*=\s*\+\+_rangeModeRefreshToken/.test(dataSrc)
-      && /_afterNextPaint\(\(\) => \{[\s\S]{0,500}navigateDataView\(state\.currentView \|\| 'dashboard',\s*data\)/.test(dataSrc));
+      /function _afterNextPaint\(fn\)/.test(dataViewControlsSrc)
+      && dataViewControlsSrc.includes("import { scheduleUtilsAfterNextPaint } from './utils-runtime.js';")
+      && /scheduleUtilsAfterNextPaint\(fn\)/.test(dataViewControlsSrc)
+      && /const token\s*=\s*\+\+_rangeModeRefreshToken/.test(dataViewControlsSrc)
+      && /_afterNextPaint\(\(\) => \{[\s\S]{0,500}navigateDataView\(state\.currentView \|\| 'dashboard',\s*data\)/.test(dataViewControlsSrc));
     assert('range mode refresh preserves current category card order',
-      /function _captureCategoryCardOrderForRangeRefresh\(route\)/.test(dataSrc)
-      && /state\._preserveCategoryCardOrder\s*=\s*preservedOrder/.test(dataSrc)
+      /function _captureCategoryCardOrderForRangeRefresh\(route\)/.test(dataViewControlsSrc)
+      && /state\._preserveCategoryCardOrder\s*=\s*preservedOrder/.test(dataViewControlsSrc)
       && /function sortCategoryChartEntries\(entries,\s*categoryKey\)/.test(categoryPageViewSrc)
       && /preserved\?\.categoryKey === categoryKey/.test(categoryPageViewSrc)
       && /delete state\._preserveCategoryCardOrder/.test(categoryPageViewSrc));
     assert('data.js: header range toggle patches existing buttons',
-      /const canPatch\s*=/.test(dataSrc)
-      && /btn\.classList\.toggle\('active',\s*active\)/.test(dataSrc)
-      && /data-range="\$\{m\}"/.test(dataSrc));
+      /const canPatch\s*=/.test(dataViewControlsSrc)
+      && /btn\.classList\.toggle\('active',\s*active\)/.test(dataViewControlsSrc)
+      && /data-range="\$\{m\}"/.test(dataViewControlsSrc));
     assert('data.js: active data cache avoids rebuilding marker data during modal browsing',
       /let _activeDataCache\s*=\s*null/.test(dataSrc)
       && /export function invalidateActiveDataCache\(\)/.test(dataSrc)
@@ -623,7 +624,7 @@ const _origProfileSex = state ? state.profileSex : null;
       && /legacyWeightStamp/.test(dataSrc)
       && /saveImportedData\([^)]*\)[\s\S]{0,120}invalidateActiveDataCache\(\)/.test(dataSrc)
       && !/_makeActiveDataCacheMeta\(\)[\s\S]{0,900}rangeMode:\s*state\.rangeMode/.test(dataSrc)
-      && !/switchRangeMode\(mode\)[\s\S]{0,220}invalidateActiveDataCache\(\)/.test(dataSrc));
+      && !/switchRangeMode\(mode\)[\s\S]{0,220}invalidateActiveDataCache\(\)/.test(dataViewControlsSrc));
     assert('category-glyphs.js: marker category surfaces use coded glyphs instead of emoji icons',
       /export function renderCategoryGlyph\(categoryKey,\s*label/.test(categoryGlyphsSrc)
       && /getCategoryGlyphCode\(categoryKey,\s*label\)/.test(categoryGlyphsSrc)

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -97,6 +97,7 @@
     '/js/onboarding-view-runtime.js',
     '/js/onboarding-view.js',
     '/js/data-merge-lab-entries.js',
+    '/js/data-view-controls.js',
     '/js/pii-review.js',
     '/js/marker-detail-modal.js',
     '/js/marker-detail-modal-impl.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -127,6 +127,7 @@
     "js/data-merge-lab-entries.js",
     "js/data-merge.js",
     "js/data.js",
+    "js/data-view-controls.js",
     "js/dna.js",
     "js/dna-ui.js",
     "js/dna-file-detection.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -125,6 +125,7 @@
     "js/data-merge-lab-entries.js",
     "js/data-merge.js",
     "js/data.js",
+    "js/data-view-controls.js",
     "js/dna.js",
     "js/dna-ui.js",
     "js/dna-runtime.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.474';
+self.APP_VERSION = '1.10.475';


### PR DESCRIPTION
## What changed

- extracted browser-facing data controls, delegated actions, chart-layer controls, and display preferences into `js/data-view-controls.js`
- kept `js/data.js` as the stable public facade and injected the core data callbacks without introducing a module cycle
- added the new owner to offline caching, check-JS scopes, architecture documentation, and focused source-contract tests
- reduced `js/data.js` from 1,095 logical lines to 752 and ratcheted the oversized-file baseline from 3 to 2
- bumped the app version to 1.10.475

## Why

`js/data.js` mixed the data pipeline with browser presentation and navigation controls, pushing it above the 800-line maintainability threshold. The extraction gives those controls a cohesive owner while preserving every existing public export and runtime behavior.

## Validation

- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run typecheck:strict-null`
- `npm run quality`
- `npm run architecture:check`
- `npm run production:check`
- focused legacy data, cycle, unit, accessibility, and integration tests via Vitest
- `npx vitest run tests/service-worker-app-shell.test.js`
- `node tests/verify-modules.js`
- `PORT=8137 npx playwright test tests/playwright/data-browser-coverage.spec.js --workers=1`
