### PR TITLE
Harden privacy-sensitive diagnostics

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -9,8 +9,8 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 
 | Metric | Current |
 | --- | ---: |
-| Modules | 540 |
-| Internal import edges | 2402 |
+| Modules | 541 |
+| Internal import edges | 2404 |
 | Dynamic internal edges | 88 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -45,7 +45,7 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 | [`js/utils.js`](js/utils.js) | 245 | [`js/app-shell-hooks.js`](js/app-shell-hooks.js) | 72 |
 | [`js/state.js`](js/state.js) | 170 | [`js/app-light-sun-modules.js`](js/app-light-sun-modules.js) | 36 |
 | [`js/caught-error.js`](js/caught-error.js) | 77 | [`js/sync-configure.js`](js/sync-configure.js) | 27 |
-| [`js/data.js`](js/data.js) | 77 | [`js/pdf-import.js`](js/pdf-import.js) | 25 |
+| [`js/data.js`](js/data.js) | 77 | [`js/pdf-import.js`](js/pdf-import.js) | 26 |
 | [`js/modal-lifecycle.js`](js/modal-lifecycle.js) | 70 | [`js/settings.js`](js/settings.js) | 25 |
 | [`js/api.js`](js/api.js) | 65 | [`js/chat-send.js`](js/chat-send.js) | 22 |
 | [`js/profile.js`](js/profile.js) | 47 | [`js/views.js`](js/views.js) | 22 |
@@ -620,7 +620,7 @@ Native browser modules shipped with the static application.
 
 - [`js/pdf-import-ai-utils.js`](js/pdf-import-ai-utils.js) → [`js/api.js`](js/api.js), [`js/utils.js`](js/utils.js)
 - [`js/pdf-import-commit.js`](js/pdf-import-commit.js) → [`js/adapters.js`](js/adapters.js), [`js/crypto.js`](js/crypto.js), [`js/data-merge.js`](js/data-merge.js), [`js/data.js`](js/data.js), [`js/import-benchmarks.js`](js/import-benchmarks.js), [`js/lab-entry-mutations.js`](js/lab-entry-mutations.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/pdf-import-marker-mapping.js`](js/pdf-import-marker-mapping.js), [`js/pdf-import-persistence.js`](js/pdf-import-persistence.js), [`js/pdf-import-review.js`](js/pdf-import-review.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/unique-id.js`](js/unique-id.js), [`js/utils.js`](js/utils.js)
