### PR TITLE
Restore healthy CAMS proxy runtime

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -10,8 +10,8 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | Metric | Current |
 | --- | ---: |
 | Modules | 546 |
-| Internal import edges | 2407 |
-| Dynamic internal edges | 65 |
+| Internal import edges | 2406 |
+| Dynamic internal edges | 66 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
 | Largest cyclic component | 0 |
@@ -1041,7 +1041,7 @@ Vercel request handlers and hosted API entry points.
 
 <details><summary><code>proxy</code> family — 1 module</summary>
 
-- [`api/proxy.js`](api/proxy.js) → [`lib/error-utils.js`](lib/error-utils.js), [`lib/proxy-policy.js`](lib/proxy-policy.js), [`lib/proxy-rate-limit.js`](lib/proxy-rate-limit.js), [`lib/proxy-upstream.js`](lib/proxy-upstream.js)
+- [`api/proxy.js`](api/proxy.js) → [`lib/error-utils.js`](lib/error-utils.js), [`lib/proxy-policy.js`](lib/proxy-policy.js), [`lib/proxy-rate-limit.js`](lib/proxy-rate-limit.js) *(dynamic)*, [`lib/proxy-upstream.js`](lib/proxy-upstream.js)
 
 </details>
 
@@ -1073,7 +1073,7 @@ Node-only policy and transport code shared by hosted runtimes.
 
 - [`lib/proxy-network.js`](lib/proxy-network.js) → [`lib/error-utils.js`](lib/error-utils.js), [`lib/proxy-policy.js`](lib/proxy-policy.js)
 - [`lib/proxy-policy.js`](lib/proxy-policy.js) → no in-scope imports
-- [`lib/proxy-rate-limit.js`](lib/proxy-rate-limit.js) → [`lib/vercel-blob-rest.js`](lib/vercel-blob-rest.js)
+- [`lib/proxy-rate-limit.js`](lib/proxy-rate-limit.js) → no in-scope imports
 - [`lib/proxy-upstream.js`](lib/proxy-upstream.js) → [`lib/error-utils.js`](lib/error-utils.js), [`lib/proxy-network.js`](lib/proxy-network.js), [`lib/proxy-policy.js`](lib/proxy-policy.js)
 
 </details>

--- a/api/proxy.js
+++ b/api/proxy.js
@@ -9,7 +9,6 @@ import {
   normalizeProxyMethod,
   sanitizeProxyHeaders,
 } from '../lib/proxy-policy.js';
