### PR TITLE
Harden proxy abuse controls and upstream guardrails

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -63,15 +63,23 @@ UVDATA_UPSTREAM=
 UVDATA_BEARER=
 
 # ── Production proxy safety tuning ──
-# The defaults allow 300 requests per client per 60-second Edge-isolate window
-# (enough for a 90-day Ultrahuman backfill) and wait up to 180 seconds for
-# generic provider response headers, matching the longest AI import timeout.
-# Vercel Firewall (or an equivalent distributed limit) should still be configured for
-# a public deployment because function-instance memory is not globally shared.
-# These are optional; leave blank to use the defaults.
+# The defaults allow 300 requests per client per 60-second window (enough for
+# a 90-day Ultrahuman backfill) and bound the entire upstream response
+# lifecycle to 180 seconds.
+#
+# Hosted Vercel deployments require a shared Vercel Blob store for the proxy
+# rate limit and fail closed when neither token is available. Prefer a
+# dedicated private Blob token in PROXY_RATE_LIMIT_BLOB_TOKEN; when blank, the
+# existing BLOB_READ_WRITE_TOKEN used by encrypted profile sharing is reused.
+#
+# Non-Vercel/self-host development uses a bounded in-process fallback. Set
+# PROXY_ALLOW_INSTANCE_RATE_LIMIT=1 only when a Vercel self-host knowingly
+# accepts that weaker per-instance limit.
 
 PROXY_RATE_LIMIT_MAX=
 PROXY_RATE_LIMIT_WINDOW_MS=
+PROXY_RATE_LIMIT_BLOB_TOKEN=
+PROXY_ALLOW_INSTANCE_RATE_LIMIT=
 PROXY_UPSTREAM_TIMEOUT_MS=
 
 # ── Catalog deploy hooks (used by the getbased-tools editor's Deploy button)

--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -9,8 +9,8 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 
 | Metric | Current |
 | --- | ---: |
-| Modules | 531 |
-| Internal import edges | 2386 |
+| Modules | 533 |
+| Internal import edges | 2389 |
 | Dynamic internal edges | 88 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -1004,7 +1004,7 @@ Vercel request handlers and hosted API entry points.
 
 <details><summary><code>proxy</code> family — 1 module</summary>
 
-- [`api/proxy.js`](api/proxy.js) → [`lib/proxy-network.js`](lib/proxy-network.js), [`lib/proxy-policy.js`](lib/proxy-policy.js)
+- [`api/proxy.js`](api/proxy.js) → [`lib/proxy-policy.js`](lib/proxy-policy.js), [`lib/proxy-rate-limit.js`](lib/proxy-rate-limit.js), [`lib/proxy-upstream.js`](lib/proxy-upstream.js)
 
 </details>
 
@@ -1018,9 +1018,11 @@ Vercel request handlers and hosted API entry points.
 
 Node-only policy and transport code shared by hosted runtimes.
 
-<details><summary><code>proxy</code> family — 2 modules</summary>
+<details><summary><code>proxy</code> family — 4 modules</summary>
 
 - [`lib/proxy-network.js`](lib/proxy-network.js) → [`lib/proxy-policy.js`](lib/proxy-policy.js)
 - [`lib/proxy-policy.js`](lib/proxy-policy.js) → no in-scope imports
+- [`lib/proxy-rate-limit.js`](lib/proxy-rate-limit.js) → no in-scope imports
+- [`lib/proxy-upstream.js`](lib/proxy-upstream.js) → [`lib/proxy-network.js`](lib/proxy-network.js), [`lib/proxy-policy.js`](lib/proxy-policy.js)
 
 </details>

--- a/api/proxy.js
+++ b/api/proxy.js
@@ -9,16 +9,16 @@ import {
   normalizeProxyMethod,
   sanitizeProxyHeaders,
 } from '../lib/proxy-policy.js';
-import { fetchWithPinnedProxyDns } from '../lib/proxy-network.js';
+import { enforceProxyRateLimit } from '../lib/proxy-rate-limit.js';
+import {
+  PROXY_MAX_CREDENTIAL_RESPONSE_BYTES,
+  capReadableStream,
+  fetchWithValidatedRedirects,
+  readRequestTextWithCap,
+  readResponseTextWithCap,
+} from '../lib/proxy-upstream.js';
 
 const DEFAULT_UVDATA_UPSTREAM = 'https://uvdata.getbased.health';
-const PROXY_REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
-const PROXY_MAX_REDIRECTS = 5;
-const DEFAULT_PROXY_UPSTREAM_TIMEOUT_MS = 180_000;
-const DEFAULT_PROXY_RATE_LIMIT_WINDOW_MS = 60_000;
-const DEFAULT_PROXY_RATE_LIMIT_MAX = 300;
-const MAX_PROXY_RATE_LIMIT_BUCKETS = 4_096;
-const proxyRateLimitBuckets = new Map();
 
 export default async function handler(req) {
   // Treat Origin as a server-side browser boundary, not merely a response
@@ -49,7 +49,33 @@ export default async function handler(req) {
     });
   }
 
