### PR TITLE
Restore proven proxy transport and defer initialization

### DIFF
--- a/lib/proxy-network.js
+++ b/lib/proxy-network.js
@@ -5,14 +5,21 @@
 // the actual socket connection.
 
 import { lookup as dnsLookup } from 'node:dns/promises';
-// Keep the direct runtime dependency on Undici's Node-24-aligned 7.x line.
-// The 8.x line is bundled with Node 26; upgrading this Node 24 deployment to
-// it coincided with Vercel function-initialization timeouts before even
-// lightweight OPTIONS requests reached the handler.
-import { Agent, fetch as undiciFetch } from 'undici';
 
 import { createErrorWithCode } from './error-utils.js';
 import { isProxyHostBlocked } from './proxy-policy.js';
+
+/** @type {Promise<typeof import('undici')> | null} */
+let undiciModulePromise = null;
+
+// Keep the transport out of the proxy's module-initialization path. Lightweight
+// OPTIONS and method-rejection responses must not depend on a Node networking
+// package loading successfully. The package itself is pinned to the exact
+// 7.28.0 artifact proven by the last healthy Node 24 production deployment.
+function loadUndiciTransport() {
+  undiciModulePromise ||= import('undici');
+  return undiciModulePromise;
+}
 
 function proxyDnsError(message) {
   return createErrorWithCode('PROXY_DNS_BLOCKED', message);
@@ -141,7 +148,7 @@ function resolveWithAbort(hostname, lookup, signal) {
  * @param {Record<string, any>} [options]
  * @param {{
  *   lookup?: typeof dnsLookup,
- *   fetch?: typeof undiciFetch,
+ *   fetch?: Function,
  *   createDispatcher?: (lookup: Function) => any,
  * }} [deps]
  */
@@ -149,10 +156,13 @@ export async function fetchWithPinnedProxyDns(url, options = {}, deps = {}) {
   const hostname = new URL(url).hostname;
   const addresses = await resolveWithAbort(hostname, deps.lookup || dnsLookup, options.signal);
   const pinnedLookup = createPinnedProxyLookup(addresses);
+  const transport = !deps.fetch || !deps.createDispatcher
+    ? await loadUndiciTransport()
+    : null;
   const dispatcher = deps.createDispatcher
     ? deps.createDispatcher(pinnedLookup)
-    : new Agent({ connect: { lookup: pinnedLookup } });
-  const fetchImpl = deps.fetch || undiciFetch;
+    : new transport.Agent({ connect: { lookup: pinnedLookup } });
+  const fetchImpl = deps.fetch || transport.fetch;
 
   try {
     const response = await fetchImpl(url, { ...options, dispatcher });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "ehbp": "0.3.1",
         "tinfoil": "^1.1.12",
-        "undici": "7.29.0"
+        "undici": "7.28.0"
       },
       "devDependencies": {
         "@cashu/cashu-ts": "4.7.2",
@@ -2259,9 +2259,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
-      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
   "dependencies": {
     "ehbp": "0.3.1",
     "tinfoil": "^1.1.12",
-    "undici": "7.29.0"
+    "undici": "7.28.0"
   }
 }

--- a/tests/proxy-network.test.js
+++ b/tests/proxy-network.test.js
@@ -8,14 +8,25 @@ import {
 } from '../lib/proxy-network.js';
 
 describe('proxy DNS pinning transport', () => {
-  it('keeps the production transport on the Undici line aligned with Node 24', () => {
+  it('pins the proven Node 24 transport and keeps it out of proxy initialization', () => {
     const packageJson = JSON.parse(readFileSync(
       new URL('../package.json', import.meta.url),
       'utf8',
     ));
+    const packageLock = JSON.parse(readFileSync(
+      new URL('../package-lock.json', import.meta.url),
+      'utf8',
+    ));
+    const source = readFileSync(
+      new URL('../lib/proxy-network.js', import.meta.url),
+      'utf8',
+    );
 
     expect(packageJson.engines.node).toBe('24.x');
-    expect(packageJson.dependencies.undici).toMatch(/^7\./);
+    expect(packageJson.dependencies.undici).toBe('7.28.0');
+    expect(packageLock.packages['node_modules/undici'].version).toBe('7.28.0');
+    expect(source).toContain("import('undici')");
+    expect(source).not.toMatch(/from\s+['"]undici['"]/);
   });
 
   it('deduplicates public DNS answers and pins the validated address set', async () => {


### PR DESCRIPTION
## Summary
- restore the exact `undici@7.28.0` artifact from the last healthy Node 24 production deployment (the prior hotfix used unproven `7.29.0`)
- lazy-load Undici only when an upstream POST actually needs the pinned transport
- keep lightweight `OPTIONS` and method-rejection responses independent of transport package initialization
- lock the exact package and lazy-import boundary with a regression test

## Production evidence
- production converged to merged SHA `22a6753adfe02a63096ac15790510c2d492a91a9`
- `/api/commit` reported that exact SHA and `main`
- `OPTIONS /api/proxy` still returned zero bytes and timed out at both 10s and 30s
- the last healthy production deployment at `807732a83ba860034c4384c0891340f3a647f348` used exactly `undici@7.28.0`

## Verification
- 40 focused proxy/upstream/API-runtime/production-canary assertions pass
- server typecheck passes
- quality guardrails: 17/17
- architecture: 546 modules, 0 cycles
- production bundle budgets pass
- supply-chain validation passes
- `npm audit`: 0 vulnerabilities
- `git diff --check` passes

The exhaustive Chromium and coverage matrix remains owned by GitHub Actions per repository policy.