### PR TITLE
Use hosted CAMS relay in local development

### DIFF
--- a/js/sun-uvdata.js
+++ b/js/sun-uvdata.js
@@ -1,6 +1,6 @@
 // @ts-check
 // sun-uvdata.js — Multi-source UV/ozone/atmosphere client for Sun Sessions
-import { getErrorName } from './caught-error.js';
+import { getErrorMessage, getErrorName } from './caught-error.js';
 import { isValidExternalUrl } from './url-safety.js';
 import { isSunDebugRuntime } from './sun-runtime.js';
 import { initMeteoConfigCache, getMeteoConfig, saveMeteoConfig } from './sun-uvdata-config.js';
@@ -48,6 +48,11 @@ let _warnedAboutRejectedSelfhostUrl = false;
 const CACHE_PREFIX = 'meteo:v2:';
 const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 const NETWORK_TIMEOUT_MS = 8000;
+const HOSTED_CAMS_PROXY_URL = 'https://app.getbased.health/api/proxy';
+const HOSTED_CAMS_LOCAL_ORIGINS = new Set([
+  'http://localhost:8000',
+  'http://127.0.0.1:8000',
+]);
 
 // ─── Public API ────────────────────────────────────────────────────────
 
@@ -248,11 +253,23 @@ const PROVIDERS = {
       // bearer for getbased-uvdata is injected server-side so the
       // token never reaches the browser. Self-hosters bypass this and
       // use the `selfhost` provider directly.
-      const json = await fetchJson('/api/proxy', {
+      const options = {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ meteo: 'cams', latitude: lat, longitude: lon, time: isoTime }),
-      });
+      };
+      let json;
+      try {
+        json = await fetchJson('/api/proxy', options);
+      } catch (error) {
+        // The checked-in local environment cannot contain Vercel's
+        // UVDATA_BEARER. The production relay explicitly allows the
+        // documented localhost origins, so local development can retry there
+        // without copying the server credential into the browser or repo.
+        const origin = typeof location !== 'undefined' ? location.origin : '';
+        if (getErrorMessage(error) !== 'HTTP 503' || !HOSTED_CAMS_LOCAL_ORIGINS.has(origin)) throw error;
+        json = await fetchJson(HOSTED_CAMS_PROXY_URL, options);
+      }
       return shapeCamsResponse(json, isoTime, 'cams');
     },
   },