-  const rateLimit = enforceProxyRateLimit(req);
+  let rateLimit;
+  try {
+    rateLimit = await enforceProxyRateLimit(req);
+  } catch {
+    return new Response(JSON.stringify({
+      error: 'Proxy rate limit is temporarily unavailable.',
+    }), {
+      status: 503,
+      headers: {
+        ...corsHeaders(req),
+        'Content-Type': 'application/json',
+        'Retry-After': '60',
+      },
+    });
+  }
+  if (rateLimit.unavailable) {
+    return new Response(JSON.stringify({
+      error: 'Proxy rate limit is not configured for this hosted deployment.',
+    }), {
+      status: 503,
+      headers: {
+        ...corsHeaders(req),
+        'Content-Type': 'application/json',
+        'Retry-After': String(rateLimit.retryAfterSeconds),
+      },
+    });
+  }
   if (rateLimit.limited) {
     return new Response(JSON.stringify({
       error: 'Too many proxy requests. Try again later.',
@@ -66,22 +92,15 @@ export default async function handler(req) {
 
   let payload;
   try {
-    const contentLength = parseInt(req.headers.get('content-length') || '0', 10);
-    if (contentLength > PROXY_MAX_REQUEST_BYTES) {
-      return new Response(JSON.stringify({ error: 'Proxy request body too large' }), {
-        status: 413,
-        headers: { ...corsHeaders(req), 'Content-Type': 'application/json' },
-      });
-    }
-    const rawBody = await req.text();
-    if (new TextEncoder().encode(rawBody).length > PROXY_MAX_REQUEST_BYTES) {
-      return new Response(JSON.stringify({ error: 'Proxy request body too large' }), {
-        status: 413,
-        headers: { ...corsHeaders(req), 'Content-Type': 'application/json' },
-      });
-    }
+    const rawBody = await readRequestTextWithCap(req, PROXY_MAX_REQUEST_BYTES);
     payload = JSON.parse(rawBody);
-  } catch {
+  } catch (error) {
+    if (error?.code === 'PROXY_REQUEST_TOO_LARGE') {
+      return new Response(JSON.stringify({ error: 'Proxy request body too large' }), {
+        status: 413,
+        headers: { ...corsHeaders(req), 'Content-Type': 'application/json' },
+      });
+    }
     return new Response(JSON.stringify({ error: 'Invalid JSON body' }), {
       status: 400,
       headers: { ...corsHeaders(req), 'Content-Type': 'application/json' },
@@ -192,14 +211,14 @@ export default async function handler(req) {
     if (fetchMethod !== 'GET' && body) {
       fetchOpts.body = typeof body === 'string' ? body : JSON.stringify(body);
     }
-    const upstreamRes = await fetchWithValidatedRedirects(url, fetchOpts);
+    const upstreamRes = await fetchWithValidatedRedirects(url, fetchOpts, { signal: req.signal });
 
     // For non-streaming responses or errors, forward as-is
     const contentType = upstreamRes.headers.get('content-type') || '';
     const isStream = contentType.includes('text/event-stream') || contentType.includes('application/x-ndjson');
 
     if (!isStream) {
-      const responseBody = await readResponseTextWithCap(upstreamRes);
+      const responseBody = await readResponseTextWithCap(upstreamRes, PROXY_MAX_RESPONSE_BYTES);
       return new Response(responseBody, {
         status: upstreamRes.status,
         headers: {
@@ -220,230 +239,8 @@ export default async function handler(req) {
       },
     });
   } catch (e) {
-    const dnsBlocked = e?.code === 'PROXY_DNS_BLOCKED';
-    const timedOut = e?.code === 'PROXY_UPSTREAM_TIMEOUT';
-    const error = dnsBlocked ? 'URL not allowed' : `Upstream error: ${e.message}`;
-    return new Response(JSON.stringify({ error }), {
-      status: dnsBlocked ? 403 : (timedOut ? 504 : 502),
-      headers: { ...corsHeaders(req), 'Content-Type': 'application/json' },
-    });
+    return proxyUpstreamErrorResponse(req, e);
   }
-}
-
-function readBoundedEnvInteger(name, fallback, min, max) {
-  const raw = typeof process !== 'undefined' ? process.env?.[name] : undefined;
-  if (!raw) return fallback;
-  const value = Number.parseInt(raw, 10);
-  return Number.isFinite(value) && value >= min && value <= max ? value : fallback;
-}
-
-function proxyRuntimeError(code, message) {
-  const error = new Error(message);
-  error.code = code;
-  return error;
-}
-
-function redirectRequestOptions(status, options) {
-  const method = String(options.method || 'GET').toUpperCase();
-  if (status !== 303 && !((status === 301 || status === 302) && method === 'POST')) {
-    return options;
-  }
-  const headers = { ...(options.headers || {}) };
-  for (const name of Object.keys(headers)) {
-    if (['content-length', 'content-type'].includes(name.toLowerCase())) delete headers[name];
-  }
-  return { ...options, method: 'GET', headers, body: undefined };
-}
-
-function stripProxyCredentialHeaders(options) {
-  const headers = { ...(options.headers || {}) };
-  for (const name of Object.keys(headers)) {
-    if (['api-key', 'authorization', 'x-api-key'].includes(name.toLowerCase())) delete headers[name];
-  }
-  return { ...options, headers };
-}
-
-async function discardResponseBody(response) {
-  try { await response.body?.cancel?.(); } catch {}
-}
-
-// Fetch redirects manually so every destination passes the same SSRF policy.
-// Credentialed/body-bearing cross-origin redirects are constrained so API
-// secrets and request payloads never migrate to a new host. Safe GET redirects
-// remain supported for ordinary product pages that canonicalize to `www`.
-async function fetchWithValidatedRedirects(initialUrl, initialOptions) {
-  const timeoutMs = readBoundedEnvInteger(
-    'PROXY_UPSTREAM_TIMEOUT_MS',
-    DEFAULT_PROXY_UPSTREAM_TIMEOUT_MS,
-    10,
-    300_000,
-  );
-  const controller = new AbortController();
-  let timedOut = false;
-  const timeout = setTimeout(() => {
-    timedOut = true;
-    controller.abort();
-  }, timeoutMs);
-  let url = new URL(initialUrl).toString();
-  let options = { ...initialOptions };
-  let redirects = 0;
-
-  try {
-    while (true) {
-      if (!isAllowedProxyUrl(url)) {
-        throw proxyRuntimeError('PROXY_REDIRECT_BLOCKED', 'Proxy redirect target not allowed');
-      }
-      let response;
-      try {
-        response = await fetchWithPinnedProxyDns(url, {
-          ...options,
-          redirect: 'manual',
-          signal: controller.signal,
-        });
-      } catch (error) {
-        if (timedOut || controller.signal.aborted) {
-          throw proxyRuntimeError('PROXY_UPSTREAM_TIMEOUT', 'Proxy upstream timed out');
-        }
-        throw error;
-      }
-
-      if (!PROXY_REDIRECT_STATUSES.has(response.status)) return response;
-      const location = response.headers.get('location');
-      if (!location) return response;
-      if (redirects >= PROXY_MAX_REDIRECTS) {
-        await discardResponseBody(response);
-        throw proxyRuntimeError('PROXY_REDIRECT_LIMIT', 'Proxy redirect limit exceeded');
-      }
-
-      let nextUrl;
-      try {
-        nextUrl = new URL(location, url).toString();
-      } catch {
-        await discardResponseBody(response);
-        throw proxyRuntimeError('PROXY_REDIRECT_BLOCKED', 'Proxy redirect target not allowed');
-      }
-      if (!isAllowedProxyUrl(nextUrl)) {
-        await discardResponseBody(response);
-        throw proxyRuntimeError('PROXY_REDIRECT_BLOCKED', 'Proxy redirect target not allowed');
-      }
-      let nextOptions = redirectRequestOptions(response.status, options);
-      if (new URL(nextUrl).origin !== new URL(url).origin && nextOptions.body != null) {
-        await discardResponseBody(response);
-        throw proxyRuntimeError(
-          'PROXY_CROSS_ORIGIN_BODY_REDIRECT',
-          'Cross-origin proxy redirects with a request body are not allowed',
-        );
-      }
-      if (new URL(nextUrl).origin !== new URL(url).origin) {
-        nextOptions = stripProxyCredentialHeaders(nextOptions);
-      }
-
-      await discardResponseBody(response);
-      options = nextOptions;
-      url = nextUrl;
-      redirects++;
-    }
-  } finally {
-    clearTimeout(timeout);
-  }
-}
-
-function getProxyRateLimitSubject(req) {
-  const forwarded = req.headers.get('x-forwarded-for') || '';
-  const ip = forwarded.split(',')[0]?.trim()
-    || req.headers.get('x-real-ip')
-    || req.headers.get('cf-connecting-ip')
-    || 'unknown-client';
-  return `${req.headers.get('origin') || 'no-origin'}|${String(ip).slice(0, 128)}`;
-}
-
-// Function instances do not share memory, so this is a per-instance abuse brake,
-// not a replacement for a deployment-level distributed rate limit.
-function enforceProxyRateLimit(req) {
-  const now = Date.now();
-  const windowMs = readBoundedEnvInteger(
-    'PROXY_RATE_LIMIT_WINDOW_MS',
-    DEFAULT_PROXY_RATE_LIMIT_WINDOW_MS,
-    1_000,
-    60 * 60 * 1000,
-  );
-  const maxRequests = readBoundedEnvInteger(
-    'PROXY_RATE_LIMIT_MAX',
-    DEFAULT_PROXY_RATE_LIMIT_MAX,
-    1,
-    10_000,
-  );
-  const subject = getProxyRateLimitSubject(req);
-  let bucket = proxyRateLimitBuckets.get(subject);
-  if (!bucket || bucket.resetAt <= now) {
-    bucket = { count: 0, resetAt: now + windowMs };
-  }
-  bucket.count++;
-  proxyRateLimitBuckets.set(subject, bucket);
-
-  if (proxyRateLimitBuckets.size > MAX_PROXY_RATE_LIMIT_BUCKETS) {
-    for (const [key, candidate] of proxyRateLimitBuckets) {
-      if (candidate.resetAt <= now || proxyRateLimitBuckets.size > MAX_PROXY_RATE_LIMIT_BUCKETS) {
-        proxyRateLimitBuckets.delete(key);
-      }
-    }
-  }
-
-  return {
-    limited: bucket.count > maxRequests,
-    retryAfterSeconds: Math.max(1, Math.ceil((bucket.resetAt - now) / 1000)),
-  };
-}
-
-async function readResponseTextWithCap(response) {
-  const contentLength = parseInt(response.headers.get('content-length') || '0', 10);
-  if (contentLength > PROXY_MAX_RESPONSE_BYTES) throw new Error('Proxy response exceeds size cap');
-  const reader = response.body?.getReader?.();
-  if (!reader) return response.text();
-  const chunks = [];
-  let bytes = 0;
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    bytes += value?.byteLength || 0;
-    if (bytes > PROXY_MAX_RESPONSE_BYTES) {
-      try { await reader.cancel(); } catch {}
-      throw new Error('Proxy response exceeds size cap');
-    }
-    chunks.push(value);
-  }
-  const out = new Uint8Array(bytes);
-  let offset = 0;
-  for (const chunk of chunks) {
-    out.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  return new TextDecoder().decode(out);
-}
-
-function capReadableStream(body, maxBytes) {
-  if (!body?.getReader || typeof ReadableStream !== 'function') return body;
-  const reader = body.getReader();
-  let bytes = 0;
-  return new ReadableStream({
-    async pull(controller) {
-      const { done, value } = await reader.read();
-      if (done) {
-        controller.close();
-        return;
-      }
-      bytes += value?.byteLength || 0;
-      if (bytes > maxBytes) {
-        try { await reader.cancel(); } catch {}
-        controller.error(new Error('Proxy response exceeds size cap'));
-        return;
-      }
-      controller.enqueue(value);
-    },
-    cancel(reason) {
-      return reader.cancel(reason);
-    },
-  });
 }
 
 // Origins permitted to call /api/proxy. Same-origin requests support self-hosted
@@ -476,10 +273,51 @@ function corsHeaders(req) {
   const h = {
     'Access-Control-Allow-Methods': 'POST, OPTIONS',
     'Access-Control-Allow-Headers': 'Content-Type',
+    'Cache-Control': 'no-store',
     'Vary': 'Origin',
   };
   if (allow) h['Access-Control-Allow-Origin'] = allow;
   return h;
+}
+
+function proxyUpstreamErrorResponse(req, error, fallback = 'Upstream request failed') {
+  const code = error?.code;
+  const dnsBlocked = code === 'PROXY_DNS_BLOCKED';
+  const timedOut = code === 'PROXY_UPSTREAM_TIMEOUT';
+  const knownMessages = new Map([
+    ['PROXY_REDIRECT_BLOCKED', 'Proxy redirect target not allowed'],
+    ['PROXY_REDIRECT_LIMIT', 'Proxy redirect limit exceeded'],
+    ['PROXY_CROSS_ORIGIN_BODY_REDIRECT', 'Cross-origin proxy redirects with a request body are not allowed'],
+    ['PROXY_RESPONSE_TOO_LARGE', 'Proxy response exceeds size cap'],
+  ]);
+  const message = dnsBlocked
+    ? 'URL not allowed'
+    : timedOut
+      ? 'Proxy upstream timed out'
+      : knownMessages.get(code) || fallback;
+  return new Response(JSON.stringify({ error: message }), {
+    status: dnsBlocked ? 403 : (timedOut ? 504 : 502),
+    headers: { ...corsHeaders(req), 'Content-Type': 'application/json' },
+  });
+}
+
+async function relayGuardedText(url, options, req, fallback) {
+  try {
+    const response = await fetchWithValidatedRedirects(url, options, { signal: req.signal });
+    const body = await readResponseTextWithCap(
+      response,
+      PROXY_MAX_CREDENTIAL_RESPONSE_BYTES,
+    );
+    return new Response(body, {
+      status: response.status,
+      headers: {
+        ...corsHeaders(req),
+        'Content-Type': response.headers.get('content-type') || 'application/json',
+      },
+    });
+  } catch (error) {
+    return proxyUpstreamErrorResponse(req, error, fallback);
+  }
 }
 
 // ─── Oura token handler ────────────────────────────────────────────
@@ -521,22 +359,11 @@ async function handleOuraTokenRequest(payload, req) {
     });
   }
 
-  try {
-    const res = await fetchWithPinnedProxyDns('https://api.ouraring.com/oauth/token', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: form.toString(),
-    });
-    const body = await res.text();
-    return new Response(body, {
-      status: res.status,
-      headers: { ...corsHeaders(req), 'Content-Type': res.headers.get('content-type') || 'application/json' },
-    });
-  } catch (e) {
-    return new Response(JSON.stringify({ error: 'Token endpoint unreachable: ' + e.message }), {
-      status: 502, headers: { ...corsHeaders(req), 'Content-Type': 'application/json' },
-    });
-  }
+  return relayGuardedText('https://api.ouraring.com/oauth/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: form.toString(),
+  }, req, 'Oura token endpoint unavailable');
 }
 
 // ─── Withings token handler ────────────────────────────────────────
@@ -584,22 +411,11 @@ async function handleWithingsTokenRequest(payload, req) {
     });
   }
 
-  try {
-    const res = await fetchWithPinnedProxyDns('https://wbsapi.withings.net/v2/oauth2', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: form.toString(),
-    });
-    const body = await res.text();
-    return new Response(body, {
-      status: res.status,
-      headers: { ...corsHeaders(req), 'Content-Type': res.headers.get('content-type') || 'application/json' },
-    });
-  } catch (e) {
-    return new Response(JSON.stringify({ error: 'Withings token endpoint unreachable: ' + e.message }), {
-      status: 502, headers: { ...corsHeaders(req), 'Content-Type': 'application/json' },
-    });
-  }
+  return relayGuardedText('https://wbsapi.withings.net/v2/oauth2', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: form.toString(),
+  }, req, 'Withings token endpoint unavailable');
 }
 
 // ─── Ultrahuman token handler ──────────────────────────────────────
@@ -636,22 +452,11 @@ async function handleUltrahumanTokenRequest(payload, req) {
     });
   }
 
