### PR TITLE
Enforce production PWA and cold-load budgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Default to tests related to the current change. GitHub Actions runs the exhausti
 `COVERAGE=1 ./run-tests.sh` also combines Vitest and Playwright V8 function coverage and enforces the committed ratchet in `scripts/coverage-baseline.json`; CI runs this mode on every change.
 `npm run test:firefox` runs the focused Firefox critical-flow suite; install its browser binary once with `npx playwright install firefox`.
 `npm run performance:check` runs the focused cold mobile-load check and enforces the committed request-count, compressed-transfer, and decoded-byte ceilings.
-`npm run production:check` builds the deploy artifact in a temporary directory and enforces the production startup and lazy-chunk budgets without changing the worktree.
+`npm run production:check` builds the deploy artifact in a temporary directory and enforces the production startup, lazy-chunk, and PWA app-shell precache resource/decoded-byte budgets without changing the worktree.
 `npm run sbom` writes a combined CycloneDX inventory for npm and vendored browser components to `artifacts/getbased.cdx.json`.
 
 ## Tech stack

--- a/scripts/app-shell-budget.json
+++ b/scripts/app-shell-budget.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": 1,
+  "scenario": "Production service-worker app-shell precache during PWA installation",
+  "maximums": {
+    "resources": 300,
+    "decodedBytes": 15000000
+  },
+  "reference": {
+    "resources": 270,
+    "decodedBytes": 13563714
+  },
+  "referenceCommit": "4500c0c9",
+  "measuredAt": "2026-07-29"
+}

