### PR TITLE
Complete profile data cleanup lifecycle

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -9,9 +9,9 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 
 | Metric | Current |
 | --- | ---: |
-| Modules | 528 |
-| Internal import edges | 2367 |
-| Dynamic internal edges | 93 |
+| Modules | 529 |
+| Internal import edges | 2368 |
+| Dynamic internal edges | 88 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
 | Largest cyclic component | 0 |
@@ -46,9 +46,9 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 | [`js/api.js`](js/api.js) | 65 | [`js/chat-send.js`](js/chat-send.js) | 22 |
 | [`js/profile.js`](js/profile.js) | 47 | [`js/views.js`](js/views.js) | 22 |
 | [`js/schema.js`](js/schema.js) | 34 | [`js/wearables-connect.js`](js/wearables-connect.js) | 21 |
-| [`js/crypto.js`](js/crypto.js) | 29 | [`js/dashboard-view-composition.js`](js/dashboard-view-composition.js) | 20 |
+| [`js/crypto.js`](js/crypto.js) | 30 | [`js/dashboard-view-composition.js`](js/dashboard-view-composition.js) | 20 |
 | [`js/data-merge.js`](js/data-merge.js) | 29 | [`js/biology-scores.js`](js/biology-scores.js) | 19 |
-| [`js/constants.js`](js/constants.js) | 21 | [`js/export.js`](js/export.js) | 18 |
+| [`js/constants.js`](js/constants.js) | 21 | [`js/export.js`](js/export.js) | 17 |
 | [`js/utils-runtime.js`](js/utils-runtime.js) | 20 | [`js/lab-context.js`](js/lab-context.js) | 17 |
 | [`js/marker-analysis.js`](js/marker-analysis.js) | 19 | [`js/marker-detail-modal-impl.js`](js/marker-detail-modal-impl.js) | 17 |
 | [`js/chat-runtime.js`](js/chat-runtime.js) | 17 | [`js/sun.js`](js/sun.js) | 17 |
@@ -375,7 +375,7 @@ Native browser modules shipped with the static application.
 - [`js/export-report-html.js`](js/export-report-html.js) → [`js/export-report.js`](js/export-report.js), [`js/marker-analysis.js`](js/marker-analysis.js), [`js/state.js`](js/state.js), [`js/supplement-impact.js`](js/supplement-impact.js), [`js/utils.js`](js/utils.js)
 - [`js/export-report.js`](js/export-report.js) → [`js/api.js`](js/api.js), [`js/cycle.js`](js/cycle.js), [`js/data.js`](js/data.js), [`js/marker-analysis.js`](js/marker-analysis.js), [`js/profile.js`](js/profile.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/export-runtime.js`](js/export-runtime.js) → [`js/cashu-wallet.js`](js/cashu-wallet.js) *(dynamic)*, [`js/crypto.js`](js/crypto.js), [`js/state.js`](js/state.js)
-- [`js/export.js`](js/export.js) → [`js/biology-score-context-ai.js`](js/biology-score-context-ai.js) *(dynamic)*, [`js/caught-error.js`](js/caught-error.js), [`js/context-cards.js`](js/context-cards.js) *(dynamic)*, [`js/crypto.js`](js/crypto.js), [`js/cycle-store.js`](js/cycle-store.js) *(dynamic)*, [`js/data.js`](js/data.js), [`js/export-import.js`](js/export-import.js) *(dynamic)*, [`js/export-report-builder.js`](js/export-report-builder.js) *(dynamic)*, [`js/export-report-html.js`](js/export-report-html.js), [`js/export-report.js`](js/export-report.js), [`js/export-runtime.js`](js/export-runtime.js), [`js/lab-entry-mutations.js`](js/lab-entry-mutations.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/nostr-discovery.js`](js/nostr-discovery.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js), [`js/wearables-store.js`](js/wearables-store.js) *(dynamic)*
+- [`js/export.js`](js/export.js) → [`js/biology-score-context-ai.js`](js/biology-score-context-ai.js) *(dynamic)*, [`js/caught-error.js`](js/caught-error.js), [`js/context-cards.js`](js/context-cards.js) *(dynamic)*, [`js/crypto.js`](js/crypto.js), [`js/data.js`](js/data.js), [`js/export-import.js`](js/export-import.js) *(dynamic)*, [`js/export-report-builder.js`](js/export-report-builder.js) *(dynamic)*, [`js/export-report-html.js`](js/export-report-html.js), [`js/export-report.js`](js/export-report.js), [`js/export-runtime.js`](js/export-runtime.js), [`js/lab-entry-mutations.js`](js/lab-entry-mutations.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/nostr-discovery.js`](js/nostr-discovery.js), [`js/profile-storage-cleanup.js`](js/profile-storage-cleanup.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 
 </details>
 
@@ -643,7 +643,7 @@ Native browser modules shipped with the static application.
 
 </details>
 
-<details><summary><code>profile</code> family — 9 modules</summary>
+<details><summary><code>profile</code> family — 10 modules</summary>
 
 - [`js/profile-context.js`](js/profile-context.js) → [`js/context-source-registry.js`](js/context-source-registry.js), [`js/state.js`](js/state.js)
 - [`js/profile-data-migrations.js`](js/profile-data-migrations.js) → [`js/adapters.js`](js/adapters.js), [`js/context-source-registry.js`](js/context-source-registry.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/light-env-evening.js`](js/light-env-evening.js), [`js/profile-marker-migrations.js`](js/profile-marker-migrations.js), [`js/schema.js`](js/schema.js)
@@ -652,8 +652,9 @@ Native browser modules shipped with the static application.
 - [`js/profile-runtime.js`](js/profile-runtime.js) → [`js/chat-loader.js`](js/chat-loader.js), [`js/data.js`](js/data.js) *(dynamic)*, [`js/lab-context.js`](js/lab-context.js) *(dynamic)*, [`js/nav.js`](js/nav.js) *(dynamic)*, [`js/state.js`](js/state.js), [`js/views.js`](js/views.js) *(dynamic)*, [`js/wearables-connect.js`](js/wearables-connect.js) *(dynamic)*, [`js/wearables-manual.js`](js/wearables-manual.js) *(dynamic)*, [`js/wearables-summary.js`](js/wearables-summary.js) *(dynamic)*
 - [`js/profile-share-loader.js`](js/profile-share-loader.js) → [`js/profile-share.js`](js/profile-share.js) *(dynamic)*, [`js/utils-runtime.js`](js/utils-runtime.js), [`js/utils.js`](js/utils.js)
 - [`js/profile-share.js`](js/profile-share.js) → [`js/caught-error.js`](js/caught-error.js), [`js/export.js`](js/export.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils-runtime.js`](js/utils-runtime.js), [`js/utils.js`](js/utils.js)
+- [`js/profile-storage-cleanup.js`](js/profile-storage-cleanup.js) → [`js/blob-storage.js`](js/blob-storage.js), [`js/crypto.js`](js/crypto.js), [`js/cycle-store.js`](js/cycle-store.js) *(dynamic)*, [`js/profile-storage-key.js`](js/profile-storage-key.js), [`js/wearables-store.js`](js/wearables-store.js) *(dynamic)*
 - [`js/profile-storage-key.js`](js/profile-storage-key.js) → no in-scope imports
-- [`js/profile.js`](js/profile.js) → [`js/api.js`](js/api.js), [`js/blob-storage.js`](js/blob-storage.js) *(dynamic)*, [`js/constants.js`](js/constants.js), [`js/crypto.js`](js/crypto.js), [`js/cycle-store.js`](js/cycle-store.js) *(dynamic)*, [`js/profile-data-migrations.js`](js/profile-data-migrations.js), [`js/profile-storage-key.js`](js/profile-storage-key.js), [`js/state.js`](js/state.js), [`js/sync.js`](js/sync.js) *(dynamic)*, [`js/utils.js`](js/utils.js), [`js/wearables-store.js`](js/wearables-store.js) *(dynamic)*
+- [`js/profile.js`](js/profile.js) → [`js/api.js`](js/api.js), [`js/constants.js`](js/constants.js), [`js/crypto.js`](js/crypto.js), [`js/profile-data-migrations.js`](js/profile-data-migrations.js), [`js/profile-storage-cleanup.js`](js/profile-storage-cleanup.js), [`js/profile-storage-key.js`](js/profile-storage-key.js), [`js/state.js`](js/state.js), [`js/sync.js`](js/sync.js) *(dynamic)*, [`js/utils.js`](js/utils.js)
 
 </details>
 
@@ -888,7 +889,7 @@ Native browser modules shipped with the static application.
 - [`js/sync-state.js`](js/sync-state.js) → no in-scope imports
 - [`js/sync-storage-cleanup.js`](js/sync-storage-cleanup.js) → [`js/caught-error.js`](js/caught-error.js), [`js/data-merge.js`](js/data-merge.js), [`js/state.js`](js/state.js), [`js/sync-state.js`](js/sync-state.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-subscriptions.js`](js/sync-subscriptions.js) → no in-scope imports