-  try {
-    const res = await fetchWithPinnedProxyDns('https://partner.ultrahuman.com/api/partners/oauth/token', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: form.toString(),
-    });
-    const body = await res.text();
-    return new Response(body, {
-      status: res.status,
-      headers: { ...corsHeaders(req), 'Content-Type': res.headers.get('content-type') || 'application/json' },
-    });
-  } catch (e) {
-    return new Response(JSON.stringify({ error: 'Ultrahuman token endpoint unreachable: ' + e.message }), {
-      status: 502, headers: { ...corsHeaders(req), 'Content-Type': 'application/json' },
-    });
-  }
+  return relayGuardedText('https://partner.ultrahuman.com/api/partners/oauth/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: form.toString(),
+  }, req, 'Ultrahuman token endpoint unavailable');
 }
 
 // ─── Polar token handler ───────────────────────────────────────────
@@ -693,26 +498,15 @@ async function handlePolarTokenRequest(payload, req) {
   }
 
   const basicAuth = 'Basic ' + btoa(`${clientId}:${secret}`);
-  try {
-    const res = await fetchWithPinnedProxyDns('https://polarremote.com/v2/oauth2/token', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-        'Accept': 'application/json;charset=UTF-8',
-        'Authorization': basicAuth,
-      },
-      body: form.toString(),
-    });
-    const body = await res.text();
-    return new Response(body, {
-      status: res.status,
-      headers: { ...corsHeaders(req), 'Content-Type': res.headers.get('content-type') || 'application/json' },
-    });
-  } catch (e) {
-    return new Response(JSON.stringify({ error: 'Polar token endpoint unreachable: ' + e.message }), {
-      status: 502, headers: { ...corsHeaders(req), 'Content-Type': 'application/json' },
-    });
-  }
+  return relayGuardedText('https://polarremote.com/v2/oauth2/token', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'Accept': 'application/json;charset=UTF-8',
+      'Authorization': basicAuth,
+    },
+    body: form.toString(),
+  }, req, 'Polar token endpoint unavailable');
 }
 
 // CAMS atmosphere relay → getbased-uvdata. Defaults to the maintainer-run
@@ -762,50 +556,14 @@ async function handleCamsRelay(payload, req) {
   const headers = { 'Accept': 'application/json' };
   if (bearer) headers['Authorization'] = `Bearer ${bearer}`;
   try {
-    const res = await fetchWithPinnedProxyDns(url, { headers });
+    const res = await fetchWithValidatedRedirects(url, { headers }, { signal: req.signal });
     // Cap upstream response so a misbehaving / compromised CAMS relay
     // can't blow up the function's memory. Real CAMS UV payloads sit
     // around 5-10 KB; 256 KB leaves generous headroom while bounding
     // the worst case. Greptile PR #175 review caught this.
-    const MAX_UPSTREAM_BYTES = 256 * 1024;
-    const cl = parseInt(res.headers.get('content-length') || '0', 10);
-    if (Number.isFinite(cl) && cl > MAX_UPSTREAM_BYTES) {
-      return new Response(JSON.stringify({ error: 'CAMS response exceeds size cap' }), {
-        status: 502,
-        headers: { ...corsHeaders(req), 'Content-Type': 'application/json' },
-      });
-    }
-    // Even when Content-Length is absent or lying, read with a running
-    // byte counter and bail past the cap.
-    const reader = res.body?.getReader();
-    if (!reader) {
-      return new Response(JSON.stringify({ error: 'CAMS response had no body' }), {
-        status: 502,
-        headers: { ...corsHeaders(req), 'Content-Type': 'application/json' },
-      });
-    }
-    const chunks = [];
-    let total = 0;
-    while (true) {
-      const { value, done } = await reader.read();
-      if (done) break;
-      total += value.byteLength;
-      if (total > MAX_UPSTREAM_BYTES) {
-        try { await reader.cancel(); } catch (_) {}
-        return new Response(JSON.stringify({ error: 'CAMS response exceeds size cap' }), {
-          status: 502,
-          headers: { ...corsHeaders(req), 'Content-Type': 'application/json' },
-        });
-      }
-      chunks.push(value);
-    }
-    const body = new TextDecoder().decode(
-      chunks.length === 1 ? chunks[0] : (() => {
-        const out = new Uint8Array(total);
-        let off = 0;
-        for (const c of chunks) { out.set(c, off); off += c.byteLength; }
-        return out;
-      })()
+    const body = await readResponseTextWithCap(
+      res,
+      PROXY_MAX_CREDENTIAL_RESPONSE_BYTES,
     );
     return new Response(body, {
       status: res.status,
@@ -814,10 +572,10 @@ async function handleCamsRelay(payload, req) {
         'Content-Type': res.headers.get('content-type') || 'application/json',
       },
     });
-  } catch (e) {
-    return new Response(JSON.stringify({ error: 'CAMS upstream unreachable: ' + e.message }), {
-      status: 502,
-      headers: { ...corsHeaders(req), 'Content-Type': 'application/json' },
-    });
+  } catch (error) {
+    const fallback = error?.code === 'PROXY_RESPONSE_TOO_LARGE'
+      ? 'CAMS response exceeds size cap'
+      : 'CAMS upstream unavailable';
+    return proxyUpstreamErrorResponse(req, error, fallback);
   }
 }

--- a/lib/proxy-rate-limit.js
+++ b/lib/proxy-rate-limit.js
@@ -1,0 +1,228 @@
+// @ts-check
+// Shared proxy abuse control. Hosted Vercel deployments use atomic Vercel
+// Blob markers so the limit spans function instances. Local and explicitly
+// opted-in self-hosted deployments retain a bounded in-process fallback.
+
+import {
+  BlobPreconditionFailedError,
+  del as deleteBlobs,
+  list as listBlobs,
+  put as putBlob,
+} from '@vercel/blob';
+
+const DEFAULT_PROXY_RATE_LIMIT_WINDOW_MS = 60_000;
+const DEFAULT_PROXY_RATE_LIMIT_MAX = 300;
+const MAX_DISTRIBUTED_RATE_LIMIT_SLOTS = 1_000;
+const MAX_LOCAL_RATE_LIMIT_BUCKETS = 4_096;
+const DISTRIBUTED_RATE_LIMIT_TIMEOUT_MS = 5_000;
+const RATE_LIMIT_PREFIX = 'proxy-rate/v1/';
+const localRateLimitBuckets = new Map();
+
+function readBoundedEnvInteger(name, fallback, min, max) {
+  const raw = typeof process !== 'undefined' ? process.env?.[name] : undefined;
+  if (!raw) return fallback;
+  const value = Number.parseInt(raw, 10);
+  return Number.isFinite(value) && value >= min && value <= max ? value : fallback;
+}
+
+function getProxyRateLimitSubject(req) {
+  const forwarded = req.headers.get('x-vercel-forwarded-for')
+    || req.headers.get('x-forwarded-for')
+    || '';
+  const ip = forwarded.split(',')[0]?.trim()
+    || req.headers.get('x-real-ip')
+    || req.headers.get('cf-connecting-ip')
+    || 'unknown-client';
+  return String(ip).slice(0, 128);
+}
+
+async function sha256Hex(value) {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(String(value || '')));
+  return Array.from(new Uint8Array(digest), byte => byte.toString(16).padStart(2, '0')).join('');
+}
+
+function windowStartFor(now, windowMs) {
+  return Math.floor(now / windowMs) * windowMs;
+}
+
+function subjectPrefix(subjectHash) {
+  return `${RATE_LIMIT_PREFIX}${subjectHash}/`;
+}
+
+function windowPrefix(subjectHash, windowStart) {
+  return `${subjectPrefix(subjectHash)}${windowStart}/`;
+}
+
+function markerPath(subjectHash, windowStart, slot) {
+  return `${windowPrefix(subjectHash, windowStart)}${slot}.json`;
+}
+
+function randomSlot(maxRequests) {
+  const bytes = new Uint32Array(1);
+  crypto.getRandomValues(bytes);
+  return bytes[0] % maxRequests;
+}
+
+function isSlotConflict(error) {
+  return error instanceof BlobPreconditionFailedError
+    || /precondition|already exists|overwrite/i.test(String(error?.message || ''));
+}
+
+async function cleanupExpiredMarkers(subjectHash, currentWindowStart, token, abortSignal) {
+  const prefix = subjectPrefix(subjectHash);
+  let cursor;
+  const stale = [];
+  do {
+    const page = await listBlobs({ prefix, cursor, limit: 1_000, token, abortSignal });
+    for (const blob of page.blobs || []) {
+      const relative = String(blob.pathname || '').slice(prefix.length);
+      const markerWindowStart = Number(relative.split('/')[0]);
+      if (Number.isFinite(markerWindowStart) && markerWindowStart < currentWindowStart) {
+        stale.push(blob.pathname);
+      }
+    }
+    cursor = page.hasMore ? page.cursor : undefined;
+  } while (cursor && stale.length < 1_000);
+  if (stale.length) await deleteBlobs(stale, { token, abortSignal });
+}
+
+async function enforceDistributedRateLimit(
+  subject,
+  now,
+  windowMs,
+  maxRequests,
+  token,
+  abortSignal,
+) {
+  const subjectHash = await sha256Hex(subject);
+  const windowStart = windowStartFor(now, windowMs);
+  const resetAt = windowStart + windowMs;
+  const prefix = windowPrefix(subjectHash, windowStart);
+  const page = await listBlobs({
+    prefix,
+    limit: Math.min(maxRequests + 1, 1_000),
+    token,
+    abortSignal,
+  });
+  const occupied = new Set();
+  for (const blob of page.blobs || []) {
+    const match = String(blob.pathname || '').slice(prefix.length).match(/^(\d+)\.json$/);
+    if (match) occupied.add(Number(match[1]));
+  }
+  if (occupied.size >= maxRequests) {
+    return {
+      limited: true,
+      retryAfterSeconds: Math.max(1, Math.ceil((resetAt - now) / 1000)),
+      scope: 'distributed',
+    };
+  }
+
+  const offset = randomSlot(maxRequests);
+  for (let attempt = 0; attempt < maxRequests; attempt++) {
+    const slot = (offset + attempt) % maxRequests;
+    if (occupied.has(slot)) continue;
+    try {
+      await putBlob(markerPath(subjectHash, windowStart, slot), '{}', {
+        access: 'private',
+        addRandomSuffix: false,
+        allowOverwrite: false,
+        cacheControlMaxAge: 60,
+        contentType: 'application/json',
+        token,
+        abortSignal,
+      });
+      if (slot === 0) {
+        await cleanupExpiredMarkers(
+          subjectHash,
+          windowStart,
+          token,
+          abortSignal,
+        ).catch(() => {});
+      }
+      return {
+        limited: false,
+        retryAfterSeconds: Math.max(1, Math.ceil((resetAt - now) / 1000)),
+        scope: 'distributed',
+      };
+    } catch (error) {
+      if (isSlotConflict(error)) continue;
+      throw error;
+    }
+  }
+
+  return {
+    limited: true,
+    retryAfterSeconds: Math.max(1, Math.ceil((resetAt - now) / 1000)),
+    scope: 'distributed',
+  };
+}
+
+function enforceLocalRateLimit(subject, now, windowMs, maxRequests) {
+  let bucket = localRateLimitBuckets.get(subject);
+  if (!bucket || bucket.resetAt <= now) {
+    bucket = { count: 0, resetAt: now + windowMs };
+  }
+  bucket.count++;
+  localRateLimitBuckets.set(subject, bucket);
+
+  if (localRateLimitBuckets.size > MAX_LOCAL_RATE_LIMIT_BUCKETS) {
+    for (const [key, candidate] of localRateLimitBuckets) {
+      if (candidate.resetAt <= now || localRateLimitBuckets.size > MAX_LOCAL_RATE_LIMIT_BUCKETS) {
+        localRateLimitBuckets.delete(key);
+      }
+    }
+  }
+
+  return {
+    limited: bucket.count > maxRequests,
+    retryAfterSeconds: Math.max(1, Math.ceil((bucket.resetAt - now) / 1000)),
+    scope: 'instance',
+  };
+}
+
+export async function enforceProxyRateLimit(req) {
+  const now = Date.now();
+  const windowMs = readBoundedEnvInteger(
+    'PROXY_RATE_LIMIT_WINDOW_MS',
+    DEFAULT_PROXY_RATE_LIMIT_WINDOW_MS,
+    1_000,
+    60 * 60 * 1000,
+  );
+  const maxRequests = readBoundedEnvInteger(
+    'PROXY_RATE_LIMIT_MAX',
+    DEFAULT_PROXY_RATE_LIMIT_MAX,
+    1,
+    MAX_DISTRIBUTED_RATE_LIMIT_SLOTS,
+  );
+  const subject = getProxyRateLimitSubject(req);
+  const env = typeof process !== 'undefined' ? process.env || {} : {};
+  const token = env.PROXY_RATE_LIMIT_BLOB_TOKEN || env.BLOB_READ_WRITE_TOKEN || '';
+
+  if (token) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => {
+      controller.abort(new Error('Proxy distributed rate limit timed out'));
+    }, DISTRIBUTED_RATE_LIMIT_TIMEOUT_MS);
+    try {
+      return await enforceDistributedRateLimit(
+        subject,
+        now,
+        windowMs,
+        maxRequests,
+        token,
+        controller.signal,
+      );
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+  if (env.VERCEL && env.PROXY_ALLOW_INSTANCE_RATE_LIMIT !== '1') {
+    return {
+      limited: false,
+      unavailable: true,
+      retryAfterSeconds: 60,
+      scope: 'unavailable',
+    };
+  }
+  return enforceLocalRateLimit(subject, now, windowMs, maxRequests);
+}

