### PR TITLE
Harden Withings OAuth timeout handling

### DIFF
--- a/js/wearables-withings-auth.js
+++ b/js/wearables-withings-auth.js
@@ -76,17 +76,36 @@ async function withingsTokenRequest(payload) {
   // AbortController predates AbortSignal.timeout across supported browsers.
   // Build the deadline explicitly so older engines cannot silently fall back
   // to the unbounded request that originally blocked the startup sequence.
+  // Keep the deadline around response parsing too: fetch() resolves when
+  // headers arrive, while a stalled JSON body can otherwise block forever.
   const controller = new AbortController();
-  const timeout = setTimeout(() => {
-    controller.abort(new DOMException('Withings token request timed out', 'TimeoutError'));
-  }, TOKEN_REQUEST_TIMEOUT_MS);
-  try {
-    return await fetch(PROXY_URL, {
+  let timeout;
+  /** @type {Promise<never>} */
+  const deadline = new Promise((_resolve, reject) => {
+    timeout = setTimeout(() => {
+      const error = new DOMException('Withings token request timed out', 'TimeoutError');
+      controller.abort(error);
+      reject(error);
+    }, TOKEN_REQUEST_TIMEOUT_MS);
+  });
+  const request = (async () => {
+    const response = await fetch(PROXY_URL, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
       signal: controller.signal,
     });
+    let body;
+    try {
+      body = await response.json();
+    } catch (error) {
+      if (controller.signal.aborted) throw controller.signal.reason || error;
+      body = {};
+    }
+    return { response, body };
+  })();
+  try {
+    return await Promise.race([request, deadline]);
   } finally {
     clearTimeout(timeout);
   }
@@ -124,9 +143,9 @@ export async function completeOAuthCallback(urlParams) {
     return { ok: false, error: 'OAuth flow expired — please try connecting again' };
   }
 
-  let res;
+  let tokenResult;
   try {
-    res = await withingsTokenRequest({
+    tokenResult = await withingsTokenRequest({
       withings_token_exchange: {
         code,
         redirect_uri: pending.redirectUri,
@@ -136,7 +155,7 @@ export async function completeOAuthCallback(urlParams) {
   } catch (error) {
     return { ok: false, error: withingsTokenRequestError(error, 'token exchange').message };
   }
-  const body = await res.json().catch(() => ({}));
+  const { response: res, body } = tokenResult;
   if (!res.ok) return { ok: false, error: body?.error || body?.error_description || `Token exchange failed (${res.status})` };
   // Withings wraps successful responses in `{status: 0, body: {...}}` —
   // the proxy unwraps so we receive the plain token object.
@@ -160,15 +179,15 @@ export function isWithingsCallback(urlParams) {
 }
 
 export async function refreshTokens({ clientId, refreshToken }) {
-  let res;
+  let tokenResult;
   try {
-    res = await withingsTokenRequest({
+    tokenResult = await withingsTokenRequest({
       withings_token_refresh: { refresh_token: refreshToken, client_id: clientId },
     });
   } catch (error) {
     throw withingsTokenRequestError(error, 'token refresh');
   }
-  const body = await res.json().catch(() => ({}));
+  const { response: res, body } = tokenResult;
   if (!res.ok) {
     /** @type {Error & { status?: number }} */
     const err = new Error(body?.error || body?.error_description || `Refresh failed (${res.status})`);

--- a/js/wearables-withings-auth.js
+++ b/js/wearables-withings-auth.js
@@ -72,17 +72,24 @@ export function beginOAuth({ clientId, registeredUris, scopes = DEFAULT_WITHINGS
   redirectWearableAuth(url);
 }
 
-function withingsTokenRequest(payload) {
-  const timeoutSignal = typeof AbortSignal !== 'undefined'
-    && typeof AbortSignal.timeout === 'function'
-    ? AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS)
-    : undefined;
-  return fetch(PROXY_URL, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload),
-    ...(timeoutSignal ? { signal: timeoutSignal } : {}),
-  });
+async function withingsTokenRequest(payload) {
+  // AbortController predates AbortSignal.timeout across supported browsers.
+  // Build the deadline explicitly so older engines cannot silently fall back
+  // to the unbounded request that originally blocked the startup sequence.
+  const controller = new AbortController();
+  const timeout = setTimeout(() => {
+    controller.abort(new DOMException('Withings token request timed out', 'TimeoutError'));
+  }, TOKEN_REQUEST_TIMEOUT_MS);
+  try {
+    return await fetch(PROXY_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 function withingsTokenRequestError(error, operation) {

--- a/js/wearables-withings-auth.js
+++ b/js/wearables-withings-auth.js
@@ -25,6 +25,11 @@ const PROXY_URL     = '/api/proxy';
 const STATE_KEY     = 'withings-oauth-pending';
 const REFRESH_LEAD_MS  = 5 * 60 * 1000;
 const REFRESH_LOCK_KEY = 'withings-oauth-refresh';
+// Withings authorization codes must be exchanged promptly. Never let a
+// stalled proxy hold the startup sequence open until the hosting platform's
+// multi-minute function timeout; fail back to the rendered app with a useful
+// reconnect message instead.
+const TOKEN_REQUEST_TIMEOUT_MS = 20_000;
 
 export const DEFAULT_WITHINGS_SCOPES = ['user.info', 'user.metrics', 'user.activity', 'user.sleepevents'];
 
@@ -67,6 +72,31 @@ export function beginOAuth({ clientId, registeredUris, scopes = DEFAULT_WITHINGS
   redirectWearableAuth(url);
 }
 
+function withingsTokenRequest(payload) {
+  const timeoutSignal = typeof AbortSignal !== 'undefined'
+    && typeof AbortSignal.timeout === 'function'
+    ? AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS)
+    : undefined;
+  return fetch(PROXY_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+    ...(timeoutSignal ? { signal: timeoutSignal } : {}),
+  });
+}
+
+function withingsTokenRequestError(error, operation) {
+  const name = error instanceof Error ? error.name : '';
+  const timedOut = name === 'TimeoutError' || name === 'AbortError';
+  /** @type {Error & { code?: string, status?: number }} */
+  const wrapped = new Error(timedOut
+    ? `Withings ${operation} timed out — please connect Withings again`
+    : `Withings ${operation} failed — check your connection and try again`);
+  wrapped.code = timedOut ? 'timeout' : 'network';
+  wrapped.status = 503;
+  return wrapped;
+}
+
 export async function completeOAuthCallback(urlParams) {
   const code = urlParams.get('code');
   const returnedState = urlParams.get('state');
@@ -87,17 +117,18 @@ export async function completeOAuthCallback(urlParams) {
     return { ok: false, error: 'OAuth flow expired — please try connecting again' };
   }
 
-  const res = await fetch(PROXY_URL, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
+  let res;
+  try {
+    res = await withingsTokenRequest({
       withings_token_exchange: {
         code,
         redirect_uri: pending.redirectUri,
         client_id: pending.clientId,
       },
-    }),
-  });
+    });
+  } catch (error) {
+    return { ok: false, error: withingsTokenRequestError(error, 'token exchange').message };
+  }
   const body = await res.json().catch(() => ({}));
   if (!res.ok) return { ok: false, error: body?.error || body?.error_description || `Token exchange failed (${res.status})` };
   // Withings wraps successful responses in `{status: 0, body: {...}}` —
@@ -122,13 +153,14 @@ export function isWithingsCallback(urlParams) {
 }
 
 export async function refreshTokens({ clientId, refreshToken }) {
-  const res = await fetch(PROXY_URL, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
+  let res;
+  try {
+    res = await withingsTokenRequest({
       withings_token_refresh: { refresh_token: refreshToken, client_id: clientId },
-    }),
-  });
+    });
+  } catch (error) {
+    throw withingsTokenRequestError(error, 'token refresh');
+  }
   const body = await res.json().catch(() => ({}));
   if (!res.ok) {
     /** @type {Error & { status?: number }} */

--- a/scripts/production-smoke.mjs
+++ b/scripts/production-smoke.mjs
@@ -88,6 +88,53 @@ export async function smokeProductionApis({
   }, timeoutMs);
   assertResponse(methodProbe.status === 405, `/api/proxy method probe returned ${methodProbe.status}`);
 
+  // The 2026-07-26 Withings incident left OPTIONS and GET looking healthy
+  // while every POST invocation hung until Vercel's function timeout. Exercise
+  // a secret-free runtime-config POST and the Withings-specific validation
+  // branch so future entrypoint/adapter regressions fail the deployment smoke.
+  const runtimeConfig = await request(fetchImpl, `${baseUrl}/api/proxy`, {
+    method: 'POST',
+    headers: {
+      origin: allowedOrigin,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({ wearable_runtime_config: true }),
+  }, timeoutMs);
+  const runtimeConfigBody = await runtimeConfig.json().catch(() => null);
+  assertResponse(runtimeConfig.status === 200, `/api/proxy runtime-config probe returned ${runtimeConfig.status}`);
+  assertResponse(
+    runtimeConfig.headers.get('access-control-allow-origin') === allowedOrigin,
+    '/api/proxy runtime-config probe omitted its allowed-origin CORS header',
+  );
+  assertResponse(
+    runtimeConfigBody?.overrides
+      && typeof runtimeConfigBody.overrides === 'object'
+      && !Array.isArray(runtimeConfigBody.overrides),
+    '/api/proxy runtime-config probe returned an invalid payload',
+  );
+
+  const withingsValidation = await request(fetchImpl, `${baseUrl}/api/proxy`, {
+    method: 'POST',
+    headers: {
+      origin: allowedOrigin,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({ withings_token_exchange: {} }),
+  }, timeoutMs);
+  const withingsValidationBody = await withingsValidation.json().catch(() => null);
+  assertResponse(
+    withingsValidation.status === 400,
+    `/api/proxy Withings validation probe returned ${withingsValidation.status}`,
+  );
+  assertResponse(
+    withingsValidation.headers.get('access-control-allow-origin') === allowedOrigin,
+    '/api/proxy Withings validation probe omitted its allowed-origin CORS header',
+  );
+  assertResponse(
+    withingsValidationBody?.error === 'withings_token_exchange requires code, redirect_uri, client_id',
+    '/api/proxy Withings validation probe returned an unexpected payload',
+  );
+
   const allowedShare = await request(fetchImpl, `${baseUrl}/api/share`, {
     method: 'OPTIONS',
     headers: { origin: allowedOrigin },

--- a/tests/production-smoke.test.js
+++ b/tests/production-smoke.test.js
@@ -43,7 +43,7 @@ describe('production API smoke canary', () => {
     })).rejects.toThrow(/did not converge/);
   });
 
-  it('checks proxy liveness, proxy origin rejection, method handling, and share liveness', async () => {
+  it('checks proxy POST liveness, Withings validation, origin rejection, method handling, and share liveness', async () => {
     const fetchImpl = vi.fn(async (url, init) => {
       const pathname = new URL(url).pathname;
       const origin = init.headers.origin;
@@ -53,6 +53,21 @@ describe('production API smoke canary', () => {
       if (pathname === '/api/proxy' && init.method === 'GET') {
         return response(405, {}, { 'access-control-allow-origin': origin });
       }
+      if (pathname === '/api/proxy' && init.method === 'POST') {
+        const body = JSON.parse(init.body);
+        if (body.wearable_runtime_config) {
+          return response(200, { overrides: { fitbit: 'public-client-id' } }, {
+            'access-control-allow-origin': origin,
+          });
+        }
+        if (body.withings_token_exchange) {
+          return response(400, {
+            error: 'withings_token_exchange requires code, redirect_uri, client_id',
+          }, {
+            'access-control-allow-origin': origin,
+          });
+        }
+      }
       return response(204, null, { 'access-control-allow-origin': origin });
     });
 
@@ -60,7 +75,29 @@ describe('production API smoke canary', () => {
       baseUrl: 'https://app.getbased.health',
       fetchImpl,
     })).resolves.toBeUndefined();
-    expect(fetchImpl).toHaveBeenCalledTimes(4);
+    expect(fetchImpl).toHaveBeenCalledTimes(6);
+  });
+
+  it('rejects a deployment whose proxy POST adapter is still hanging', async () => {
+    const fetchImpl = vi.fn(async (url, init) => {
+      const pathname = new URL(url).pathname;
+      const origin = init.headers.origin;
+      if (pathname === '/api/proxy' && init.method === 'OPTIONS' && origin.endsWith('.invalid')) {
+        return response(403);
+      }
+      if (pathname === '/api/proxy' && init.method === 'GET') return response(405);
+      if (pathname === '/api/proxy' && init.method === 'POST') {
+        throw new DOMException('The operation was aborted due to timeout', 'TimeoutError');
+      }
+      return response(204, null, { 'access-control-allow-origin': origin });
+    });
+
+    await expect(smokeProductionApis({
+      baseUrl: 'https://app.getbased.health',
+      fetchImpl,
+    })).rejects.toThrow(
+      'POST /api/proxy failed: The operation was aborted due to timeout',
+    );
   });
 
   it('validates the expected SHA before touching production', async () => {

--- a/tests/withings-auth-runtime.test.js
+++ b/tests/withings-auth-runtime.test.js
@@ -6,6 +6,7 @@ import {
 } from '../js/wearables-withings-auth.js';
 
 const realFetch = globalThis.fetch;
+let savedAbortSignalTimeoutDescriptor;
 
 function storePendingCallback() {
   sessionStorage.setItem('withings-oauth-pending', JSON.stringify({
@@ -19,28 +20,44 @@ function storePendingCallback() {
 
 beforeEach(() => {
   sessionStorage.clear();
+  savedAbortSignalTimeoutDescriptor = Object.getOwnPropertyDescriptor(AbortSignal, 'timeout');
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   globalThis.fetch = realFetch;
+  if (savedAbortSignalTimeoutDescriptor) {
+    Object.defineProperty(AbortSignal, 'timeout', savedAbortSignalTimeoutDescriptor);
+  } else {
+    delete AbortSignal.timeout;
+  }
   vi.restoreAllMocks();
 });
 
 describe('Withings OAuth proxy failures', () => {
-  it('bounds callback exchange time and returns a renderable reconnect error', async () => {
-    const timeoutSignal = new AbortController().signal;
-    vi.spyOn(AbortSignal, 'timeout').mockReturnValue(timeoutSignal);
-    globalThis.fetch = vi.fn(async (_url, init) => {
-      expect(init.signal).toBe(timeoutSignal);
-      throw new DOMException('The operation was aborted due to timeout', 'TimeoutError');
+  it('bounds callback exchange time without AbortSignal.timeout and returns a renderable reconnect error', async () => {
+    vi.useFakeTimers();
+    Object.defineProperty(AbortSignal, 'timeout', {
+      configurable: true,
+      value: undefined,
+    });
+    let requestSignal;
+    globalThis.fetch = vi.fn((_url, init) => {
+      requestSignal = init.signal;
+      return new Promise((_resolve, reject) => {
+        init.signal.addEventListener('abort', () => reject(init.signal.reason), { once: true });
+      });
     });
     storePendingCallback();
 
-    const result = await completeOAuthCallback(
+    const resultPromise = completeOAuthCallback(
       new URLSearchParams('code=withings-code&state=withings-state'),
     );
+    await vi.advanceTimersByTimeAsync(20_000);
+    const result = await resultPromise;
 
-    expect(AbortSignal.timeout).toHaveBeenCalledWith(20_000);
+    expect(requestSignal).toBeInstanceOf(AbortSignal);
+    expect(requestSignal.aborted).toBe(true);
     expect(result).toEqual({
       ok: false,
       error: 'Withings token exchange timed out — please connect Withings again',
@@ -49,7 +66,6 @@ describe('Withings OAuth proxy failures', () => {
   });
 
   it('surfaces refresh transport failures without waiting for the host timeout', async () => {
-    vi.spyOn(AbortSignal, 'timeout').mockReturnValue(new AbortController().signal);
     globalThis.fetch = vi.fn(async () => {
       throw new TypeError('network unavailable');
     });

--- a/tests/withings-auth-runtime.test.js
+++ b/tests/withings-auth-runtime.test.js
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  completeOAuthCallback,
+  refreshTokens,
+} from '../js/wearables-withings-auth.js';
+
+const realFetch = globalThis.fetch;
+
+function storePendingCallback() {
+  sessionStorage.setItem('withings-oauth-pending', JSON.stringify({
+    state: 'withings-state',
+    redirectUri: 'https://app.getbased.health/',
+    startedAt: Date.now(),
+    clientId: 'withings-client',
+    profileId: 'profile-1',
+  }));
+}
+
+beforeEach(() => {
+  sessionStorage.clear();
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  vi.restoreAllMocks();
+});
+
+describe('Withings OAuth proxy failures', () => {
+  it('bounds callback exchange time and returns a renderable reconnect error', async () => {
+    const timeoutSignal = new AbortController().signal;
+    vi.spyOn(AbortSignal, 'timeout').mockReturnValue(timeoutSignal);
+    globalThis.fetch = vi.fn(async (_url, init) => {
+      expect(init.signal).toBe(timeoutSignal);
+      throw new DOMException('The operation was aborted due to timeout', 'TimeoutError');
+    });
+    storePendingCallback();
+
+    const result = await completeOAuthCallback(
+      new URLSearchParams('code=withings-code&state=withings-state'),
+    );
+
+    expect(AbortSignal.timeout).toHaveBeenCalledWith(20_000);
+    expect(result).toEqual({
+      ok: false,
+      error: 'Withings token exchange timed out — please connect Withings again',
+    });
+    expect(sessionStorage.getItem('withings-oauth-pending')).toBeNull();
+  });
+
+  it('surfaces refresh transport failures without waiting for the host timeout', async () => {
+    vi.spyOn(AbortSignal, 'timeout').mockReturnValue(new AbortController().signal);
+    globalThis.fetch = vi.fn(async () => {
+      throw new TypeError('network unavailable');
+    });
+
+    await expect(refreshTokens({
+      clientId: 'withings-client',
+      refreshToken: 'withings-refresh',
+    })).rejects.toMatchObject({
+      message: 'Withings token refresh failed — check your connection and try again',
+      code: 'network',
+      status: 503,
+    });
+  });
+});

--- a/tests/withings-auth-runtime.test.js
+++ b/tests/withings-auth-runtime.test.js
@@ -79,4 +79,24 @@ describe('Withings OAuth proxy failures', () => {
       status: 503,
     });
   });
+
+  it('keeps the callback deadline active while the response body is pending', async () => {
+    vi.useFakeTimers();
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: () => new Promise(() => {}),
+    }));
+    storePendingCallback();
+
+    const resultPromise = completeOAuthCallback(
+      new URLSearchParams('code=withings-code&state=withings-state'),
+    );
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    await expect(resultPromise).resolves.toEqual({
+      ok: false,
+      error: 'Withings token exchange timed out — please connect Withings again',
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- bound Withings OAuth token exchange and refresh requests to 20 seconds so a stalled relay returns a normal reconnect error instead of blocking app startup until the hosting timeout
- extend the post-deploy production smoke to exercise a real `/api/proxy` POST, validate its CORS response, and enter the Withings-specific validation branch
- add focused regression coverage for callback timeout handling, refresh transport failures, and a hanging production POST adapter

## Root cause

Issue #1385 reported both `wearable_runtime_config` and `withings_token_exchange` hanging for five minutes. That shared failure was the Vercel proxy entrypoint ambiguity fixed in #1501: a bare default function returned a Web `Response`, while the hosted adapter could interpret it as the legacy `(request, response)` contract and wait indefinitely.

The live deployment now returns wearable runtime config in under a second, and a deliberately invalid non-user Withings authorization code reaches Withings and returns its structured error in about three seconds. This change hardens the browser UX and closes the deployment-smoke gap that allowed POST to fail while OPTIONS and GET still looked healthy.

## Verification

- `npm test -- tests/production-smoke.test.js tests/withings-auth-runtime.test.js tests/api-network-runtime.test.js` — 34/34
- focused Chromium wearable-auth and startup-OAuth specs — 3/3
- `npm run typecheck:checkjs`
- `npm run typecheck:server`
- `npm run quality` — 17/17
- `npm run architecture:check` — 546 modules, 0 cycles
- `npm run production:check`
- strengthened production API smoke against deployed SHA `3513209cf434eeaffa8831728241cf03244f2538`

Fixes #1385