### PR TITLE
Use explicit Vercel proxy fetch handler

### DIFF
--- a/api/proxy.js
+++ b/api/proxy.js
@@ -31,7 +31,7 @@ function loadProxyRateLimit() {
   return proxyRateLimitModulePromise;
 }
 
-export default async function handler(req) {
+export async function handler(req) {
   // Treat Origin as a server-side browser boundary, not merely a response
   // decoration. It prevents another website from driving this credentialed
   // relay. Non-browser clients can forge Origin, so the rate limit below and
@@ -254,6 +254,12 @@ export default async function handler(req) {
     return proxyUpstreamErrorResponse(req, e);
   }
 }
+
+// Use Vercel's explicit Web-standard Node.js function contract. A bare
+// default function is also the legacy (request, response) handler shape; when
+// it returns a Web Response instead of ending the legacy response, the
+// platform can leave the invocation open until timeout.
+export default { fetch: handler };
 
 // Origins permitted to call /api/proxy. Same-origin requests support self-hosted
 // deployments; explicit production surfaces cover app.getbased.health calling

--- a/tests/api-network-runtime.test.js
+++ b/tests/api-network-runtime.test.js
@@ -5,7 +5,7 @@ vi.mock('../lib/proxy-network.js', () => ({
 }));
 
 import commitHandler from '../api/commit.js';
-import proxyHandler from '../api/proxy.js';
+import { handler as proxyHandler } from '../api/proxy.js';
 import {
   PROXY_MAX_REQUEST_BYTES,
   PROXY_MAX_RESPONSE_BYTES,

--- a/tests/proxy-entrypoint-runtime.test.js
+++ b/tests/proxy-entrypoint-runtime.test.js
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import proxyHandler from '../api/proxy.js';
+import proxyEntrypoint, { handler as proxyHandler } from '../api/proxy.js';
 
 const ENV_KEYS = [
   'BLOB_READ_WRITE_TOKEN',
@@ -38,6 +38,10 @@ afterEach(() => {
 });
 
 describe('proxy production entrypoint', () => {
+  it('uses Vercel Node.js Web-standard fetch handler contract', () => {
+    expect(proxyEntrypoint).toEqual({ fetch: proxyHandler });
+  });
+
   it('pins the Blob runtime artifacts from the last healthy deployment', () => {
     const packageJson = JSON.parse(readFileSync(
       new URL('../package.json', import.meta.url),


### PR DESCRIPTION
## What changed

- Exports `/api/proxy` using Vercel's explicit Web-standard Node.js handler contract: `export default { fetch: handler }`.
- Keeps the implementation as a named export for direct behavioral testing.
- Adds a regression assertion for the deployed entrypoint shape and updates existing direct-call tests to use the named handler.

## Root cause

The function was exported as a bare default function but returned a Web `Response`. That shape is ambiguous with Vercel's legacy `(request, response)` Node handler contract. The current production symptom—handler logic works when invoked directly, while every hosted method holds the connection open with zero response bytes—is consistent with the platform ignoring the returned Web `Response` and waiting for the legacy response object to be ended.

Vercel's current Node.js runtime documentation specifies the Web handler as a default object with a `fetch(request)` method. Making that contract explicit removes the adapter ambiguity and leaves the DNS-pinned Node transport intact.

Official contract: https://vercel.com/docs/functions/runtimes/node-js#creating-a-node.js-function

## Impact

This targets the shared hosted `/api/proxy` entrypoint used by CAMS, Sun/UV data, wearables, OAuth/provider calls, and generic proxy requests. No proxy behavior, security policy, rate limiting, or upstream transport logic changes.

## Validation

- 87 focused proxy/API Vitest tests
- server typecheck
- architecture boundary check
- production bundle check
- quality guardrails
- `git diff --check`

After deployment, production will be probed for preflight, rejected origin, method rejection, runtime config, CAMS, and generic provider transport.