--- a/lib/proxy-rate-limit.js
+++ b/lib/proxy-rate-limit.js
@@ -15,7 +15,8 @@ const DEFAULT_PROXY_RATE_LIMIT_MAX = 300;
 const MAX_DISTRIBUTED_RATE_LIMIT_SLOTS = 1_000;
 const MAX_LOCAL_RATE_LIMIT_BUCKETS = 4_096;
 const DISTRIBUTED_RATE_LIMIT_TIMEOUT_MS = 5_000;
-const RATE_LIMIT_PREFIX = 'proxy-rate/v1/';
+const RATE_LIMIT_PREFIX = 'proxy-rate/v2/';
+const RATE_LIMIT_CLEANUP_PREFIX = 'proxy-rate-cleanup/v2/';
 const localRateLimitBuckets = new Map();
 
 function readBoundedEnvInteger(name, fallback, min, max) {
@@ -45,12 +46,8 @@ function windowStartFor(now, windowMs) {
   return Math.floor(now / windowMs) * windowMs;
 }
 
-function subjectPrefix(subjectHash) {
-  return `${RATE_LIMIT_PREFIX}${subjectHash}/`;
-}
-
 function windowPrefix(subjectHash, windowStart) {
-  return `${subjectPrefix(subjectHash)}${windowStart}/`;
+  return `${RATE_LIMIT_PREFIX}${windowStart}/${subjectHash}/`;
 }
 
 function markerPath(subjectHash, windowStart, slot) {
@@ -68,22 +65,65 @@ function isSlotConflict(error) {
     || /precondition|already exists|overwrite/i.test(String(error?.message || ''));
 }
 
-async function cleanupExpiredMarkers(subjectHash, currentWindowStart, token, abortSignal) {
-  const prefix = subjectPrefix(subjectHash);
+function cleanupLeasePath(windowStart) {
+  return `${RATE_LIMIT_CLEANUP_PREFIX}${windowStart}.json`;
+}
+
+function markerWindowStart(pathname, prefix) {
+  const relative = String(pathname || '').slice(prefix.length);
+  return Number(relative.split('/')[0]?.replace(/\.json$/, ''));
+}
+
+async function deleteExpiredPrefix(prefix, currentWindowStart, token, abortSignal) {
   let cursor;
-  const stale = [];
   do {
     const page = await listBlobs({ prefix, cursor, limit: 1_000, token, abortSignal });
+    const stale = [];
     for (const blob of page.blobs || []) {
-      const relative = String(blob.pathname || '').slice(prefix.length);
-      const markerWindowStart = Number(relative.split('/')[0]);
-      if (Number.isFinite(markerWindowStart) && markerWindowStart < currentWindowStart) {
+      const windowStart = markerWindowStart(blob.pathname, prefix);
+      if (Number.isFinite(windowStart) && windowStart < currentWindowStart) {
         stale.push(blob.pathname);
       }
     }
+    if (stale.length) await deleteBlobs(stale, { token, abortSignal });
     cursor = page.hasMore ? page.cursor : undefined;
-  } while (cursor && stale.length < 1_000);
-  if (stale.length) await deleteBlobs(stale, { token, abortSignal });
+  } while (cursor);
+}
+
+async function cleanupExpiredMarkers(currentWindowStart, token, abortSignal) {
+  const leasePath = cleanupLeasePath(currentWindowStart);
+  try {
+    await putBlob(leasePath, '{}', {
+      access: 'private',
+      addRandomSuffix: false,
+      allowOverwrite: false,
+      cacheControlMaxAge: 60,
+      contentType: 'application/json',
+      token,
+      abortSignal,
+    });
+  } catch (error) {
+    if (isSlotConflict(error)) return;
+    throw error;
+  }
+
+  try {
+    await deleteExpiredPrefix(
+      RATE_LIMIT_PREFIX,
+      currentWindowStart,
+      token,
+      abortSignal,
+    );
+    await deleteExpiredPrefix(
+      RATE_LIMIT_CLEANUP_PREFIX,
+      currentWindowStart,
+      token,
+      abortSignal,
+    );
+  } catch (error) {
+    await deleteBlobs(leasePath, { token, abortSignal }).catch(() => {});
+    throw error;
+  }
 }
 
 async function enforceDistributedRateLimit(
@@ -131,14 +171,7 @@ async function enforceDistributedRateLimit(
         token,
         abortSignal,
       });
-      if (slot === 0) {
-        await cleanupExpiredMarkers(
-          subjectHash,
-          windowStart,
-          token,
-          abortSignal,
-        ).catch(() => {});
-      }
+      await cleanupExpiredMarkers(windowStart, token, abortSignal);
       return {
         limited: false,
         retryAfterSeconds: Math.max(1, Math.ceil((resetAt - now) / 1000)),

--- a/lib/proxy-rate-limit.js
+++ b/lib/proxy-rate-limit.js
@@ -145,6 +145,10 @@ async function enforceDistributedRateLimit(
   const windowStart = windowStartFor(now, windowMs);
   const resetAt = windowStart + windowMs;
   const prefix = windowPrefix(subjectHash, windowStart);
+  // Cleanup is a fail-closed prerequisite, not post-request maintenance.
+  // A request that receives 503 because cleanup failed must not consume one
+  // of the client's atomic slots.
+  await cleanupExpiredMarkers(windowStart, token, abortSignal);
   const page = await listBlobs({
     prefix,
     limit: Math.min(maxRequests + 1, 1_000),
@@ -178,7 +182,6 @@ async function enforceDistributedRateLimit(
         token,
         abortSignal,
       });
-      await cleanupExpiredMarkers(windowStart, token, abortSignal);
       return {
         limited: false,
         retryAfterSeconds: Math.max(1, Math.ceil((resetAt - now) / 1000)),

--- a/lib/proxy-rate-limit.js
+++ b/lib/proxy-rate-limit.js
@@ -91,9 +91,35 @@ async function deleteExpiredPrefix(prefix, currentWindowStart, token, abortSigna
 }
 
 async function cleanupExpiredMarkers(currentWindowStart, token, abortSignal) {
-  const leasePath = cleanupLeasePath(currentWindowStart);
+  const completionPath = cleanupLeasePath(currentWindowStart);
+  const completion = await listBlobs({
+    prefix: completionPath,
+    limit: 1,
+    token,
+    abortSignal,
+  });
+  if ((completion.blobs || []).some(blob => blob.pathname === completionPath)) {
+    return;
+  }
+
+  // Write the completion marker only after both global sweeps succeed.
+  // Concurrent first requests may duplicate the idempotent sweep, but a
+  // failed/aborted cleaner cannot leave a poisoned lease that suppresses
+  // cleanup for the rest of the window.
+  await deleteExpiredPrefix(
+    RATE_LIMIT_PREFIX,
+    currentWindowStart,
+    token,
+    abortSignal,
+  );
+  await deleteExpiredPrefix(
+    RATE_LIMIT_CLEANUP_PREFIX,
+    currentWindowStart,
+    token,
+    abortSignal,
+  );
   try {
-    await putBlob(leasePath, '{}', {
+    await putBlob(completionPath, '{}', {
       access: 'private',
       addRandomSuffix: false,
       allowOverwrite: false,
@@ -103,26 +129,7 @@ async function cleanupExpiredMarkers(currentWindowStart, token, abortSignal) {
       abortSignal,
     });
   } catch (error) {
-    if (isSlotConflict(error)) return;
-    throw error;
-  }
-
-  try {
-    await deleteExpiredPrefix(
-      RATE_LIMIT_PREFIX,
-      currentWindowStart,
-      token,
-      abortSignal,
-    );
-    await deleteExpiredPrefix(
-      RATE_LIMIT_CLEANUP_PREFIX,
-      currentWindowStart,
-      token,
-      abortSignal,
-    );
-  } catch (error) {
-    await deleteBlobs(leasePath, { token, abortSignal }).catch(() => {});
-    throw error;
+    if (!isSlotConflict(error)) throw error;
   }
 }
 

--- a/lib/proxy-upstream.js
+++ b/lib/proxy-upstream.js
@@ -1,0 +1,313 @@
+// @ts-check
+// Shared upstream lifecycle for every server-side proxy branch. Redirect
+// validation, DNS pinning, cancellation, timeouts, and byte caps belong here
+// so secret-bearing relays cannot accidentally bypass the generic safeguards.
+
+import { fetchWithPinnedProxyDns } from './proxy-network.js';
+import { isAllowedProxyUrl } from './proxy-policy.js';
+
+const PROXY_REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+const PROXY_MAX_REDIRECTS = 5;
+const DEFAULT_PROXY_UPSTREAM_TIMEOUT_MS = 180_000;
+
+export const PROXY_MAX_CREDENTIAL_RESPONSE_BYTES = 256 * 1024;
+
+function readBoundedEnvInteger(name, fallback, min, max) {
+  const raw = typeof process !== 'undefined' ? process.env?.[name] : undefined;
+  if (!raw) return fallback;
+  const value = Number.parseInt(raw, 10);
+  return Number.isFinite(value) && value >= min && value <= max ? value : fallback;
+}
+
+function proxyRuntimeError(code, message) {
+  const error = new Error(message);
+  error.code = code;
+  return error;
+}
+
+function requestTooLargeError() {
+  return proxyRuntimeError('PROXY_REQUEST_TOO_LARGE', 'Proxy request body too large');
+}
+
+function responseTooLargeError() {
+  return proxyRuntimeError('PROXY_RESPONSE_TOO_LARGE', 'Proxy response exceeds size cap');
+}
+
+function redirectRequestOptions(status, options) {
+  const method = String(options.method || 'GET').toUpperCase();
+  if (status !== 303 && !((status === 301 || status === 302) && method === 'POST')) {
+    return options;
+  }
+  const headers = { ...(options.headers || {}) };
+  for (const name of Object.keys(headers)) {
+    if (['content-length', 'content-type'].includes(name.toLowerCase())) delete headers[name];
+  }
+  return { ...options, method: 'GET', headers, body: undefined };
+}
+
+function stripProxyCredentialHeaders(options) {
+  const headers = { ...(options.headers || {}) };
+  for (const name of Object.keys(headers)) {
+    if (['api-key', 'authorization', 'x-api-key'].includes(name.toLowerCase())) delete headers[name];
+  }
+  return { ...options, headers };
+}
+
+async function discardResponseBody(response) {
+  try {
+    await response.body?.cancel?.();
+  } catch {}
+}
+
+function createUpstreamLifecycle(externalSignal) {
+  const timeoutMs = readBoundedEnvInteger(
+    'PROXY_UPSTREAM_TIMEOUT_MS',
+    DEFAULT_PROXY_UPSTREAM_TIMEOUT_MS,
+    10,
+    180_000,
+  );
+  const controller = new AbortController();
+  let timedOut = false;
+  let settled = false;
+  const abortFromCaller = () => {
+    controller.abort(externalSignal?.reason || proxyRuntimeError(
+      'PROXY_CLIENT_ABORTED',
+      'Proxy client disconnected',
+    ));
+  };
+  if (externalSignal?.aborted) abortFromCaller();
+  else externalSignal?.addEventListener?.('abort', abortFromCaller, { once: true });
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    controller.abort(proxyRuntimeError('PROXY_UPSTREAM_TIMEOUT', 'Proxy upstream timed out'));
+  }, timeoutMs);
+
+  return {
+    signal: controller.signal,
+    mapError(error) {
+      if (timedOut) {
+        return proxyRuntimeError('PROXY_UPSTREAM_TIMEOUT', 'Proxy upstream timed out');
+      }
+      if (externalSignal?.aborted) {
+        return proxyRuntimeError('PROXY_CLIENT_ABORTED', 'Proxy client disconnected');
+      }
+      return error;
+    },
+    settle() {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      externalSignal?.removeEventListener?.('abort', abortFromCaller);
+    },
+    abort(reason) {
+      if (!controller.signal.aborted) controller.abort(reason);
+    },
+  };
+}
+
+function bindResponseLifecycle(response, lifecycle) {
+  if (!response.body?.getReader || typeof ReadableStream !== 'function') {
+    lifecycle.settle();
+    return response;
+  }
+  const reader = response.body.getReader();
+  let settled = false;
+  const settle = () => {
+    if (settled) return;
+    settled = true;
+    lifecycle.settle();
+  };
+  const body = new ReadableStream({
+    async pull(controller) {
+      try {
+        const { done, value } = await reader.read();
+        if (done) {
+          settle();
+          controller.close();
+          return;
+        }
+        controller.enqueue(value);
+      } catch (error) {
+        const mapped = lifecycle.mapError(error);
+        settle();
+        controller.error(mapped);
+      }
+    },
+    async cancel(reason) {
+      lifecycle.abort(reason instanceof Error ? reason : new Error('Proxy response cancelled'));
+      try {
+        await reader.cancel(reason);
+      } finally {
+        settle();
+      }
+    },
+  });
+  return new Response(body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}
+
+// Fetch redirects manually so every destination passes the same SSRF policy.
+// Credentialed/body-bearing cross-origin redirects are constrained so API
+// secrets and request payloads never migrate to a new host. Safe GET redirects
+// remain supported for ordinary product pages that canonicalize to `www`.
+export async function fetchWithValidatedRedirects(initialUrl, initialOptions = {}, {
+  signal: externalSignal,
+} = {}) {
+  const lifecycle = createUpstreamLifecycle(externalSignal);
+  let url = '';
+  let options = { ...initialOptions };
+  let redirects = 0;
+
+  try {
+    url = new URL(initialUrl).toString();
+    while (true) {
+      if (!isAllowedProxyUrl(url)) {
+        throw proxyRuntimeError('PROXY_REDIRECT_BLOCKED', 'Proxy redirect target not allowed');
+      }
+      const response = await fetchWithPinnedProxyDns(url, {
+        ...options,
+        redirect: 'manual',
+        signal: lifecycle.signal,
+      });
+
+      if (!PROXY_REDIRECT_STATUSES.has(response.status)) {
+        return bindResponseLifecycle(response, lifecycle);
+      }
+      const location = response.headers.get('location');
+      if (!location) return bindResponseLifecycle(response, lifecycle);
+      if (redirects >= PROXY_MAX_REDIRECTS) {
+        await discardResponseBody(response);
+        throw proxyRuntimeError('PROXY_REDIRECT_LIMIT', 'Proxy redirect limit exceeded');
+      }
+
+      let nextUrl;
+      try {
+        nextUrl = new URL(location, url).toString();
+      } catch {
+        await discardResponseBody(response);
+        throw proxyRuntimeError('PROXY_REDIRECT_BLOCKED', 'Proxy redirect target not allowed');
+      }
+      if (!isAllowedProxyUrl(nextUrl)) {
+        await discardResponseBody(response);
+        throw proxyRuntimeError('PROXY_REDIRECT_BLOCKED', 'Proxy redirect target not allowed');
+      }
+      let nextOptions = redirectRequestOptions(response.status, options);
+      if (new URL(nextUrl).origin !== new URL(url).origin && nextOptions.body != null) {
+        await discardResponseBody(response);
+        throw proxyRuntimeError(
+          'PROXY_CROSS_ORIGIN_BODY_REDIRECT',
+          'Cross-origin proxy redirects with a request body are not allowed',
+        );
+      }
+      if (new URL(nextUrl).origin !== new URL(url).origin) {
+        nextOptions = stripProxyCredentialHeaders(nextOptions);
+      }
+
+      await discardResponseBody(response);
+      options = nextOptions;
+      url = nextUrl;
+      redirects++;
+    }
+  } catch (error) {
+    lifecycle.settle();
+    throw lifecycle.mapError(error);
+  }
+}
+
+export async function readRequestTextWithCap(request, maxBytes) {
+  const contentLength = Number.parseInt(request.headers.get('content-length') || '0', 10);
+  if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+    try {
+      await request.body?.cancel?.();
+    } catch {}
+    throw requestTooLargeError();
+  }
+  const reader = request.body?.getReader?.();
+  if (!reader) {
+    const body = await request.text();
+    if (new TextEncoder().encode(body).length > maxBytes) throw requestTooLargeError();
+    return body;
+  }
+
+  const decoder = new TextDecoder();
+  let body = '';
+  let bytes = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    bytes += value?.byteLength || 0;
+    if (bytes > maxBytes) {
+      try {
+        await reader.cancel();
+      } catch {}
+      throw requestTooLargeError();
+    }
+    body += decoder.decode(value, { stream: true });
+  }
+  return body + decoder.decode();
+}
+
+export async function readResponseTextWithCap(response, maxBytes) {
+  const contentLength = Number.parseInt(response.headers.get('content-length') || '0', 10);
+  if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+    await discardResponseBody(response);
+    throw responseTooLargeError();
+  }
+  const reader = response.body?.getReader?.();
+  if (!reader) {
+    const body = await response.text();
+    if (new TextEncoder().encode(body).length > maxBytes) throw responseTooLargeError();
+    return body;
+  }
+
+  const decoder = new TextDecoder();
+  let body = '';
+  let bytes = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    bytes += value?.byteLength || 0;
+    if (bytes > maxBytes) {
+      try {
+        await reader.cancel();
+      } catch {}
+      throw responseTooLargeError();
+    }
+    body += decoder.decode(value, { stream: true });
+  }
+  return body + decoder.decode();
+}
+
+export function capReadableStream(body, maxBytes) {
+  if (!body?.getReader || typeof ReadableStream !== 'function') return body;
+  const reader = body.getReader();
+  let bytes = 0;
+  return new ReadableStream({
+    async pull(controller) {
+      try {
+        const { done, value } = await reader.read();
+        if (done) {
+          controller.close();
+          return;
+        }
+        bytes += value?.byteLength || 0;
+        if (bytes > maxBytes) {
+          try {
+            await reader.cancel();
+          } catch {}
+          controller.error(responseTooLargeError());
+          return;
+        }
+        controller.enqueue(value);
+      } catch (error) {
+        controller.error(error);
+      }
+    },
+    cancel(reason) {
+      return reader.cancel(reason);
+    },
+  });
+}

--- a/tests/api-network-runtime.test.js
+++ b/tests/api-network-runtime.test.js
@@ -30,7 +30,10 @@ const ENV_KEYS = [
   'UVDATA_BEARER',
   'PROXY_RATE_LIMIT_MAX',
   'PROXY_RATE_LIMIT_WINDOW_MS',
+  'PROXY_RATE_LIMIT_BLOB_TOKEN',
+  'PROXY_ALLOW_INSTANCE_RATE_LIMIT',
   'PROXY_UPSTREAM_TIMEOUT_MS',
+  'VERCEL',
   'VERCEL_GIT_COMMIT_SHA',
   'VERCEL_GIT_COMMIT_REF',
 ];
@@ -496,6 +499,7 @@ describe('AI proxy runtime behavior', () => {
     process.env.WITHINGS_CLIENT_ID = '   ';
     const runtime = await proxyHandler(makeProxyRequest({ wearable_runtime_config: true }));
     expect(runtime.status).toBe(200);
+    expect(runtime.headers.get('Cache-Control')).toBe('no-store');
     expect(await responseJson(runtime)).toEqual({
       overrides: {
         oura: 'oura-selfhost',
@@ -508,6 +512,20 @@ describe('AI proxy runtime behavior', () => {
       requestUrl: 'https://health.example.net/api/proxy',
     }));
     expect(selfHosted.status).toBe(200);
+  });
+
+  it('fails closed when a hosted deployment has no distributed proxy limiter', async () => {
+    process.env.VERCEL = '1';
+
+    const response = await proxyHandler(makeProxyRequest({
+      wearable_runtime_config: true,
+    }, { clientIp: '203.0.113.79' }));
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get('Retry-After')).toBe('60');
+    expect(await responseJson(response)).toEqual({
+      error: 'Proxy rate limit is not configured for this hosted deployment.',
+    });
   });
 
   it('blocks SSRF targets and forwards allowed custom HTTPS endpoints', async () => {
@@ -563,7 +581,7 @@ describe('AI proxy runtime behavior', () => {
       body: { prompt: 'hello' },
     }));
     expect(failed.status).toBe(502);
-    expect(await responseJson(failed)).toEqual({ error: 'Upstream error: offline' });
+    expect(await responseJson(failed)).toEqual({ error: 'Upstream request failed' });
   });
 
   it('revalidates redirect targets and never forwards credentials across origins', async () => {
@@ -578,7 +596,7 @@ describe('AI proxy runtime behavior', () => {
     }));
     expect(privateRedirect.status).toBe(502);
     expect(await responseJson(privateRedirect)).toEqual({
-      error: 'Upstream error: Proxy redirect target not allowed',
+      error: 'Proxy redirect target not allowed',
     });
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
 
@@ -593,7 +611,7 @@ describe('AI proxy runtime behavior', () => {
     }));
     expect(crossOriginRedirect.status).toBe(502);
     expect(await responseJson(crossOriginRedirect)).toEqual({
-      error: 'Upstream error: Cross-origin proxy redirects with a request body are not allowed',
+      error: 'Cross-origin proxy redirects with a request body are not allowed',
     });
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
 
@@ -656,7 +674,7 @@ describe('AI proxy runtime behavior', () => {
     }));
     expect(redirectLoop.status).toBe(502);
     expect(await responseJson(redirectLoop)).toEqual({
-      error: 'Upstream error: Proxy redirect limit exceeded',
+      error: 'Proxy redirect limit exceeded',
     });
     expect(globalThis.fetch).toHaveBeenCalledTimes(6);
   });
@@ -671,7 +689,7 @@ describe('AI proxy runtime behavior', () => {
     }, { clientIp: '203.0.113.80' }));
     expect(timedOut.status).toBe(504);
     expect(await responseJson(timedOut)).toEqual({
-      error: 'Upstream error: Proxy upstream timed out',
+      error: 'Proxy upstream timed out',
     });
 
     delete process.env.PROXY_UPSTREAM_TIMEOUT_MS;
@@ -691,6 +709,28 @@ describe('AI proxy runtime behavior', () => {
       retryAfterSeconds: expect.any(Number),
     });
     expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps the timeout active while an upstream response body is stalled', async () => {
+    process.env.PROXY_UPSTREAM_TIMEOUT_MS = '10';
+    globalThis.fetch = vi.fn(async (_url, init) => new Response(new ReadableStream({
+      start(controller) {
+        init.signal.addEventListener('abort', () => {
+          controller.error(new Error('aborted'));
+        }, { once: true });
+      },
+    }), {
+      headers: { 'Content-Type': 'application/json' },
+    }));
+
+    const timedOut = await proxyHandler(makeProxyRequest({
+      url: 'https://slow-body.example.com/v1/chat',
+    }, { clientIp: '203.0.113.82' }));
+
+    expect(timedOut.status).toBe(504);
+    expect(await responseJson(timedOut)).toEqual({
+      error: 'Proxy upstream timed out',
+    });
   });
 
   it('preserves provider-compatible headers for proxied custom API calls', async () => {
@@ -790,7 +830,7 @@ describe('AI proxy runtime behavior', () => {
     }));
     expect(oversizedResponse.status).toBe(502);
     expect(await responseJson(oversizedResponse)).toEqual({
-      error: 'Upstream error: Proxy response exceeds size cap',
+      error: 'Proxy response exceeds size cap',
     });
 
     globalThis.fetch = vi.fn(async () => jsonResponse({ ok: true }));
@@ -872,6 +912,46 @@ describe('AI proxy runtime behavior', () => {
     });
   });
 