--- a/tests/test-sun-uvdata-flow.js
+++ b/tests/test-sun-uvdata-flow.js
@@ -175,7 +175,57 @@ const {
   assert('Auto mode did not need Open-Meteo fallback when CAMS succeeded',
     !openMeteoAfterAuto);
 
-  // ── 6. Selfhost mode → exercises _looksLikeOpenMeteoResponse ──────────
+  // ── 6. Local dev CAMS retries through the hosted credential boundary ──
+  // Local checkouts intentionally do not contain Vercel's CAMS bearer. The
+  // documented localhost origin may use the deployed relay, which injects
+  // the credential server-side without exposing it to the browser or repo.
+  purgeMeteoCache();
+  const savedLocation = globalThis.location;
+  globalThis.location = { origin: 'http://localhost:8000' };
+  const localFallbackCalls = [];
+  window.fetch = async (u) => {
+    const url = String(u);
+    localFallbackCalls.push(url);
+    if (url === '/api/proxy') {
+      return new Response('{"error":"CAMS hosted relay requires UVDATA_BEARER"}', {
+        status: 503,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    if (url === 'https://app.getbased.health/api/proxy') {
+      return responseJson({
+        ...omForecast,
+        hourly: {
+          ...omForecast.hourly,
+          ozone_du: [314],
+          aod: [0.06],
+        },
+        airQuality: omAirQuality,
+        _camsMeta: { ageSec: 120 },
+      });
+    }
+    throw new Error(`Unexpected local CAMS fallback URL: ${url}`);
+  };
+  saveMeteoConfig({ ...origCfg, mode: 'cams' });
+  const localCams = await fetchAtmosphere({
+    lat: 49.98,
+    lon: 14.51,
+    isoTime: cacheIso,
+    noCache: true,
+  });
+  assert('Local CAMS first tries the same-origin dev proxy',
+    localFallbackCalls[0] === '/api/proxy',
+    JSON.stringify(localFallbackCalls));
+  assert('Local CAMS retries through the deployed credential boundary after 503',
+    localFallbackCalls[1] === 'https://app.getbased.health/api/proxy',
+    JSON.stringify(localFallbackCalls));
+  assert('Local CAMS hosted retry returns CAMS data',
+    localCams?.source === 'cams' && localCams.ozoneDU === 314,
+    JSON.stringify(localCams));
+  if (savedLocation === undefined) delete globalThis.location;
+  else globalThis.location = savedLocation;
+
+  // ── 7. Selfhost mode → exercises _looksLikeOpenMeteoResponse ──────────
   // The selfhost provider validates that the upstream response matches
   // Open-Meteo's structural shape before trusting the payload. Stub fetch
   // to return a valid OM-shaped JSON; selfhost.fetch invokes
@@ -193,7 +243,7 @@ const {
   await withTimeout(() => fetchAtmosphere({ lat: 50, lon: 14, isoTime: '2026-05-12T01:30:00Z', noCache: true }));
   assert('fetchAtmosphere selfhost mode validated OM-shaped payload (_looksLikeOpenMeteoResponse fired)', true);
 
-  // ── 7. NOAA mode → exercises shapeNoaaResponse ────────────────────────
+  // ── 8. NOAA mode → exercises shapeNoaaResponse ────────────────────────
   // NOAA endpoint returns its own shape — shapeNoaaResponse is the per-
   // provider adapter. Stub fetch to return a NOAA-shaped payload with a
   // numeric uv_index; the shaper extracts uvIndex / ozone.
@@ -204,7 +254,7 @@ const {
   await withTimeout(() => fetchAtmosphere({ lat: 40, lon: -100, isoTime: '2026-05-12T18:00:00Z', noCache: true }));
   assert('fetchAtmosphere noaa mode shaped the NOAA response (shapeNoaaResponse fired)', true);
 
-  // ── 8. readStaleCache fallback ────────────────────────────────────────
+  // ── 9. readStaleCache fallback ────────────────────────────────────────
   // When all providers fail, fetchAtmosphere falls back to a stale-cache
   // lookup. Seed localStorage with a matching cache entry, then drive
   // fetchAtmosphere with all providers blocked → readStaleCache fires.


### PR DESCRIPTION
## What changed

- When the documented local app origins (`localhost:8000` or `127.0.0.1:8000`) receive a 503 from their same-origin CAMS proxy, retry through `https://app.getbased.health/api/proxy`.
- Keep all other origins, status codes, providers, and self-host modes unchanged.
- Add behavioral coverage proving the local request happens first, the hosted retry happens second, and CAMS data is returned.

## Why

A local checkout intentionally has no access to Vercel's `UVDATA_BEARER`, so its dev relay correctly returns 503 even though the deployed relay is healthy. The deployed proxy already permits the documented localhost origins and injects the bearer server-side. Retrying there makes CAMS work locally without copying a production credential into `.env.local`, browser storage, or the repository.

## Impact and privacy

The retry is browser-to-production, so production's existing CORS and distributed rate limit remain enforced. The browser never sees the upstream bearer. Coordinates follow the existing privacy-rounding setting before either request, and local `selfhost` mode is unaffected.

## Validation

- real Chromium acceptance: local proxy POST -> 503 -> hosted proxy POST -> CAMS result with numeric UV and ozone
- production localhost preflight: 204 with exact reflected CORS origin
- 20/20 Sun provider-flow tests
- 83/83 Sun data/security tests
- 159/159 dev-server/proxy helper tests
- 3/3 focused Sun/UV Playwright tests
- full app checkJs and server typecheck
- architecture boundary check
- production bundle check
- quality guardrails
- `git diff --check`