### PR TITLE
Split PDF import file handlers

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -9,8 +9,8 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 
 | Metric | Current |
 | --- | ---: |
-| Modules | 526 |
-| Internal import edges | 2347 |
+| Modules | 527 |
+| Internal import edges | 2362 |
 | Dynamic internal edges | 93 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -38,14 +38,14 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 
 | High fan-in | Dependants | High fan-out | Imports |
 | --- | ---: | --- | ---: |
-| [`js/utils.js`](js/utils.js) | 243 | [`js/app-shell-hooks.js`](js/app-shell-hooks.js) | 72 |
-| [`js/state.js`](js/state.js) | 168 | [`js/app-light-sun-modules.js`](js/app-light-sun-modules.js) | 36 |
-| [`js/data.js`](js/data.js) | 77 | [`js/sync-configure.js`](js/sync-configure.js) | 27 |
-| [`js/caught-error.js`](js/caught-error.js) | 76 | [`js/settings.js`](js/settings.js) | 25 |
-| [`js/modal-lifecycle.js`](js/modal-lifecycle.js) | 69 | [`js/pdf-import.js`](js/pdf-import.js) | 24 |
-| [`js/api.js`](js/api.js) | 64 | [`js/chat-send.js`](js/chat-send.js) | 22 |
+| [`js/utils.js`](js/utils.js) | 244 | [`js/app-shell-hooks.js`](js/app-shell-hooks.js) | 72 |
+| [`js/state.js`](js/state.js) | 169 | [`js/app-light-sun-modules.js`](js/app-light-sun-modules.js) | 36 |
+| [`js/caught-error.js`](js/caught-error.js) | 77 | [`js/sync-configure.js`](js/sync-configure.js) | 27 |
+| [`js/data.js`](js/data.js) | 77 | [`js/pdf-import.js`](js/pdf-import.js) | 25 |
+| [`js/modal-lifecycle.js`](js/modal-lifecycle.js) | 70 | [`js/settings.js`](js/settings.js) | 25 |
+| [`js/api.js`](js/api.js) | 65 | [`js/chat-send.js`](js/chat-send.js) | 22 |
 | [`js/profile.js`](js/profile.js) | 47 | [`js/views.js`](js/views.js) | 22 |
-| [`js/schema.js`](js/schema.js) | 33 | [`js/wearables-connect.js`](js/wearables-connect.js) | 21 |
+| [`js/schema.js`](js/schema.js) | 34 | [`js/wearables-connect.js`](js/wearables-connect.js) | 21 |
 | [`js/crypto.js`](js/crypto.js) | 29 | [`js/dashboard-view-composition.js`](js/dashboard-view-composition.js) | 20 |
 | [`js/data-merge.js`](js/data-merge.js) | 29 | [`js/biology-scores.js`](js/biology-scores.js) | 19 |
 | [`js/constants.js`](js/constants.js) | 21 | [`js/export.js`](js/export.js) | 18 |
@@ -611,10 +611,11 @@ Native browser modules shipped with the static application.
 
 </details>
 