+  it('applies redirect, timeout, and response-size guardrails to secret-bearing OAuth relays', async () => {
+    process.env.OURA_CLIENT_SECRET = 'oura-secret';
+    globalThis.fetch = vi.fn(async () => new Response(null, {
+      status: 307,
+      headers: { Location: 'https://collector.example.com/capture' },
+    }));
+
+    const redirected = await proxyHandler(makeProxyRequest({
+      oura_token_exchange: {
+        code: 'oura-code',
+        redirect_uri: 'https://app.example.com/cb',
+        client_id: 'oura-client',
+      },
+    }, { clientIp: '203.0.113.83' }));
+
+    expect(redirected.status).toBe(502);
+    expect(await responseJson(redirected)).toEqual({
+      error: 'Cross-origin proxy redirects with a request body are not allowed',
+    });
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+
+    globalThis.fetch = vi.fn(async () => new Response('{}', {
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': String(300 * 1024),
+      },
+    }));
+    const oversized = await proxyHandler(makeProxyRequest({
+      oura_token_refresh: {
+        refresh_token: 'oura-refresh',
+        client_id: 'oura-client',
+      },
+    }, { clientIp: '203.0.113.84' }));
+
+    expect(oversized.status).toBe(502);
+    expect(await responseJson(oversized)).toEqual({
+      error: 'Proxy response exceeds size cap',
+    });
+  });
+
   it('validates and relays CAMS atmosphere requests without exposing the bearer token to callers', async () => {
     const hostedWithoutBearer = await proxyHandler(makeProxyRequest({
       meteo: 'cams',
@@ -883,7 +963,7 @@ describe('AI proxy runtime behavior', () => {
       error: expect.stringContaining('CAMS hosted relay requires UVDATA_BEARER'),
     });
 
-    process.env.UVDATA_UPSTREAM = 'https://uv.example.test/base/';
+    process.env.UVDATA_UPSTREAM = 'https://uv.example.com/base/';
     const badCoords = await proxyHandler(makeProxyRequest({
       meteo: 'cams',
       latitude: 91,
@@ -906,7 +986,7 @@ describe('AI proxy runtime behavior', () => {
     expect(relayed.status).toBe(200);
     expect(await responseJson(relayed)).toEqual({ uv: 4.2 });
     const [url, init] = globalThis.fetch.mock.calls.at(-1);
-    expect(url).toBe('https://uv.example.test/base/uv?latitude=50.1&longitude=14.4&time=2026-06-06T12%3A00%3A00Z');
+    expect(url).toBe('https://uv.example.com/base/uv?latitude=50.1&longitude=14.4&time=2026-06-06T12%3A00%3A00Z');
     expect(init.headers.Authorization).toBe('Bearer uv-secret');
 
     globalThis.fetch = vi.fn(async () => new Response('{}', {
@@ -919,7 +999,34 @@ describe('AI proxy runtime behavior', () => {
       longitude: 14.4,
     }));
     expect(oversized.status).toBe(502);
-    expect(await responseJson(oversized)).toEqual({ error: 'CAMS response exceeds size cap' });
+    expect(await responseJson(oversized)).toEqual({ error: 'Proxy response exceeds size cap' });
+  });
+
+  it('strips the CAMS bearer before following an allowed cross-origin redirect', async () => {
+    process.env.UVDATA_UPSTREAM = 'https://uv.example.com';
+    process.env.UVDATA_BEARER = 'uv-secret';
+    globalThis.fetch = vi.fn(async (url) => {
+      if (url.startsWith('https://uv.example.com/uv?')) {
+        return new Response(null, {
+          status: 302,
+          headers: { Location: 'https://uv-cdn.example.com/result' },
+        });
+      }
+      return jsonResponse({ uv: 3.1 });
+    });
+
+    const relayed = await proxyHandler(makeProxyRequest({
+      meteo: 'cams',
+      latitude: 50.1,
+      longitude: 14.4,
+    }, { clientIp: '203.0.113.85' }));
+
+    expect(relayed.status).toBe(200);
+    expect(await responseJson(relayed)).toEqual({ uv: 3.1 });
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    const [redirectUrl, redirectInit] = globalThis.fetch.mock.calls[1];
+    expect(redirectUrl).toBe('https://uv-cdn.example.com/result');
+    expect(redirectInit.headers).not.toHaveProperty('Authorization');
   });
 });
 

--- a/tests/api-network-runtime.test.js
+++ b/tests/api-network-runtime.test.js
@@ -733,6 +733,81 @@ describe('AI proxy runtime behavior', () => {
     });
   });
 
+  it('streams responses to completion and propagates downstream cancellation', async () => {
+    globalThis.fetch = vi.fn(async () => new Response(
+      'data: {"ok":true}\n\n',
+      { headers: { 'Content-Type': 'text/event-stream' } },
+    ));
+    const completed = await proxyHandler(makeProxyRequest({
+      url: 'https://stream.example.com/v1/chat',
+    }, { clientIp: '203.0.113.86' }));
+
+    expect(completed.status).toBe(200);
+    expect(completed.headers.get('Content-Type')).toBe('text/event-stream');
+    expect(await completed.text()).toBe('data: {"ok":true}\n\n');
+
+    let upstreamCancelled = false;
+    globalThis.fetch = vi.fn(async () => new Response(new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('data: first\n\n'));
+      },
+      cancel() {
+        upstreamCancelled = true;
+      },
+    }), {
+      headers: { 'Content-Type': 'text/event-stream' },
+    }));
+    const cancellable = await proxyHandler(makeProxyRequest({
+      url: 'https://stream.example.com/v1/chat',
+    }, { clientIp: '203.0.113.87' }));
+    const reader = cancellable.body.getReader();
+    expect((await reader.read()).done).toBe(false);
+    await reader.cancel('client stopped reading');
+
+    expect(upstreamCancelled).toBe(true);
+  });
+
+  it('propagates timeout and byte-cap errors through the streaming response path', async () => {
+    process.env.PROXY_UPSTREAM_TIMEOUT_MS = '10';
+    globalThis.fetch = vi.fn(async (_url, init) => new Response(new ReadableStream({
+      start(controller) {
+        init.signal.addEventListener('abort', () => {
+          controller.error(new Error('aborted'));
+        }, { once: true });
+      },
+    }), {
+      headers: { 'Content-Type': 'text/event-stream' },
+    }));
+    const stalled = await proxyHandler(makeProxyRequest({
+      url: 'https://stream.example.com/v1/chat',
+    }, { clientIp: '203.0.113.88' }));
+
+    await expect(stalled.text()).rejects.toMatchObject({
+      code: 'PROXY_UPSTREAM_TIMEOUT',
+    });
+
+    delete process.env.PROXY_UPSTREAM_TIMEOUT_MS;
+    let upstreamCancelled = false;
+    globalThis.fetch = vi.fn(async () => new Response(new ReadableStream({
+      start(controller) {
+        controller.enqueue(new Uint8Array(PROXY_MAX_RESPONSE_BYTES + 1));
+      },
+      cancel() {
+        upstreamCancelled = true;
+      },
+    }), {
+      headers: { 'Content-Type': 'application/x-ndjson' },
+    }));
+    const oversized = await proxyHandler(makeProxyRequest({
+      url: 'https://stream.example.com/v1/chat',
+    }, { clientIp: '203.0.113.89' }));
+
+    await expect(oversized.text()).rejects.toMatchObject({
+      code: 'PROXY_RESPONSE_TOO_LARGE',
+    });
+    expect(upstreamCancelled).toBe(true);
+  });
+
   it('preserves provider-compatible headers for proxied custom API calls', async () => {
     globalThis.fetch = vi.fn(async () => jsonResponse({ ok: true }));
 

--- a/tests/proxy-rate-limit.test.js
+++ b/tests/proxy-rate-limit.test.js
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const blobMock = vi.hoisted(() => {
+  const store = new Map();
+  return {
+    store,
+    list: vi.fn(async ({ prefix = '', limit = 1000 } = {}) => ({
+      blobs: Array.from(store.keys())
+        .filter(pathname => pathname.startsWith(prefix))
+        .slice(0, limit)
+        .map(pathname => ({ pathname })),
+      hasMore: false,
+    })),
+    put: vi.fn(async (pathname, body) => {
+      if (store.has(pathname)) throw new Error('already exists');
+      store.set(pathname, body);
+      return { pathname, url: `https://blob.example.com/${pathname}` };
+    }),
+    del: vi.fn(async (pathnames) => {
+      for (const pathname of Array.isArray(pathnames) ? pathnames : [pathnames]) {
+        store.delete(pathname);
+      }
+    }),
+  };
+});
+
+vi.mock('@vercel/blob', async importOriginal => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    list: blobMock.list,
+    put: blobMock.put,
+    del: blobMock.del,
+  };
+});
+
+import { enforceProxyRateLimit } from '../lib/proxy-rate-limit.js';
+
+const ENV_KEYS = [
+  'BLOB_READ_WRITE_TOKEN',
+  'PROXY_ALLOW_INSTANCE_RATE_LIMIT',
+  'PROXY_RATE_LIMIT_BLOB_TOKEN',
+  'PROXY_RATE_LIMIT_MAX',
+  'PROXY_RATE_LIMIT_WINDOW_MS',
+  'VERCEL',
+];
+let savedEnv;
+
+function rateRequest(ip = '203.0.113.90') {
+  return new Request('https://getbased.health/api/proxy', {
+    headers: {
+      origin: 'https://app.getbased.health',
+      'x-forwarded-for': ip,
+    },
+  });
+}
+
+function vercelRateRequest(vercelIp, forwardedIp) {
+  return new Request('https://getbased.health/api/proxy', {
+    headers: {
+      origin: 'https://app.getbased.health',
+      'x-vercel-forwarded-for': vercelIp,
+      'x-forwarded-for': forwardedIp,
+    },
+  });
+}
+
+beforeEach(() => {
+  savedEnv = Object.fromEntries(ENV_KEYS.map(key => [key, process.env[key]]));
+  for (const key of ENV_KEYS) delete process.env[key];
+  blobMock.store.clear();
+  blobMock.list.mockClear();
+  blobMock.put.mockClear();
+  blobMock.del.mockClear();
+});
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  vi.restoreAllMocks();
+});
+
+describe('proxy distributed rate limit', () => {
+  it('enforces a shared atomic-slot limit without storing the raw client subject', async () => {
+    process.env.VERCEL = '1';
+    process.env.PROXY_RATE_LIMIT_BLOB_TOKEN = 'vercel_blob_rw_store_secret';
+    process.env.PROXY_RATE_LIMIT_MAX = '2';
+    process.env.PROXY_RATE_LIMIT_WINDOW_MS = '1000';
+    const request = rateRequest();
+
+    expect(await enforceProxyRateLimit(request)).toMatchObject({
+      limited: false,
+      scope: 'distributed',
+    });
+    expect(await enforceProxyRateLimit(request)).toMatchObject({
+      limited: false,
+      scope: 'distributed',
+    });
+    expect(await enforceProxyRateLimit(request)).toMatchObject({
+      limited: true,
+      scope: 'distributed',
+      retryAfterSeconds: expect.any(Number),
+    });
+
+    expect(blobMock.store.size).toBe(2);
+    expect(blobMock.list.mock.calls[0][0].abortSignal).toBeInstanceOf(AbortSignal);
+    expect(blobMock.put.mock.calls[0][2].abortSignal).toBeInstanceOf(AbortSignal);
+    expect(Array.from(blobMock.store.keys()).every(path => path.startsWith('proxy-rate/v1/'))).toBe(true);
+    expect(Array.from(blobMock.store.keys()).join('|')).not.toContain('203.0.113.90');
+    expect(Array.from(blobMock.store.keys()).join('|')).not.toContain('app.getbased.health');
+  });
+
+  it('fails closed on Vercel when no distributed limiter is configured', async () => {
+    process.env.VERCEL = '1';
+
+    expect(await enforceProxyRateLimit(rateRequest('203.0.113.91'))).toEqual({
+      limited: false,
+      unavailable: true,
+      retryAfterSeconds: 60,
+      scope: 'unavailable',
+    });
+    expect(blobMock.list).not.toHaveBeenCalled();
+    expect(blobMock.put).not.toHaveBeenCalled();
+  });
+
+  it('prefers Vercel’s non-overridable forwarding header for the shared subject', async () => {
+    process.env.VERCEL = '1';
+    process.env.PROXY_RATE_LIMIT_BLOB_TOKEN = 'vercel_blob_rw_store_secret';
+    process.env.PROXY_RATE_LIMIT_MAX = '1';
+
+    expect(await enforceProxyRateLimit(vercelRateRequest(
+      '203.0.113.94',
+      '198.51.100.1',
+    ))).toMatchObject({ limited: false });
+    expect(await enforceProxyRateLimit(vercelRateRequest(
+      '203.0.113.94',
+      '198.51.100.2',
+    ))).toMatchObject({ limited: true });
+  });
+
+  it('allows an explicit per-instance fallback for self-hosted Vercel deployments', async () => {
+    process.env.VERCEL = '1';
+    process.env.PROXY_ALLOW_INSTANCE_RATE_LIMIT = '1';
+    process.env.PROXY_RATE_LIMIT_MAX = '1';
+
+    expect(await enforceProxyRateLimit(rateRequest('203.0.113.92'))).toMatchObject({
+      limited: false,
+      scope: 'instance',
+    });
+    expect(await enforceProxyRateLimit(rateRequest('203.0.113.92'))).toMatchObject({
+      limited: true,
+      scope: 'instance',
+    });
+  });
+
+  it('propagates distributed storage failures so the route can return 503', async () => {
+    process.env.VERCEL = '1';
+    process.env.BLOB_READ_WRITE_TOKEN = 'vercel_blob_rw_store_secret';
+    blobMock.list.mockRejectedValueOnce(new Error('blob unavailable'));
+
+    await expect(enforceProxyRateLimit(rateRequest('203.0.113.93')))
+      .rejects.toThrow('blob unavailable');
+  });
+});