-- [`js/sync-tombstones.js`](js/sync-tombstones.js) → [`js/crypto.js`](js/crypto.js), [`js/cycle-store.js`](js/cycle-store.js) *(dynamic)*, [`js/profile-storage-key.js`](js/profile-storage-key.js), [`js/state.js`](js/state.js), [`js/sync-payload.js`](js/sync-payload.js), [`js/utils.js`](js/utils.js), [`js/wearables-store.js`](js/wearables-store.js) *(dynamic)*
+- [`js/sync-tombstones.js`](js/sync-tombstones.js) → [`js/crypto.js`](js/crypto.js), [`js/profile-storage-cleanup.js`](js/profile-storage-cleanup.js), [`js/profile-storage-key.js`](js/profile-storage-key.js), [`js/state.js`](js/state.js), [`js/sync-payload.js`](js/sync-payload.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-ui.js`](js/sync-ui.js) → [`js/settings-runtime-bridge.js`](js/settings-runtime-bridge.js), [`js/sync-environment.js`](js/sync-environment.js), [`js/sync-relay-health.js`](js/sync-relay-health.js), [`js/sync-state.js`](js/sync-state.js), [`js/utils.js`](js/utils.js)
 - [`js/sync.js`](js/sync.js) → [`js/sync-actions.js`](js/sync-actions.js), [`js/sync-cutover.js`](js/sync-cutover.js), [`js/sync-diagnose-ui.js`](js/sync-diagnose-ui.js), [`js/sync-diagnostics.js`](js/sync-diagnostics.js), [`js/sync-environment.js`](js/sync-environment.js), [`js/sync-identity.js`](js/sync-identity.js), [`js/sync-init.js`](js/sync-init.js), [`js/sync-messenger.js`](js/sync-messenger.js), [`js/sync-relay-health.js`](js/sync-relay-health.js), [`js/sync-save-hooks.js`](js/sync-save-hooks.js), [`js/sync-settings-state.js`](js/sync-settings-state.js), [`js/sync-state.js`](js/sync-state.js), [`js/sync-storage-cleanup.js`](js/sync-storage-cleanup.js), [`js/sync-tombstones.js`](js/sync-tombstones.js), [`js/sync-ui.js`](js/sync-ui.js)
 

--- a/js/blob-storage.js
+++ b/js/blob-storage.js
@@ -76,7 +76,11 @@ export async function setBlob(key, value) {
   }));
 }
 
-export async function deleteBlob(key) {
+/**
+ * @param {string} key
+ * @param {{ throwOnError?: boolean }} [options]
+ */
+export async function deleteBlob(key, options = {}) {
   if (!_idbAvailable) return;
   try {
     const db = await _openDB();
@@ -89,7 +93,7 @@ export async function deleteBlob(key) {
     }));
   } catch (e) {
     console.warn('[blob-storage] deleteBlob failed:', getErrorMessage(e, e));
-    throw e;
+    if (options.throwOnError) throw e;
   }
 }
 

--- a/js/blob-storage.js
+++ b/js/blob-storage.js
@@ -89,7 +89,20 @@ export async function deleteBlob(key) {
     }));
   } catch (e) {
     console.warn('[blob-storage] deleteBlob failed:', getErrorMessage(e, e));
+    throw e;
   }
+}
+
+export async function getBlobKeys() {
+  if (!_idbAvailable) return [];
+  const db = await _openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const store = tx.objectStore(STORE_NAME);
+    const req = store.getAllKeys();
+    req.onsuccess = () => resolve((req.result || []).filter(key => typeof key === 'string'));
+    req.onerror = () => reject(req.error);
+  });
 }
 
 // Sum of stored blob sizes — for diagnostics. Walks all keys.
@@ -117,9 +130,11 @@ export async function getBlobStorageSize() {
 }
 
 // Detect which keys should be backed by IDB (vs localStorage).
-// Currently: any `*-imported` profile blob. Also routed: the legacy
-// pre-profile `labcharts-imported` key from very old installs (handled
-// by the same -imported suffix match).
+// Currently: any `*-imported` profile blob and its corrupt-recovery copy.
+// Also routed: the legacy pre-profile `labcharts-imported` key from very old
+// installs (handled by the same suffix match).
 export function shouldUseBlob(key) {
-  return _idbAvailable && typeof key === 'string' && key.endsWith('-imported');
+  return _idbAvailable
+    && typeof key === 'string'
+    && (key.endsWith('-imported') || key.endsWith('-imported-corrupt'));
 }

--- a/js/crypto.js
+++ b/js/crypto.js
@@ -87,6 +87,7 @@ export function configureCryptoProfileDeps(deps = {}) {
 // ═══════════════════════════════════════════════
 const SENSITIVE_PATTERNS = [
   /^labcharts-.+-imported$/,
+  /^labcharts-.+-imported-corrupt$/,
   /^labcharts-.+-chat$/,
   /^labcharts-.+-chat-threads$/,
   /^labcharts-.+-chat-t_.+$/,
@@ -359,9 +360,17 @@ export async function encryptedGetItem(key) {
 // keys are removed from BOTH backends. Use this for any cleanup path
 // that wipes profile data, otherwise IDB residue accumulates after
 // profile deletion / reset.
-export async function encryptedRemoveItem(key) {
+/**
+ * @param {string} key
+ * @param {{ throwOnBlobError?: boolean }} [options]
+ */
+export async function encryptedRemoveItem(key, options = {}) {
   if (shouldUseBlob(key)) {
-    try { await deleteBlob(key); } catch {}
+    try {
+      await deleteBlob(key);
+    } catch (error) {
+      if (options.throwOnBlobError) throw error;
+    }
   }
   try { localStorage.removeItem(key); } catch {}
 }
@@ -406,7 +415,10 @@ async function migrationProfileIds() {
 
 async function sensitiveBlobKeys() {
   const keys = new Set(['labcharts-imported']);
-  for (const profileId of await migrationProfileIds()) keys.add(profileStorageKey(profileId, 'imported'));
+  for (const profileId of await migrationProfileIds()) {
+    keys.add(profileStorageKey(profileId, 'imported'));
+    keys.add(profileStorageKey(profileId, 'imported-corrupt'));
+  }
   return [...keys];
 }
 

--- a/js/crypto.js
+++ b/js/crypto.js
@@ -367,7 +367,7 @@ export async function encryptedGetItem(key) {
 export async function encryptedRemoveItem(key, options = {}) {
   if (shouldUseBlob(key)) {
     try {
-      await deleteBlob(key);
+      await deleteBlob(key, { throwOnError: options.throwOnBlobError });
     } catch (error) {
       if (options.throwOnBlobError) throw error;
     }

--- a/js/export.js
+++ b/js/export.js
@@ -5,8 +5,9 @@ import { getErrorMessage } from './caught-error.js';
 import { state } from './state.js';
 import { showNotification, showConfirmDialog } from './utils.js';
 import { saveImportedData, updateHeaderDates } from './data.js';
-import { getProfiles, profileStorageKey, saveProfiles, migrateProfileData } from './profile.js';
-import { encryptedGetItem, getEncryptionEnabled, encryptedRemoveItem } from './crypto.js';
+import { createDefaultProfileData, getProfiles, profileStorageKey, saveProfiles, migrateProfileData } from './profile.js';
+import { encryptedGetItem, encryptedRemoveItem } from './crypto.js';
+import { clearProfileStorage, listStoredProfileIds } from './profile-storage-cleanup.js';
 import { findOrCreateLabEntry } from './lab-entry-mutations.js';
 import { setLabEntryMarker } from './lab-entry.js';
 import { getSelectedNodeUrl } from './nostr-discovery.js';
@@ -424,54 +425,21 @@ export async function clearAllData() {
     ? `Clear ALL data across ${profiles.length} profiles, including the Cashu wallet balance and seed? This cannot be undone.`
     : 'Clear all imported data, including the Cashu wallet balance and seed? This cannot be undone.';
   if (await showConfirmDialog(msg)) {
-    // Wipe storage for every profile
-    for (const p of profiles) {
-      const id = p.id;
-      // The `-imported` blob lives in IndexedDB now → encryptedRemoveItem
-      // hits both backends so the IDB residue is also wiped.
-      await encryptedRemoveItem(profileStorageKey(id, 'imported'));
-      await encryptedRemoveItem(profileStorageKey(id, 'imported-corrupt'));
-      localStorage.removeItem(profileStorageKey(id, 'units'));
-      localStorage.removeItem(profileStorageKey(id, 'suppOverlay'));
-      localStorage.removeItem(profileStorageKey(id, 'noteOverlay'));
-      localStorage.removeItem(profileStorageKey(id, 'rangeMode'));
-      localStorage.removeItem(profileStorageKey(id, 'suppImpact'));
-      localStorage.removeItem(`labcharts-${id}-chat`);
-      let threadIndexRaw;
-      if (getEncryptionEnabled()) {
-        try { threadIndexRaw = await encryptedGetItem(`labcharts-${id}-chat-threads`); } catch { threadIndexRaw = null; }
-      } else {
-        threadIndexRaw = localStorage.getItem(`labcharts-${id}-chat-threads`);
+    try {
+      const profileIds = await listStoredProfileIds(profiles.map(profile => profile.id));
+      for (const id of profileIds) {
+        await clearProfileStorage(id);
       }
-      if (threadIndexRaw) {
-        try { for (const t of JSON.parse(threadIndexRaw)) localStorage.removeItem(`labcharts-${id}-chat-t_${t.id}`); } catch {}
-        localStorage.removeItem(`labcharts-${id}-chat-threads`);
-      }
-      localStorage.removeItem(`labcharts-${id}-chatRailOpen`);
-      localStorage.removeItem(`labcharts-${id}-chatPersonality`);
-      localStorage.removeItem(`labcharts-${id}-chatPersonalityCustom`);
-      localStorage.removeItem(`labcharts-${id}-focusCard`);
-      localStorage.removeItem(`labcharts-${id}-contextHealth`);
-      localStorage.removeItem(`labcharts-${id}-onboarded`);
-      localStorage.removeItem(`labcharts-${id}-emptyTour`);
-      localStorage.removeItem(`labcharts-${id}-tour`);
-      localStorage.removeItem(`labcharts-${id}-cycleTour`);
-      localStorage.removeItem(`labcharts-${id}-phaseOverlay`);
-      localStorage.removeItem(`labcharts-${id}-sync-ts`);
-      try {
-        const { deleteWearablesDB } = await import('./wearables-store.js');
-        await deleteWearablesDB(id);
-      } catch {}
-      try {
-        const { deleteCycleDB } = await import('./cycle-store.js');
-        await deleteCycleDB(id);
-      } catch {}
+    } catch (error) {
+      console.warn('[export] Clear-all profile cleanup failed:', error);
+      showNotification('Could not clear all profile data. Close other Get Based tabs and try again.', 'error', 8000);
+      return;
     }
     // Reset to single default profile
     const defaultId = profiles[0]?.id || 'default';
     const defaultName = profiles[0]?.name || 'Profile 1';
-    saveProfiles([{ id: defaultId, name: defaultName, sex: null, dob: null, location: { country: '', zip: '' }, tags: [], notes: '', status: 'active', avatar: null, height: null, heightUnit: 'cm', createdAt: Date.now(), lastUpdated: Date.now(), pinned: false }]);
-    state.importedData = { entries: [], notes: [], supplements: [], healthGoals: [], diagnoses: null, diet: null, exercise: null, sleepRest: null, lightCircadian: null, stress: null, loveLife: null, environment: null, interpretiveLens: '', contextNotes: '', customMarkers: {}, refOverrides: {}, menstrualCycle: null, emfAssessment: null, genetics: null, biometrics: null, markerNotes: {}, markerValueNotes: {}, biologyScoreAI: {}, contextSourceSettings: {}, changeHistory: [], importSnapshots: [] };
+    await saveProfiles([{ id: defaultId, name: defaultName, sex: null, dob: null, location: { country: '', zip: '' }, tags: [], notes: '', status: 'active', avatar: null, height: null, heightUnit: 'cm', createdAt: Date.now(), lastUpdated: Date.now(), pinned: false }]);
+    state.importedData = createDefaultProfileData();
     state.currentProfile = defaultId;
     localStorage.setItem('labcharts-active-profile', defaultId);
     // Clear Cashu wallet database

--- a/js/profile-storage-cleanup.js
+++ b/js/profile-storage-cleanup.js
@@ -1,0 +1,128 @@
+// @ts-check
+// profile-storage-cleanup.js — complete profile-scoped browser storage cleanup.
+
+import { encryptedRemoveItem } from './crypto.js';
+import { getBlobKeys } from './blob-storage.js';
+import { profileStorageKey } from './profile-storage-key.js';
+
+const PROFILE_ID_RE = /^[A-Za-z0-9_-]{1,128}$/;
+const PROFILE_BLOB_KEY_RE = /^labcharts-([A-Za-z0-9_-]{1,128})-imported(?:-corrupt)?$/;
+const PROFILE_DATABASE_RE = /^labcharts-(?:wearables|cycle)-([A-Za-z0-9_-]{1,128})$/;
+const ALTERNATE_LOCAL_PREFIXES = [
+  'labcharts-onboard-provider-skipped-',
+  'labcharts-onboard-extras-done-',
+  'labcharts-onboard-context-cards-skipped-',
+  'labcharts-onboard-context-cards-done-',
+  'labcharts-chat-nudge-dismissed-',
+  'labcharts-wearable-stub-dismissed-',
+  'labcharts-tombstone-pending-',
+];
+
+const cleanupDeps = {
+  encryptedRemoveItem,
+  getBlobKeys,
+  getDatabaseNames: async () => {
+    if (typeof indexedDB === 'undefined' || typeof indexedDB.databases !== 'function') return [];
+    const databases = await indexedDB.databases();
+    return databases.map(database => database.name).filter(name => typeof name === 'string');
+  },
+  deleteWearablesDB: async (profileId) => {
+    if (typeof indexedDB === 'undefined') return;
+    const store = await import('./wearables-store.js');
+    await store.deleteWearablesDB(profileId);
+  },
+  deleteCycleDB: async (profileId) => {
+    if (typeof indexedDB === 'undefined') return;
+    const store = await import('./cycle-store.js');
+    await store.deleteCycleDB(profileId);
+  },
+};
+
+export function configureProfileStorageCleanupDeps(deps = {}) {
+  const previous = { ...cleanupDeps };
+  for (const key of Object.keys(cleanupDeps)) {
+    if (typeof deps[key] === 'function') cleanupDeps[key] = deps[key];
+  }
+  return previous;
+}
+
+function storageKeys(storage) {
+  const keys = [];
+  if (!storage) return keys;
+  for (let i = 0; i < storage.length; i++) {
+    const key = storage.key(i);
+    if (key) keys.push(key);
+  }
+  return keys;
+}
+
+function addProfileId(ids, value) {
+  if (typeof value === 'string' && PROFILE_ID_RE.test(value)) ids.add(value);
+}
+
+function addProfileIdFromBlobKey(ids, key) {
+  const match = typeof key === 'string' ? key.match(PROFILE_BLOB_KEY_RE) : null;
+  if (match) addProfileId(ids, match[1]);
+}
+
+function addProfileIdFromDatabaseName(ids, name) {
+  const match = typeof name === 'string' ? name.match(PROFILE_DATABASE_RE) : null;
+  if (match) addProfileId(ids, match[1]);
+}
+
+export async function listStoredProfileIds(seedIds = []) {
+  const ids = new Set();
+  for (const id of seedIds) addProfileId(ids, id);
+  for (const key of storageKeys(globalThis.localStorage)) addProfileIdFromBlobKey(ids, key);
+  for (const key of await cleanupDeps.getBlobKeys()) addProfileIdFromBlobKey(ids, key);
+  for (const name of await cleanupDeps.getDatabaseNames()) addProfileIdFromDatabaseName(ids, name);
+  return [...ids];
+}
+
+function clearProfileLocalKeys(profileId) {
+  const storage = globalThis.localStorage;
+  const standardPrefix = `labcharts-${profileId}-`;
+  const alternateKeys = new Set(ALTERNATE_LOCAL_PREFIXES.map(prefix => `${prefix}${profileId}`));
+  for (const key of storageKeys(storage)) {
+    if (key.startsWith(standardPrefix) || alternateKeys.has(key)) {
+      storage.removeItem(key);
+    }
+  }
+}
+
+function clearProfileSessionKeys(profileId) {
+  const storage = globalThis.sessionStorage;
+  for (const key of storageKeys(storage)) {
+    if (key.startsWith('chat-onboard-') && key.endsWith(`-${profileId}`)) {
+      storage.removeItem(key);
+    }
+  }
+}
+
+export async function clearProfileStorage(profileId) {
+  if (!PROFILE_ID_RE.test(profileId || '')) throw new Error('Invalid profile id for storage cleanup.');
+
+  // Delete dedicated databases first. If another tab blocks either delete,
+  // leave the canonical profile/localStorage records intact so the user can
+  // close the tab and retry instead of seeing a false-success deletion.
+  await Promise.all([
+    cleanupDeps.deleteWearablesDB(profileId),
+    cleanupDeps.deleteCycleDB(profileId),
+  ]);
+
+  await Promise.all([
+    cleanupDeps.encryptedRemoveItem(
+      profileStorageKey(profileId, 'imported'),
+      { throwOnBlobError: true },
+    ),
+    cleanupDeps.encryptedRemoveItem(
+      profileStorageKey(profileId, 'imported-corrupt'),
+      { throwOnBlobError: true },
+    ),
+  ]);
+
+  // Prefix cleanup covers chat messages even when an encrypted/corrupt thread
+  // index cannot be parsed, plus new profile-scoped keys added in the future.
+  clearProfileLocalKeys(profileId);
+  clearProfileSessionKeys(profileId);
+}

--- a/js/profile.js
+++ b/js/profile.js
@@ -5,9 +5,10 @@ import { state } from './state.js';
 import { COUNTRY_LATITUDES, LATITUDE_BANDS } from './constants.js';
 import { callClaudeAPI } from './api.js';
 import { isDebugMode, showConfirmDialog, showNotification } from './utils.js';
-import { encryptedSetItem, encryptedGetItem, encryptedRemoveItem } from './crypto.js';
+import { encryptedSetItem, encryptedGetItem, getEncryptionEnabled, isUnlocked } from './crypto.js';
 import { migrateProfileData } from './profile-data-migrations.js';
 import { profileStorageKey } from './profile-storage-key.js';
+import { clearProfileStorage } from './profile-storage-cleanup.js';
 
 export { migrateProfileData, profileStorageKey };
 
@@ -305,39 +306,43 @@ export async function loadProfile(profileId) {
   await invalidateProfileContextCache();
   const savedImported = await encryptedGetItem(profileStorageKey(profileId, 'imported'));
   const defaultData = createDefaultProfileData();
-  state.importedData = savedImported ? (function() {
+  state.importedData = defaultData;
+  if (savedImported) {
     try {
       const d = JSON.parse(savedImported);
       if (!d.notes) d.notes = [];
       if (!d.supplements) d.supplements = [];
-      return migrateProfileData(d);
+      state.importedData = migrateProfileData(d);
     } catch (e) {
       // Don't silently substitute defaults — preserve the corrupted bytes so
       // the user can recover (or we can debug). Same key suffix every time
       // so a second corruption doesn't shadow the first recoverable copy.
-      // Route through IDB when the blob is large (the very condition that
-      // commonly triggers the corruption); fall back to localStorage otherwise.
-      // Fire-and-forget — the IIFE this catch lives in is sync, so we kick
-      // the IDB write off via Promise chain rather than awaiting it here.
+      // The recovery key is sensitive and blob-backed, so encryptedSetItem
+      // preserves the at-rest guarantee and removes any legacy localStorage
+      // duplicate only after IndexedDB has the canonical copy.
+      let recoverySaved = false;
       try {
         const corruptKey = profileStorageKey(profileId, 'imported-corrupt');
-        if (!localStorage.getItem(corruptKey)) {
-          if (savedImported.length < 4_000_000) {
-            try { localStorage.setItem(corruptKey, savedImported); }
-            catch { /* fall through to IDB */ }
+        const existingRecovery = await encryptedGetItem(corruptKey);
+        if (existingRecovery === null) {
+          if (getEncryptionEnabled() && !isUnlocked()) {
+            throw new Error('Encryption key is locked; refusing a plaintext recovery write.');
           }
-          import('./blob-storage.js').then(async ({ setBlob, getBlob }) => {
-            const existing = await getBlob(corruptKey).catch(() => null);
-            if (!existing) await setBlob(corruptKey, savedImported);
-          }).catch(() => {});
+          await encryptedSetItem(corruptKey, savedImported);
         }
-      } catch {}
-      // Surface to the user via the global notification system if available;
-      // fall back to console so headless paths still log it.
-      profileDeps.showNotification('Profile data was corrupted and could not be loaded. The original bytes were saved as a backup — open Settings → Data to export them or contact support.', 'error', 12000);
-      return defaultData;
+        recoverySaved = true;
+      } catch (recoveryError) {
+        console.warn('[profile] Could not preserve corrupt profile bytes:', recoveryError);
+      }
+      profileDeps.showNotification(
+        recoverySaved
+          ? 'Profile data was corrupted and could not be loaded. The original bytes were saved as a recovery copy. Contact support before making more changes.'
+          : 'Profile data was corrupted and could not be loaded, and the recovery copy could not be saved. Contact support before making more changes.',
+        'error',
+        12000,
+      );
     }
-  })() : defaultData;
+  }
   const savedUnits = localStorage.getItem(profileStorageKey(profileId, 'units'));
   state.unitSystem = savedUnits === 'US' ? 'US' : 'EU';
   const savedRange = localStorage.getItem(profileStorageKey(profileId, 'rangeMode'));
@@ -449,43 +454,14 @@ export async function deleteProfile(profileId, onComplete) {
   if (profiles.length <= 1) { profileDeps.showNotification("Cannot delete the last profile", "error"); return; }
   if (await profileDeps.showConfirmDialog('Delete this profile and all its data? This cannot be undone.')) {
     const updated = profiles.filter(p => p.id !== profileId);
-    await saveProfiles(updated);
-    // The `-imported` blob lives in IndexedDB now → encryptedRemoveItem
-    // hits both backends so the IDB residue is also wiped.
-    await encryptedRemoveItem(profileStorageKey(profileId, 'imported'));
-    localStorage.removeItem(profileStorageKey(profileId, 'units'));
-    localStorage.removeItem(profileStorageKey(profileId, 'suppOverlay'));
-    localStorage.removeItem(profileStorageKey(profileId, 'noteOverlay'));
-    localStorage.removeItem(profileStorageKey(profileId, 'rangeMode'));
-    localStorage.removeItem(profileStorageKey(profileId, 'showAltUnits'));
-    localStorage.removeItem(profileStorageKey(profileId, 'suppImpact'));
-    localStorage.removeItem(`labcharts-${profileId}-chat`);
-    // Remove thread index + all per-thread message keys
-    const threadIndexRaw = localStorage.getItem(`labcharts-${profileId}-chat-threads`);
-    if (threadIndexRaw) {
-      try {
-        const threads = JSON.parse(threadIndexRaw);
-        for (const t of threads) {
-          localStorage.removeItem(`labcharts-${profileId}-chat-t_${t.id}`);
-        }
-      } catch {}
-      localStorage.removeItem(`labcharts-${profileId}-chat-threads`);
+    try {
+      await clearProfileStorage(profileId);
+    } catch (error) {
+      console.warn('[profile] Profile cleanup failed:', error);
+      profileDeps.showNotification('Could not delete all profile data. Close other Get Based tabs and try again.', 'error', 8000);
+      return;
     }
-    localStorage.removeItem(`labcharts-${profileId}-chatRailOpen`);
-    localStorage.removeItem(`labcharts-${profileId}-chatPersonality`);
-    localStorage.removeItem(`labcharts-${profileId}-chatPersonalityCustom`);
-    localStorage.removeItem(`labcharts-${profileId}-focusCard`);
-    localStorage.removeItem(`labcharts-${profileId}-contextHealth`);
-    localStorage.removeItem(`labcharts-${profileId}-onboarded`);
-    localStorage.removeItem(`labcharts-${profileId}-emptyTour`);
-    localStorage.removeItem(`labcharts-${profileId}-tour`);
-    localStorage.removeItem(`labcharts-${profileId}-cycleTour`);
-    localStorage.removeItem(`labcharts-${profileId}-phaseOverlay`);
-    // Wearable per-profile IDB (`labcharts-wearables-${profileId}`) lives
-    // outside localStorage. Drop it too so deleted profiles don't leak 90d
-    // of HRV/sleep/RHR + manual entries onto disk indefinitely.
-    import('./wearables-store.js').then(m => m.deleteWearablesDB(profileId)).catch(() => {});
-    import('./cycle-store.js').then(m => m.deleteCycleDB(profileId)).catch(() => {});
+    await saveProfiles(updated);
     // Propagate the delete to the relay so other devices stop seeing this
     // profile. Without this, a paired device pulling later would resurrect
     // the profile (the Evolu row's dataJson outlives our local wipe).

--- a/js/sync-tombstones.js
+++ b/js/sync-tombstones.js
@@ -4,8 +4,9 @@
 import { state } from './state.js';
 import { showNotification } from './utils.js';
 import { profileStorageKey } from './profile-storage-key.js';
-import { getEncryptionEnabled, encryptedGetItem, encryptedRemoveItem } from './crypto.js';
+import { getEncryptionEnabled, encryptedGetItem } from './crypto.js';
 import { parseSyncPayload } from './sync-payload.js';
+import { clearProfileStorage } from './profile-storage-cleanup.js';
 
 /** @type {() => any} */
 let _getEvolu = () => null;
@@ -94,34 +95,7 @@ const TOMBSTONE_BATCH_THRESHOLD = 2; // two or more tombstones at once require c
 
 /** @param {string} profileId */
 async function wipeProfileLocal(profileId) {
-  await encryptedRemoveItem(profileStorageKey(profileId, 'imported'));
-  for (const key of ['units', 'suppOverlay', 'noteOverlay', 'rangeMode', 'showAltUnits', 'suppImpact']) {
-    localStorage.removeItem(profileStorageKey(profileId, key));
-  }
-  const threadIndexRaw = localStorage.getItem(`labcharts-${profileId}-chat-threads`);
-  if (threadIndexRaw) {
-    try {
-      const threads = JSON.parse(threadIndexRaw);
-      for (const t of threads || []) {
-        if (t?.id) localStorage.removeItem(`labcharts-${profileId}-chat-t_${t.id}`);
-      }
-    } catch {}
-  }
-  for (const key of [
-    'chat', 'chat-threads', 'chatRailOpen', 'chatPersonality',
-    'chatPersonalityCustom', 'focusCard', 'contextHealth', 'onboarded',
-    'emptyTour', 'tour', 'cycleTour', 'phaseOverlay', 'sync-ts',
-  ]) {
-    localStorage.removeItem(`labcharts-${profileId}-${key}`);
-  }
-  try {
-    const wsMod = await import('./wearables-store.js');
-    await wsMod.deleteWearablesDB(profileId).catch(() => {});
-  } catch {}
-  try {
-    const cycleMod = await import('./cycle-store.js');
-    await cycleMod.deleteCycleDB(profileId).catch(() => {});
-  } catch {}
+  await clearProfileStorage(profileId);
 }
 
 // Soft-delete a profile's row on the relay so other devices stop seeing it.

--- a/service-worker.js
+++ b/service-worker.js
@@ -146,6 +146,7 @@ const APP_SHELL = [
   '/js/profile-fatty-acid-migrations.js',
   '/js/profile-marker-migrations.js',
   '/js/profile-storage-key.js',
+  '/js/profile-storage-cleanup.js',
   '/js/profile.js',
   '/js/profile-runtime.js',
   '/js/profile-share.js',

--- a/tests/profile-corrupt-recovery.test.js
+++ b/tests/profile-corrupt-recovery.test.js
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { deleteBlob, getBlob, setBlob } from '../js/blob-storage.js';
+import {
+  _setTestSessionKey,
+  encryptedSetItem,
+} from '../js/crypto.js';
+import {
+  configureProfileDeps,
+  configureProfileRuntimeDeps,
+  loadProfile,
+} from '../js/profile.js';
+import { state } from '../js/state.js';
+
+const PROFILE_ID = 'corrupt-recovery';
+const IMPORTED_KEY = `labcharts-${PROFILE_ID}-imported`;
+const CORRUPT_KEY = `labcharts-${PROFILE_ID}-imported-corrupt`;
+
+let previousProfileDeps;
+let previousRuntimeDeps;
+let previousState;
+let previousActiveProfile;
+let previousEncryptionEnabled;
+let showNotification;
+
+beforeEach(async () => {
+  previousState = {
+    currentProfile: state.currentProfile,
+    importedData: state.importedData,
+  };
+  previousActiveProfile = localStorage.getItem('labcharts-active-profile');
+  previousEncryptionEnabled = localStorage.getItem('labcharts-encryption-enabled');
+  localStorage.removeItem('labcharts-encryption-enabled');
+  globalThis.__WEARABLES_TEST = true;
+  await _setTestSessionKey(null);
+  await Promise.all([deleteBlob(IMPORTED_KEY), deleteBlob(CORRUPT_KEY)]);
+  localStorage.removeItem(IMPORTED_KEY);
+  localStorage.removeItem(CORRUPT_KEY);
+  showNotification = vi.fn();
+  previousProfileDeps = configureProfileDeps({ showNotification });
+  previousRuntimeDeps = configureProfileRuntimeDeps({
+    invalidateProfileContextCache: async () => {},
+    reloadProfileRuntimeShell: async () => {},
+    refreshProfileWearables: () => {},
+  });
+});
+
+afterEach(async () => {
+  configureProfileDeps(previousProfileDeps);
+  configureProfileRuntimeDeps(previousRuntimeDeps);
+  state.currentProfile = previousState.currentProfile;
+  state.importedData = previousState.importedData;
+  if (previousActiveProfile === null) localStorage.removeItem('labcharts-active-profile');
+  else localStorage.setItem('labcharts-active-profile', previousActiveProfile);
+  if (previousEncryptionEnabled === null) localStorage.removeItem('labcharts-encryption-enabled');
+  else localStorage.setItem('labcharts-encryption-enabled', previousEncryptionEnabled);
+  await _setTestSessionKey(null);
+  delete globalThis.__WEARABLES_TEST;
+  await Promise.all([deleteBlob(IMPORTED_KEY), deleteBlob(CORRUPT_KEY)]);
+  localStorage.removeItem(IMPORTED_KEY);
+  localStorage.removeItem(CORRUPT_KEY);
+});
+
+describe('corrupt profile recovery', () => {
+  it('awaits a blob-backed recovery copy and never leaves a localStorage duplicate', async () => {
+    const malformed = '{"entries":[';
+    await encryptedSetItem(IMPORTED_KEY, malformed);
+
+    await loadProfile(PROFILE_ID);
+
+    expect(await getBlob(CORRUPT_KEY)).toBe(malformed);
+    expect(localStorage.getItem(CORRUPT_KEY)).toBeNull();
+    expect(state.importedData.entries).toEqual([]);
+    expect(showNotification).toHaveBeenCalledWith(
+      expect.stringContaining('saved as a recovery copy'),
+      'error',
+      12000,
+    );
+  });
+
+  it('preserves the first recovery copy when later data is also malformed', async () => {
+    await encryptedSetItem(CORRUPT_KEY, 'first recoverable bytes');
+    await encryptedSetItem(IMPORTED_KEY, '{"newer":');
+
+    await loadProfile(PROFILE_ID);
+
+    expect(await getBlob(CORRUPT_KEY)).toBe('first recoverable bytes');
+  });
+
+  it('refuses to write malformed plaintext while encryption is enabled but locked', async () => {
+    await setBlob(IMPORTED_KEY, '{"locked":');
+    localStorage.setItem('labcharts-encryption-enabled', 'true');
+
+    await loadProfile(PROFILE_ID);
+
+    expect(await getBlob(CORRUPT_KEY)).toBeNull();
+    expect(localStorage.getItem(CORRUPT_KEY)).toBeNull();
+    expect(showNotification).toHaveBeenCalledWith(
+      expect.stringContaining('recovery copy could not be saved'),
+      'error',
+      12000,
+    );
+  });
+});

--- a/tests/profile-storage-cleanup.test.js
+++ b/tests/profile-storage-cleanup.test.js
@@ -1,0 +1,174 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  clearProfileStorage,
+  configureProfileStorageCleanupDeps,
+  listStoredProfileIds,
+} from '../js/profile-storage-cleanup.js';
+
+let previousDeps;
+
+beforeEach(() => {
+  localStorage.clear();
+  sessionStorage.clear();
+  previousDeps = configureProfileStorageCleanupDeps({
+    encryptedRemoveItem: async key => {
+      localStorage.removeItem(key);
+    },
+    getBlobKeys: async () => [],
+    getDatabaseNames: async () => [],
+    deleteWearablesDB: async () => {},
+    deleteCycleDB: async () => {},
+  });
+});
+
+afterEach(() => {
+  configureProfileStorageCleanupDeps(previousDeps);
+  localStorage.clear();
+  sessionStorage.clear();
+});
+
+describe('profile storage cleanup', () => {
+  it('awaits dedicated database deletion and removes every profile-scoped key', async () => {
+    const events = [];
+    const encryptedRemoveItem = vi.fn(async key => {
+      await Promise.resolve();
+      events.push(`blob:${key}`);
+      localStorage.removeItem(key);
+    });
+    const deleteWearablesDB = vi.fn(async profileId => {
+      await Promise.resolve();
+      events.push(`wearables:${profileId}`);
+    });
+    const deleteCycleDB = vi.fn(async profileId => {
+      await Promise.resolve();
+      events.push(`cycle:${profileId}`);
+    });
+    configureProfileStorageCleanupDeps({
+      encryptedRemoveItem,
+      deleteWearablesDB,
+      deleteCycleDB,
+    });
+
+    const profileId = 'target-profile';
+    const targetKeys = [
+      `labcharts-${profileId}-imported`,
+      `labcharts-${profileId}-imported-corrupt`,
+      `labcharts-${profileId}-units`,
+      `labcharts-${profileId}-showAltUnits`,
+      `labcharts-${profileId}-chat-threads`,
+      `labcharts-${profileId}-chat-t_orphan`,
+      `labcharts-${profileId}-ai-ctx-summary`,
+      `labcharts-${profileId}-delta-last-sync`,
+      `labcharts-${profileId}-sync-ts`,
+      `labcharts-onboard-provider-skipped-${profileId}`,
+      `labcharts-onboard-extras-done-${profileId}`,
+      `labcharts-onboard-context-cards-skipped-${profileId}`,
+      `labcharts-onboard-context-cards-done-${profileId}`,
+      `labcharts-chat-nudge-dismissed-${profileId}`,
+      `labcharts-wearable-stub-dismissed-${profileId}`,
+      `labcharts-tombstone-pending-${profileId}`,
+    ];
+    for (const key of targetKeys) localStorage.setItem(key, 'private');
+    localStorage.setItem('labcharts-other-profile-chat-t_keep', 'keep');
+    sessionStorage.setItem(`chat-onboard-intro-${profileId}`, 'private');
+    sessionStorage.setItem('chat-onboard-intro-other-profile', 'keep');
+
+    await clearProfileStorage(profileId);
+
+    expect(deleteWearablesDB).toHaveBeenCalledWith(profileId);
+    expect(deleteCycleDB).toHaveBeenCalledWith(profileId);
+    expect(encryptedRemoveItem.mock.calls.map(([key]) => key)).toEqual([
+      `labcharts-${profileId}-imported`,
+      `labcharts-${profileId}-imported-corrupt`,
+    ]);
+    expect(events.slice(0, 2).sort()).toEqual([
+      `cycle:${profileId}`,
+      `wearables:${profileId}`,
+    ]);
+    for (const key of targetKeys) expect(localStorage.getItem(key), key).toBeNull();
+    expect(sessionStorage.getItem(`chat-onboard-intro-${profileId}`)).toBeNull();
+    expect(localStorage.getItem('labcharts-other-profile-chat-t_keep')).toBe('keep');
+    expect(sessionStorage.getItem('chat-onboard-intro-other-profile')).toBe('keep');
+  });
+
+  it('keeps canonical local data when a dedicated database deletion is blocked', async () => {
+    const encryptedRemoveItem = vi.fn();
+    configureProfileStorageCleanupDeps({
+      encryptedRemoveItem,
+      deleteWearablesDB: async () => {
+        throw new Error('blocked by another tab');
+      },
+      deleteCycleDB: async () => {},
+    });
+    localStorage.setItem('labcharts-blocked-imported', 'keep-until-retry');
+    localStorage.setItem('labcharts-blocked-units', 'US');
+
+    await expect(clearProfileStorage('blocked')).rejects.toThrow('blocked by another tab');
+
+    expect(encryptedRemoveItem).not.toHaveBeenCalled();
+    expect(localStorage.getItem('labcharts-blocked-imported')).toBe('keep-until-retry');
+    expect(localStorage.getItem('labcharts-blocked-units')).toBe('US');
+  });
+
+  it('keeps local keys and rejects when canonical blob deletion fails', async () => {
+    const encryptedRemoveItem = vi.fn(async (_key, options) => {
+      expect(options).toEqual({ throwOnBlobError: true });
+      throw new Error('blob deletion failed');
+    });
+    configureProfileStorageCleanupDeps({ encryptedRemoveItem });
+    localStorage.setItem('labcharts-blob-failure-imported', 'keep-until-retry');
+    localStorage.setItem('labcharts-blob-failure-chat-t_orphan', 'keep-until-retry');
+
+    await expect(clearProfileStorage('blob-failure')).rejects.toThrow('blob deletion failed');
+
+    expect(localStorage.getItem('labcharts-blob-failure-imported')).toBe('keep-until-retry');
+    expect(localStorage.getItem('labcharts-blob-failure-chat-t_orphan')).toBe('keep-until-retry');
+  });
+
+  it('discovers orphaned imported blobs without accepting malformed IDs', async () => {
+    configureProfileStorageCleanupDeps({
+      getBlobKeys: async () => [
+        'labcharts-idb-orphan-imported-corrupt',
+        'labcharts-idb-regular-imported',
+        'labcharts-invalid.profile-imported',
+        'third-party-imported',
+      ],
+      getDatabaseNames: async () => [
+        'labcharts-wearables-wearable-orphan',
+        'labcharts-cycle-cycle-orphan',
+        'labcharts-backups',
+        'third-party-database',
+      ],
+    });
+    localStorage.setItem('labcharts-local-orphan-imported', '{}');
+    localStorage.setItem('labcharts-local-corrupt-imported-corrupt', '{}');
+    localStorage.setItem('labcharts-not-an-imported-profile-units', 'US');
+
+    await expect(listStoredProfileIds(['listed', 'bad.profile', '', 42])).resolves.toEqual([
+      'listed',
+      'local-orphan',
+      'local-corrupt',
+      'idb-orphan',
+      'idb-regular',
+      'wearable-orphan',
+      'cycle-orphan',
+    ]);
+  });
+
+  it('rejects invalid profile IDs before touching storage', async () => {
+    await expect(clearProfileStorage('../other')).rejects.toThrow('Invalid profile id');
+  });
+
+  it('surfaces orphan-discovery failures instead of falsely reporting a complete wipe', async () => {
+    configureProfileStorageCleanupDeps({
+      getBlobKeys: async () => {
+        throw new Error('blob enumeration failed');
+      },
+    });
+
+    await expect(listStoredProfileIds(['listed'])).rejects.toThrow('blob enumeration failed');
+  });
+});

--- a/tests/test-blob-storage.js
+++ b/tests/test-blob-storage.js
@@ -18,12 +18,13 @@ function assert(name, condition, detail) {
 console.log('=== Blob Storage Tests ===\n');
 
 const blob = await import('../js/blob-storage.js');
-const { getBlob, setBlob, deleteBlob, getBlobStorageSize, shouldUseBlob } = blob;
+const { getBlob, setBlob, deleteBlob, getBlobKeys, getBlobStorageSize, shouldUseBlob } = blob;
 
 // ─── 1. shouldUseBlob routing ─────────────────────────────────────────
 console.log('1. shouldUseBlob');
 assert('routes labcharts-foo-imported', shouldUseBlob('labcharts-foo-imported'));
 assert('routes labcharts-default-imported', shouldUseBlob('labcharts-default-imported'));
+assert('routes labcharts-default-imported-corrupt', shouldUseBlob('labcharts-default-imported-corrupt'));
 assert('does NOT route -chat', !shouldUseBlob('labcharts-foo-chat'));
 assert('does NOT route -threads', !shouldUseBlob('labcharts-foo-chat-threads'));
 assert('does NOT route api keys', !shouldUseBlob('labcharts-api-key'));
@@ -37,6 +38,7 @@ const testValue = JSON.stringify({ entries: [{ id: 1, v: 'x'.repeat(1000) }] });
 await setBlob(testKey, testValue);
 const got = await getBlob(testKey);
 assert('getBlob returns the stored value', got === testValue);
+assert('getBlobKeys includes the stored value', (await getBlobKeys()).includes(testKey));
 
 // Round-trip a 2 MB string — way past the localStorage 5 MB cap when
 // accumulated across keys, well within IDB.

--- a/tests/test-chat-threads.js
+++ b/tests/test-chat-threads.js
@@ -345,9 +345,14 @@ assert('isSensitiveKey matches thread index (crypto.js SENSITIVE_PATTERNS)',
 console.log('16. Profile Delete Cleanup (source inspection)');
 const profileSrc = read('js/profile.js');
 const profileRuntimeSrc = read('js/profile-runtime.js');
-assert('deleteProfile removes chat-threads key', profileSrc.includes('chat-threads'));
-assert('deleteProfile removes chat-t_ keys', profileSrc.includes('chat-t_'));
-assert('deleteProfile removes chatRailOpen', profileSrc.includes('chatRailOpen'));
+const profileCleanupSrc = read('js/profile-storage-cleanup.js');
+assert('deleteProfile removes chat-threads key through centralized prefix cleanup',
+  profileSrc.includes('await clearProfileStorage(profileId)')
+    && profileCleanupSrc.includes('key.startsWith(standardPrefix)'));
+assert('deleteProfile removes chat-t_ keys without relying on a decryptable thread index',
+  profileCleanupSrc.includes('Prefix cleanup covers chat messages'));
+assert('deleteProfile removes chatRailOpen through centralized prefix cleanup',
+  profileCleanupSrc.includes('const standardPrefix = `labcharts-${profileId}-`'));
 assert('loadProfile resets chatThreads', profileSrc.includes('state.chatThreads = []'));
 assert('loadProfile resets currentThreadId', profileSrc.includes('state.currentThreadId = null'));
 assert('loadProfile delegates runtime refresh after profile switch',

--- a/tests/test-correctness-phase2.js
+++ b/tests/test-correctness-phase2.js
@@ -433,7 +433,9 @@ assert('_getCRP reads only hsCRP',
 console.log('\n10. Profile parse recovery');
 const profSrc = read('js/profile.js');
 assert('loadProfile backs up corrupted JSON',
-  profSrc.includes('imported-corrupt') && profSrc.includes('localStorage.setItem(corruptKey'),
+  profSrc.includes('imported-corrupt')
+    && profSrc.includes('await encryptedSetItem(corruptKey, savedImported)')
+    && !profSrc.includes('localStorage.setItem(corruptKey'),
   'previously discarded corrupted raw — user lost recovery path');
 assert('loadProfile surfaces a recovery toast',
   profSrc.includes('Profile data was corrupted'));

--- a/tests/test-crypto.js
+++ b/tests/test-crypto.js
@@ -109,6 +109,7 @@ assert('window.initProfilesCache stays module-only', !('initProfilesCache' in wi
 console.log('2. Sensitive key detection');
 assert('labcharts-default-imported is sensitive', cryptoModule.isSensitiveKey('labcharts-default-imported'));
 assert('labcharts-abc123-imported is sensitive', cryptoModule.isSensitiveKey('labcharts-abc123-imported'));
+assert('labcharts-default-imported-corrupt is sensitive', cryptoModule.isSensitiveKey('labcharts-default-imported-corrupt'));
 assert('labcharts-default-chat is sensitive', cryptoModule.isSensitiveKey('labcharts-default-chat'));
 assert('labcharts-profiles is sensitive', cryptoModule.isSensitiveKey('labcharts-profiles'));
 assert('labcharts-api-key IS sensitive', cryptoModule.isSensitiveKey('labcharts-api-key'));

--- a/tests/test-cycle-tour.js
+++ b/tests/test-cycle-tour.js
@@ -123,10 +123,17 @@ const tour = await import('../js/tour.js');
   // --- 14. Profile delete cleanup ---
   console.log('%c[14] Profile delete cleanup', 'font-weight:bold');
   const profileSrc = read('/js/profile.js');
-  assert('deleteProfile removes emptyTour key', profileSrc.includes("-emptyTour`"));
-  assert('deleteProfile removes tour key', profileSrc.includes("-tour`"));
-  assert('deleteProfile removes cycleTour key', profileSrc.includes("-cycleTour`"));
-  assert('deleteProfile removes phaseOverlay key', profileSrc.includes("-phaseOverlay`"));
+  const profileCleanupSrc = read('/js/profile-storage-cleanup.js');
+  assert('deleteProfile delegates complete profile storage cleanup',
+    profileSrc.includes('await clearProfileStorage(profileId)'));
+  assert('profile cleanup removes emptyTour through the standard profile prefix',
+    profileCleanupSrc.includes('const standardPrefix = `labcharts-${profileId}-`'));
+  assert('profile cleanup removes tour through the standard profile prefix',
+    profileCleanupSrc.includes('key.startsWith(standardPrefix)'));
+  assert('profile cleanup removes cycleTour through the standard profile prefix',
+    profileCleanupSrc.includes('key.startsWith(standardPrefix)'));
+  assert('profile cleanup removes phaseOverlay through the standard profile prefix',
+    profileCleanupSrc.includes('key.startsWith(standardPrefix)'));
 
   // --- 15. Service worker cache version ---
   console.log('%c[15] Service worker cache', 'font-weight:bold');

--- a/tests/test-export-import.js
+++ b/tests/test-export-import.js
@@ -434,25 +434,16 @@ return (async function() {
 
   assert('clearAllData exists', typeof exportModule.clearAllData === 'function');
 
-  // Verify it clears the expected storage keys. The `-imported` blob lives in
-  // IndexedDB now → encryptedRemoveItem hits both backends.
-  assert('Clears imported data key', exportSrc.includes("encryptedRemoveItem(profileStorageKey(id, 'imported'))"));
-  assert('Clears corrupt imported data key', exportSrc.includes("encryptedRemoveItem(profileStorageKey(id, 'imported-corrupt'))"));
-  assert('Clears wearable profile IDB', /clearAllData[\s\S]*?deleteWearablesDB\(id\)/.test(exportSrc));
-  assert('Clears units key', exportSrc.includes("localStorage.removeItem(profileStorageKey(id, 'units'))"));
-  assert('Clears suppOverlay key', exportSrc.includes("localStorage.removeItem(profileStorageKey(id, 'suppOverlay'))"));
-  assert('Clears noteOverlay key', exportSrc.includes("localStorage.removeItem(profileStorageKey(id, 'noteOverlay'))"));
-  assert('Clears rangeMode key', exportSrc.includes("localStorage.removeItem(profileStorageKey(id, 'rangeMode'))"));
-  assert('Clears suppImpact key', exportSrc.includes("localStorage.removeItem(profileStorageKey(id, 'suppImpact'))"));
-  assert('Clears chat key', exportSrc.includes("localStorage.removeItem(`labcharts-${id}-chat`)"));
-  assert('Clears chat threads', exportSrc.includes("localStorage.removeItem(`labcharts-${id}-chat-threads`)"));
-  assert('Clears focus card key', exportSrc.includes("localStorage.removeItem(`labcharts-${id}-focusCard`)"));
-  assert('Clears context health key', exportSrc.includes("localStorage.removeItem(`labcharts-${id}-contextHealth`)"));
-  assert('Clears onboarded key', exportSrc.includes("localStorage.removeItem(`labcharts-${id}-onboarded`)"));
-  assert('Clears empty tour key', exportSrc.includes("localStorage.removeItem(`labcharts-${id}-emptyTour`)"));
-  assert('Clears tour key', exportSrc.includes("localStorage.removeItem(`labcharts-${id}-tour`)"));
-  assert('Clears sync timestamp', exportSrc.includes("localStorage.removeItem(`labcharts-${id}-sync-ts`)"));
-  assert('Resets state.importedData', exportSrc.includes('state.importedData = { entries: []'));
+  // A shared cleanup boundary owns every profile-scoped storage surface.
+  // clearAllData also discovers orphaned profile blobs that are no longer in
+  // the profile list, then awaits the durable profile-list reset.
+  assert('Discovers listed and orphaned profile data',
+    exportSrc.includes('await listStoredProfileIds(profiles.map(profile => profile.id))'));
+  assert('Awaits centralized profile storage cleanup',
+    /for \(const id of profileIds\)[\s\S]{0,200}await clearProfileStorage\(id\)/.test(exportSrc));
+  assert('Awaits the profile-list reset', exportSrc.includes('await saveProfiles([{ id: defaultId'));
+  assert('Resets state.importedData from the canonical factory',
+    exportSrc.includes('state.importedData = createDefaultProfileData()'));
   assert('Resets to single default profile via saveProfiles', exportSrc.includes('saveProfiles([{'));
   assert('Clears Cashu wallet DB through export runtime',
     exportSrc.includes('destroyWalletRuntimeDB') &&

--- a/tests/test-multi-unit.js
+++ b/tests/test-multi-unit.js
@@ -232,6 +232,10 @@ console.log('\n-- source-shape pins (UI wiring) --');
   const dataViewControls = fs.readFileSync(new URL('../js/data-view-controls.js', import.meta.url), 'utf8');
   const state = fs.readFileSync(new URL('../js/state.js', import.meta.url), 'utf8');
   const profile = fs.readFileSync(new URL('../js/profile.js', import.meta.url), 'utf8');
+  const profileStorageCleanup = fs.readFileSync(
+    new URL('../js/profile-storage-cleanup.js', import.meta.url),
+    'utf8',
+  );
 
   // Detail modal gates alt rendering on state.showAltUnits
   assert('marker-detail-modal.js gates alt-unit summary on state.showAltUnits',
@@ -285,8 +289,9 @@ console.log('\n-- source-shape pins (UI wiring) --');
   // profile.js: load + cleanup
   assert('profile.js loads showAltUnits from localStorage on profile switch',
     /state\.showAltUnits = localStorage\.getItem\(profileStorageKey\(profileId, 'showAltUnits'\)\) === 'on'/.test(profile));
-  assert('profile.js cleans up showAltUnits key on deleteProfile',
-    /localStorage\.removeItem\(profileStorageKey\(profileId, 'showAltUnits'\)\)/.test(profile));
+  assert('deleteProfile cleanup covers showAltUnits and future profile-scoped keys',
+    profile.includes('await clearProfileStorage(profileId)')
+      && profileStorageCleanup.includes('const standardPrefix = `labcharts-${profileId}-`'));
 }
 
 console.log(`\n=== ${passed} passed, ${failed} failed ===`);

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -981,7 +981,7 @@ await import('../js/settings.js');
       && syncDiagnoseRenderSrc.includes('<th style="padding:4px 8px;text-align:right">deleted</th>'));
   assert('applyRemoteTombstones wipes the local imported blob for tombstoned profiles',
     /applyRemoteTombstones[\s\S]{0,4000}wipeProfileLocal\(tombId\)/.test(syncTombstonesSrc)
-      && /wipeProfileLocal[\s\S]{0,800}encryptedRemoveItem\(profileStorageKey\(profileId,\s*'imported'\)\)/.test(syncTombstonesSrc));
+      && /wipeProfileLocal[\s\S]{0,300}await clearProfileStorage\(profileId\)/.test(syncTombstonesSrc));
   // Quarantine: a remote-driven mass-delete (≥ 2 profiles tombstoned at
   // once) is auth'd only by the BIP-39 mnemonic. If the mnemonic leaks,
   // an attacker could publish tombstones for every profileId. Single-

--- a/tests/test-wearables.js
+++ b/tests/test-wearables.js
@@ -1996,11 +1996,15 @@ assert('changelog.js does not use plural "We never see" voice',
 // ═══════════════════════════════════════
 console.log('17z. P0 Data-Integrity');
 
-// P0-A: deleting a profile must drop its wearable IDB. The delete is
-// dispatched as a fire-and-forget dynamic import — guard the call site.
+// P0-A: deleting a profile must await the centralized cleanup boundary,
+// which in turn awaits the wearable DB deletion before profile metadata is
+// removed.
 const profileSrc = await fetch('/js/profile.js').then(r => r.text());
-assert('deleteProfile dispatches deleteWearablesDB(profileId) for the deleted profile',
-  /export (?:async )?function deleteProfile[\s\S]*?deleteWearablesDB\(profileId\)/.test(profileSrc));
+const profileCleanupSrc = await fetch('/js/profile-storage-cleanup.js').then(r => r.text());
+assert('deleteProfile awaits complete profile storage cleanup',
+  /export async function deleteProfile[\s\S]*?await clearProfileStorage\(profileId\)[\s\S]*?await saveProfiles\(updated\)/.test(profileSrc));
+assert('profile storage cleanup awaits deleteWearablesDB(profileId)',
+  /await Promise\.all\(\[[\s\S]*?cleanupDeps\.deleteWearablesDB\(profileId\)/.test(profileCleanupSrc));
 
 // P0-B: auto-backup carries wearable L1 rows. buildFullBackupSnapshot
 // exists, populates `wearableIDB`, and is called from auto-backup +

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -27,6 +27,7 @@
     "js/app-chat-hooks.js",
     "js/app-ai-interaction-modules.js",
     "js/profile-share-loader.js",
+    "js/profile-storage-cleanup.js",
     "js/app-event-listeners.js",
     "js/app-feature-modules.js",
     "js/app-foundation-modules.js",


### PR DESCRIPTION
## Summary

- centralize profile-scoped cleanup across profile deletion, clear-all, and remote tombstones
- remove encrypted/corrupt blobs, orphaned chat records, onboarding/session flags, and wearable/cycle databases with failure-aware ordering
- preserve corrupt profile bytes through an awaited, encryption-aware IndexedDB recovery path
- discover orphaned profile blobs/databases and route corrupt recovery blobs through encrypted blob storage
- add focused cleanup, recovery, storage, sync, and browser regression coverage

## Verification

- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run typecheck:strict-null`
- `npm run architecture:check`
- `npm run quality`
- `npm run production:check`
- focused Vitest profile cleanup/recovery/tombstone/service-worker tests
- focused legacy blob, crypto, correctness, sync, wearables, and multi-unit checks
- focused Chromium export/import and sync tombstone specs (3 passed)