-<details><summary><code>pdf</code> family — 12 modules</summary>
+<details><summary><code>pdf</code> family — 13 modules</summary>
 
 - [`js/pdf-import-ai-utils.js`](js/pdf-import-ai-utils.js) → [`js/api.js`](js/api.js), [`js/utils.js`](js/utils.js)
 - [`js/pdf-import-commit.js`](js/pdf-import-commit.js) → [`js/adapters.js`](js/adapters.js), [`js/crypto.js`](js/crypto.js), [`js/data-merge.js`](js/data-merge.js), [`js/data.js`](js/data.js), [`js/import-benchmarks.js`](js/import-benchmarks.js), [`js/lab-entry-mutations.js`](js/lab-entry-mutations.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/pdf-import-marker-mapping.js`](js/pdf-import-marker-mapping.js), [`js/pdf-import-persistence.js`](js/pdf-import-persistence.js), [`js/pdf-import-review.js`](js/pdf-import-review.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
+- [`js/pdf-import-file-handlers.js`](js/pdf-import-file-handlers.js) → [`js/api.js`](js/api.js), [`js/caught-error.js`](js/caught-error.js), [`js/import-benchmarks.js`](js/import-benchmarks.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/pdf-import-ai-utils.js`](js/pdf-import-ai-utils.js), [`js/pdf-import-file-utils.js`](js/pdf-import-file-utils.js), [`js/pdf-import-preflight.js`](js/pdf-import-preflight.js), [`js/pdf-import-progress.js`](js/pdf-import-progress.js), [`js/pdf-import-review.js`](js/pdf-import-review.js), [`js/pdf-import-spreadsheet.js`](js/pdf-import-spreadsheet.js), [`js/pii.js`](js/pii.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/pdf-import-file-utils.js`](js/pdf-import-file-utils.js) → [`js/pdf-import-spreadsheet.js`](js/pdf-import-spreadsheet.js), [`js/pdfjs-loader.js`](js/pdfjs-loader.js)
 - [`js/pdf-import-marker-mapping.js`](js/pdf-import-marker-mapping.js) → [`js/adapters.js`](js/adapters.js), [`js/schema.js`](js/schema.js), [`js/secondary-unit-conversions.js`](js/secondary-unit-conversions.js), [`js/state.js`](js/state.js)
 - [`js/pdf-import-marker-normalization.js`](js/pdf-import-marker-normalization.js) → [`js/adapters.js`](js/adapters.js), [`js/pdf-import-marker-mapping.js`](js/pdf-import-marker-mapping.js), [`js/schema.js`](js/schema.js), [`js/utils.js`](js/utils.js)
@@ -624,7 +625,7 @@ Native browser modules shipped with the static application.
 - [`js/pdf-import-review-runtime.js`](js/pdf-import-review-runtime.js) → [`js/data.js`](js/data.js)
 - [`js/pdf-import-review.js`](js/pdf-import-review.js) → [`js/api.js`](js/api.js), [`js/import-benchmarks.js`](js/import-benchmarks.js), [`js/import-marker-map-modal.js`](js/import-marker-map-modal.js), [`js/import-review-draft.js`](js/import-review-draft.js), [`js/import-review-row-actions.js`](js/import-review-row-actions.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/pdf-import-marker-mapping.js`](js/pdf-import-marker-mapping.js), [`js/pdf-import-review-runtime.js`](js/pdf-import-review-runtime.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/pdf-import-spreadsheet.js`](js/pdf-import-spreadsheet.js) → no in-scope imports
-- [`js/pdf-import.js`](js/pdf-import.js) → [`js/api.js`](js/api.js), [`js/caught-error.js`](js/caught-error.js), [`js/crypto.js`](js/crypto.js), [`js/cycle-import.js`](js/cycle-import.js), [`js/dna-runtime-bridge.js`](js/dna-runtime-bridge.js), [`js/export.js`](js/export.js), [`js/import-benchmarks.js`](js/import-benchmarks.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/pdf-import-ai-utils.js`](js/pdf-import-ai-utils.js), [`js/pdf-import-commit.js`](js/pdf-import-commit.js), [`js/pdf-import-file-utils.js`](js/pdf-import-file-utils.js), [`js/pdf-import-marker-mapping.js`](js/pdf-import-marker-mapping.js), [`js/pdf-import-marker-normalization.js`](js/pdf-import-marker-normalization.js), [`js/pdf-import-persistence.js`](js/pdf-import-persistence.js), [`js/pdf-import-preflight.js`](js/pdf-import-preflight.js), [`js/pdf-import-progress.js`](js/pdf-import-progress.js), [`js/pdf-import-review.js`](js/pdf-import-review.js), [`js/pdf-import-spreadsheet.js`](js/pdf-import-spreadsheet.js), [`js/pii.js`](js/pii.js), [`js/profile.js`](js/profile.js), [`js/schema.js`](js/schema.js), [`js/settings-runtime-bridge.js`](js/settings-runtime-bridge.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
+- [`js/pdf-import.js`](js/pdf-import.js) → [`js/api.js`](js/api.js), [`js/caught-error.js`](js/caught-error.js), [`js/crypto.js`](js/crypto.js), [`js/cycle-import.js`](js/cycle-import.js), [`js/dna-runtime-bridge.js`](js/dna-runtime-bridge.js), [`js/export.js`](js/export.js), [`js/import-benchmarks.js`](js/import-benchmarks.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/pdf-import-ai-utils.js`](js/pdf-import-ai-utils.js), [`js/pdf-import-commit.js`](js/pdf-import-commit.js), [`js/pdf-import-file-handlers.js`](js/pdf-import-file-handlers.js), [`js/pdf-import-file-utils.js`](js/pdf-import-file-utils.js), [`js/pdf-import-marker-mapping.js`](js/pdf-import-marker-mapping.js), [`js/pdf-import-marker-normalization.js`](js/pdf-import-marker-normalization.js), [`js/pdf-import-persistence.js`](js/pdf-import-persistence.js), [`js/pdf-import-preflight.js`](js/pdf-import-preflight.js), [`js/pdf-import-progress.js`](js/pdf-import-progress.js), [`js/pdf-import-review.js`](js/pdf-import-review.js), [`js/pdf-import-spreadsheet.js`](js/pdf-import-spreadsheet.js), [`js/pii.js`](js/pii.js), [`js/profile.js`](js/profile.js), [`js/schema.js`](js/schema.js), [`js/settings-runtime-bridge.js`](js/settings-runtime-bridge.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 
 </details>
 

--- a/js/pdf-import-file-handlers.js
+++ b/js/pdf-import-file-handlers.js
@@ -1,0 +1,361 @@
+// @ts-check
+// pdf-import-file-handlers.js — single-file PDF and image import workflows
+
+import { getErrorMessage } from './caught-error.js';
+import { state } from './state.js';
+import { calculateCost, trackUsage } from './schema.js';
+import { showNotification, showConfirmDialog, isDebugMode, isPIIReviewEnabled, hashString } from './utils.js';
+import { hasAIProvider, getAIProvider, getActiveModelId } from './api.js';
+import { obfuscatePDFText, sanitizeWithOllama, sanitizeWithOllamaStreaming, checkOllamaPII, reviewPIIBeforeSend } from './pii.js';
+import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
+import {
+  assessTextQuality,
+  extractPDFImages,
+  extractPDFText,
+} from './pdf-import-file-utils.js';
+import { runPreflightChecks } from './pdf-import-preflight.js';
+import {
+  hideImportProgress,
+  showImportProgress,
+  updateImportProgressPct,
+} from './pdf-import-progress.js';
+import { isCsvTextFile, isTextImportFile, isXlsxFile } from './pdf-import-spreadsheet.js';
+import { getUsageTokens, formatImportError } from './pdf-import-ai-utils.js';
+import { showImportPreview } from './pdf-import-review.js';
+import {
+  benchmarkResultPatch,
+  captureImportBenchmarkReviewBaseline,
+  finishImportBenchmark,
+  startImportBenchmark,
+  updateImportBenchmark,
+} from './import-benchmarks.js';
+
+const fileHandlerDeps = {
+  parseLabPDFWithAI: /** @type {((text: string, fileName: string, onProgress?: (pct: number) => void) => Promise<any>) | null} */ (null),
+  parseLabPDFWithAIImages: /** @type {((images: any[], fileName: string, onProgress?: (pct: number) => void) => Promise<any>) | null} */ (null),
+  showAINeededDialog: /** @type {((action?: string) => void) | null} */ (null),
+};
+
+/**
+ * @param {{
+ *   parseLabPDFWithAI?: (text: string, fileName: string, onProgress?: (pct: number) => void) => Promise<any>,
+ *   parseLabPDFWithAIImages?: (images: any[], fileName: string, onProgress?: (pct: number) => void) => Promise<any>,
+ *   showAINeededDialog?: (action?: string) => void,
+ * }} [deps]
+ */
+export function configurePdfImportFileHandlers(deps = {}) {
+  if (typeof deps.parseLabPDFWithAI === 'function') fileHandlerDeps.parseLabPDFWithAI = deps.parseLabPDFWithAI;
+  if (typeof deps.parseLabPDFWithAIImages === 'function') fileHandlerDeps.parseLabPDFWithAIImages = deps.parseLabPDFWithAIImages;
+  if (typeof deps.showAINeededDialog === 'function') fileHandlerDeps.showAINeededDialog = deps.showAINeededDialog;
+}
+
+async function _showImageModeDialog() {
+  return new Promise(resolve => {
+    const overlay = document.getElementById('confirm-dialog-overlay');
+    const dialog = document.getElementById('confirm-dialog');
+    if (!overlay || !dialog) { resolve('cancel'); return; }
+    dialog.innerHTML = `
+      <div style="font-size:14px;font-weight:600;margin-bottom:8px">Limited text extracted</div>
+      <div style="font-size:13px;color:var(--text-muted);margin-bottom:16px">
+        This PDF appears to be scanned or image-heavy. Text extraction found very little content.<br><br>
+        <strong>Image mode</strong> sends page screenshots to the AI instead. This skips PII obfuscation — the AI will see the full page images including any personal information.
+      </div>
+      <div style="display:flex;gap:8px;justify-content:flex-end">
+        <button class="btn" style="padding:7px 16px;border-radius:6px;border:1px solid var(--border);background:var(--bg-card);color:var(--text-primary);cursor:pointer">Cancel</button>
+        <button class="btn" style="padding:7px 16px;border-radius:6px;border:1px solid var(--border);background:var(--bg-card);color:var(--text-primary);cursor:pointer">Try text anyway</button>
+        <button class="btn" style="padding:7px 16px;border-radius:6px;border:none;background:var(--accent-gradient);color:white;cursor:pointer;font-weight:500">Use image mode</button>
+      </div>`;
+    let settled = false;
+    const closeWithChoice = (choice) => {
+      if (settled) return;
+      settled = true;
+      document.removeEventListener('keydown', onKey);
+      closeModalOverlay(overlay);
+      resolve(choice);
+    };
+    const onKey = (e) => { if (e.key === 'Escape') closeWithChoice('cancel'); };
+    document.addEventListener('keydown', onKey, { once: true });
+    dialog.querySelectorAll('button').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const action = btn.textContent?.trim();
+        if (action === 'Cancel') closeWithChoice('cancel');
+        else if (action === 'Try text anyway') closeWithChoice('text');
+        else closeWithChoice('image');
+      }, { once: true });
+    });
+    openModalOverlay(overlay, { initialFocus: 'button', focusDelay: 50 });
+  });
+}
+
+export async function handlePDFFileWorkflow(file, forceImageMode = false, preExtractedText = /** @type {string | null} */ (null)) {
+  const { parseLabPDFWithAI, parseLabPDFWithAIImages, showAINeededDialog } = fileHandlerDeps;
+  if (!parseLabPDFWithAI || !parseLabPDFWithAIImages || !showAINeededDialog) {
+    throw new Error('PDF import file handler dependencies are not configured');
+  }
+  const _startProfileId = state.currentProfile;
+  const benchmarkStarted = performance.now();
+  const benchmarkId = startImportBenchmark({ fileName: file.name, fileSize: file.size, importMode: forceImageMode ? 'image' : 'text' });
+  let benchmarkFinished = false;
+  let benchmarkStage = 'extract';
+  const setBenchmarkStage = (stage, patch = {}) => {
+    benchmarkStage = stage;
+    updateImportBenchmark(benchmarkId, { stage, ...patch }, { persist: false });
+  };
+  const finishBenchmark = (status, patch = {}) => {
+    if (benchmarkFinished) return;
+    benchmarkFinished = true;
+    finishImportBenchmark(benchmarkId, status, { stage: benchmarkStage, ...patch });
+  };
+  const hasPreExtractedText = preExtractedText !== null;
+  const isCsvImport = isCsvTextFile(file);
+  const isXlsxImport = isXlsxFile(file);
+  const isTextFileImport = isTextImportFile(file);
+  const textImportKind = isXlsxImport ? 'Excel workbook' : isCsvImport ? 'CSV' : isTextFileImport ? 'text file' : 'PDF';
+  const textAction = isXlsxImport ? 'xlsx' : isCsvImport ? 'csv' : isTextFileImport ? 'text' : 'import';
+  try {
+    await showImportProgress(0, file.name);
+    const pdfText = hasPreExtractedText ? preExtractedText : await extractPDFText(file);
+    const textQuality = hasPreExtractedText ? 'good' : assessTextQuality(pdfText);
+    setBenchmarkStage('mode-selection', {
+      inputChars: pdfText.length,
+      pageCount: (pdfText.match(/^=== Page \d+ ===$/gm) || []).length,
+      textQuality,
+    });
+
+    let useImageMode = forceImageMode;
+    if (!forceImageMode && (textQuality === 'empty' || textQuality === 'poor')) {
+      const choice = await _showImageModeDialog();
+      if (choice === 'cancel') { hideImportProgress(); return; }
+      useImageMode = choice === 'image';
+      updateImportBenchmark(benchmarkId, { importMode: useImageMode ? 'image' : 'text' }, { persist: false });
+      if (isDebugMode()) console.log(`[Import] User chose ${choice} for ${textQuality} text quality`);
+    }
+
+    if (useImageMode) {
+      if (!hasAIProvider()) {
+        hideImportProgress('error');
+        showAINeededDialog('image');
+        return;
+      }
+      await showImportProgress(3, file.name);
+      const images = await extractPDFImages(file);
+      if (images.length === 0) { hideImportProgress('error'); showNotification("Could not render PDF pages", "error"); return; }
+      await showImportProgress(3, file.name);
+      const analysisStart = performance.now();
+      setBenchmarkStage('analysis', { importMode: 'image', pageCount: images.length });
+      const result = await parseLabPDFWithAIImages(images, file.name, updateImportProgressPct);
+      const analysisMs = Math.round(performance.now() - analysisStart);
+      const analysisTime = Math.round(analysisMs / 1000);
+      if (isDebugMode()) console.log(`[Analysis] Image mode parsed in ${analysisTime}s`);
+      result.privacyMethod = 'none (image mode)';
+      result.timings = { pii: 0, analysis: analysisTime, piiMs: 0, analysisMs };
+      const prov = result.provider || getAIProvider();
+      const mid = getActiveModelId();
+      const tokens = getUsageTokens(result.usage);
+      result.costInfo = {
+        provider: prov, modelId: mid,
+        inputTokens: tokens.inputTokens,
+        outputTokens: tokens.outputTokens,
+        cost: calculateCost(prov, mid, tokens.inputTokens, tokens.outputTokens)
+      };
+      trackUsage(prov, mid, tokens.inputTokens, tokens.outputTokens);
+      result.importHash = hashString(images.map(image => image.base64).join('|'));
+      result.benchmarkId = benchmarkId;
+      captureImportBenchmarkReviewBaseline(result);
+      result._importProfileId = _startProfileId;
+      if (!result.date) showNotification("Could not find collection date in PDF", "error");
+      if (result.markers.length === 0) { finishBenchmark('no-markers', benchmarkResultPatch(result, performance.now() - benchmarkStarted)); hideImportProgress('error'); showNotification("No biomarkers found in PDF images", "error"); return; }
+      finishBenchmark('preview', benchmarkResultPatch(result, performance.now() - benchmarkStarted));
+      await showImportProgress(4, file.name);
+      showImportPreview(result);
+      hideImportProgress();
+      return;
+    }
+
+    if (!pdfText.trim()) { hideImportProgress('error'); showNotification(`${textImportKind} appears empty — no text extracted`, "error"); return; }
+
+    if (!hasAIProvider()) {
+      hideImportProgress('error');
+      showAINeededDialog(textAction);
+      return;
+    }
+
+    await showImportProgress(1, file.name);
+    setBenchmarkStage('preflight');
+    const preflight = await runPreflightChecks(pdfText, file.name);
+    if (!preflight) { hideImportProgress('cancel'); return; }
+
+    await showImportProgress(2, file.name);
+    setBenchmarkStage('privacy');
+    let textForAI = pdfText;
+    let privacyMethod = null;
+    let privacyReplacements = 0;
+    let privacyOriginal = null;
+    let piiTime = 0;
+    let piiMs = 0;
+    const ollama = await checkOllamaPII();
+
+    if (ollama.available && isPIIReviewEnabled()) {
+      const piiStart = performance.now();
+      const reviewResult = await reviewPIIBeforeSend(pdfText, {
+        streamFn: (onChunk, signal, onThinking) => sanitizeWithOllamaStreaming(pdfText, onChunk, signal, onThinking)
+      });
+      piiMs = Math.round(performance.now() - piiStart);
+      piiTime = Math.round(piiMs / 1000);
+      if (reviewResult === 'cancel') { hideImportProgress('cancel'); showNotification('Import cancelled.', 'info'); return; }
+      textForAI = reviewResult;
+      privacyMethod = 'ollama+review';
+      privacyOriginal = pdfText;
+    } else if (ollama.available) {
+      try {
+        const piiStart = performance.now();
+        textForAI = await sanitizeWithOllama(pdfText);
+        piiMs = Math.round(performance.now() - piiStart);
+        piiTime = Math.round(piiMs / 1000);
+        privacyMethod = 'ollama';
+        privacyOriginal = pdfText;
+        if (isDebugMode()) console.log(`[PII] Obfuscated via Local AI (${piiTime}s)`);
+      } catch (e) {
+        if (isDebugMode()) console.warn('[PII] Local AI failed, falling back to regex:', getErrorMessage(e));
+        try {
+          const result = obfuscatePDFText(pdfText);
+          textForAI = result.obfuscated;
+          privacyReplacements = result.replacements;
+          privacyOriginal = result.original;
+          privacyMethod = 'regex';
+        } catch (e2) {
+          hideImportProgress('error');
+          showNotification('Privacy protection failed \u2014 PDF not sent to AI. Try again or check Settings.', 'error');
+          return;
+        }
+      }
+    } else {
+      try {
+        const result = obfuscatePDFText(pdfText);
+        textForAI = result.obfuscated;
+        privacyReplacements = result.replacements;
+        privacyOriginal = result.original;
+        privacyMethod = 'regex';
+      } catch (e) {
+        hideImportProgress('error');
+        showNotification('Privacy protection failed \u2014 PDF not sent to AI. Try again or check Settings.', 'error');
+        return;
+      }
+      if (isPIIReviewEnabled()) {
+        const reviewResult = await reviewPIIBeforeSend(pdfText, { obfuscatedText: textForAI });
+        if (reviewResult === 'cancel') { hideImportProgress('cancel'); showNotification('Import cancelled.', 'info'); return; }
+        textForAI = reviewResult;
+      }
+    }
+    if (isDebugMode()) { console.log('[PII] Original:', pdfText); console.log('[PII] Obfuscated:', textForAI); }
+
+    await showImportProgress(3, file.name);
+    setBenchmarkStage('analysis');
+    const analysisStart = performance.now();
+    const result = await parseLabPDFWithAI(textForAI, file.name, updateImportProgressPct);
+    const analysisMs = Math.round(performance.now() - analysisStart);
+    const analysisTime = Math.round(analysisMs / 1000);
+    if (isDebugMode()) console.log(`[Analysis] Parsed in ${analysisTime}s`);
+    result.privacyMethod = privacyMethod;
+    result.privacyReplacements = privacyReplacements;
+    result.timings = { pii: piiTime, analysis: analysisTime, piiMs, analysisMs };
+    const prov = result.provider || getAIProvider();
+    const mid = getActiveModelId();
+    const tokens = getUsageTokens(result.usage);
+    result.costInfo = {
+      provider: prov, modelId: mid,
+      inputTokens: tokens.inputTokens,
+      outputTokens: tokens.outputTokens,
+      cost: calculateCost(prov, mid, tokens.inputTokens, tokens.outputTokens)
+    };
+    trackUsage(prov, mid, tokens.inputTokens, tokens.outputTokens);
+    result.importHash = hashString(pdfText);
+    result.benchmarkId = benchmarkId;
+    captureImportBenchmarkReviewBaseline(result);
+    result._importProfileId = _startProfileId;
+    if (isDebugMode()) { result.privacyOriginal = privacyOriginal; result.privacyObfuscated = textForAI; }
+    if (!result.date) { showNotification(`Could not find collection date in ${textImportKind}`, "error"); }
+    if (result.markers.length === 0) { finishBenchmark('no-markers', benchmarkResultPatch(result, performance.now() - benchmarkStarted)); hideImportProgress('error'); showNotification(`No biomarkers found in ${textImportKind}`, "error"); return; }
+    finishBenchmark('preview', benchmarkResultPatch(result, performance.now() - benchmarkStarted));
+    await showImportProgress(4, file.name);
+    showImportPreview(result);
+    hideImportProgress();
+  } catch (err) {
+    finishBenchmark('failed', { error: formatImportError(err), totalMs: Math.round(performance.now() - benchmarkStarted) });
+    hideImportProgress('error');
+    if (isDebugMode()) console.error("PDF parse error:", err);
+    showNotification("Error parsing PDF: " + formatImportError(err), "error", 10000);
+  } finally {
+    if (!benchmarkFinished) finishBenchmark('stopped', { reason: benchmarkStage, totalMs: Math.round(performance.now() - benchmarkStarted) });
+  }
+}
+
+export async function handleImageFileWorkflow(file) {
+  const { parseLabPDFWithAIImages, showAINeededDialog } = fileHandlerDeps;
+  if (!parseLabPDFWithAIImages || !showAINeededDialog) {
+    throw new Error('PDF import image handler dependencies are not configured');
+  }
+  if (!hasAIProvider()) {
+    showAINeededDialog('image');
+    return;
+  }
+  if (!await showConfirmDialog(
+    'This image will be sent directly to the configured AI server or provider. Personal details visible in the image cannot be scrubbed before upload. Continue?'
+  )) return;
+  const _startProfileId = state.currentProfile;
+  const benchmarkStarted = performance.now();
+  const benchmarkId = startImportBenchmark({ fileName: file.name, fileSize: file.size, importMode: 'image', pageCount: 1 });
+  try {
+    await showImportProgress(3, file.name);
+    const base64 = await new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(String(reader.result || '').split(',')[1] || '');
+      reader.onerror = reject;
+      reader.readAsDataURL(file);
+    });
+    const mediaType = file.type || (file.name.match(/\.png$/i) ? 'image/png' : file.name.match(/\.webp$/i) ? 'image/webp' : 'image/jpeg');
+    const images = [{ base64, mediaType, page: 1 }];
+    const analysisStart = performance.now();
+    updateImportBenchmark(benchmarkId, { stage: 'analysis', pageCount: 1 }, { persist: false });
+    const result = await parseLabPDFWithAIImages(images, file.name, updateImportProgressPct);
+    const analysisMs = Math.round(performance.now() - analysisStart);
+    const analysisTime = Math.round(analysisMs / 1000);
+    if (isDebugMode()) console.log(`[Analysis] Image file parsed in ${analysisTime}s`);
+    result.privacyMethod = 'none (image mode)';
+    result.timings = { pii: 0, analysis: analysisTime, piiMs: 0, analysisMs };
+    const prov = result.provider || getAIProvider();
+    const mid = getActiveModelId();
+    const tokens = getUsageTokens(result.usage);
+    result.costInfo = {
+      provider: prov, modelId: mid,
+      inputTokens: tokens.inputTokens,
+      outputTokens: tokens.outputTokens,
+      cost: calculateCost(prov, mid, tokens.inputTokens, tokens.outputTokens)
+    };
+    trackUsage(prov, mid, tokens.inputTokens, tokens.outputTokens);
+    result.importHash = hashString(base64);
+    result.benchmarkId = benchmarkId;
+    captureImportBenchmarkReviewBaseline(result);
+    result._importProfileId = _startProfileId;
+    if (!result.date) showNotification("Could not find collection date in image", "error");
+    if (result.markers.length === 0) {
+      finishImportBenchmark(benchmarkId, 'no-markers', benchmarkResultPatch(result, performance.now() - benchmarkStarted));
+      hideImportProgress('error');
+      showNotification("No biomarkers found in image", "error");
+      return;
+    }
+    finishImportBenchmark(benchmarkId, 'preview', benchmarkResultPatch(result, performance.now() - benchmarkStarted));
+    await showImportProgress(4, file.name);
+    showImportPreview(result);
+    hideImportProgress();
+  } catch (err) {
+    finishImportBenchmark(benchmarkId, 'failed', {
+      stage: 'analysis',
+      error: formatImportError(err),
+      totalMs: Math.round(performance.now() - benchmarkStarted),
+    });
+    if (isDebugMode()) console.error('Image import error:', err);
+    hideImportProgress('error');
+    showNotification(`Import failed: ${formatImportError(err)}`, 'error');
+  }
+}

--- a/js/pdf-import.js
+++ b/js/pdf-import.js
@@ -4,7 +4,7 @@
 import { getErrorMessage } from './caught-error.js';
 import { state } from './state.js';
 import { calculateCost, trackUsage } from './schema.js';
-import { showNotification, showConfirmDialog, isDebugMode, isPIIReviewEnabled, hashString } from './utils.js';
+import { showNotification, isDebugMode, isPIIReviewEnabled, hashString } from './utils.js';
 import { hasAIProvider, getAIProvider, getActiveModelId, AI_IMPORT_REQUEST_TIMEOUT_MS, startOpenRouterOAuth } from './api.js';
 import { obfuscatePDFText, sanitizeWithOllama, sanitizeWithOllamaStreaming, checkOllamaPII, reviewPIIBeforeSend } from './pii.js';
 import { getProfileLocation, getActiveProfileId } from './profile.js';
@@ -14,12 +14,11 @@ import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 import {
   callImportAIWithStreamFallback,
   compactMarkerReference,
-  formatImportError,
   getUsageTokens,
   IMPORT_JSON_SCHEMA,
   tryParseJSON,
 } from './pdf-import-ai-utils.js';
-import { extractXLSXText, isCsvTextFile, isTextImportFile, isXlsxFile } from './pdf-import-spreadsheet.js';
+import { extractXLSXText, isCsvTextFile, isXlsxFile } from './pdf-import-spreadsheet.js';
 import { handleCycleImportFile, isCycleImportFile, maybeHandleCycleTextImport } from './cycle-import.js';
 import {
   assessTextQuality as assessImportedTextQuality,
@@ -37,14 +36,12 @@ import {
   hideImportProgress,
   isImportRunning,
   showBatchImportProgress,
-  showImportProgress,
   updateImportProgressPct,
 } from './pdf-import-progress.js';
 import {
   buildMarkerReference, getExistingImportMarkerKeys,
 } from './pdf-import-marker-mapping.js';
 import {
-  showImportPreview,
   showImportPreviewAsync,
 } from './pdf-import-review.js';
 import {
@@ -59,6 +56,11 @@ import {
   startImportBenchmark,
   updateImportBenchmark,
 } from './import-benchmarks.js';
+import {
+  configurePdfImportFileHandlers,
+  handleImageFileWorkflow,
+  handlePDFFileWorkflow,
+} from './pdf-import-file-handlers.js';
 
 const pdfImportDeps = {
   importDataJSON,
@@ -66,6 +68,12 @@ const pdfImportDeps = {
   maybeShowEncryptionNudge,
   startOpenRouterOAuth,
 };
+
+configurePdfImportFileHandlers({
+  parseLabPDFWithAI,
+  parseLabPDFWithAIImages,
+  showAINeededDialog,
+});
 
 export function configurePdfImportDeps(deps = {}) {
   const previous = { ...pdfImportDeps };
@@ -521,249 +529,8 @@ Return ONLY valid JSON in this exact format:
   };
 }
 
-async function _showImageModeDialog() {
-  return new Promise(resolve => {
-    const overlay = document.getElementById('confirm-dialog-overlay');
-    const dialog = document.getElementById('confirm-dialog');
-    if (!overlay || !dialog) { resolve('cancel'); return; }
-    dialog.innerHTML = `
-      <div style="font-size:14px;font-weight:600;margin-bottom:8px">Limited text extracted</div>
-      <div style="font-size:13px;color:var(--text-muted);margin-bottom:16px">
-        This PDF appears to be scanned or image-heavy. Text extraction found very little content.<br><br>
-        <strong>Image mode</strong> sends page screenshots to the AI instead. This skips PII obfuscation — the AI will see the full page images including any personal information.
-      </div>
-      <div style="display:flex;gap:8px;justify-content:flex-end">
-        <button class="btn" style="padding:7px 16px;border-radius:6px;border:1px solid var(--border);background:var(--bg-card);color:var(--text-primary);cursor:pointer">Cancel</button>
-        <button class="btn" style="padding:7px 16px;border-radius:6px;border:1px solid var(--border);background:var(--bg-card);color:var(--text-primary);cursor:pointer">Try text anyway</button>
-        <button class="btn" style="padding:7px 16px;border-radius:6px;border:none;background:var(--accent-gradient);color:white;cursor:pointer;font-weight:500">Use image mode</button>
-      </div>`;
-    let settled = false;
-    const closeWithChoice = (choice) => {
-      if (settled) return;
-      settled = true;
-      document.removeEventListener('keydown', onKey);
-      closeModalOverlay(overlay);
-      resolve(choice);
-    };
-    const onKey = (e) => { if (e.key === 'Escape') closeWithChoice('cancel'); };
-    document.addEventListener('keydown', onKey, { once: true });
-    dialog.querySelectorAll('button').forEach(btn => {
-      btn.addEventListener('click', () => {
-        const action = btn.textContent.trim();
-        if (action === 'Cancel') closeWithChoice('cancel');
-        else if (action === 'Try text anyway') closeWithChoice('text');
-        else closeWithChoice('image');
-      }, { once: true });
-    });
-    openModalOverlay(overlay, { initialFocus: 'button', focusDelay: 50 });
-  });
-}
-
 export async function handlePDFFile(file, forceImageMode = false, preExtractedText = /** @type {string | null} */ (null)) {
-  const _startProfileId = state.currentProfile;
-  const benchmarkStarted = performance.now();
-  const benchmarkId = startImportBenchmark({ fileName: file.name, fileSize: file.size, importMode: forceImageMode ? 'image' : 'text' });
-  let benchmarkFinished = false;
-  let benchmarkStage = 'extract';
-  const setBenchmarkStage = (stage, patch = {}) => {
-    benchmarkStage = stage;
-    updateImportBenchmark(benchmarkId, { stage, ...patch }, { persist: false });
-  };
-  const finishBenchmark = (status, patch = {}) => {
-    if (benchmarkFinished) return;
-    benchmarkFinished = true;
-    finishImportBenchmark(benchmarkId, status, { stage: benchmarkStage, ...patch });
-  };
-  const hasPreExtractedText = preExtractedText !== null;
-  const isCsvImport = isCsvTextFile(file);
-  const isXlsxImport = isXlsxFile(file);
-  const isTextFileImport = isTextImportFile(file);
-  const textImportKind = isXlsxImport ? 'Excel workbook' : isCsvImport ? 'CSV' : isTextFileImport ? 'text file' : 'PDF';
-  const textAction = isXlsxImport ? 'xlsx' : isCsvImport ? 'csv' : isTextFileImport ? 'text' : 'import';
-  try {
-    await showImportProgress(0, file.name);
-    const pdfText = hasPreExtractedText ? preExtractedText : await extractPDFText(file);
-    const textQuality = hasPreExtractedText ? 'good' : assessTextQuality(pdfText);
-    setBenchmarkStage('mode-selection', {
-      inputChars: pdfText.length,
-      pageCount: (pdfText.match(/^=== Page \d+ ===$/gm) || []).length,
-      textQuality,
-    });
-
-    // Determine import mode — ask user for scanned/empty PDFs
-    let useImageMode = forceImageMode;
-    if (!forceImageMode && (textQuality === 'empty' || textQuality === 'poor')) {
-      const choice = await _showImageModeDialog();
-      if (choice === 'cancel') { hideImportProgress(); return; }
-      useImageMode = choice === 'image';
-      updateImportBenchmark(benchmarkId, { importMode: useImageMode ? 'image' : 'text' }, { persist: false });
-      if (isDebugMode()) console.log(`[Import] User chose ${choice} for ${textQuality} text quality`);
-    }
-
-    if (useImageMode) {
-      // Image mode path — skip PII, render pages as images
-      if (!hasAIProvider()) {
-        hideImportProgress('error');
-        showAINeededDialog('image');
-        return;
-      }
-      await showImportProgress(3, file.name);
-      const images = await extractPDFImages(file);
-      if (images.length === 0) { hideImportProgress('error'); showNotification("Could not render PDF pages", "error"); return; }
-      await showImportProgress(3, file.name);
-      const analysisStart = performance.now();
-      setBenchmarkStage('analysis', { importMode: 'image', pageCount: images.length });
-      const result = await parseLabPDFWithAIImages(images, file.name, updateImportProgressPct);
-      const analysisMs = Math.round(performance.now() - analysisStart);
-      const analysisTime = Math.round(analysisMs / 1000);
-      if (isDebugMode()) console.log(`[Analysis] Image mode parsed in ${analysisTime}s`);
-      result.privacyMethod = 'none (image mode)';
-      result.timings = { pii: 0, analysis: analysisTime, piiMs: 0, analysisMs };
-      const prov = result.provider || getAIProvider();
-      const mid = getActiveModelId();
-      const tokens = getUsageTokens(result.usage);
-      result.costInfo = {
-        provider: prov, modelId: mid,
-        inputTokens: tokens.inputTokens,
-        outputTokens: tokens.outputTokens,
-        cost: calculateCost(prov, mid, tokens.inputTokens, tokens.outputTokens)
-      };
-      trackUsage(prov, mid, tokens.inputTokens, tokens.outputTokens);
-      result.importHash = hashString(images.map(image => image.base64).join('|'));
-      result.benchmarkId = benchmarkId;
-      captureImportBenchmarkReviewBaseline(result);
-      result._importProfileId = _startProfileId;
-      if (!result.date) showNotification("Could not find collection date in PDF", "error");
-      if (result.markers.length === 0) { finishBenchmark('no-markers', benchmarkResultPatch(result, performance.now() - benchmarkStarted)); hideImportProgress('error'); showNotification("No biomarkers found in PDF images", "error"); return; }
-      finishBenchmark('preview', benchmarkResultPatch(result, performance.now() - benchmarkStarted));
-      await showImportProgress(4, file.name);
-      showImportPreview(result);
-      hideImportProgress();
-      return;
-    }
-
-    // Text mode path (original flow)
-    if (!pdfText.trim()) { hideImportProgress('error'); showNotification(`${textImportKind} appears empty — no text extracted`, "error"); return; }
-
-    if (!hasAIProvider()) {
-      hideImportProgress('error');
-      showAINeededDialog(textAction);
-      return;
-    }
-
-    // Pre-flight checks — before spending tokens
-    await showImportProgress(1, file.name);
-    setBenchmarkStage('preflight');
-    const preflight = await runPreflightChecks(pdfText, file.name);
-    if (!preflight) { hideImportProgress('cancel'); return; }
-
-    // PII obfuscation step
-    await showImportProgress(2, file.name);
-    setBenchmarkStage('privacy');
-    let textForAI = pdfText;
-    let privacyMethod = null;
-    let privacyReplacements = 0;
-    let privacyOriginal = null;
-    let piiTime = 0;
-    let piiMs = 0;
-    const ollama = await checkOllamaPII();
-
-    if (ollama.available && isPIIReviewEnabled()) {
-      // Streaming mode — modal opens immediately, AI streams into it
-      const piiStart = performance.now();
-      const reviewResult = await reviewPIIBeforeSend(pdfText, {
-        streamFn: (onChunk, signal, onThinking) => sanitizeWithOllamaStreaming(pdfText, onChunk, signal, onThinking)
-      });
-      piiMs = Math.round(performance.now() - piiStart);
-      piiTime = Math.round(piiMs / 1000);
-      if (reviewResult === 'cancel') { hideImportProgress('cancel'); showNotification('Import cancelled.', 'info'); return; }
-      textForAI = reviewResult;
-      privacyMethod = 'ollama+review';
-      privacyOriginal = pdfText;
-    } else if (ollama.available) {
-      // Non-streaming background path (review disabled)
-      try {
-        const piiStart = performance.now();
-        textForAI = await sanitizeWithOllama(pdfText);
-        piiMs = Math.round(performance.now() - piiStart);
-        piiTime = Math.round(piiMs / 1000);
-        privacyMethod = 'ollama';
-        privacyOriginal = pdfText;
-        if (isDebugMode()) console.log(`[PII] Obfuscated via Local AI (${piiTime}s)`);
-      } catch (e) {
-        if (isDebugMode()) console.warn('[PII] Local AI failed, falling back to regex:', getErrorMessage(e));
-        try {
-          const result = obfuscatePDFText(pdfText);
-          textForAI = result.obfuscated;
-          privacyReplacements = result.replacements;
-          privacyOriginal = result.original;
-          privacyMethod = 'regex';
-        } catch (e2) {
-          hideImportProgress('error');
-          showNotification('Privacy protection failed \u2014 PDF not sent to AI. Try again or check Settings.', 'error');
-          return;
-        }
-      }
-    } else {
-      // Regex-only path
-      try {
-        const result = obfuscatePDFText(pdfText);
-        textForAI = result.obfuscated;
-        privacyReplacements = result.replacements;
-        privacyOriginal = result.original;
-        privacyMethod = 'regex';
-      } catch (e) {
-        hideImportProgress('error');
-        showNotification('Privacy protection failed \u2014 PDF not sent to AI. Try again or check Settings.', 'error');
-        return;
-      }
-      if (isPIIReviewEnabled()) {
-        const reviewResult = await reviewPIIBeforeSend(pdfText, { obfuscatedText: textForAI });
-        if (reviewResult === 'cancel') { hideImportProgress('cancel'); showNotification('Import cancelled.', 'info'); return; }
-        textForAI = reviewResult;
-      }
-    }
-    if (isDebugMode()) { console.log('[PII] Original:', pdfText); console.log('[PII] Obfuscated:', textForAI); }
-
-    await showImportProgress(3, file.name);
-    setBenchmarkStage('analysis');
-    const analysisStart = performance.now();
-    const result = await parseLabPDFWithAI(textForAI, file.name, updateImportProgressPct);
-    const analysisMs = Math.round(performance.now() - analysisStart);
-    const analysisTime = Math.round(analysisMs / 1000);
-    if (isDebugMode()) console.log(`[Analysis] Parsed in ${analysisTime}s`);
-    result.privacyMethod = privacyMethod;
-    result.privacyReplacements = privacyReplacements;
-    result.timings = { pii: piiTime, analysis: analysisTime, piiMs, analysisMs };
-    const prov = result.provider || getAIProvider();
-    const mid = getActiveModelId();
-    const tokens = getUsageTokens(result.usage);
-    result.costInfo = {
-      provider: prov, modelId: mid,
-      inputTokens: tokens.inputTokens,
-      outputTokens: tokens.outputTokens,
-      cost: calculateCost(prov, mid, tokens.inputTokens, tokens.outputTokens)
-    };
-    trackUsage(prov, mid, tokens.inputTokens, tokens.outputTokens);
-    result.importHash = hashString(pdfText);
-    result.benchmarkId = benchmarkId;
-    captureImportBenchmarkReviewBaseline(result);
-    result._importProfileId = _startProfileId;
-    if (isDebugMode()) { result.privacyOriginal = privacyOriginal; result.privacyObfuscated = textForAI; }
-    if (!result.date) { showNotification(`Could not find collection date in ${textImportKind}`, "error"); }
-    if (result.markers.length === 0) { finishBenchmark('no-markers', benchmarkResultPatch(result, performance.now() - benchmarkStarted)); hideImportProgress('error'); showNotification(`No biomarkers found in ${textImportKind}`, "error"); return; }
-    finishBenchmark('preview', benchmarkResultPatch(result, performance.now() - benchmarkStarted));
-    await showImportProgress(4, file.name);
-    showImportPreview(result);
-    hideImportProgress();
-  } catch (err) {
-    finishBenchmark('failed', { error: formatImportError(err), totalMs: Math.round(performance.now() - benchmarkStarted) });
-    hideImportProgress('error');
-    if (isDebugMode()) console.error("PDF parse error:", err);
-    showNotification("Error parsing PDF: " + formatImportError(err), "error", 10000);
-  } finally {
-    if (!benchmarkFinished) finishBenchmark('stopped', { reason: benchmarkStage, totalMs: Math.round(performance.now() - benchmarkStarted) });
-  }
+  return handlePDFFileWorkflow(file, forceImageMode, preExtractedText);
 }
 
 // ═══════════════════════════════════════════════
@@ -938,70 +705,7 @@ export async function handleBatchPDFs(pdfFiles) {
 // IMAGE FILE IMPORT (JPG/PNG lab reports)
 // ═══════════════════════════════════════════════
 export async function handleImageFile(file) {
-  if (!hasAIProvider()) {
-    showAINeededDialog('image');
-    return;
-  }
-  // PII warning — images cannot be scrubbed
-  if (!await showConfirmDialog(
-    'This image will be sent directly to the configured AI server or provider. Personal details visible in the image cannot be scrubbed before upload. Continue?'
-  )) return;
-  const _startProfileId = state.currentProfile;
-  const benchmarkStarted = performance.now();
-  const benchmarkId = startImportBenchmark({ fileName: file.name, fileSize: file.size, importMode: 'image', pageCount: 1 });
-  try {
-    await showImportProgress(3, file.name);
-    const base64 = await new Promise((resolve, reject) => {
-      const reader = new FileReader();
-      reader.onload = () => resolve(String(reader.result || '').split(',')[1] || '');
-      reader.onerror = reject;
-      reader.readAsDataURL(file);
-    });
-    const mediaType = file.type || (file.name.match(/\.png$/i) ? 'image/png' : file.name.match(/\.webp$/i) ? 'image/webp' : 'image/jpeg');
-    const images = [{ base64, mediaType, page: 1 }];
-    const analysisStart = performance.now();
-    updateImportBenchmark(benchmarkId, { stage: 'analysis', pageCount: 1 }, { persist: false });
-    const result = await parseLabPDFWithAIImages(images, file.name, updateImportProgressPct);
-    const analysisMs = Math.round(performance.now() - analysisStart);
-    const analysisTime = Math.round(analysisMs / 1000);
-    if (isDebugMode()) console.log(`[Analysis] Image file parsed in ${analysisTime}s`);
-    result.privacyMethod = 'none (image mode)';
-    result.timings = { pii: 0, analysis: analysisTime, piiMs: 0, analysisMs };
-    const prov = result.provider || getAIProvider();
-    const mid = getActiveModelId();
-    const tokens = getUsageTokens(result.usage);
-    result.costInfo = {
-      provider: prov, modelId: mid,
-      inputTokens: tokens.inputTokens,
-      outputTokens: tokens.outputTokens,
-      cost: calculateCost(prov, mid, tokens.inputTokens, tokens.outputTokens)
-    };
-    trackUsage(prov, mid, tokens.inputTokens, tokens.outputTokens);
-    result.importHash = hashString(base64);
-    result.benchmarkId = benchmarkId;
-    captureImportBenchmarkReviewBaseline(result);
-    result._importProfileId = _startProfileId;
-    if (!result.date) showNotification("Could not find collection date in image", "error");
-    if (result.markers.length === 0) {
-      finishImportBenchmark(benchmarkId, 'no-markers', benchmarkResultPatch(result, performance.now() - benchmarkStarted));
-      hideImportProgress('error');
-      showNotification("No biomarkers found in image", "error");
-      return;
-    }
-    finishImportBenchmark(benchmarkId, 'preview', benchmarkResultPatch(result, performance.now() - benchmarkStarted));
-    await showImportProgress(4, file.name);
-    showImportPreview(result);
-    hideImportProgress();
-  } catch (err) {
-    finishImportBenchmark(benchmarkId, 'failed', {
-      stage: 'analysis',
-      error: formatImportError(err),
-      totalMs: Math.round(performance.now() - benchmarkStarted),
-    });
-    if (isDebugMode()) console.error('Image import error:', err);
-    hideImportProgress('error');
-    showNotification(`Import failed: ${formatImportError(err)}`, 'error');
-  }
+  return handleImageFileWorkflow(file);
 }
 
 // ═══════════════════════════════════════════════

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -7,6 +7,6 @@
   "viewRuntimeBridgeLookups": 0,
   "labStateAppFiles": 0,
   "labStateTestFiles": 0,
-  "largeJsFilesOver800Lines": 1,
-  "maxJsFileLines": 1026
+  "largeJsFilesOver800Lines": 0,
+  "maxJsFileLines": 799
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -203,6 +203,7 @@ const APP_SHELL = [
   '/js/image-utils.js',
   '/js/pdf-import.js',
   '/js/pdf-import-commit.js',
+  '/js/pdf-import-file-handlers.js',
   '/js/pdf-import-file-utils.js',
   '/js/pdf-import-spreadsheet.js',
   '/js/pdf-import-preflight.js',

--- a/tests/test-correctness-phase2.js
+++ b/tests/test-correctness-phase2.js
@@ -115,6 +115,7 @@ const pwaAppShellAssets = [
   '/js/import-drop-zone.js',
   '/js/pdf-import.js',
   '/js/pdf-import-commit.js',
+  '/js/pdf-import-file-handlers.js',
   '/js/pdf-import-file-utils.js',
   '/js/pdf-import-spreadsheet.js',
   '/js/pdf-import-preflight.js',

--- a/tests/test-image-utils.js
+++ b/tests/test-image-utils.js
@@ -168,12 +168,13 @@ assert('Image badge in renderChatMessages', chatRenderSrc.includes('chat-image-b
 assert('buildVisionContent used in sendChatMessage', chatSendSrc.includes('buildVisionContent(imageBlocks'));
 
 const pdfSrc = await fetchWithRetry('js/pdf-import.js');
+const pdfFileHandlersSrc = await fetchWithRetry('js/pdf-import-file-handlers.js');
 const pdfFileUtilsSrc = await fetchWithRetry('js/pdf-import-file-utils.js');
 assert('assessTextQuality in pdf-import', pdfSrc.includes('export function assessTextQuality'));
 assert('extractPDFImages in pdf-import', pdfSrc.includes('export async function extractPDFImages'));
 assert('parseLabPDFWithAIImages in pdf-import', pdfSrc.includes('export async function parseLabPDFWithAIImages'));
 assert('handleImageFile in pdf-import', pdfSrc.includes('export async function handleImageFile'));
-assert('Image mode dialog for poor text quality', pdfSrc.includes("_showImageModeDialog"));
+assert('Image mode dialog for poor text quality', pdfFileHandlersSrc.includes("_showImageModeDialog"));
 assert('PDF reads use FileReader fallback after Blob.arrayBuffer aborts',
   pdfFileUtilsSrc.includes('function readFileArrayBuffer') && pdfFileUtilsSrc.includes('new FileReader()'));
 assert('PDF text extraction uses resilient file read helper',

--- a/tests/test-modal-lifecycle-integrations.js
+++ b/tests/test-modal-lifecycle-integrations.js
@@ -51,6 +51,7 @@ const markerDetailSrc = [
   'marker-detail-custom-markers.js',
 ].map(file => fs.readFileSync(path.join(root, 'js', file), 'utf8')).join('\n');
 const pdfImportSrc = fs.readFileSync(path.join(root, 'js/pdf-import.js'), 'utf8');
+const pdfImportFileHandlersSrc = fs.readFileSync(path.join(root, 'js/pdf-import-file-handlers.js'), 'utf8');
 const pdfImportPreflightSrc = fs.readFileSync(path.join(root, 'js/pdf-import-preflight.js'), 'utf8');
 const pdfImportReviewSrc = fs.readFileSync(path.join(root, 'js/pdf-import-review.js'), 'utf8');
 const piiReviewSrc = fs.readFileSync(path.join(root, 'js/pii-review.js'), 'utf8');
@@ -386,13 +387,14 @@ assert('report builder, profile share, and dashboard widget picker use shared ov
 
 assert('PDF import dialogs and review modal use shared overlay lifecycle helpers',
   pdfImportSrc.includes("import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';") &&
+    pdfImportFileHandlersSrc.includes("import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';") &&
     pdfImportReviewSrc.includes("import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';") &&
     pdfImportSrc.includes("openModalOverlay(overlay, { initialFocus: '#ai-needed-or', focusDelay: 50 })") &&
-    pdfImportSrc.includes("openModalOverlay(overlay, { initialFocus: 'button', focusDelay: 50 })") &&
-    (pdfImportSrc.match(/closeModalOverlay\(overlay\)/g) || []).length >= 2 &&
+    pdfImportFileHandlersSrc.includes("openModalOverlay(overlay, { initialFocus: 'button', focusDelay: 50 })") &&
+    (`${pdfImportSrc}\n${pdfImportFileHandlersSrc}`.match(/closeModalOverlay\(overlay\)/g) || []).length >= 2 &&
     pdfImportReviewSrc.includes("closeModalOverlay('import-modal-overlay')") &&
     pdfImportReviewSrc.includes('openModalOverlay(overlay)') &&
-    [pdfImportSrc, pdfImportReviewSrc].every(src =>
+    [pdfImportSrc, pdfImportFileHandlersSrc, pdfImportReviewSrc].every(src =>
       !src.includes("overlay.classList.add('show')") &&
         !src.includes("overlay.classList.remove('show')") &&
         !src.includes("document.getElementById('import-modal-overlay')?.classList.remove('show')")) &&

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -218,6 +218,7 @@ const highValueCheckJsModules = [
   'js/marker-detail-custom-markers.js',
   'js/marker-detail-manual-entry.js',
   'js/pdf-import-commit.js',
+  'js/pdf-import-file-handlers.js',
   'js/pdf-import.js',
   'js/profile-data-migrations.js',
   'js/profile.js',

--- a/tests/test-v1-6-shipped.js
+++ b/tests/test-v1-6-shipped.js
@@ -444,6 +444,7 @@ const _origProfileSex = state ? state.profileSex : null;
   console.log('%c 15. PDF import inherits stream + request timeouts ', 'font-weight:bold;color:#0891b2');
   {
     const pdfSrc = await fetchSrc('js/pdf-import.js');
+    const pdfFileHandlersSrc = await fetchSrc('js/pdf-import-file-handlers.js');
     const pdfAiUtilsSrc = await fetchSrc('js/pdf-import-ai-utils.js');
     // PDF import calls callClaudeAPI through its AI helper, which routes
     // through _fetchWithRetry and the streaming helpers. We don't
@@ -465,7 +466,7 @@ const _origProfileSex = state ? state.profileSex : null;
       && /requestTimeoutMs:\s*AI_IMPORT_REQUEST_TIMEOUT_MS/.test(pdfAiUtilsSrc)
       && /parseLabPDFWithAI[\s\S]+?callImportAIWithStreamFallback/.test(pdfSrc));
     assert('pdf-import.js: catch path closes the import modal on error',
-      /catch\s*\([^)]+\)\s*\{[\s\S]{0,500}hideImportProgress\('error'\)/.test(pdfSrc));
+      /catch\s*\([^)]+\)\s*\{[\s\S]{0,500}hideImportProgress\('error'\)/.test(pdfFileHandlersSrc));
   }
 
   // ─── 16. v1.6.7 Sun-context warnings iterate the sparse array ──────

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -158,6 +158,7 @@
     '/js/charts-runtime.js',
     '/js/notes-runtime.js',
     '/js/pdf-import-review-runtime.js',
+    '/js/pdf-import-file-handlers.js',
     '/js/theme-runtime.js',
     '/js/tour-runtime.js',
     '/js/touch-tooltip-runtime.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -238,6 +238,7 @@
     "js/onboarding-view.js",
     "js/pdf-import-ai-utils.js",
     "js/pdf-import-commit.js",
+    "js/pdf-import-file-handlers.js",
     "js/pdf-import-file-utils.js",
     "js/pdf-import-marker-mapping.js",
     "js/pdf-import-marker-normalization.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -228,6 +228,7 @@
     "js/onboarding-view-runtime.js",
     "js/onboarding-view.js",
     "js/pdf-import-commit.js",
+    "js/pdf-import-file-handlers.js",
     "js/pdf-import.js",
     "js/pdf-import-marker-mapping.js",
     "js/pdf-import-marker-normalization.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.476';
+self.APP_VERSION = '1.10.477';


### PR DESCRIPTION
## Summary
- extract single-file PDF and image workflows into `pdf-import-file-handlers.js`
- preserve the `pdf-import.js` public facade while reducing it from 1,026 to 730 logical lines
- update offline caching, module/type-check contracts, architecture metadata, and version to 1.10.477
- ratchet the oversized-JS baseline from 1 file to 0 (largest remaining file: 799 lines)

## Focused verification
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run typecheck:strict-null`
- `npm run quality`
- `npm run architecture:check`
- `npm run production:check`
- `node tests/verify-modules.js`
- PDF/import source-contract test scripts
- `npm test -- tests/pdf-import-review-boundaries.test.js tests/service-worker-app-shell.test.js tests/import-file-input-runtime.test.js`
- `PORT=8139 npx playwright test tests/playwright/pdf-import-browser-coverage.spec.js --workers=1` (10 passed)
