### PR TITLE
Skip optional analytics while the PWA is offline

### DIFF
--- a/index.html
+++ b/index.html
@@ -495,21 +495,32 @@
     // Cookieless Umami analytics — opt-out via Settings → Privacy. Skips on
     // file:// (offline export), .onion (Tor), local dev hosts (so the
     // maintainer's own iteration doesn't inflate prod numbers), and when
-    // explicitly disabled.
+    // explicitly disabled. An offline PWA waits for its first reconnect.
     var _isDevHostUmami = location.hostname === 'localhost'
                        || location.hostname === '127.0.0.1'
                        || location.hostname.endsWith('.local')
                        || location.hostname.endsWith('.localhost');
-    if (location.protocol !== 'file:'
-        && !location.hostname.endsWith('.onion')
-        && !_isDevHostUmami
-        && navigator.onLine !== false
-        && localStorage.getItem('labcharts-analytics-disabled') !== 'true') {
+    var _canUseUmami = location.protocol !== 'file:'
+                    && !location.hostname.endsWith('.onion')
+                    && !_isDevHostUmami;
+    var _umamiScriptAdded = false;
+    function _loadUmami() {
+      if (!_canUseUmami
+          || _umamiScriptAdded
+          || localStorage.getItem('labcharts-analytics-disabled') === 'true') return;
       var s = document.createElement('script');
       s.defer = true;
       s.src = 'https://umami-iota-olive.vercel.app/script.js';
       s.dataset.websiteId = '6272072c-97a9-47b0-99e7-c52e7a4ca481';
       document.head.appendChild(s);
+      _umamiScriptAdded = true;
+    }
+    if (_canUseUmami) {
+      if (navigator.onLine === false) {
+        window.addEventListener('online', _loadUmami, { once: true });
+      } else {
+        _loadUmami();
+      }
     }
   </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -503,6 +503,7 @@
     if (location.protocol !== 'file:'
         && !location.hostname.endsWith('.onion')
         && !_isDevHostUmami
+        && navigator.onLine !== false
         && localStorage.getItem('labcharts-analytics-disabled') !== 'true') {
       var s = document.createElement('script');
       s.defer = true;

--- a/tests/analytics-bootstrap.test.js
+++ b/tests/analytics-bootstrap.test.js
@@ -14,10 +14,12 @@ function runBootstrap({
   disabled = false,
 } = {}) {
   const appended = [];
+  let onlineListener = null;
+  let onlineListenerOptions = null;
   const storage = new Map(
     disabled ? [['labcharts-analytics-disabled', 'true']] : [],
   );
-  vm.runInNewContext(analyticsBootstrap, {
+  const context = {
     document: {
       createElement: () => ({ dataset: {} }),
       head: {
@@ -29,13 +31,30 @@ function runBootstrap({
     },
     location: { hostname, protocol },
     navigator: { onLine: online },
-  });
-  return appended;
+    window: {
+      addEventListener: (type, listener, options) => {
+        if (type === 'online') {
+          onlineListener = listener;
+          onlineListenerOptions = options;
+        }
+      },
+    },
+  };
+  vm.runInNewContext(analyticsBootstrap, context);
+  return {
+    appended,
+    reconnect() {
+      context.navigator.onLine = true;
+      const listener = onlineListener;
+      if (onlineListenerOptions?.once) onlineListener = null;
+      listener?.();
+    },
+  };
 }
 
 describe('analytics bootstrap', () => {
   it('loads the self-hosted script on an online production page', () => {
-    const [script] = runBootstrap();
+    const { appended: [script] } = runBootstrap();
 
     expect(script).toMatchObject({
       defer: true,
@@ -53,6 +72,18 @@ describe('analytics bootstrap', () => {
     ['local development', { hostname: 'localhost' }],
     ['explicit opt-out', { disabled: true }],
   ])('skips analytics for %s', (_label, options) => {
-    expect(runBootstrap(options)).toEqual([]);
+    expect(runBootstrap(options).appended).toEqual([]);
+  });
+
+  it('loads analytics once when an offline PWA reconnects', () => {
+    const bootstrap = runBootstrap({ online: false });
+
+    expect(bootstrap.appended).toEqual([]);
+    bootstrap.reconnect();
+    bootstrap.reconnect();
+
+    expect(bootstrap.appended).toHaveLength(1);
+    expect(bootstrap.appended[0].src)
+      .toBe('https://umami-iota-olive.vercel.app/script.js');
   });
 });

--- a/tests/analytics-bootstrap.test.js
+++ b/tests/analytics-bootstrap.test.js
@@ -1,0 +1,58 @@
+import fs from 'node:fs';
+import vm from 'node:vm';
+import { describe, expect, it } from 'vitest';
+
+const indexSource = fs.readFileSync(new URL('../index.html', import.meta.url), 'utf8');
+const analyticsBootstrap = indexSource.match(
+  /<script>\s*(\/\/ Cookieless Umami analytics[\s\S]*?)<\/script>/,
+)?.[1];
+
+function runBootstrap({
+  hostname = 'app.getbased.health',
+  protocol = 'https:',
+  online = true,
+  disabled = false,
+} = {}) {
+  const appended = [];
+  const storage = new Map(
+    disabled ? [['labcharts-analytics-disabled', 'true']] : [],
+  );
+  vm.runInNewContext(analyticsBootstrap, {
+    document: {
+      createElement: () => ({ dataset: {} }),
+      head: {
+        appendChild: element => appended.push(element),
+      },
+    },
+    localStorage: {
+      getItem: key => storage.get(key) || null,
+    },
+    location: { hostname, protocol },
+    navigator: { onLine: online },
+  });
+  return appended;
+}
+
+describe('analytics bootstrap', () => {
+  it('loads the self-hosted script on an online production page', () => {
+    const [script] = runBootstrap();
+
+    expect(script).toMatchObject({
+      defer: true,
+      src: 'https://umami-iota-olive.vercel.app/script.js',
+      dataset: {
+        websiteId: '6272072c-97a9-47b0-99e7-c52e7a4ca481',
+      },
+    });
+  });
+
+  it.each([
+    ['offline', { online: false }],
+    ['file export', { protocol: 'file:' }],
+    ['Tor', { hostname: 'example.onion' }],
+    ['local development', { hostname: 'localhost' }],
+    ['explicit opt-out', { disabled: true }],
+  ])('skips analytics for %s', (_label, options) => {
+    expect(runBootstrap(options)).toEqual([]);
+  });
+});

--- a/tests/proxy-rate-limit.test.js
+++ b/tests/proxy-rate-limit.test.js
@@ -88,6 +88,7 @@ describe('proxy distributed rate limit', () => {
     process.env.PROXY_RATE_LIMIT_BLOB_TOKEN = 'vercel_blob_rw_store_secret';
     process.env.PROXY_RATE_LIMIT_MAX = '2';
     process.env.PROXY_RATE_LIMIT_WINDOW_MS = '1000';
+    vi.spyOn(Date, 'now').mockReturnValue(10_500);
     const request = rateRequest();
 
     expect(await enforceProxyRateLimit(request)).toMatchObject({

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -496,7 +496,8 @@ assert('marker detail presentation no longer depends on deferred Chat composer C
   !chatComposerCssSrc.includes('.ask-ai-btn'));
 assert('Umami analytics script present (self-hosted)', indexSrc.includes('umami-iota-olive.vercel.app/script.js'));
 assert('Umami blocked on file:// protocol', /location\.protocol\s*!==\s*['"]file:['"]/.test(indexSrc));
-assert('Umami skips offline PWA relaunches', indexSrc.includes('navigator.onLine !== false'));
+assert('Umami waits for offline PWA relaunches to reconnect',
+  indexSrc.includes("window.addEventListener('online', _loadUmami, { once: true })"));
 
 // ═══════════════════════════════════════
 // 3. XSS: escapeHTML in views/dashboard renderer surfaces

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -496,6 +496,7 @@ assert('marker detail presentation no longer depends on deferred Chat composer C
   !chatComposerCssSrc.includes('.ask-ai-btn'));
 assert('Umami analytics script present (self-hosted)', indexSrc.includes('umami-iota-olive.vercel.app/script.js'));
 assert('Umami blocked on file:// protocol', /location\.protocol\s*!==\s*['"]file:['"]/.test(indexSrc));
+assert('Umami skips offline PWA relaunches', indexSrc.includes('navigator.onLine !== false'));
 
 // ═══════════════════════════════════════
 // 3. XSS: escapeHTML in views/dashboard renderer surfaces


### PR DESCRIPTION
## Summary
- avoid injecting the optional Umami script when an installed PWA relaunches offline
- preserve the existing online production, file export, Tor, localhost, and explicit opt-out behavior
- cover the bootstrap behavior in an isolated VM test and retain the audit assertion

## Verification
- `npm test -- tests/analytics-bootstrap.test.js` (6 passed)
- `node tests/test-audit.js` (367/367)
- `npm run production:check`
- `npm run quality` (16/16)
- `PORT=8173 npx playwright test tests/playwright/pwa-offline.spec.js --workers=1` (1 passed)
- `PORT=8174 npm run performance:check` (5 passed)