--- a/scripts/app-shell-budget.mjs
+++ b/scripts/app-shell-budget.mjs
@@ -1,0 +1,139 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import ts from 'typescript';
+
+const METRICS = [
+  ['resources', 'precache resources'],
+  ['decodedBytes', 'precache decoded bytes'],
+];
+
+function requireNonNegativeNumber(value, label) {
+  const number = Number(value);
+  if (!Number.isFinite(number) || number < 0) {
+    throw new Error(`${label} must be a non-negative number.`);
+  }
+  return number;
+}
+
+function requirePositiveNumber(value, label) {
+  const number = Number(value);
+  if (!Number.isFinite(number) || number <= 0) {
+    throw new Error(`${label} must be a number greater than zero.`);
+  }
+  return number;
+}
+
+export function parseAppShellEntries(source) {
+  const sourceFile = ts.createSourceFile(
+    'service-worker.js',
+    String(source),
+    ts.ScriptTarget.Latest,
+    false,
+    ts.ScriptKind.JS,
+  );
+  if (sourceFile.parseDiagnostics.length) {
+    throw new Error('Could not parse service-worker.js while reading APP_SHELL.');
+  }
+  const declarations = [];
+
+  function visit(node) {
+    if (
+      ts.isVariableDeclaration(node)
+      && ts.isIdentifier(node.name)
+      && node.name.text === 'APP_SHELL'
+    ) {
+      declarations.push(node);
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(sourceFile);
+
+  if (declarations.length !== 1) {
+    throw new Error(`Expected exactly one APP_SHELL declaration; found ${declarations.length}.`);
+  }
+  const initializer = declarations[0].initializer;
+  if (!initializer || !ts.isArrayLiteralExpression(initializer)) {
+    throw new Error('APP_SHELL must be an array literal.');
+  }
+
+  const entries = initializer.elements.map((element) => {
+    if (!ts.isStringLiteralLike(element)) {
+      throw new Error('APP_SHELL entries must be static string literals.');
+    }
+    if (!element.text.startsWith('/')) {
+      throw new Error(`APP_SHELL entry must be root-relative: ${element.text}`);
+    }
+    return element.text;
+  });
+  const duplicates = entries.filter((entry, index) => entries.indexOf(entry) !== index);
+  if (duplicates.length) {
+    throw new Error(`APP_SHELL contains duplicate entries: ${[...new Set(duplicates)].join(', ')}`);
+  }
+  return entries;
+}
+
+function relativeAssetPath(entry) {
+  const route = entry === '/app' ? '/index.html' : entry;
+  const relative = path.posix.normalize(route).replace(/^\/+/, '');
+  if (!relative || relative === '..' || relative.startsWith('../')) {
+    throw new Error(`APP_SHELL entry escapes the artifact root: ${entry}`);
+  }
+  return relative;
+}
+
+async function fileSizeFromRoots(relative, roots) {
+  for (const root of roots) {
+    try {
+      const stat = await fs.stat(path.join(root, ...relative.split('/')));
+      if (stat.isFile()) return stat.size;
+    } catch (error) {
+      if (error?.code !== 'ENOENT') throw error;
+    }
+  }
+  throw new Error(`APP_SHELL asset does not exist: /${relative}`);
+}
+
+export async function summarizeAppShell({
+  serviceWorkerSource,
+  artifactRoot,
+  sourceRoot = artifactRoot,
+}) {
+  const entries = parseAppShellEntries(serviceWorkerSource);
+  const roots = [...new Set([path.resolve(artifactRoot), path.resolve(sourceRoot)])];
+  const sizes = await Promise.all(
+    entries.map((entry) => fileSizeFromRoots(relativeAssetPath(entry), roots)),
+  );
+  return {
+    resources: entries.length,
+    decodedBytes: sizes.reduce((total, size) => total + size, 0),
+  };
+}
+
+export function enforceAppShellBudget(metrics, budget) {
+  const maximums = budget?.maximums;
+  const failures = [];
+  const result = {};
+
+  for (const [key, label] of METRICS) {
+    const actual = requireNonNegativeNumber(metrics?.[key], `app-shell ${key}`);
+    const maximum = requirePositiveNumber(maximums?.[key], `app-shell maximums.${key}`);
+    result[key] = {
+      actual,
+      maximum,
+      remaining: maximum - actual,
+    };
+    if (actual > maximum) failures.push(`${label} ${actual} exceeds ${maximum}`);
+  }
+
+  if (failures.length) {
+    throw new Error(`App-shell budget exceeded: ${failures.join('; ')}.`);
+  }
+  return result;
+}
+
+export function formatAppShellSummary(metrics) {
+  return [
+    `${metrics.resources} resources`,
+    `${(metrics.decodedBytes / 1024).toFixed(1)} KiB decoded`,
+  ].join(', ');
+}

--- a/scripts/build-production.mjs
+++ b/scripts/build-production.mjs
@@ -6,6 +6,12 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { build, RUNTIME_MODULE_ID } from 'rolldown';
 
+import {
+  enforceAppShellBudget,
+  formatAppShellSummary,
+  summarizeAppShell,
+} from './app-shell-budget.mjs';
+
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const MAIN_ENTRY = path.join(ROOT, 'js', 'main.js');
 const RETRY_QUERY = '?lazy-retry=1';
@@ -190,7 +196,6 @@ export async function buildProduction({ outputRoot = ROOT } = {}) {
     outputDecodedBytes,
     lazyJavaScriptFiles: chunks.length - startupFiles.size,
   };
-  await enforceBuildBudget(summary);
 
   const [indexSource, legalBootstrapSource, serviceWorkerSource, serviceWorkerRuntimeSource] = await Promise.all([
     fs.readFile(path.join(ROOT, 'index.html'), 'utf8'),
@@ -235,6 +240,19 @@ export async function buildProduction({ outputRoot = ROOT } = {}) {
     fs.writeFile(path.join(outputRoot, 'service-worker-runtime.js'), serviceWorkerRuntimeSource),
   ]);
 
+  await enforceBuildBudget(summary);
+  const appShellMetrics = await summarizeAppShell({
+    serviceWorkerSource: builtServiceWorker,
+    artifactRoot: outputRoot,
+    sourceRoot: ROOT,
+  });
+  const appShellBudget = JSON.parse(
+    await fs.readFile(path.join(ROOT, 'scripts', 'app-shell-budget.json'), 'utf8'),
+  );
+  enforceAppShellBudget(appShellMetrics, appShellBudget);
+  summary.appShellResources = appShellMetrics.resources;
+  summary.appShellDecodedBytes = appShellMetrics.decodedBytes;
+
   return summary;
 }
 
@@ -257,6 +275,10 @@ async function runCli() {
       `Lazy output: ${summary.lazyJavaScriptFiles} JS files; `
       + `${formatBytes(summary.outputDecodedBytes)} total decoded`,
     );
+    console.log(`PWA precache: ${formatAppShellSummary({
+      resources: summary.appShellResources,
+      decodedBytes: summary.appShellDecodedBytes,
+    })}`);
     console.log(`Entry: js/${summary.entryFile}`);
   } finally {
     if (checkOnly) await fs.rm(outputRoot, { recursive: true, force: true });

--- a/scripts/cold-load-budget.json
+++ b/scripts/cold-load-budget.json
@@ -3,15 +3,15 @@
   "route": "/app",
   "scenario": "Fresh mobile returning-user load with browser cache and service workers disabled",
   "maximums": {
-    "requests": 286,
+    "requests": 290,
     "transferBytes": 1193220,
-    "decodedBytes": 2742210
+    "decodedBytes": 2875000
   },
   "reference": {
-    "requests": 264,
-    "transferBytes": 998275,
-    "decodedBytes": 2694653
+    "requests": 276,
+    "transferBytes": 1015573,
+    "decodedBytes": 2733812
   },
-  "referenceCommit": "ad05f165",
-  "measuredAt": "2026-07-26"
+  "referenceCommit": "4500c0c9",
+  "measuredAt": "2026-07-29"
 }

--- a/tests/app-shell-budget.test.js
+++ b/tests/app-shell-budget.test.js
@@ -1,0 +1,127 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  enforceAppShellBudget,
+  formatAppShellSummary,
+  parseAppShellEntries,
+  summarizeAppShell,
+} from '../scripts/app-shell-budget.mjs';
+
+const temporaryRoots = [];
+const BUDGET = {
+  maximums: {
+    resources: 3,
+    decodedBytes: 1000,
+  },
+};
+
+afterEach(async () => {
+  await Promise.all(temporaryRoots.splice(0).map(
+    root => fs.rm(root, { recursive: true, force: true }),
+  ));
+});
+
+async function temporaryRoot() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'getbased-app-shell-budget-'));
+  temporaryRoots.push(root);
+  return root;
+}
+
+describe('PWA app-shell budget', () => {
+  it('parses one static, root-relative APP_SHELL declaration', () => {
+    expect(parseAppShellEntries(`
+      const APP_SHELL = [
+        '/app',
+        '/styles.css',
+      ];
+    `)).toEqual(['/app', '/styles.css']);
+
+    expect(() => parseAppShellEntries('const other = [];')).toThrow(
+      'Expected exactly one APP_SHELL declaration',
+    );
+    expect(() => parseAppShellEntries('const APP_SHELL = [')).toThrow(
+      'Could not parse service-worker.js',
+    );
+    expect(() => parseAppShellEntries('const APP_SHELL = getEntries();')).toThrow(
+      'APP_SHELL must be an array literal',
+    );
+    expect(() => parseAppShellEntries("const APP_SHELL = ['/ok', dynamicEntry];")).toThrow(
+      'APP_SHELL entries must be static string literals',
+    );
+    expect(() => parseAppShellEntries("const APP_SHELL = ['relative.js'];")).toThrow(
+      'APP_SHELL entry must be root-relative',
+    );
+    expect(() => parseAppShellEntries("const APP_SHELL = ['/same', '/same'];")).toThrow(
+      'APP_SHELL contains duplicate entries',
+    );
+  });
+
+  it('measures the built app route and falls back to unchanged source assets', async () => {
+    const sourceRoot = await temporaryRoot();
+    const artifactRoot = await temporaryRoot();
+    await fs.writeFile(path.join(artifactRoot, 'index.html'), 'built app');
+    await fs.mkdir(path.join(artifactRoot, 'js'));
+    await fs.writeFile(path.join(artifactRoot, 'js', 'bundle.js'), 'bundle');
+    await fs.writeFile(path.join(sourceRoot, 'styles.css'), 'styles');
+
+    await expect(summarizeAppShell({
+      serviceWorkerSource: `
+        const APP_SHELL = [
+          '/app',
+          '/js/bundle.js',
+          '/styles.css',
+        ];
+      `,
+      artifactRoot,
+      sourceRoot,
+    })).resolves.toEqual({
+      resources: 3,
+      decodedBytes: 21,
+    });
+  });
+
+  it('rejects missing artifact resources', async () => {
+    const root = await temporaryRoot();
+    await expect(summarizeAppShell({
+      serviceWorkerSource: "const APP_SHELL = ['/missing.js'];",
+      artifactRoot: root,
+    })).rejects.toThrow('APP_SHELL asset does not exist: /missing.js');
+  });
+
+  it('passes at the ceilings and reports remaining margin', () => {
+    expect(enforceAppShellBudget({
+      resources: 3,
+      decodedBytes: 900,
+    }, BUDGET)).toEqual({
+      resources: { actual: 3, maximum: 3, remaining: 0 },
+      decodedBytes: { actual: 900, maximum: 1000, remaining: 100 },
+    });
+  });
+
+  it('reports every exceeded ceiling and rejects malformed input', () => {
+    expect(() => enforceAppShellBudget({
+      resources: 4,
+      decodedBytes: 1100,
+    }, BUDGET)).toThrow(
+      'precache resources 4 exceeds 3; precache decoded bytes 1100 exceeds 1000',
+    );
+    expect(() => enforceAppShellBudget({
+      resources: -1,
+      decodedBytes: 0,
+    }, BUDGET)).toThrow('app-shell resources must be a non-negative number');
+    expect(() => enforceAppShellBudget({
+      resources: 0,
+      decodedBytes: 0,
+    }, { maximums: {} })).toThrow('maximums.resources');
+  });
+
+  it('formats a compact CI summary', () => {
+    expect(formatAppShellSummary({
+      resources: 200,
+      decodedBytes: 4096,
+    })).toBe('200 resources, 4.0 KiB decoded');
+  });
+});