--- a/tests/proxy-rate-limit.test.js
+++ b/tests/proxy-rate-limit.test.js
@@ -167,6 +167,24 @@ describe('proxy distributed rate limit', () => {
     expect(blobMock.del).toHaveBeenCalled();
   });
 
+  it('does not publish cleanup completion when the global sweep fails', async () => {
+    process.env.VERCEL = '1';
+    process.env.PROXY_RATE_LIMIT_BLOB_TOKEN = 'vercel_blob_rw_store_secret';
+    process.env.PROXY_RATE_LIMIT_MAX = '2';
+    process.env.PROXY_RATE_LIMIT_WINDOW_MS = '1000';
+    vi.spyOn(Date, 'now').mockReturnValue(3_100);
+    blobMock.list
+      .mockResolvedValueOnce({ blobs: [], hasMore: false })
+      .mockResolvedValueOnce({ blobs: [], hasMore: false })
+      .mockRejectedValueOnce(new Error('cleanup unavailable'));
+
+    await expect(enforceProxyRateLimit(rateRequest('203.0.113.97')))
+      .rejects.toThrow('cleanup unavailable');
+    expect(Array.from(blobMock.store.keys()).some(path => (
+      path === 'proxy-rate-cleanup/v2/3000.json'
+    ))).toBe(false);
+  });
+
   it('allows an explicit per-instance fallback for self-hosted Vercel deployments', async () => {
     process.env.VERCEL = '1';
     process.env.PROXY_ALLOW_INSTANCE_RATE_LIMIT = '1';

--- a/tests/proxy-rate-limit.test.js
+++ b/tests/proxy-rate-limit.test.js
@@ -175,11 +175,13 @@ describe('proxy distributed rate limit', () => {
     vi.spyOn(Date, 'now').mockReturnValue(3_100);
     blobMock.list
       .mockResolvedValueOnce({ blobs: [], hasMore: false })
-      .mockResolvedValueOnce({ blobs: [], hasMore: false })
       .mockRejectedValueOnce(new Error('cleanup unavailable'));
 
     await expect(enforceProxyRateLimit(rateRequest('203.0.113.97')))
       .rejects.toThrow('cleanup unavailable');
+    expect(Array.from(blobMock.store.keys()).some(path => (
+      path.startsWith('proxy-rate/v2/3000/')
+    ))).toBe(false);
     expect(Array.from(blobMock.store.keys()).some(path => (
       path === 'proxy-rate-cleanup/v2/3000.json'
     ))).toBe(false);

--- a/tests/proxy-rate-limit.test.js
+++ b/tests/proxy-rate-limit.test.js
@@ -104,10 +104,11 @@ describe('proxy distributed rate limit', () => {
       retryAfterSeconds: expect.any(Number),
     });
 
-    expect(blobMock.store.size).toBe(2);
+    const requestMarkers = Array.from(blobMock.store.keys())
+      .filter(path => path.startsWith('proxy-rate/v2/'));
+    expect(requestMarkers).toHaveLength(2);
     expect(blobMock.list.mock.calls[0][0].abortSignal).toBeInstanceOf(AbortSignal);
     expect(blobMock.put.mock.calls[0][2].abortSignal).toBeInstanceOf(AbortSignal);
-    expect(Array.from(blobMock.store.keys()).every(path => path.startsWith('proxy-rate/v1/'))).toBe(true);
     expect(Array.from(blobMock.store.keys()).join('|')).not.toContain('203.0.113.90');
     expect(Array.from(blobMock.store.keys()).join('|')).not.toContain('app.getbased.health');
   });
@@ -138,6 +139,32 @@ describe('proxy distributed rate limit', () => {
       '203.0.113.94',
       '198.51.100.2',
     ))).toMatchObject({ limited: true });
+  });
+
+  it('globally removes stale one-off-subject markers in the next window', async () => {
+    process.env.VERCEL = '1';
+    process.env.PROXY_RATE_LIMIT_BLOB_TOKEN = 'vercel_blob_rw_store_secret';
+    process.env.PROXY_RATE_LIMIT_MAX = '2';
+    process.env.PROXY_RATE_LIMIT_WINDOW_MS = '1000';
+    const now = vi.spyOn(Date, 'now');
+
+    now.mockReturnValue(1_100);
+    expect(await enforceProxyRateLimit(rateRequest('203.0.113.95')))
+      .toMatchObject({ limited: false });
+    expect(Array.from(blobMock.store.keys()).some(path => path.includes('/1000/')))
+      .toBe(true);
+
+    now.mockReturnValue(2_100);
+    expect(await enforceProxyRateLimit(rateRequest('203.0.113.96')))
+      .toMatchObject({ limited: false });
+
+    expect(Array.from(blobMock.store.keys()).some(path => path.includes('/1000/')))
+      .toBe(false);
+    expect(Array.from(blobMock.store.keys()).some(path => path.includes('/2000/')))
+      .toBe(true);
+    expect(Array.from(blobMock.store.keys()).some(path => path.endsWith('/1000.json')))
+      .toBe(false);
+    expect(blobMock.del).toHaveBeenCalled();
   });
 
   it('allows an explicit per-instance fallback for self-hosted Vercel deployments', async () => {

--- a/tests/proxy-upstream.test.js
+++ b/tests/proxy-upstream.test.js
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../lib/proxy-network.js', () => ({
+  fetchWithPinnedProxyDns: (url, options) => globalThis.fetch(url, options),
+}));
+
+import {
+  readRequestTextWithCap,
+  readResponseTextWithCap,
+} from '../lib/proxy-upstream.js';
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  vi.restoreAllMocks();
+});
+
+describe('proxy upstream body boundaries', () => {
+  it('cancels an oversized streaming request before buffering the remaining body', async () => {
+    let pulls = 0;
+    let cancelled = false;
+    const body = new ReadableStream({
+      pull(controller) {
+        pulls++;
+        if (pulls === 1) controller.enqueue(new TextEncoder().encode('12345678'));
+        else if (pulls === 2) controller.enqueue(new TextEncoder().encode('abcdefgh'));
+        else controller.enqueue(new TextEncoder().encode('must-not-be-buffered'));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    const request = {
+      headers: new Headers({ 'Content-Type': 'application/json' }),
+      body,
+    };
+
+    await expect(readRequestTextWithCap(request, 10)).rejects.toMatchObject({
+      code: 'PROXY_REQUEST_TOO_LARGE',
+    });
+    expect(cancelled).toBe(true);
+    expect(pulls).toBeLessThanOrEqual(3);
+  });
+
+  it('counts response bytes while streaming and cancels when the cap is crossed', async () => {
+    let cancelled = false;
+    const response = new Response(new ReadableStream({
+      start(controller) {
+        controller.enqueue(new Uint8Array(6));
+        controller.enqueue(new Uint8Array(6));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    }), {
+      headers: { 'Content-Type': 'application/octet-stream' },
+    });
+
+    await expect(readResponseTextWithCap(response, 10)).rejects.toMatchObject({
+      code: 'PROXY_RESPONSE_TOO_LARGE',
+    });
+    expect(cancelled).toBe(true);
+  });
+
+  it('preserves UTF-8 characters split across request chunks', async () => {
+    const encoded = new TextEncoder().encode('{"value":"🙂"}');
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoded.slice(0, 12));
+        controller.enqueue(encoded.slice(12));
+        controller.close();
+      },
+    });
+
+    const text = await readRequestTextWithCap({
+      headers: new Headers(),
+      body,
+    }, 100);
+
+    expect(JSON.parse(text)).toEqual({ value: '🙂' });
+  });
+});