-import { enforceProxyRateLimit } from '../lib/proxy-rate-limit.js';
 import {
   PROXY_MAX_CREDENTIAL_RESPONSE_BYTES,
   capReadableStream,
@@ -20,6 +19,17 @@ import {
 import { errorCode } from '../lib/error-utils.js';
 
 const DEFAULT_UVDATA_UPSTREAM = 'https://uvdata.getbased.health';
+/** @type {Promise<typeof import('../lib/proxy-rate-limit.js')> | null} */
+let proxyRateLimitModulePromise = null;
+
+// The distributed limiter pulls in Vercel's Node-only Blob client. Keep that
+// dependency outside the entrypoint's initialization path so preflight,
+// rejected-origin, and method-probe responses remain available even if a
+// deployment packages the optional storage transport incorrectly.
+function loadProxyRateLimit() {
+  proxyRateLimitModulePromise ||= import('../lib/proxy-rate-limit.js');
+  return proxyRateLimitModulePromise;
+}
 
 export default async function handler(req) {
   // Treat Origin as a server-side browser boundary, not merely a response
@@ -52,6 +62,7 @@ export default async function handler(req) {
 
   let rateLimit;
   try {
+    const { enforceProxyRateLimit } = await loadProxyRateLimit();
     rateLimit = await enforceProxyRateLimit(req);
   } catch {
     return new Response(JSON.stringify({

--- a/lib/proxy-rate-limit.js
+++ b/lib/proxy-rate-limit.js
@@ -4,11 +4,11 @@
 // opted-in self-hosted deployments retain a bounded in-process fallback.
 
 import {
-  deleteBlobs,
-  isBlobPreconditionFailure,
-  listBlobs,
-  putBlob,
-} from './vercel-blob-rest.js';
+  BlobPreconditionFailedError,
+  del as deleteBlobs,
+  list as listBlobs,
+  put as putBlob,
+} from '@vercel/blob';
 
 const DEFAULT_PROXY_RATE_LIMIT_WINDOW_MS = 60_000;
 const DEFAULT_PROXY_RATE_LIMIT_MAX = 300;
@@ -61,7 +61,8 @@ function randomSlot(maxRequests) {
 }
 
 function isSlotConflict(error) {
-  return isBlobPreconditionFailure(error);
+  return error instanceof BlobPreconditionFailedError
+    || /precondition|already exists|overwrite/i.test(String(error?.message || ''));
 }
 
 function cleanupLeasePath(windowStart) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "getbased",
       "version": "1.3.9",
       "dependencies": {
+        "@vercel/blob": "2.4.0",
         "ehbp": "0.3.1",
         "tinfoil": "^1.1.12",
         "undici": "7.28.0"
@@ -974,6 +975,31 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@vercel/blob": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.4.0.tgz",
+      "integrity": "sha512-ncQ8CRb6XoEAYJwjOTRGpACRT6h/AeY+/33gLyeVxG5BIes27OPm1jmqreF+JHjcTmGhClTP+kBpmyLfbV0xew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async-retry": "^1.3.3",
+        "is-buffer": "^2.0.5",
+        "is-node-process": "^1.2.0",
+        "throttleit": "^2.1.0",
+        "undici": "^6.23.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@vercel/blob/node_modules/undici": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/@vitest/coverage-v8": {
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
@@ -1144,6 +1170,15 @@
         "@jridgewell/trace-mapping": "^0.3.31",
         "estree-walker": "^3.0.3",
         "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
       }
     },
     "node_modules/axe-core": {
@@ -1370,6 +1405,35 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
       "license": "MIT"
     },
     "node_modules/is-potential-custom-element-name": {
@@ -2009,6 +2073,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.1.tgz",
@@ -2119,6 +2192,18 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/tinfoil": {
       "version": "1.1.12",

--- a/package.json
+++ b/package.json
@@ -44,8 +44,14 @@
     "vitest": "^4.1.10"
   },
   "dependencies": {
+    "@vercel/blob": "2.4.0",
     "ehbp": "0.3.1",
     "tinfoil": "^1.1.12",
     "undici": "7.28.0"
+  },
+  "overrides": {
+    "@vercel/blob": {
+      "undici": "6.27.0"
+    }
   }
 }

--- a/tests/proxy-entrypoint-runtime.test.js
+++ b/tests/proxy-entrypoint-runtime.test.js
@@ -1,0 +1,84 @@
+import { readFileSync } from 'node:fs';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import proxyHandler from '../api/proxy.js';
+
+const ENV_KEYS = [
+  'BLOB_READ_WRITE_TOKEN',
+  'PROXY_ALLOW_INSTANCE_RATE_LIMIT',
+  'PROXY_RATE_LIMIT_BLOB_TOKEN',
+  'UVDATA_BEARER',
+  'UVDATA_UPSTREAM',
+  'VERCEL',
+];
+let savedEnv;
+
+function proxyRequest(method, body) {
+  return new Request('https://getbased.health/api/proxy', {
+    method,
+    headers: {
+      origin: 'https://getbased.health',
+      ...(body === undefined ? {} : { 'content-type': 'application/json' }),
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  savedEnv = Object.fromEntries(ENV_KEYS.map(key => [key, process.env[key]]));
+  for (const key of ENV_KEYS) delete process.env[key];
+});
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe('proxy production entrypoint', () => {
+  it('pins the Blob runtime artifacts from the last healthy deployment', () => {
+    const packageJson = JSON.parse(readFileSync(
+      new URL('../package.json', import.meta.url),
+      'utf8',
+    ));
+    const packageLock = JSON.parse(readFileSync(
+      new URL('../package-lock.json', import.meta.url),
+      'utf8',
+    ));
+
+    expect(packageJson.dependencies['@vercel/blob']).toBe('2.4.0');
+    expect(packageLock.packages['node_modules/@vercel/blob'].version).toBe('2.4.0');
+    expect(packageLock.packages['node_modules/@vercel/blob/node_modules/undici'].version)
+      .toBe('6.27.0');
+  });
+
+  it('answers preflight and method probes without initializing Blob storage', async () => {
+    process.env.VERCEL = '1';
+
+    const preflight = await proxyHandler(proxyRequest('OPTIONS'));
+    expect(preflight.status).toBe(204);
+    expect(preflight.headers.get('access-control-allow-origin'))
+      .toBe('https://getbased.health');
+
+    const methodProbe = await proxyHandler(proxyRequest('GET'));
+    expect(methodProbe.status).toBe(405);
+  });
+
+  it('loads the real limiter boundary and reaches CAMS validation', async () => {
+    process.env.VERCEL = '1';
+    process.env.PROXY_ALLOW_INSTANCE_RATE_LIMIT = '1';
+
+    const response = await proxyHandler(proxyRequest('POST', {
+      meteo: 'cams',
+      latitude: 50.0755,
+      longitude: 14.4378,
+    }));
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      error: expect.stringContaining('CAMS hosted relay requires UVDATA_BEARER'),
+    });
+  });
+});

--- a/tests/proxy-rate-limit.test.js
+++ b/tests/proxy-rate-limit.test.js
@@ -24,13 +24,13 @@ const blobMock = vi.hoisted(() => {
   };
 });
 
-vi.mock('../lib/vercel-blob-rest.js', async importOriginal => {
+vi.mock('@vercel/blob', async importOriginal => {
   const actual = await importOriginal();
   return {
     ...actual,
-    listBlobs: blobMock.list,
-    putBlob: blobMock.put,
-    deleteBlobs: blobMock.del,
+    list: blobMock.list,
+    put: blobMock.put,
+    del: blobMock.del,
   };
 });
 

--- a/tests/test-profile-share.js
+++ b/tests/test-profile-share.js
@@ -168,9 +168,10 @@ assert('Shared profile import uses existing importDataJSON path',
   profileShareSrc.includes("await importDataJSON(new File([json], 'getbased-shared-profile.json'"));
 
 console.log('5. Vercel Blob API safeguards');
-assert('Package avoids the @vercel/blob runtime dependency',
-  !packageJson.dependencies?.['@vercel/blob']);
-assert('API uses the shared private Vercel Blob REST boundary',
+assert('Edge API avoids importing the Node-only @vercel/blob client',
+  !apiShareSrc.includes("from '@vercel/blob'"));
+assert('Edge API uses the shared private Vercel Blob REST boundary',
+  packageJson.dependencies?.['@vercel/blob'] === '2.4.0' &&
   apiShareSrc.includes("from '../lib/vercel-blob-rest.js'") &&
   apiShareSrc.includes("access: 'private'") &&
   apiShareSrc.includes('BLOB_READ_WRITE_TOKEN'));

--- a/tests/test-security-phase1.js
+++ b/tests/test-security-phase1.js
@@ -145,7 +145,7 @@ if (exists('dev-server.js')) {
   assert('proxy runtime bounds upstream lifetimes and applies a distributed abuse brake',
     proxyUpstreamSrc.includes('PROXY_UPSTREAM_TIMEOUT_MS')
       && edgeProxySrc.includes('await enforceProxyRateLimit(req)')
-      && proxyRateLimitSrc.includes("from './vercel-blob-rest.js'")
+      && proxyRateLimitSrc.includes("from '@vercel/blob'")
       && proxyRateLimitSrc.includes('allowOverwrite: false')
       && edgeProxySrc.includes("'Retry-After'"));
   assert('proxy upstream runtime resolves and pins public DNS answers before connecting',


### PR DESCRIPTION
## What changed

- restore the official `@vercel/blob` limiter client used by the last healthy production deployment
- pin `@vercel/blob` 2.4.0 and its previously working Undici 6.27.0 transport artifact
- lazy-load the distributed limiter after origin and method validation, keeping `OPTIONS`, rejected-origin, and `GET` probes outside the storage initialization path
- retain the Edge-safe Blob REST boundary for `/api/share`
- add an unmocked proxy-entrypoint regression test covering artifact pins, lightweight route liveness, the real limiter import, and CAMS validation

## Why

Production `/api/proxy` began timing out after #1495, including requests that should return before rate limiting or upstream networking. That regression replaced the proven Vercel Blob SDK boundary with the custom Edge-oriented REST client and updated the function dependency graph. The Undici-only restorations in #1496 and #1497 did not recover the route.

This change restores the remaining runtime boundary from the last healthy deployment while isolating it from lightweight handler responses. CAMS, wearable OAuth, and generic proxy POST requests retain the distributed fail-closed limiter.

## User impact

Once deployed, the proxy should initialize normally again and CAMS-first Light & Sun requests should stop falling through because `/api/proxy` timed out. If the hosted CAMS bearer is missing, callers will receive the existing explicit 503 instead of a function-level hang.

## Verification

- `npm test -- tests/proxy-entrypoint-runtime.test.js tests/proxy-rate-limit.test.js tests/proxy-network.test.js tests/proxy-upstream.test.js tests/api-network-runtime.test.js` — 44/44 passed
- `npm test -- tests/production-smoke.test.js tests/supply-chain.test.js tests/architecture-map.test.js` — 15/15 passed
- `node tests/test-profile-share.js` — 35/35 passed
- `node tests/test-security-phase1.js` — 38/38 passed
- `npm run typecheck:server`
- `npm run architecture:check`
- `npm run supply-chain:check`
- `npm run quality`
- `npm run production:check`
- `npm audit --omit=dev --audit-level=moderate` — zero vulnerabilities
- real request through the CAMS handler reached `uvdata.getbased.health` in 261 ms and relayed the expected unauthenticated 401