### PR TITLE
Pin GitHub Actions to immutable commits

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,9 +24,9 @@ jobs:
       matrix:
         language: [javascript-typescript]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: github/codeql-action/init@v4
+      - uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           languages: ${{ matrix.language }}
           # security-extended adds taint-flow + injection rules beyond the
@@ -66,6 +66,6 @@ jobs:
               - exclude:
                   id: js/xss-through-dom
 
-      - uses: github/codeql-action/analyze@v4
+      - uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           category: /language:${{ matrix.language }}

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -32,9 +32,9 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24
           cache: npm
@@ -46,7 +46,7 @@ jobs:
         run: npm run sbom
 
       - name: Upload CycloneDX SBOM
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: getbased-cyclonedx-sbom
           path: artifacts/getbased.cdx.json
@@ -62,9 +62,9 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,9 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24
           cache: npm
@@ -57,7 +57,7 @@ jobs:
         run: npm run quality
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.cache/ms-playwright
           key: playwright-browsers-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -81,7 +81,7 @@ jobs:
 
       - name: Upload test logs on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: test-logs
           path: /tmp/dev-server.log

--- a/scripts/quality-guardrails.mjs
+++ b/scripts/quality-guardrails.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const BASELINE_PATH = path.join(ROOT, 'scripts', 'quality-baseline.json');
+const GITHUB_AUTOMATION_DIR = path.join(ROOT, '.github');
 // tests/ is intentionally omitted; this check covers app JS only, not test helpers.
 const SYNTAX_DIRS = ['js', 'api', 'lib', 'scripts'];
 const APP_JS_DIR = path.join(ROOT, 'js');