--- a/tests/production-build.test.js
+++ b/tests/production-build.test.js
@@ -7,6 +7,9 @@ import { buildProduction } from '../scripts/build-production.mjs';
 
 let outputRoot;
 let summary;
+const appShellBudget = JSON.parse(
+  await fs.readFile('scripts/app-shell-budget.json', 'utf8'),
+);
 
 beforeAll(async () => {
   outputRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'getbased-production-build-test-'));
@@ -60,6 +63,12 @@ describe('production startup build', () => {
     expect(serviceWorker).toContain("'/js/lens-local-store.js',");
     expect(serviceWorker).toContain("'/service-worker-runtime.js',");
     expect(serviceWorkerRuntime).toContain('installServiceWorkerRuntime');
+    expect(summary.appShellResources).toBeLessThanOrEqual(
+      appShellBudget.maximums.resources,
+    );
+    expect(summary.appShellDecodedBytes).toBeLessThanOrEqual(
+      appShellBudget.maximums.decodedBytes,
+    );
   });
 
   it('keeps the cold Latin body font from repainting the mobile LCP text', async () => {


### PR DESCRIPTION
## Summary
- parse the built service worker's `APP_SHELL` as a fail-closed static contract
- measure every production precache URL against the generated artifact or unchanged source asset
- enforce committed PWA installation ceilings of 300 resources and 15,000,000 decoded bytes
- rebaseline the cold-load reference after the recent large-module extractions and restore roughly 5% request/decoded-byte headroom
- report the measured precache footprint from `npm run production:check` and document the expanded gate

## References
- production PWA precache: 270 resources / 13,563,714 decoded bytes
- source-mode cold load: 276 requests / 1,015,573 transfer bytes / 2,733,812 decoded bytes
- the cold-load increase from the prior reference is 12 focused modules extracted from large owners; a deterministic before/after profile confirmed the prior owners shrank correspondingly and no deferred feature returned to startup

## Verification
- `npm test -- tests/app-shell-budget.test.js tests/production-build.test.js tests/service-worker-app-shell.test.js` (14 passed)
- `npm test -- tests/cold-load-budget.test.js` (5 passed)
- `npm run production:check`
- `npm run quality` (16/16)
- `npm run typecheck:service-worker`
- `npm run typecheck`
- `PORT=8173 npx playwright test tests/playwright/pwa-offline.spec.js --workers=1` (1 passed)
- `PORT=8174 npm run performance:check` (5 passed; reference reproduced exactly)