--- a/tests/test-security-phase1.js
+++ b/tests/test-security-phase1.js
@@ -124,21 +124,25 @@ if (exists('dev-server.js')) {
       && edgeProxySrc.includes('sanitizeProxyHeaders(headers)')
       && edgeProxySrc.includes('PROXY_MAX_REQUEST_BYTES')
       && edgeProxySrc.includes('PROXY_MAX_RESPONSE_BYTES'));
+  const proxyUpstreamSrc = read('lib/proxy-upstream.js');
+  const proxyRateLimitSrc = read('lib/proxy-rate-limit.js');
   assert('api/proxy.js rejects disallowed callers server-side',
     edgeProxySrc.includes('if (!isAllowedCallerOrigin(req))')
       && edgeProxySrc.includes("error: 'Origin not allowed.'"));
-  assert('api/proxy.js manually validates every redirect destination',
-    edgeProxySrc.includes("redirect: 'manual'")
-      && edgeProxySrc.includes('isAllowedProxyUrl(nextUrl)')
-      && edgeProxySrc.includes('stripProxyCredentialHeaders(nextOptions)')
-      && edgeProxySrc.includes('Cross-origin proxy redirects with a request body are not allowed'));
-  assert('api/proxy.js bounds upstream waits and applies an abuse brake',
-    edgeProxySrc.includes('PROXY_UPSTREAM_TIMEOUT_MS')
-      && edgeProxySrc.includes('enforceProxyRateLimit(req)')
+  assert('proxy upstream runtime manually validates every redirect destination',
+    proxyUpstreamSrc.includes("redirect: 'manual'")
+      && proxyUpstreamSrc.includes('isAllowedProxyUrl(nextUrl)')
+      && proxyUpstreamSrc.includes('stripProxyCredentialHeaders(nextOptions)')
+      && proxyUpstreamSrc.includes('Cross-origin proxy redirects with a request body are not allowed'));
+  assert('proxy runtime bounds upstream lifetimes and applies a distributed abuse brake',
+    proxyUpstreamSrc.includes('PROXY_UPSTREAM_TIMEOUT_MS')
+      && edgeProxySrc.includes('await enforceProxyRateLimit(req)')
+      && proxyRateLimitSrc.includes("from '@vercel/blob'")
+      && proxyRateLimitSrc.includes('allowOverwrite: false')
       && edgeProxySrc.includes("'Retry-After'"));
-  assert('api/proxy.js resolves and pins public DNS answers before connecting',
-    edgeProxySrc.includes("from '../lib/proxy-network.js'")
-      && edgeProxySrc.includes('fetchWithPinnedProxyDns(url')
+  assert('proxy upstream runtime resolves and pins public DNS answers before connecting',
+    proxyUpstreamSrc.includes("from './proxy-network.js'")
+      && proxyUpstreamSrc.includes('fetchWithPinnedProxyDns(url')
       && !edgeProxySrc.includes("runtime: 'edge'"));
 } else {
   console.log('  (dev-server.js not present — production build, skipping CORS source asserts)');

--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,12 @@
   },
   "buildCommand": "node scripts/fetch-catalog.mjs && node scripts/build-production.mjs",
   "outputDirectory": ".",
+  "functions": {
+    "api/proxy.js": {
+      "maxDuration": 190,
+      "supportsCancellation": true
+    }
+  },
   "routes": [
     {
       "src": "^/js/bundle-.*\\.js$",


### PR DESCRIPTION
## Summary

- enforce a distributed, atomic Vercel Blob rate limit for hosted proxy traffic, with a bounded local fallback only outside Vercel or by explicit opt-in
- stream and cap request bodies before full buffering, and give rate-limit storage, upstream headers, response bodies, and streams bounded lifetimes
- route generic AI, OAuth token, and CAMS requests through one redirect/DNS/credential/size guardrail layer
- strip credential headers on safe cross-origin GET redirects, reject body-bearing cross-origin redirects, and stop returning raw upstream exception text
- make proxy responses non-cacheable and opt the Vercel function into cancellation with an explicit duration cap
- reduce `api/proxy.js` from 823 to 581 lines and refresh the generated architecture map

## Greptile follow-up

- fixed the P1 persistent-marker finding with a time-first marker layout and a global per-window sweep across all client subjects
- publish the cleanup-completion marker only after both marker and completion-history sweeps succeed, so failed or aborted cleanup remains retryable
- run cleanup before atomic request-slot commitment, so a cleanup-induced 503 never consumes client quota
- added end-to-end SSE/NDJSON coverage for normal completion, downstream cancellation, lifecycle timeout, and byte-cap overflow

## Verification

- `npm test -- tests/api-network-runtime.test.js tests/proxy-network.test.js tests/proxy-upstream.test.js tests/proxy-rate-limit.test.js tests/architecture-map.test.js`
- `node tests/test-security-phase1.js`
- `node tests/test-custom-api.js`
- `node tests/test-sun-uvdata.js`
- exact Firefox smoke reproduction on an isolated local port
- `npm run architecture:check`
- `npm run quality`
- `npm run production:check`
- `git diff --check`

All scoped checks pass locally. The production check reports only the repository's existing ineffective-dynamic-import warnings.