### PR TITLE
Restore exact static proxy transport

### DIFF
--- a/lib/proxy-network.js
+++ b/lib/proxy-network.js
@@ -5,21 +5,10 @@
 // the actual socket connection.
 
 import { lookup as dnsLookup } from 'node:dns/promises';
+import { Agent, fetch as undiciFetch } from 'undici';
 
 import { createErrorWithCode } from './error-utils.js';
 import { isProxyHostBlocked } from './proxy-policy.js';
-
-/** @type {Promise<typeof import('undici')> | null} */
-let undiciModulePromise = null;
-
-// Keep the transport out of the proxy's module-initialization path. Lightweight
-// OPTIONS and method-rejection responses must not depend on a Node networking
-// package loading successfully. The package itself is pinned to the exact
-// 7.28.0 artifact proven by the last healthy Node 24 production deployment.
-function loadUndiciTransport() {
-  undiciModulePromise ||= import('undici');
-  return undiciModulePromise;
-}
 
 function proxyDnsError(message) {
   return createErrorWithCode('PROXY_DNS_BLOCKED', message);
@@ -148,7 +137,7 @@ function resolveWithAbort(hostname, lookup, signal) {
  * @param {Record<string, any>} [options]
  * @param {{
  *   lookup?: typeof dnsLookup,
- *   fetch?: Function,
+ *   fetch?: typeof undiciFetch,
  *   createDispatcher?: (lookup: Function) => any,
  * }} [deps]
  */
@@ -156,13 +145,10 @@ export async function fetchWithPinnedProxyDns(url, options = {}, deps = {}) {
   const hostname = new URL(url).hostname;
   const addresses = await resolveWithAbort(hostname, deps.lookup || dnsLookup, options.signal);
   const pinnedLookup = createPinnedProxyLookup(addresses);
-  const transport = !deps.fetch || !deps.createDispatcher
-    ? await loadUndiciTransport()
-    : null;
   const dispatcher = deps.createDispatcher
     ? deps.createDispatcher(pinnedLookup)
-    : new transport.Agent({ connect: { lookup: pinnedLookup } });
-  const fetchImpl = deps.fetch || transport.fetch;
+    : new Agent({ connect: { lookup: pinnedLookup } });
+  const fetchImpl = deps.fetch || undiciFetch;
 
   try {
     const response = await fetchImpl(url, { ...options, dispatcher });

--- a/tests/proxy-network.test.js
+++ b/tests/proxy-network.test.js
@@ -8,7 +8,7 @@ import {
 } from '../lib/proxy-network.js';
 
 describe('proxy DNS pinning transport', () => {
-  it('pins the proven Node 24 transport and keeps it out of proxy initialization', () => {
+  it('pins the exact static transport used by the last healthy Node 24 deployment', () => {
     const packageJson = JSON.parse(readFileSync(
       new URL('../package.json', import.meta.url),
       'utf8',
@@ -25,8 +25,8 @@ describe('proxy DNS pinning transport', () => {
     expect(packageJson.engines.node).toBe('24.x');
     expect(packageJson.dependencies.undici).toBe('7.28.0');
     expect(packageLock.packages['node_modules/undici'].version).toBe('7.28.0');
-    expect(source).toContain("import('undici')");
-    expect(source).not.toMatch(/from\s+['"]undici['"]/);
+    expect(source).toContain("import { Agent, fetch as undiciFetch } from 'undici'");
+    expect(source).not.toContain("import('undici')");
   });
 
   it('deduplicates public DNS answers and pins the validated address set', async () => {


### PR DESCRIPTION
## What changed

- Restores the static `undici` 7.28.0 import in the DNS-pinned proxy transport.
- Adds a regression contract requiring that exact static transport and forbidding a dynamic `import('undici')`.
- Retains the official `@vercel/blob` limiter and its lazy import from `/api/proxy`.

## Root cause

Hosted `/api/proxy` currently hangs before the handler initializes: OPTIONS, rejected methods, malformed requests, wearable runtime config, and CAMS all time out with zero response bytes. The prior fixes tested individual halves of the last healthy runtime but never restored its exact combination. This branch makes `lib/proxy-network.js` byte-for-byte identical to the last healthy production commit (`807732a8`) while preserving the newer limiter isolation.

## Impact

This recovers the shared proxy entrypoint used by CAMS, Sun/UV data, wearables, OAuth/provider calls, and generic proxied requests. Locally, real proxy transport requests now complete; CAMS correctly reports missing `UVDATA_BEARER` when that local secret is absent instead of hanging.

## Validation

- 86 focused Vitest proxy/API tests
- 422 legacy proxy-consumer tests across dev server, Sun/UV, wearables, runtime config, and sync flows
- 6 focused Playwright browser tests covering proxy retry/abort/streaming, Sun/UV, and wearables
- real local `/api/proxy` probes for CAMS, Oura, OpenAI, runtime config, OPTIONS, and method rejection
- server typecheck
- architecture boundary check
- production bundle check
- quality guardrails
- `git diff --check`

Production will be probed directly after deployment for OPTIONS, origin rejection, method rejection, runtime config, CAMS, and generic provider transport.