-- [`js/pdf-import-file-handlers.js`](js/pdf-import-file-handlers.js) → [`js/api.js`](js/api.js), [`js/caught-error.js`](js/caught-error.js), [`js/import-benchmarks.js`](js/import-benchmarks.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/pdf-import-ai-utils.js`](js/pdf-import-ai-utils.js), [`js/pdf-import-file-utils.js`](js/pdf-import-file-utils.js), [`js/pdf-import-preflight.js`](js/pdf-import-preflight.js), [`js/pdf-import-progress.js`](js/pdf-import-progress.js), [`js/pdf-import-review.js`](js/pdf-import-review.js), [`js/pdf-import-spreadsheet.js`](js/pdf-import-spreadsheet.js), [`js/pii.js`](js/pii.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
+- [`js/pdf-import-file-handlers.js`](js/pdf-import-file-handlers.js) → [`js/api.js`](js/api.js), [`js/caught-error.js`](js/caught-error.js), [`js/import-benchmarks.js`](js/import-benchmarks.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/pdf-import-ai-utils.js`](js/pdf-import-ai-utils.js), [`js/pdf-import-file-utils.js`](js/pdf-import-file-utils.js), [`js/pdf-import-preflight.js`](js/pdf-import-preflight.js), [`js/pdf-import-progress.js`](js/pdf-import-progress.js), [`js/pdf-import-review.js`](js/pdf-import-review.js), [`js/pdf-import-spreadsheet.js`](js/pdf-import-spreadsheet.js), [`js/pii.js`](js/pii.js), [`js/privacy-safe-diagnostics.js`](js/privacy-safe-diagnostics.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/pdf-import-file-utils.js`](js/pdf-import-file-utils.js) → [`js/pdf-import-spreadsheet.js`](js/pdf-import-spreadsheet.js), [`js/pdfjs-loader.js`](js/pdfjs-loader.js)
 - [`js/pdf-import-marker-mapping.js`](js/pdf-import-marker-mapping.js) → [`js/adapters.js`](js/adapters.js), [`js/schema.js`](js/schema.js), [`js/secondary-unit-conversions.js`](js/secondary-unit-conversions.js), [`js/state.js`](js/state.js)
 - [`js/pdf-import-marker-normalization.js`](js/pdf-import-marker-normalization.js) → [`js/adapters.js`](js/adapters.js), [`js/pdf-import-marker-mapping.js`](js/pdf-import-marker-mapping.js), [`js/schema.js`](js/schema.js), [`js/utils.js`](js/utils.js)
@@ -630,7 +630,7 @@ Native browser modules shipped with the static application.
 - [`js/pdf-import-review-runtime.js`](js/pdf-import-review-runtime.js) → [`js/data.js`](js/data.js)
 - [`js/pdf-import-review.js`](js/pdf-import-review.js) → [`js/api.js`](js/api.js), [`js/import-benchmarks.js`](js/import-benchmarks.js), [`js/import-marker-map-modal.js`](js/import-marker-map-modal.js), [`js/import-review-draft.js`](js/import-review-draft.js), [`js/import-review-row-actions.js`](js/import-review-row-actions.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/pdf-import-marker-mapping.js`](js/pdf-import-marker-mapping.js), [`js/pdf-import-review-runtime.js`](js/pdf-import-review-runtime.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/pdf-import-spreadsheet.js`](js/pdf-import-spreadsheet.js) → no in-scope imports
-- [`js/pdf-import.js`](js/pdf-import.js) → [`js/api.js`](js/api.js), [`js/caught-error.js`](js/caught-error.js), [`js/crypto.js`](js/crypto.js), [`js/cycle-import.js`](js/cycle-import.js), [`js/dna-runtime-bridge.js`](js/dna-runtime-bridge.js), [`js/export.js`](js/export.js), [`js/import-benchmarks.js`](js/import-benchmarks.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/pdf-import-ai-utils.js`](js/pdf-import-ai-utils.js), [`js/pdf-import-commit.js`](js/pdf-import-commit.js), [`js/pdf-import-file-handlers.js`](js/pdf-import-file-handlers.js), [`js/pdf-import-file-utils.js`](js/pdf-import-file-utils.js), [`js/pdf-import-marker-mapping.js`](js/pdf-import-marker-mapping.js), [`js/pdf-import-marker-normalization.js`](js/pdf-import-marker-normalization.js), [`js/pdf-import-persistence.js`](js/pdf-import-persistence.js), [`js/pdf-import-preflight.js`](js/pdf-import-preflight.js), [`js/pdf-import-progress.js`](js/pdf-import-progress.js), [`js/pdf-import-review.js`](js/pdf-import-review.js), [`js/pdf-import-spreadsheet.js`](js/pdf-import-spreadsheet.js), [`js/pii.js`](js/pii.js), [`js/profile.js`](js/profile.js), [`js/schema.js`](js/schema.js), [`js/settings-runtime-bridge.js`](js/settings-runtime-bridge.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
+- [`js/pdf-import.js`](js/pdf-import.js) → [`js/api.js`](js/api.js), [`js/caught-error.js`](js/caught-error.js), [`js/crypto.js`](js/crypto.js), [`js/cycle-import.js`](js/cycle-import.js), [`js/dna-runtime-bridge.js`](js/dna-runtime-bridge.js), [`js/export.js`](js/export.js), [`js/import-benchmarks.js`](js/import-benchmarks.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/pdf-import-ai-utils.js`](js/pdf-import-ai-utils.js), [`js/pdf-import-commit.js`](js/pdf-import-commit.js), [`js/pdf-import-file-handlers.js`](js/pdf-import-file-handlers.js), [`js/pdf-import-file-utils.js`](js/pdf-import-file-utils.js), [`js/pdf-import-marker-mapping.js`](js/pdf-import-marker-mapping.js), [`js/pdf-import-marker-normalization.js`](js/pdf-import-marker-normalization.js), [`js/pdf-import-persistence.js`](js/pdf-import-persistence.js), [`js/pdf-import-preflight.js`](js/pdf-import-preflight.js), [`js/pdf-import-progress.js`](js/pdf-import-progress.js), [`js/pdf-import-review.js`](js/pdf-import-review.js), [`js/pdf-import-spreadsheet.js`](js/pdf-import-spreadsheet.js), [`js/pii.js`](js/pii.js), [`js/privacy-safe-diagnostics.js`](js/privacy-safe-diagnostics.js), [`js/profile.js`](js/profile.js), [`js/schema.js`](js/schema.js), [`js/settings-runtime-bridge.js`](js/settings-runtime-bridge.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 
 </details>
 
@@ -644,6 +644,12 @@ Native browser modules shipped with the static application.
 
 - [`js/pii-review.js`](js/pii-review.js) → [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/utils.js`](js/utils.js)
 - [`js/pii.js`](js/pii.js) → [`js/api-transport.js`](js/api-transport.js), [`js/api.js`](js/api.js), [`js/caught-error.js`](js/caught-error.js), [`js/local-ai-discovery.js`](js/local-ai-discovery.js), [`js/local-ai-provider-registry.js`](js/local-ai-provider-registry.js), [`js/pii-review.js`](js/pii-review.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
+
+</details>
+
+<details><summary><code>privacy</code> family — 1 module</summary>
+
+- [`js/privacy-safe-diagnostics.js`](js/privacy-safe-diagnostics.js) → [`js/utils.js`](js/utils.js)
 
 </details>
 
@@ -864,7 +870,7 @@ Native browser modules shipped with the static application.
 - [`js/sync-diagnose-runtime.js`](js/sync-diagnose-runtime.js) → [`js/utils.js`](js/utils.js)
 - [`js/sync-diagnose-ui.js`](js/sync-diagnose-ui.js) → [`js/caught-error.js`](js/caught-error.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/sync-diagnose-actions.js`](js/sync-diagnose-actions.js), [`js/sync-diagnose-render.js`](js/sync-diagnose-render.js), [`js/sync-diagnostics.js`](js/sync-diagnostics.js), [`js/sync-relay-health.js`](js/sync-relay-health.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-diagnostics-context.js`](js/sync-diagnostics-context.js) → no in-scope imports
-- [`js/sync-diagnostics-snapshot.js`](js/sync-diagnostics-snapshot.js) → [`js/caught-error.js`](js/caught-error.js), [`js/state.js`](js/state.js), [`js/sync-delta.js`](js/sync-delta.js), [`js/sync-diagnostics-context.js`](js/sync-diagnostics-context.js), [`js/sync-environment.js`](js/sync-environment.js), [`js/sync-payload-codec.js`](js/sync-payload-codec.js), [`js/sync-state.js`](js/sync-state.js), [`js/utils.js`](js/utils.js)
+- [`js/sync-diagnostics-snapshot.js`](js/sync-diagnostics-snapshot.js) → [`js/caught-error.js`](js/caught-error.js), [`js/state.js`](js/state.js), [`js/sync-delta.js`](js/sync-delta.js), [`js/sync-diagnostics-context.js`](js/sync-diagnostics-context.js), [`js/sync-environment.js`](js/sync-environment.js), [`js/sync-payload-codec.js`](js/sync-payload-codec.js), [`js/sync-state.js`](js/sync-state.js)
 - [`js/sync-diagnostics-text.js`](js/sync-diagnostics-text.js) → no in-scope imports
 - [`js/sync-diagnostics.js`](js/sync-diagnostics.js) → [`js/sync-diagnostics-context.js`](js/sync-diagnostics-context.js), [`js/sync-diagnostics-snapshot.js`](js/sync-diagnostics-snapshot.js), [`js/sync-diagnostics-text.js`](js/sync-diagnostics-text.js)
 - [`js/sync-disable-cleanup.js`](js/sync-disable-cleanup.js) → no in-scope imports

--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -10,7 +10,7 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | Metric | Current |
 | --- | ---: |
 | Modules | 541 |
-| Internal import edges | 2404 |
+| Internal import edges | 2403 |
 | Dynamic internal edges | 88 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -44,8 +44,8 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 | --- | ---: | --- | ---: |
 | [`js/utils.js`](js/utils.js) | 245 | [`js/app-shell-hooks.js`](js/app-shell-hooks.js) | 72 |
 | [`js/state.js`](js/state.js) | 170 | [`js/app-light-sun-modules.js`](js/app-light-sun-modules.js) | 36 |
-| [`js/caught-error.js`](js/caught-error.js) | 77 | [`js/sync-configure.js`](js/sync-configure.js) | 27 |
-| [`js/data.js`](js/data.js) | 77 | [`js/pdf-import.js`](js/pdf-import.js) | 26 |
+| [`js/data.js`](js/data.js) | 77 | [`js/sync-configure.js`](js/sync-configure.js) | 27 |
+| [`js/caught-error.js`](js/caught-error.js) | 76 | [`js/pdf-import.js`](js/pdf-import.js) | 26 |
 | [`js/modal-lifecycle.js`](js/modal-lifecycle.js) | 70 | [`js/settings.js`](js/settings.js) | 25 |
 | [`js/api.js`](js/api.js) | 65 | [`js/chat-send.js`](js/chat-send.js) | 22 |
 | [`js/profile.js`](js/profile.js) | 47 | [`js/views.js`](js/views.js) | 22 |
@@ -870,7 +870,7 @@ Native browser modules shipped with the static application.
 - [`js/sync-diagnose-runtime.js`](js/sync-diagnose-runtime.js) → [`js/utils.js`](js/utils.js)
 - [`js/sync-diagnose-ui.js`](js/sync-diagnose-ui.js) → [`js/caught-error.js`](js/caught-error.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/sync-diagnose-actions.js`](js/sync-diagnose-actions.js), [`js/sync-diagnose-render.js`](js/sync-diagnose-render.js), [`js/sync-diagnostics.js`](js/sync-diagnostics.js), [`js/sync-relay-health.js`](js/sync-relay-health.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-diagnostics-context.js`](js/sync-diagnostics-context.js) → no in-scope imports
-- [`js/sync-diagnostics-snapshot.js`](js/sync-diagnostics-snapshot.js) → [`js/caught-error.js`](js/caught-error.js), [`js/state.js`](js/state.js), [`js/sync-delta.js`](js/sync-delta.js), [`js/sync-diagnostics-context.js`](js/sync-diagnostics-context.js), [`js/sync-environment.js`](js/sync-environment.js), [`js/sync-payload-codec.js`](js/sync-payload-codec.js), [`js/sync-state.js`](js/sync-state.js)
+- [`js/sync-diagnostics-snapshot.js`](js/sync-diagnostics-snapshot.js) → [`js/state.js`](js/state.js), [`js/sync-delta.js`](js/sync-delta.js), [`js/sync-diagnostics-context.js`](js/sync-diagnostics-context.js), [`js/sync-environment.js`](js/sync-environment.js), [`js/sync-payload-codec.js`](js/sync-payload-codec.js), [`js/sync-state.js`](js/sync-state.js)
 - [`js/sync-diagnostics-text.js`](js/sync-diagnostics-text.js) → no in-scope imports
 - [`js/sync-diagnostics.js`](js/sync-diagnostics.js) → [`js/sync-diagnostics-context.js`](js/sync-diagnostics-context.js), [`js/sync-diagnostics-snapshot.js`](js/sync-diagnostics-snapshot.js), [`js/sync-diagnostics-text.js`](js/sync-diagnostics-text.js)
 - [`js/sync-disable-cleanup.js`](js/sync-disable-cleanup.js) → no in-scope imports

--- a/js/pdf-import-file-handlers.js
+++ b/js/pdf-import-file-handlers.js
@@ -1,7 +1,7 @@
 // @ts-check
 // pdf-import-file-handlers.js — single-file PDF and image import workflows
 
-import { getErrorMessage } from './caught-error.js';
+import { getErrorName } from './caught-error.js';
 import { state } from './state.js';
 import { calculateCost, trackUsage } from './schema.js';
 import { showNotification, showConfirmDialog, isDebugMode, isPIIReviewEnabled, hashString } from './utils.js';
@@ -29,6 +29,7 @@ import {
   startImportBenchmark,
   updateImportBenchmark,
 } from './import-benchmarks.js';
+import { logPrivacyDiagnostic } from './privacy-safe-diagnostics.js';
 
 const fileHandlerDeps = {
   parseLabPDFWithAI: /** @type {((text: string, fileName: string, onProgress?: (pct: number) => void) => Promise<any>) | null} */ (null),
@@ -128,7 +129,7 @@ export async function handlePDFFileWorkflow(file, forceImageMode = false, preExt
       if (choice === 'cancel') { hideImportProgress(); return; }
       useImageMode = choice === 'image';
       updateImportBenchmark(benchmarkId, { importMode: useImageMode ? 'image' : 'text' }, { persist: false });
-      if (isDebugMode()) console.log(`[Import] User chose ${choice} for ${textQuality} text quality`);
+      logPrivacyDiagnostic('import-mode-selected', { mode: choice, quality: textQuality });
     }
 
     if (useImageMode) {
@@ -146,7 +147,7 @@ export async function handlePDFFileWorkflow(file, forceImageMode = false, preExt
       const result = await parseLabPDFWithAIImages(images, file.name, updateImportProgressPct);
       const analysisMs = Math.round(performance.now() - analysisStart);
       const analysisTime = Math.round(analysisMs / 1000);
-      if (isDebugMode()) console.log(`[Analysis] Image mode parsed in ${analysisTime}s`);
+      logPrivacyDiagnostic('image-analysis-complete', { analysisMs });
       result.privacyMethod = 'none (image mode)';
       result.timings = { pii: 0, analysis: analysisTime, piiMs: 0, analysisMs };
       const prov = result.provider || getAIProvider();
@@ -214,9 +215,11 @@ export async function handlePDFFileWorkflow(file, forceImageMode = false, preExt
         piiTime = Math.round(piiMs / 1000);
         privacyMethod = 'ollama';
         privacyOriginal = pdfText;
-        if (isDebugMode()) console.log(`[PII] Obfuscated via Local AI (${piiTime}s)`);
+        logPrivacyDiagnostic('local-sanitizer-complete', { durationMs: piiMs });
       } catch (e) {
-        if (isDebugMode()) console.warn('[PII] Local AI failed, falling back to regex:', getErrorMessage(e));
+        logPrivacyDiagnostic('local-sanitizer-fallback', {
+          errorName: getErrorName(e) || 'Error',
+        });
         try {
           const result = obfuscatePDFText(pdfText);
           textForAI = result.obfuscated;
@@ -247,7 +250,13 @@ export async function handlePDFFileWorkflow(file, forceImageMode = false, preExt
         textForAI = reviewResult;
       }
     }
-    if (isDebugMode()) { console.log('[PII] Original:', pdfText); console.log('[PII] Obfuscated:', textForAI); }
+    logPrivacyDiagnostic('transform-complete', {
+      method: privacyMethod || 'unknown',
+      durationMs: piiMs,
+      replacements: privacyReplacements,
+      inputChars: pdfText.length,
+      outputChars: textForAI.length,
+    });
 
     await showImportProgress(3, file.name);
     setBenchmarkStage('analysis');
@@ -255,7 +264,7 @@ export async function handlePDFFileWorkflow(file, forceImageMode = false, preExt
     const result = await parseLabPDFWithAI(textForAI, file.name, updateImportProgressPct);
     const analysisMs = Math.round(performance.now() - analysisStart);
     const analysisTime = Math.round(analysisMs / 1000);
-    if (isDebugMode()) console.log(`[Analysis] Parsed in ${analysisTime}s`);
+    logPrivacyDiagnostic('analysis-complete', { analysisMs });
     result.privacyMethod = privacyMethod;
     result.privacyReplacements = privacyReplacements;
     result.timings = { pii: piiTime, analysis: analysisTime, piiMs, analysisMs };
@@ -283,7 +292,10 @@ export async function handlePDFFileWorkflow(file, forceImageMode = false, preExt
   } catch (err) {
     finishBenchmark('failed', { error: formatImportError(err), totalMs: Math.round(performance.now() - benchmarkStarted) });
     hideImportProgress('error');
-    if (isDebugMode()) console.error("PDF parse error:", err);
+    logPrivacyDiagnostic('parse-failed', {
+      stage: benchmarkStage,
+      errorName: getErrorName(err) || 'Error',
+    });
     showNotification("Error parsing PDF: " + formatImportError(err), "error", 10000);
   } finally {
     if (!benchmarkFinished) finishBenchmark('stopped', { reason: benchmarkStage, totalMs: Math.round(performance.now() - benchmarkStarted) });
@@ -320,7 +332,7 @@ export async function handleImageFileWorkflow(file) {
     const result = await parseLabPDFWithAIImages(images, file.name, updateImportProgressPct);
     const analysisMs = Math.round(performance.now() - analysisStart);
     const analysisTime = Math.round(analysisMs / 1000);
-    if (isDebugMode()) console.log(`[Analysis] Image file parsed in ${analysisTime}s`);
+    logPrivacyDiagnostic('image-analysis-complete', { analysisMs });
     result.privacyMethod = 'none (image mode)';
     result.timings = { pii: 0, analysis: analysisTime, piiMs: 0, analysisMs };
     const prov = result.provider || getAIProvider();
@@ -354,7 +366,9 @@ export async function handleImageFileWorkflow(file) {
       error: formatImportError(err),
       totalMs: Math.round(performance.now() - benchmarkStarted),
     });
-    if (isDebugMode()) console.error('Image import error:', err);
+    logPrivacyDiagnostic('image-import-failed', {
+      errorName: getErrorName(err) || 'Error',
+    });
     hideImportProgress('error');
     showNotification(`Import failed: ${formatImportError(err)}`, 'error');
   }

--- a/js/pdf-import.js
+++ b/js/pdf-import.js
@@ -1,7 +1,7 @@
 // @ts-check
 // pdf-import.js — PDF parsing pipeline, import preview, drop zone, batch import
 
-import { getErrorMessage } from './caught-error.js';
+import { getErrorMessage, getErrorName } from './caught-error.js';
 import { state } from './state.js';
 import { calculateCost, trackUsage } from './schema.js';
 import { showNotification, isDebugMode, isPIIReviewEnabled, hashString } from './utils.js';
@@ -61,6 +61,7 @@ import {
   handleImageFileWorkflow,
   handlePDFFileWorkflow,
 } from './pdf-import-file-handlers.js';
+import { logPrivacyDiagnostic } from './privacy-safe-diagnostics.js';
 
 const pdfImportDeps = {
   importDataJSON,
@@ -585,7 +586,11 @@ async function _processBatchFile(file, ollama, fileNum, totalFiles) {
       privacyMethod = 'ollama';
       privacyOriginal = pdfText;
     } catch (e) {
-      if (isDebugMode()) console.warn(`[PII] Local AI failed for ${file.name}, regex fallback:`, getErrorMessage(e));
+      logPrivacyDiagnostic('batch-local-sanitizer-fallback', {
+        fileIndex: fileNum,
+        totalFiles,
+        errorName: getErrorName(e) || 'Error',
+      });
       try {
         const r = obfuscatePDFText(pdfText);
         textForAI = r.obfuscated; privacyReplacements = r.replacements; privacyOriginal = r.original;
@@ -610,14 +615,26 @@ async function _processBatchFile(file, ollama, fileNum, totalFiles) {
       textForAI = reviewResult;
     }
   }
-  if (isDebugMode()) console.log(`[PII] ${file.name} \u2014 method: ${privacyMethod}, ${piiTime}s`);
+  logPrivacyDiagnostic('batch-transform-complete', {
+    fileIndex: fileNum,
+    totalFiles,
+    method: privacyMethod || 'unknown',
+    durationMs: piiMs,
+    replacements: privacyReplacements,
+    inputChars: pdfText.length,
+    outputChars: textForAI.length,
+  });
 
   await showBatchImportProgress(3, file.name, fileNum, totalFiles);
   const analysisStart = performance.now();
   const result = await parseLabPDFWithAI(textForAI, file.name, updateImportProgressPct);
   const analysisMs = Math.round(performance.now() - analysisStart);
   const analysisTime = Math.round(analysisMs / 1000);
-  if (isDebugMode()) console.log(`[Analysis] ${file.name} parsed in ${analysisTime}s`);
+  logPrivacyDiagnostic('batch-analysis-complete', {
+    fileIndex: fileNum,
+    totalFiles,
+    analysisMs,
+  });
   result.privacyMethod = privacyMethod;
   result.privacyReplacements = privacyReplacements;
   result.timings = { pii: piiTime, analysis: analysisTime, piiMs, analysisMs };
@@ -663,7 +680,11 @@ export async function handleBatchPDFs(pdfFiles) {
       else if (result === 'skipped') skipped++;
       else if (result === 'empty' || result === 'pii-fail' || result === 'no-markers') failed++;
     } catch (err) {
-      if (isDebugMode()) console.error(`Batch import error (${file.name}):`, err);
+      logPrivacyDiagnostic('batch-import-failed', {
+        fileIndex: i + 1,
+        totalFiles: pdfFiles.length,
+        errorName: getErrorName(err) || 'Error',
+      });
       showNotification(`Error: ${file.name} — ${getErrorMessage(err)}`, 'error');
       failedFiles.push({ file, error: getErrorMessage(err) });
     }
@@ -681,7 +702,11 @@ export async function handleBatchPDFs(pdfFiles) {
         else if (result === 'skipped') skipped++;
         else failed++;
       } catch (err) {
-        if (isDebugMode()) console.error(`Retry failed (${file.name}):`, err);
+        logPrivacyDiagnostic('batch-retry-failed', {
+          fileIndex: i + 1,
+          totalFiles: failedFiles.length,
+          errorName: getErrorName(err) || 'Error',
+        });
         retryFailed++;
         failed++;
       }

--- a/js/privacy-safe-diagnostics.js
+++ b/js/privacy-safe-diagnostics.js
@@ -1,0 +1,82 @@
+// @ts-check
+// privacy-safe-diagnostics.js — Metadata-only debug logging for PII workflows.
+
+import { isDebugMode } from './utils.js';
+
+const NUMERIC_FIELDS = new Set([
+  'analysisMs',
+  'durationMs',
+  'fileIndex',
+  'inputChars',
+  'outputChars',
+  'pageCount',
+  'replacements',
+  'totalFiles',
+]);
+const DIAGNOSTIC_EVENTS = new Set([
+  'analysis-complete',
+  'batch-analysis-complete',
+  'batch-import-failed',
+  'batch-local-sanitizer-fallback',
+  'batch-retry-failed',
+  'batch-transform-complete',
+  'image-analysis-complete',
+  'image-import-failed',
+  'import-mode-selected',
+  'local-sanitizer-complete',
+  'local-sanitizer-fallback',
+  'parse-failed',
+  'transform-complete',
+]);
+const TOKEN_VALUES = new Map([
+  ['errorName', new Set([
+    'AbortError',
+    'DataError',
+    'Error',
+    'NetworkError',
+    'NotAllowedError',
+    'QuotaExceededError',
+    'RangeError',
+    'SyntaxError',
+    'TimeoutError',
+    'TypeError',
+  ])],
+  ['method', new Set(['ollama', 'ollama+review', 'regex', 'unknown'])],
+  ['mode', new Set(['cancel', 'image', 'text'])],
+  ['quality', new Set(['empty', 'good', 'poor'])],
+  ['stage', new Set(['analysis', 'extract', 'mode-selection', 'preflight', 'privacy'])],
+]);
+
+/**
+ * Reduce diagnostic input to a small, non-content-bearing metadata object.
+ * Unknown keys, objects, arrays, filenames, and free-form strings are dropped.
+ *
+ * @param {Record<string, unknown>} [details]
+ */
+export function sanitizePrivacyDiagnostic(details = {}) {
+  /** @type {Record<string, number | string>} */
+  const safe = {};
+  for (const [key, value] of Object.entries(details)) {
+    if (NUMERIC_FIELDS.has(key)) {
+      if (typeof value === 'number' && Number.isFinite(value) && value >= 0) safe[key] = value;
+      continue;
+    }
+    const allowedValues = TOKEN_VALUES.get(key);
+    if (typeof value === 'string' && allowedValues?.has(value)) safe[key] = value;
+  }
+  return Object.freeze(safe);
+}
+
+/**
+ * Emit a metadata-only diagnostic when the user explicitly enabled debug mode.
+ *
+ * @param {string} event
+ * @param {Record<string, unknown>} [details]
+ */
+export function logPrivacyDiagnostic(event, details = {}) {
+  if (!isDebugMode()) return null;
+  const safeEvent = DIAGNOSTIC_EVENTS.has(event) ? event : 'event';
+  const safeDetails = sanitizePrivacyDiagnostic(details);
+  console.debug(`[privacy] ${safeEvent}`, safeDetails);
+  return safeDetails;
+}

--- a/js/sync-diagnose-render.js
+++ b/js/sync-diagnose-render.js
@@ -29,7 +29,7 @@ function renderRelayHealthPanel(healthVerdict) {
   const detail = isHealthy
     ? 'Last verified ' + new Date(healthVerdict.at).toISOString().slice(11, 19) + 'Z. Storage state has advanced since the previous check.'
     : (healthVerdict.reason || 'No relay-side advance observed since the previous check.');
-  const scope = '<div style="color:var(--text-muted);font-size:11px;margin-top:6px">This verdict is local/outbound: another device can show healthy or unknown until it pushes and probes its own relay baseline. Compare Owner ID / Mnemonic prefix across devices first.</div>';
+  const scope = '<div style="color:var(--text-muted);font-size:11px;margin-top:6px">This verdict is local/outbound: another device can show healthy or unknown until it pushes and probes its own relay baseline. Compare Owner ID across devices first.</div>';
   const recovery = isHealthy ? scope : scope + '<div style="color:var(--text-muted);font-size:11px;margin-top:6px">This matches the Evolu silent-reject pattern. The fix is identity rotation — generate a fresh 24-word mnemonic and restore every syncing device to it. See <a href="https://docs.getbased.health/guides/cross-device-sync" target="_blank" style="color:var(--accent)">cross-device sync docs</a>.</div>';
   return `<div style="margin-bottom:12px;padding:10px;border:1px solid var(--border);border-radius:6px">
     <div style="display:flex;align-items:center;gap:8px;margin-bottom:4px">
@@ -164,8 +164,8 @@ export function renderSyncDiagnoseModal({
         <div><b>Sync enabled:</b> ${d.syncEnabled ? 'yes' : 'no'}</div>
         <div><b>Relay:</b> <span style="font-family:monospace;font-size:11px;word-break:break-all">${escapeHTML(d.relay || '—')}</span></div>
         <div><b>Owner ID:</b> <span style="font-family:monospace;font-size:11px">${escapeHTML(d.ownerId || '— (not initialized)')}</span></div>
-        <div><b>Mnemonic prefix:</b> <span style="font-family:monospace;font-size:11px">${escapeHTML(d.mnemonicPrefix || '—')}</span></div>
-        <div style="color:var(--text-muted);font-size:11px;margin-top:6px">If two devices show different Owner ID or Mnemonic prefix, they are using different identities and will never see each other's data even on the same relay.</div>
+        <div><b>Recovery phrase configured:</b> ${d.mnemonicConfigured ? 'yes' : 'no'}</div>
+        <div style="color:var(--text-muted);font-size:11px;margin-top:6px">If two devices show different Owner IDs, they are using different identities and will never see each other's data even on the same relay. Recovery-phrase words are intentionally never included in diagnostics.</div>
       </div>
       <div style="margin-bottom:12px">
         <div><b>Active profile (this device):</b> <span style="font-family:monospace;font-size:11px">${escapeHTML(d.activeProfileId || '?')}</span></div>

--- a/js/sync-diagnose-render.js
+++ b/js/sync-diagnose-render.js
@@ -14,7 +14,11 @@ function renderRowsHtml(rows) {
   return rows.map(r => {
     const pidCell = escapeHTML(r.profileId || '?');
     const pidNote = r.profileIdSource === 'payload' ? ' <span style="color:var(--orange);font-size:10px" title="profileId column empty; recovered from payload">*</span>' : '';
-    const fmtCell = r.format === 'gz' ? '<span title="gzip envelope (v1.6.4)" style="color:var(--green)">gz</span>' : 'plain';
+    const fmtCell = r.format === 'gz'
+      ? '<span title="gzip envelope (v1.6.4)" style="color:var(--green)">gz</span>'
+      : r.format === 'invalid'
+        ? '<span title="payload could not be decoded" style="color:var(--orange)">invalid</span>'
+        : 'plain';
     const delCell = r.isDeleted ? '<span style="color:var(--orange);font-weight:600">yes</span>' : 'no';
     return `<tr><td style="padding:4px 8px;font-family:monospace;font-size:11px">${pidCell}${pidNote}</td><td style="padding:4px 8px;text-align:right;font-size:11px">${delCell}</td><td style="padding:4px 8px;font-family:monospace;font-size:11px;color:var(--text-muted)">${r.syncedAtMs}</td><td style="padding:4px 8px;text-align:right">${r.sun}</td><td style="padding:4px 8px;text-align:right">${r.dev}</td><td style="padding:4px 8px;text-align:right;color:var(--text-muted);font-size:11px">${r.bytes}b</td><td style="padding:4px 8px;text-align:right;font-size:11px">${fmtCell}</td></tr>`;
   }).join('');
@@ -157,6 +161,16 @@ export function renderSyncDiagnoseModal({
 }) {
   const d = diagnostics;
   const rowsHtml = renderRowsHtml(d.rows);
+  const rowParseFailureCount = Number.isSafeInteger(d.rowParseFailureCount) && d.rowParseFailureCount > 0
+    ? d.rowParseFailureCount
+    : 0;
+  const rowWarnings = [
+    ...(rowParseFailureCount > 0 ? [`${rowParseFailureCount} row payload${rowParseFailureCount === 1 ? '' : 's'} could not be decoded.`] : []),
+    ...(d.rowsReadFailed ? ['Row query failed.'] : []),
+  ];
+  const rowWarningHtml = rowWarnings.length > 0
+    ? `<div style="color:var(--orange);font-size:11px;margin-top:6px">${rowWarnings.join(' ')}</div>`
+    : '';
   return `<div class="modal" role="dialog" aria-label="Sync diagnose" style="max-width:640px">
     <div class="modal-header"><h3>Sync diagnose</h3><button class="modal-close" data-sync-diagnose-close aria-label="Close">×</button></div>
     <div class="modal-body" style="font-size:13px">
@@ -177,11 +191,12 @@ export function renderSyncDiagnoseModal({
       ${renderCutoverPanel(d.cutoverReadiness, isDebug, cutoverEnabled)}
       <div>
         <b>Rows in this device's local Evolu DB:</b>
+        ${rowWarningHtml}
         <table style="width:100%;border-collapse:collapse;margin-top:6px;font-size:12px">
           <thead><tr style="border-bottom:1px solid var(--border);text-align:left"><th style="padding:4px 8px">profileId</th><th style="padding:4px 8px;text-align:right">deleted</th><th style="padding:4px 8px">syncedAt(ms)</th><th style="padding:4px 8px;text-align:right">sun</th><th style="padding:4px 8px;text-align:right">dev</th><th style="padding:4px 8px;text-align:right">size</th><th style="padding:4px 8px;text-align:right">fmt</th></tr></thead>
           <tbody>${rowsHtml}</tbody>
         </table>
-        <div style="color:var(--text-muted);font-size:11px;margin-top:6px">Compare this table on phone vs desktop. Same profileId, same deleted state, same syncedAt(ms), same sun/dev counts → both devices already have the same data and the issue is rendering. Different counts → relay-replication isn't propagating between Evolu instances. <b>fmt</b> column: <span style="color:var(--green)">gz</span> = v1.6.4 gzip envelope, plain = pre-v1.6.4. <span style="color:var(--orange)">*</span> next to a profileId means it was recovered from the payload because the column was empty.</div>
+        <div style="color:var(--text-muted);font-size:11px;margin-top:6px">Compare this table on phone vs desktop. Same profileId, same deleted state, same syncedAt(ms), same sun/dev counts → both devices already have the same data and the issue is rendering. Different counts → relay-replication isn't propagating between Evolu instances. <b>fmt</b> column: <span style="color:var(--green)">gz</span> = v1.6.4 gzip envelope, plain = pre-v1.6.4, <span style="color:var(--orange)">invalid</span> = payload could not be decoded. <span style="color:var(--orange)">*</span> next to a profileId means it was recovered from the payload because the column was empty.</div>
       </div>
       <div style="margin-top:14px;display:flex;gap:8px;justify-content:flex-end">
         <button class="ctx-btn-option" ${syncDiagnoseActionAttrs('copy-snapshot')} title="Copy this snapshot to the clipboard so you can paste it elsewhere">Copy</button>

--- a/js/sync-diagnose-ui.js
+++ b/js/sync-diagnose-ui.js
@@ -87,10 +87,10 @@ export function configureSyncDiagnoseUI({
   });
 }
 
-// Read-only modal that dumps Evolu's local state - both devices should
-// show the same `ownerId` / `mnemonicPrefix`. If they differ, the two
-// devices are talking to different Evolu owners and will never see each
-// other's data despite using the same relay URL.
+// Read-only modal that dumps Evolu's local state. Both devices should show
+// the same `ownerId`; recovery-phrase words are intentionally never exposed
+// in diagnostics. Different owner IDs cannot see each other's data despite
+// using the same relay URL.
 export async function showSyncDiagnose() {
   const diagnostics = await getEvoluDiagnostics();
   /** @type {{ verdict: string, at: number, reason: string | null }} */

--- a/js/sync-diagnostics-snapshot.js
+++ b/js/sync-diagnostics-snapshot.js
@@ -3,7 +3,6 @@
 
 import { getErrorMessage } from './caught-error.js';
 import { state } from './state.js';
-import { isDebugMode } from './utils.js';
 import { getDeltaCutoverReadiness, getDeltaTelemetry } from './sync-delta.js';
 import { getSyncRelay } from './sync-environment.js';
 import { parseSyncPayload } from './sync-payload-codec.js';
@@ -49,10 +48,6 @@ export function _syncDiag() {
     }
   }
   info.localTimestamps = tsList;
-  if (isDebugMode()) {
-    console.table?.(info.evoluRows);
-    console.log('[sync] Diagnostics:', JSON.stringify(info, null, 2));
-  }
   return info;
 }
 
@@ -70,7 +65,7 @@ export async function getEvoluDiagnostics() {
     syncEnabled: currentDiagnosticSyncEnabled(),
     relay: getSyncRelay(),
     ownerId: appOwner?.id ? String(appOwner.id).slice(0, 12) + '…' : null,
-    mnemonicPrefix: appOwner?.mnemonic ? appOwner.mnemonic.split(' ').slice(0, 2).join(' ') + ' …' : null,
+    mnemonicConfigured: !!appOwner?.mnemonic,
     rows: /** @type {any[]} */ ([]),
     activeProfileId: state.currentProfile,
     activeImported: { sunSessions: 0, lightDevices: 0 },

--- a/js/sync-diagnostics-snapshot.js
+++ b/js/sync-diagnostics-snapshot.js
@@ -1,7 +1,6 @@
 // @ts-check
 // sync-diagnostics-snapshot.js - Evolu row diagnostics snapshots.
 
-import { getErrorMessage } from './caught-error.js';
 import { state } from './state.js';
 import { getDeltaCutoverReadiness, getDeltaTelemetry } from './sync-delta.js';
 import { getSyncRelay } from './sync-environment.js';
@@ -67,6 +66,8 @@ export async function getEvoluDiagnostics() {
     ownerId: appOwner?.id ? String(appOwner.id).slice(0, 12) + '…' : null,
     mnemonicConfigured: !!appOwner?.mnemonic,
     rows: /** @type {any[]} */ ([]),
+    rowParseFailureCount: 0,
+    rowsReadFailed: false,
     activeProfileId: state.currentProfile,
     activeImported: { sunSessions: 0, lightDevices: 0 },
   };
@@ -92,12 +93,14 @@ export async function getEvoluDiagnostics() {
         // wild on cross-device replication of older inserts) - read it
         // from the payload's nested profile object.
         payloadProfileId = parsed?.profile?.id || null;
-      } catch (e) {
+      } catch {
         // v1.7.15 audit fix: previously silent. The diagnose modal would
         // render the row as 0/0 - indistinguishable from a real empty row.
-        // Log so triage can see which rows the parse path is rejecting
-        // (gzip-bomb defence trips, malformed envelope, etc).
-        logSyncEvent('skip', `Diagnose row ${String(row.id || '?').slice(0, 8)} parse failed: ${String(getErrorMessage(e, e)).slice(0, 80)}`);
+        // Record only a fixed status and bounded count: parser messages can
+        // quote malformed payload content and must not enter support output.
+        format = 'invalid';
+        out.rowParseFailureCount++;
+        logSyncEvent('skip', 'Diagnose row parse failed');
       }
       out.rows.push({
         profileId: row.profileId || payloadProfileId,
@@ -109,7 +112,10 @@ export async function getEvoluDiagnostics() {
         bytes: (row.dataJson || '').length,
       });
     }
-  } catch (e) { out.rowsError = String(getErrorMessage(e, e)); }
+  } catch {
+    out.rowsReadFailed = true;
+    logSyncEvent('skip', 'Diagnose row query failed');
+  }
   // What's actually in this device's active state right now.
   out.activeImported.sunSessions = Array.isArray(state.importedData?.sunSessions) ? state.importedData.sunSessions.length : 0;
   out.activeImported.lightDevices = Array.isArray(state.importedData?.lightDevices) ? state.importedData.lightDevices.length : 0;

--- a/js/sync-diagnostics-text.js
+++ b/js/sync-diagnostics-text.js
@@ -5,6 +5,9 @@
 // in showSyncDiagnose, so a user can paste the device's state into chat /
 // support without retyping. Mirrors the modal's structure exactly.
 export function _evoluDiagnosticsText(d) {
+  const rowParseFailureCount = Number.isSafeInteger(d.rowParseFailureCount) && d.rowParseFailureCount > 0
+    ? d.rowParseFailureCount
+    : 0;
   const lines = [
     `Sync diagnose @ ${new Date().toISOString()}`,
     `Sync enabled: ${d.syncEnabled ? 'yes' : 'no'}`,
@@ -31,7 +34,8 @@ export function _evoluDiagnosticsText(d) {
       lines.push(`  ${pid} ${del}  ${ts} ${sun}  ${dev}  ${size}  ${fmt} ${src}`);
     }
   }
-  if (d.rowsError) lines.push(`Rows read error: ${d.rowsError}`);
+  if (rowParseFailureCount > 0) lines.push(`Unreadable row payloads: ${rowParseFailureCount}`);
+  if (d.rowsReadFailed) lines.push('Row query status: failed');
   const t = d.deltaTelemetry;
   if (t) {
     const s = t.summary;

--- a/js/sync-diagnostics-text.js
+++ b/js/sync-diagnostics-text.js
@@ -10,7 +10,7 @@ export function _evoluDiagnosticsText(d) {
     `Sync enabled: ${d.syncEnabled ? 'yes' : 'no'}`,
     `Relay: ${d.relay || '-'}`,
     `Owner ID: ${d.ownerId || '- (not initialized)'}`,
-    `Mnemonic prefix: ${d.mnemonicPrefix || '-'}`,
+    `Recovery phrase configured: ${d.mnemonicConfigured ? 'yes' : 'no'}`,
     `Active profile: ${d.activeProfileId || '?'}`,
     `In-memory state: sunSessions=${d.activeImported.sunSessions} lightDevices=${d.activeImported.lightDevices}`,
     `Rows in this device's local Evolu DB:`,

--- a/scripts/quality-guardrails.mjs
+++ b/scripts/quality-guardrails.mjs
@@ -25,6 +25,20 @@ const VIEW_RUNTIME_LOOKUP_RE = /\bgetViewRuntimeFunction\s*\(/g;
 const LAB_STATE_RE = /\b_labState\b/g;
 const VIEW_RUNTIME_BRIDGE_FILE = 'js/views-runtime-bridge.js';
 const LAB_STATE_GUARDRAIL_TEST_FILE = 'tests/test-quality-guardrails.js';
+const PRIVACY_CRITICAL_LOG_FILES = [
+  'js/pdf-import.js',
+  'js/pdf-import-file-handlers.js',
+  'js/pii.js',
+  'js/pii-review.js',
+  'js/sync-diagnostics-snapshot.js',
+];
+const CONSOLE_REFERENCE_RE = /\bconsole\b/g;
+const SYNC_DIAGNOSTIC_FILES = [
+  'js/sync-diagnostics-snapshot.js',
+  'js/sync-diagnostics-text.js',
+  'js/sync-diagnose-render.js',
+];
+const RECOVERY_PHRASE_FRAGMENT_RE = /\bmnemonicPrefix\b|\bmnemonic\s*(?:\?\.|\.)\s*split\s*\(/g;
 // Keep this value in sync with the baseline key name largeJsFilesOver800Lines.
 const LARGE_FILE_LINE_LIMIT = 800;
 
@@ -134,6 +148,30 @@ function collectOversizedProductionFiles() {
     .sort((a, b) => b.lines - a.lines);
 }
 
+function collectPrivacyConsoleViolations() {
+  const violations = [];
+  for (const relativeFile of PRIVACY_CRITICAL_LOG_FILES) {
+    const source = fs.readFileSync(path.join(ROOT, relativeFile), 'utf8');
+    const matches = [...source.matchAll(CONSOLE_REFERENCE_RE)];
+    if (matches.length > 0) {
+      violations.push({ file: relativeFile, count: matches.length });
+    }
+  }
+  return violations;
+}
+
+function collectRecoveryPhraseDiagnosticViolations() {
+  const violations = [];
+  for (const relativeFile of SYNC_DIAGNOSTIC_FILES) {
+    const source = fs.readFileSync(path.join(ROOT, relativeFile), 'utf8');
+    const matches = [...source.matchAll(RECOVERY_PHRASE_FRAGMENT_RE)];
+    if (matches.length > 0) {
+      violations.push({ file: relativeFile, count: matches.length });
+    }
+  }
+  return violations;
+}
+
 function collectSyntaxFiles() {
   const files = [];
   const exts = new Set(['.js', '.mjs']);
@@ -173,6 +211,8 @@ function main() {
   const metrics = collectAppMetrics();
   const testMetrics = collectTestMetrics();
   const oversizedProductionFiles = collectOversizedProductionFiles();
+  const privacyConsoleViolations = collectPrivacyConsoleViolations();
+  const recoveryPhraseDiagnosticViolations = collectRecoveryPhraseDiagnosticViolations();
 
   compareBudget('inline event attributes in js/', metrics.inlineEventAttributes, baseline.inlineEventAttributes);
   compareBudget('window global references in js/', metrics.windowReferences, baseline.windowReferences);
@@ -188,6 +228,18 @@ function main() {
   } else {
     fail('all first-party production JS files stay below 800 lines',
       oversizedProductionFiles.map(entry => `${entry.file}: ${entry.lines}`).join(', '));
+  }
+  if (privacyConsoleViolations.length === 0) {
+    pass('privacy-critical workflows avoid direct console logging');
+  } else {
+    fail('privacy-critical workflows avoid direct console logging',
+      privacyConsoleViolations.map(entry => `${entry.file}: ${entry.count}`).join(', '));
+  }
+  if (recoveryPhraseDiagnosticViolations.length === 0) {
+    pass('support diagnostics never expose recovery-phrase fragments');
+  } else {
+    fail('support diagnostics never expose recovery-phrase fragments',
+      recoveryPhraseDiagnosticViolations.map(entry => `${entry.file}: ${entry.count}`).join(', '));
   }
 
   if (metrics.largestFile.lines <= baseline.maxJsFileLines) {

--- a/scripts/quality-guardrails.mjs
+++ b/scripts/quality-guardrails.mjs
@@ -39,6 +39,7 @@ const SYNC_DIAGNOSTIC_FILES = [
   'js/sync-diagnose-render.js',
 ];
 const RECOVERY_PHRASE_FRAGMENT_RE = /\bmnemonicPrefix\b|\bmnemonic\s*(?:\?\.|\.)\s*split\s*\(/g;
+const UNBOUNDED_SYNC_DIAGNOSTIC_ERROR_RE = /\b(?:getErrorMessage|rowsError)\b/g;
 // Keep this value in sync with the baseline key name largeJsFilesOver800Lines.
 const LARGE_FILE_LINE_LIMIT = 800;
 
@@ -172,6 +173,18 @@ function collectRecoveryPhraseDiagnosticViolations() {
   return violations;
 }
 
+function collectUnboundedSyncDiagnosticErrors() {
+  const violations = [];
+  for (const relativeFile of SYNC_DIAGNOSTIC_FILES) {
+    const source = fs.readFileSync(path.join(ROOT, relativeFile), 'utf8');
+    const matches = [...source.matchAll(UNBOUNDED_SYNC_DIAGNOSTIC_ERROR_RE)];
+    if (matches.length > 0) {
+      violations.push({ file: relativeFile, count: matches.length });
+    }
+  }
+  return violations;
+}
+
 function collectSyntaxFiles() {
   const files = [];
   const exts = new Set(['.js', '.mjs']);
@@ -213,6 +226,7 @@ function main() {
   const oversizedProductionFiles = collectOversizedProductionFiles();
   const privacyConsoleViolations = collectPrivacyConsoleViolations();
   const recoveryPhraseDiagnosticViolations = collectRecoveryPhraseDiagnosticViolations();
+  const unboundedSyncDiagnosticErrors = collectUnboundedSyncDiagnosticErrors();
 
   compareBudget('inline event attributes in js/', metrics.inlineEventAttributes, baseline.inlineEventAttributes);
   compareBudget('window global references in js/', metrics.windowReferences, baseline.windowReferences);
@@ -240,6 +254,12 @@ function main() {
   } else {
     fail('support diagnostics never expose recovery-phrase fragments',
       recoveryPhraseDiagnosticViolations.map(entry => `${entry.file}: ${entry.count}`).join(', '));
+  }
+  if (unboundedSyncDiagnosticErrors.length === 0) {
+    pass('support diagnostics use bounded sync-error status');
+  } else {
+    fail('support diagnostics use bounded sync-error status',
+      unboundedSyncDiagnosticErrors.map(entry => `${entry.file}: ${entry.count}`).join(', '));
   }
 
   if (metrics.largestFile.lines <= baseline.maxJsFileLines) {

--- a/service-worker.js
+++ b/service-worker.js
@@ -166,6 +166,7 @@ const APP_SHELL = [
   '/js/data-merge-lab-entries.js',
   '/js/data-merge.js',
   '/js/pii-review.js',
+  '/js/privacy-safe-diagnostics.js',
   '/js/pii.js',
   '/js/charts-runtime.js',
   '/js/charts.js',

--- a/tests/playwright/browser-coverage-batch.spec.js
+++ b/tests/playwright/browser-coverage-batch.spec.js
@@ -420,6 +420,9 @@ test('discussion round and sync diagnose render helpers cover active and empty s
           mnemonicConfigured: true,
           activeProfileId: 'profile-1',
           activeImported: { sunSessions: 2, lightDevices: 1 },
+          rowParseFailureCount: 1,
+          rowsReadFailed: true,
+          rowsError: 'Patient Jane Example payload was malformed',
           rows: [{
             profileId: 'profile-1',
             profileIdSource: 'payload',
@@ -455,6 +458,9 @@ test('discussion round and sync diagnose render helpers cover active and empty s
         && fullHtml.includes('Relay storage')
         && fullHtml.includes('Push efficiency')
         && fullHtml.includes('Lean sync mode')
+        && fullHtml.includes('1 row payload could not be decoded.')
+        && fullHtml.includes('Row query failed.')
+        && !fullHtml.includes('Patient Jane Example')
         && fullHtml.includes('profileId column empty')
         && fullHtml.includes('notes(1/1/0)');
       outcomes.syncDiagnoseRendererUsesDelegatedActions =
@@ -476,6 +482,8 @@ test('discussion round and sync diagnose render helpers cover active and empty s
           mnemonicConfigured: false,
           activeProfileId: '',
           activeImported: { sunSessions: 0, lightDevices: 0 },
+          rowParseFailureCount: 0,
+          rowsReadFailed: false,
           rows: [],
         },
         healthVerdict: { verdict: 'healthy', at: Date.now() },
@@ -647,6 +655,9 @@ test('sync diagnostics schema and snapshot helpers cover browser contracts', asy
         mnemonicConfigured: true,
         activeProfileId: 'profile-1',
         activeImported: { sunSessions: 1, lightDevices: 2 },
+        rowParseFailureCount: 1,
+        rowsReadFailed: true,
+        rowsError: 'Patient Jane Example payload was malformed',
         rows: [{
           profileId: 'profile-1',
           isDeleted: true,
@@ -657,7 +668,6 @@ test('sync diagnostics schema and snapshot helpers cover browser contracts', asy
           format: 'gz',
           profileIdSource: 'payload',
         }],
-        rowsError: 'row read failed',
         deltaTelemetry: {
           summary: { count: 1, ratio: 0.04, totalBlobBytes: 1000, totalDeltaBytes: 40, totalOps: 1 },
           pushes: [{
@@ -682,14 +692,17 @@ test('sync diagnostics schema and snapshot helpers cover browser contracts', asy
       const renderedText = diagnosticsText._evoluDiagnosticsText(textPayload);
       outcomes.diagnosticsTextIncludesRowsAndDelta = renderedText.includes('Sync enabled: yes')
         && renderedText.includes('profile-1')
-        && renderedText.includes('Rows read error: row read failed')
+        && renderedText.includes('Unreadable row payloads: 1')
+        && renderedText.includes('Row query status: failed')
+        && !renderedText.includes('Patient Jane Example')
         && renderedText.includes('Phase 1 dual-write health')
         && renderedText.includes('notes(1/0/0)')
         && renderedText.includes('entries');
       outcomes.diagnosticsTextHandlesEmptyRows = diagnosticsText._evoluDiagnosticsText({
         ...textPayload,
         rows: [],
-        rowsError: '',
+        rowParseFailureCount: 0,
+        rowsReadFailed: false,
         deltaTelemetry: null,
         cutoverReadiness: null,
       }).includes('  (none)');
@@ -765,10 +778,13 @@ test('sync diagnostics schema and snapshot helpers cover browser contracts', asy
         && String(evoluDiagnostics.ownerId).startsWith('ownerabcdef')
         && evoluDiagnostics.mnemonicConfigured === true
         && !Object.hasOwn(evoluDiagnostics, 'mnemonicPrefix')
+        && evoluDiagnostics.rowParseFailureCount === 1
+        && evoluDiagnostics.rowsReadFailed === false
+        && !Object.hasOwn(evoluDiagnostics, 'rowsError')
         && evoluDiagnostics.rows.length === 4
         && evoluDiagnostics.rows.some(row => row.profileId === 'profile-from-payload' && row.profileIdSource === 'payload' && row.dev === 2)
         && evoluDiagnostics.rows.some(row => row.profileId === 'deleted-profile' && row.isDeleted === true)
-        && evoluDiagnostics.rows.some(row => row.profileId === 'bad-profile' && row.sun === 0);
+        && evoluDiagnostics.rows.some(row => row.profileId === 'bad-profile' && row.sun === 0 && row.format === 'invalid');
       outcomes.snapshotCountsActiveImported = evoluDiagnostics.activeImported.sunSessions === 1
         && evoluDiagnostics.activeImported.lightDevices === 2
         && evoluDiagnostics.cutoverReadiness !== null;

--- a/tests/playwright/browser-coverage-batch.spec.js
+++ b/tests/playwright/browser-coverage-batch.spec.js
@@ -417,7 +417,7 @@ test('discussion round and sync diagnose render helpers cover active and empty s
           syncEnabled: true,
           relay: 'https://relay.example.test',
           ownerId: 'owner-1',
-          mnemonicPrefix: 'alpha beta gamma',
+          mnemonicConfigured: true,
           activeProfileId: 'profile-1',
           activeImported: { sunSessions: 2, lightDevices: 1 },
           rows: [{
@@ -473,7 +473,7 @@ test('discussion round and sync diagnose render helpers cover active and empty s
           syncEnabled: false,
           relay: '',
           ownerId: '',
-          mnemonicPrefix: '',
+          mnemonicConfigured: false,
           activeProfileId: '',
           activeImported: { sunSessions: 0, lightDevices: 0 },
           rows: [],
@@ -644,7 +644,7 @@ test('sync diagnostics schema and snapshot helpers cover browser contracts', asy
         syncEnabled: true,
         relay: 'https://relay.example.test',
         ownerId: 'owner-1',
-        mnemonicPrefix: 'alpha beta',
+        mnemonicConfigured: true,
         activeProfileId: 'profile-1',
         activeImported: { sunSessions: 1, lightDevices: 2 },
         rows: [{
@@ -763,7 +763,8 @@ test('sync diagnostics schema and snapshot helpers cover browser contracts', asy
         && syncInfo.localTimestamps.some(item => item.key === 'coverage-sync-ts');
       outcomes.snapshotParsesRowsFallbacksAndDeletes = evoluDiagnostics.syncEnabled === true
         && String(evoluDiagnostics.ownerId).startsWith('ownerabcdef')
-        && String(evoluDiagnostics.mnemonicPrefix).startsWith('alpha beta')
+        && evoluDiagnostics.mnemonicConfigured === true
+        && !Object.hasOwn(evoluDiagnostics, 'mnemonicPrefix')
         && evoluDiagnostics.rows.length === 4
         && evoluDiagnostics.rows.some(row => row.profileId === 'profile-from-payload' && row.profileIdSource === 'payload' && row.dev === 2)
         && evoluDiagnostics.rows.some(row => row.profileId === 'deleted-profile' && row.isDeleted === true)

--- a/tests/privacy-safe-diagnostics.test.js
+++ b/tests/privacy-safe-diagnostics.test.js
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  logPrivacyDiagnostic,
+  sanitizePrivacyDiagnostic,
+} from '../js/privacy-safe-diagnostics.js';
+
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe('privacy-safe diagnostics', () => {
+  it('keeps bounded metadata and drops content-bearing values', () => {
+    const rawReport = 'Patient: Jane Example\nGlucose: 96 mg/dL';
+    const safe = sanitizePrivacyDiagnostic({
+      method: 'ollama+review',
+      durationMs: 1280,
+      replacements: 4,
+      inputChars: rawReport.length,
+      outputChars: 42,
+      errorName: rawReport,
+      stage: rawReport,
+      fileName: 'Jane Example lab.pdf',
+      originalText: rawReport,
+      nested: { report: rawReport },
+      invalidNumber: Number.NaN,
+      pageCount: '12',
+      fileIndex: Symbol('patient-index'),
+    });
+
+    expect(safe).toEqual({
+      method: 'ollama+review',
+      durationMs: 1280,
+      replacements: 4,
+      inputChars: rawReport.length,
+      outputChars: 42,
+    });
+    expect(JSON.stringify(safe)).not.toContain('Jane');
+    expect(Object.isFrozen(safe)).toBe(true);
+  });
+
+  it('does not emit until debug mode is explicitly enabled', () => {
+    const debug = vi.spyOn(console, 'debug').mockImplementation(() => {});
+
+    expect(logPrivacyDiagnostic('transform-complete', { inputChars: 100 })).toBeNull();
+    expect(debug).not.toHaveBeenCalled();
+
+    localStorage.setItem('labcharts-debug', 'true');
+    expect(logPrivacyDiagnostic('Patient Jane Example', {
+      inputChars: 100,
+      fileName: 'Private Patient.pdf',
+    })).toEqual({ inputChars: 100 });
+    expect(debug).toHaveBeenCalledWith(
+      '[privacy] event',
+      { inputChars: 100 },
+    );
+  });
+});

--- a/tests/sync-recovery-runtime.test.js
+++ b/tests/sync-recovery-runtime.test.js
@@ -124,7 +124,7 @@ describe('sync recovery runtime', () => {
       syncEnabled: true,
       relay: 'wss://relay.example',
       ownerId: 'owner-1',
-      mnemonicPrefix: 'alpha beta',
+      mnemonicConfigured: true,
       activeProfileId: 'profile-1',
       activeImported: { sunSessions: 2, lightDevices: 1 },
       rows: [{
@@ -192,6 +192,8 @@ describe('sync recovery runtime', () => {
     });
 
     expect(text).toContain('Sync enabled: yes');
+    expect(text).toContain('Recovery phrase configured: yes');
+    expect(text).not.toContain('alpha beta');
     expect(text).toContain('profile-1');
     expect(text).toContain('sunSessions(1/1/0)');
     expect(text).not.toContain('empty(0/0/0)');

--- a/tests/sync-recovery-runtime.test.js
+++ b/tests/sync-recovery-runtime.test.js
@@ -127,6 +127,9 @@ describe('sync recovery runtime', () => {
       mnemonicConfigured: true,
       activeProfileId: 'profile-1',
       activeImported: { sunSessions: 2, lightDevices: 1 },
+      rowParseFailureCount: 1,
+      rowsReadFailed: true,
+      rowsError: 'Patient Jane Example payload was malformed',
       rows: [{
         profileId: 'profile-1',
         isDeleted: false,
@@ -194,6 +197,9 @@ describe('sync recovery runtime', () => {
     expect(text).toContain('Sync enabled: yes');
     expect(text).toContain('Recovery phrase configured: yes');
     expect(text).not.toContain('alpha beta');
+    expect(text).toContain('Unreadable row payloads: 1');
+    expect(text).toContain('Row query status: failed');
+    expect(text).not.toContain('Patient Jane Example');
     expect(text).toContain('profile-1');
     expect(text).toContain('sunSessions(1/1/0)');
     expect(text).not.toContain('empty(0/0/0)');

--- a/tests/test-audit-fixes.js
+++ b/tests/test-audit-fixes.js
@@ -343,15 +343,19 @@ return (async function () {
       /scheduleProfilePush\(profileId,\s*data\)/.test(onChat));
   }
 
-  // ─── 7. _syncDiag — console output gated by isDebugMode() ──────────
-  console.log('%c 7. _syncDiag debug-mode gate ', 'font-weight:bold;color:#0891b2');
+  // ─── 7. _syncDiag — no implicit console disclosure ─────────────────
+  console.log('%c 7. _syncDiag privacy boundary ', 'font-weight:bold;color:#0891b2');
   {
     const src = await fetchSrc('js/sync-diagnostics-snapshot.js');
     const fn = src.slice(src.indexOf('function _syncDiag'),
                           src.indexOf('function _syncDiag') + 2000);
     assert('_syncDiag function found', fn.indexOf('function _syncDiag') === 0);
-    assert('_syncDiag wraps console.log + console.table in isDebugMode()',
-      /if\s*\(isDebugMode\(\)\)\s*\{[\s\S]*console\.table\?\.\([\s\S]*console\.log\([\s\S]*\}/.test(fn));
+    assert('_syncDiag returns diagnostics without logging them',
+      !/\bconsole\.(?:debug|error|info|log|table|warn)\s*\(/.test(fn));
+    assert('sync diagnostics never derive or expose a mnemonic prefix',
+      !src.includes('mnemonicPrefix')
+        && !/mnemonic\s*\.\s*split\s*\(/.test(src)
+        && src.includes('mnemonicConfigured: !!appOwner?.mnemonic'));
   }
 
   // ─── 8. sun-active-session.js openStartSunSessionDialog — uviPromise.then.catch ──

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -127,6 +127,21 @@ assert('quality guardrail tracks large-module budget',
     guardrailSrc.includes('all first-party production JS files stay below 800 lines') &&
     Object.hasOwn(baseline, 'largeJsFilesOver800Lines') &&
     Object.hasOwn(baseline, 'maxJsFileLines'));
+assert('quality guardrail blocks direct console logging in privacy-critical workflows',
+  guardrailSrc.includes('PRIVACY_CRITICAL_LOG_FILES') &&
+    guardrailSrc.includes('CONSOLE_REFERENCE_RE') &&
+    guardrailSrc.includes('privacy-critical workflows avoid direct console logging') &&
+    guardrailSrc.includes("'js/pdf-import.js'") &&
+    guardrailSrc.includes("'js/pdf-import-file-handlers.js'") &&
+    guardrailSrc.includes("'js/pii.js'") &&
+    guardrailSrc.includes("'js/pii-review.js'") &&
+    guardrailSrc.includes("'js/sync-diagnostics-snapshot.js'"));
+assert('quality guardrail blocks recovery-phrase fragments in support diagnostics',
+  guardrailSrc.includes('SYNC_DIAGNOSTIC_FILES') &&
+    guardrailSrc.includes('RECOVERY_PHRASE_FRAGMENT_RE') &&
+    guardrailSrc.includes('support diagnostics never expose recovery-phrase fragments') &&
+    guardrailSrc.includes("'js/sync-diagnostics-text.js'") &&
+    guardrailSrc.includes("'js/sync-diagnose-render.js'"));
 assert('quality guardrail exits non-zero on failures',
   guardrailSrc.includes('process.exit(failed > 0 ? 1 : 0)'));
 assert('full local test suite runs typecheck',

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -142,6 +142,9 @@ assert('quality guardrail blocks recovery-phrase fragments in support diagnostic
     guardrailSrc.includes('support diagnostics never expose recovery-phrase fragments') &&
     guardrailSrc.includes("'js/sync-diagnostics-text.js'") &&
     guardrailSrc.includes("'js/sync-diagnose-render.js'"));
+assert('quality guardrail blocks free-form sync errors in support diagnostics',
+  guardrailSrc.includes('UNBOUNDED_SYNC_DIAGNOSTIC_ERROR_RE') &&
+    guardrailSrc.includes('support diagnostics use bounded sync-error status'));
 assert('quality guardrail exits non-zero on failures',
   guardrailSrc.includes('process.exit(failed > 0 ? 1 : 0)'));
 assert('full local test suite runs typecheck',

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -2739,9 +2739,11 @@ await import('../js/settings.js');
   console.log('14i. v1.7.15 deferred-audit fixes');
 
   // Telemetry on diagnose pre-pass parse failure
-  assert('Diagnose pre-pass logs parse failures via logSyncEvent',
-    /Diagnose row[\s\S]{0,200}parse failed[\s\S]{0,200}logSyncEvent\('skip'/.test(deltaSearchSrc) ||
-    /logSyncEvent\('skip',\s*`Diagnose row/.test(deltaSearchSrc));
+  assert('Diagnose pre-pass logs bounded parse failure status via logSyncEvent',
+    /logSyncEvent\('skip',\s*'Diagnose row parse failed'\)/.test(deltaSearchSrc)
+      && /rowParseFailureCount\+\+/.test(deltaSearchSrc)
+      && !/Diagnose row[^'"]*\$\{/.test(deltaSearchSrc)
+      && !/\browsError\b/.test(syncDiagnosticsSearchSrc));
   // Telemetry on onSyncReceived malformed-row drop
   assert('onSyncReceived logs malformed-importedData skip via logSyncEvent',
     /malformed importedData shape, skipping row/.test(deltaSearchSrc));

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -253,6 +253,7 @@
     "js/pdf-import.js",
     "js/pdfjs-loader.js",
     "js/pii-review.js",
+    "js/privacy-safe-diagnostics.js",
     "js/pii.js",
     "js/profile-data-migrations.js",
     "js/profile-fatty-acid-migrations.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -239,6 +239,7 @@
     "js/pdf-import-review-runtime.js",
     "js/pdfjs-loader.js",
     "js/pii-review.js",
+    "js/privacy-safe-diagnostics.js",
     "js/pii.js",
     "js/profile-data-migrations.js",
     "js/profile-list-store.js",


### PR DESCRIPTION
## What changed

- replace PDF/image import console output with a metadata-only, allowlisted debug logger
- prevent raw report text, obfuscated content, filenames, free-form errors, and nested values from reaching diagnostic logs
- remove recovery-phrase word fragments from Sync Diagnose and stop `_syncDiag()` from implicitly dumping snapshot data
- add hard quality gates for console references in privacy-critical modules and recovery-phrase fragments in support diagnostics
- add the new offline app-shell module, type-check coverage, architecture-map updates, and focused regressions

## Why

Debug paths could disclose raw health-report content, filenames, and recovery-seed fragments. Diagnostics should remain useful without emitting content-bearing or secret-derived values.

## Impact

Debug output now contains only bounded metadata such as timings, counts, fixed enum values, and common error classes. Sync Diagnose reports whether a recovery phrase is configured but never displays seed words.

## Validation

- `npm test -- tests/privacy-safe-diagnostics.test.js tests/pdf-import-review-boundaries.test.js tests/sync-recovery-runtime.test.js tests/service-worker-app-shell.test.js` (10 passed)
- focused Playwright import + sync diagnostics paths (4 passed)
- `npm run quality` (14/14)
- `node tests/test-quality-guardrails.js` (40/40)
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run typecheck:strict-null` (0 diagnostics)
- `npm run architecture:check` (541 modules, 0 cycles)
- `npm run production:check`
- `node tests/test-sync.js` (834/834)
- `node tests/test-pii.js` (44/44)
- `node tests/test-image-utils.js` (73/73)
- `node tests/verify-modules.js` (159/159)