@@ -40,6 +41,8 @@ const SYNC_DIAGNOSTIC_FILES = [
 ];
 const RECOVERY_PHRASE_FRAGMENT_RE = /\bmnemonicPrefix\b|\bmnemonic\s*(?:\?\.|\.)\s*split\s*\(/g;
 const UNBOUNDED_SYNC_DIAGNOSTIC_ERROR_RE = /\b(?:getErrorMessage|rowsError)\b/g;
+const WORKFLOW_USES_RE = /^\s*(?:-\s*)?uses:\s*["']?([^"'#\s]+)["']?/;
+const IMMUTABLE_ACTION_SHA_RE = /^[0-9a-f]{40}$/;
 // Keep this value in sync with the baseline key name largeJsFilesOver800Lines.
 const LARGE_FILE_LINE_LIMIT = 800;
 
@@ -185,6 +188,24 @@ function collectUnboundedSyncDiagnosticErrors() {
   return violations;
 }
 
+function collectMutableWorkflowActionRefs() {
+  const violations = [];
+  const workflowFiles = walkFiles(GITHUB_AUTOMATION_DIR, new Set(['.yml', '.yaml']));
+  for (const file of workflowFiles) {
+    const lines = fs.readFileSync(file, 'utf8').split('\n');
+    lines.forEach((line, index) => {
+      const uses = line.match(WORKFLOW_USES_RE)?.[1] || '';
+      if (!uses || uses.startsWith('./')) return;
+      const separator = uses.lastIndexOf('@');
+      const ref = separator >= 0 ? uses.slice(separator + 1) : '';
+      if (!IMMUTABLE_ACTION_SHA_RE.test(ref)) {
+        violations.push({ file: repoRel(file), line: index + 1, uses });
+      }
+    });
+  }
+  return violations;
+}
+
 function collectSyntaxFiles() {
   const files = [];
   const exts = new Set(['.js', '.mjs']);
@@ -227,6 +248,7 @@ function main() {
   const privacyConsoleViolations = collectPrivacyConsoleViolations();
   const recoveryPhraseDiagnosticViolations = collectRecoveryPhraseDiagnosticViolations();
   const unboundedSyncDiagnosticErrors = collectUnboundedSyncDiagnosticErrors();
+  const mutableWorkflowActionRefs = collectMutableWorkflowActionRefs();
 
   compareBudget('inline event attributes in js/', metrics.inlineEventAttributes, baseline.inlineEventAttributes);
   compareBudget('window global references in js/', metrics.windowReferences, baseline.windowReferences);
@@ -260,6 +282,12 @@ function main() {
   } else {
     fail('support diagnostics use bounded sync-error status',
       unboundedSyncDiagnosticErrors.map(entry => `${entry.file}: ${entry.count}`).join(', '));
+  }
+  if (mutableWorkflowActionRefs.length === 0) {
+    pass('third-party GitHub Actions use immutable commit SHAs');
+  } else {
+    fail('third-party GitHub Actions use immutable commit SHAs',
+      mutableWorkflowActionRefs.map(entry => `${entry.file}:${entry.line} ${entry.uses}`).join(', '));
   }
 
   if (metrics.largestFile.lines <= baseline.maxJsFileLines) {

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -34,6 +34,16 @@ const moduleMap = fs.readFileSync(path.join(ROOT, 'MODULE_MAP.md'), 'utf8');
 const runTestsSrc = fs.readFileSync(path.join(ROOT, 'run-tests.sh'), 'utf8');
 const playwrightConfigSrc = fs.readFileSync(path.join(ROOT, 'playwright.config.js'), 'utf8');
 const testWorkflowSrc = fs.readFileSync(path.join(ROOT, '.github/workflows/test.yml'), 'utf8');
+function collectYamlFiles(dir) {
+  const files = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) files.push(...collectYamlFiles(full));
+    else if (entry.isFile() && /\.ya?ml$/.test(entry.name)) files.push(full);
+  }
+  return files;
+}
+const workflowFiles = collectYamlFiles(path.join(ROOT, '.github'));
 const tsConfig = JSON.parse(fs.readFileSync(path.join(ROOT, 'tsconfig.json'), 'utf8'));
 const checkJsConfig = JSON.parse(fs.readFileSync(path.join(ROOT, 'tsconfig.checkjs.json'), 'utf8'));
 const serverCheckJsConfig = JSON.parse(fs.readFileSync(path.join(ROOT, 'tsconfig.server.json'), 'utf8'));
@@ -145,6 +155,23 @@ assert('quality guardrail blocks recovery-phrase fragments in support diagnostic
 assert('quality guardrail blocks free-form sync errors in support diagnostics',
   guardrailSrc.includes('UNBOUNDED_SYNC_DIAGNOSTIC_ERROR_RE') &&
     guardrailSrc.includes('support diagnostics use bounded sync-error status'));
+const mutableWorkflowActions = [];
+for (const file of workflowFiles) {
+  const lines = fs.readFileSync(file, 'utf8').split('\n');
+  lines.forEach((line, index) => {
+    const uses = line.match(/^\s*(?:-\s*)?uses:\s*["']?([^"'#\s]+)["']?/)?.[1] || '';
+    if (!uses || uses.startsWith('./')) return;
+    const ref = uses.slice(uses.lastIndexOf('@') + 1);
+    if (!/^[0-9a-f]{40}$/.test(ref)) {
+      mutableWorkflowActions.push(`${path.basename(file)}:${index + 1} ${uses}`);
+    }
+  });
+}
+assert('all third-party GitHub Actions are pinned to immutable commit SHAs',
+  guardrailSrc.includes('collectMutableWorkflowActionRefs') &&
+    guardrailSrc.includes('third-party GitHub Actions use immutable commit SHAs') &&
+    mutableWorkflowActions.length === 0,
+  mutableWorkflowActions.join(', '));
 assert('quality guardrail exits non-zero on failures',
   guardrailSrc.includes('process.exit(failed > 0 ? 1 : 0)'));
 assert('full local test suite runs typecheck',


### PR DESCRIPTION
## What changed

- pin every third-party action in the Tests, CodeQL, and Supply chain workflows to its exact upstream commit SHA
- retain major-version comments so Dependabot can continue proposing readable updates
- add a recursive `.github` quality guard that rejects any non-local `uses:` reference unless its ref is a 40-character commit SHA
- add an independent guardrail assertion over all workflow/composite-action YAML

## Why

Major-version tags are mutable. Pinning exact commits prevents an upstream tag move from silently changing privileged CI code, while Dependabot remains configured to propose GitHub Actions updates.

## Pinned releases

- `actions/checkout` v7 → `3d3c42e5aac5ba805825da76410c181273ba90b1`
- `actions/setup-node` v6 → `249970729cb0ef3589644e2896645e5dc5ba9c38`
- `actions/cache` v6 → `55cc8345863c7cc4c66a329aec7e433d2d1c52a9`
- `actions/upload-artifact` v7 → `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a`
- `github/codeql-action` v4 (peeled commit) → `e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81`

## Validation

- resolved every tag directly from its official upstream repository
- `npm run quality` (16/16)
- `node tests/test-quality-guardrails.js` (42/42)
- `npm run supply-chain:check`
- `npm test -- tests/supply-chain.test.js` (4/4)
- all browser, server, and service-worker type-check modes plus strict-null ratchet
- `git diff --check`