### PR TITLE
Load wearable credentials when settings opens

### DIFF
--- a/js/wearables-connect.js
+++ b/js/wearables-connect.js
@@ -748,30 +748,36 @@ export function initWearableScheduler() {
 // the adapter registry has hardcoded (i.e. the hosted-user behavior).
 
 const RUNTIME_CONFIG_TIMEOUT_MS = 1500;
-let _runtimeConfigPromise = null;
+/** @type {Promise<void> | null} */ let _runtimeConfigFetchPromise = null;
+/** @type {Promise<void> | null} */ let _runtimeConfigPromise = null;
 
-export function loadWearableRuntimeConfig() {
-  if (_runtimeConfigPromise) return _runtimeConfigPromise;
-  const fetchPromise = (async () => {
-    try {
-      const res = await fetch('/api/proxy', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ wearable_runtime_config: true }),
-      });
-      if (!res.ok) return;
-      const data = await res.json();
-      if (data && data.overrides) applyOAuthOverrides(data.overrides);
-    } catch { /* offline / proxy missing — silently fall back to hardcoded */ }
-  })();
-  // Race the fetch against a soft timeout so the scheduler never blocks
-  // longer than RUNTIME_CONFIG_TIMEOUT_MS, even if the network never
-  // resolves. The fetch itself continues in the background — if it lands
-  // after the timeout, applyOAuthOverrides still runs and the *next*
-  // visibilitychange / poll-interval sync picks up the override.
-  const timeoutPromise = new Promise(resolve => setTimeout(resolve, RUNTIME_CONFIG_TIMEOUT_MS));
-  _runtimeConfigPromise = Promise.race([fetchPromise, timeoutPromise]);
-  return _runtimeConfigPromise;
+/** @param {{ waitForFetch?: boolean }} [options] @returns {Promise<void>} */
+export function loadWearableRuntimeConfig(options = {}) {
+  if (!_runtimeConfigFetchPromise) {
+    _runtimeConfigFetchPromise = (async () => {
+      try {
+        const res = await fetch('/api/proxy', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ wearable_runtime_config: true }),
+        });
+        if (!res.ok) return;
+        const data = await res.json();
+        if (data && data.overrides) applyOAuthOverrides(data.overrides);
+      } catch { /* offline / proxy missing — silently fall back to hardcoded */ }
+    })();
+    // Race the fetch against a soft timeout so the scheduler never blocks
+    // longer than RUNTIME_CONFIG_TIMEOUT_MS, even if the network never
+    // resolves. The fetch itself continues in the background — Settings can
+    // explicitly await it so a slow response still enables configured rows.
+    const timeoutPromise = /** @type {Promise<void>} */ (
+      new Promise(resolve => setTimeout(resolve, RUNTIME_CONFIG_TIMEOUT_MS))
+    );
+    _runtimeConfigPromise = Promise.race([_runtimeConfigFetchPromise, timeoutPromise]);
+  }
+  return options.waitForFetch
+    ? _runtimeConfigFetchPromise
+    : /** @type {Promise<void>} */ (_runtimeConfigPromise);
 }
 
 // Used by the scheduler to gate its first sync. If main.js skipped the

--- a/js/wearables-connect.js
+++ b/js/wearables-connect.js
@@ -750,10 +750,10 @@ export function initWearableScheduler() {
 const RUNTIME_CONFIG_TIMEOUT_MS = 1500;
 /** @type {Promise<void> | null} */ let _runtimeConfigFetchPromise = null;
 /** @type {Promise<void> | null} */ let _runtimeConfigPromise = null;
-
 /** @param {{ waitForFetch?: boolean }} [options] @returns {Promise<void>} */
 export function loadWearableRuntimeConfig(options = {}) {
   if (!_runtimeConfigFetchPromise) {
+    let loaded = false;
     _runtimeConfigFetchPromise = (async () => {
       try {
         const res = await fetch('/api/proxy', {
@@ -764,19 +764,20 @@ export function loadWearableRuntimeConfig(options = {}) {
         if (!res.ok) return;
         const data = await res.json();
         if (data && data.overrides) applyOAuthOverrides(data.overrides);
+        loaded = true;
       } catch { /* offline / proxy missing — silently fall back to hardcoded */ }
-    })();
+    })().finally(() => {
+      if (!loaded) _runtimeConfigFetchPromise = _runtimeConfigPromise = null;
+    });
     // Race the fetch against a soft timeout so the scheduler never blocks
     // longer than RUNTIME_CONFIG_TIMEOUT_MS, even if the network never
     // resolves. The fetch itself continues in the background — Settings can
     // explicitly await it so a slow response still enables configured rows.
-    const timeoutPromise = /** @type {Promise<void>} */ (
-      new Promise(resolve => setTimeout(resolve, RUNTIME_CONFIG_TIMEOUT_MS))
-    );
+    const timeoutPromise = /** @type {Promise<void>} */ (new Promise(
+      resolve => setTimeout(resolve, RUNTIME_CONFIG_TIMEOUT_MS)));
     _runtimeConfigPromise = Promise.race([_runtimeConfigFetchPromise, timeoutPromise]);
   }
-  return options.waitForFetch
-    ? _runtimeConfigFetchPromise
+  return options.waitForFetch ? _runtimeConfigFetchPromise
     : /** @type {Promise<void>} */ (_runtimeConfigPromise);
 }
 

--- a/js/wearables-connect.js
+++ b/js/wearables-connect.js
@@ -738,28 +738,27 @@ export function initWearableScheduler() {
 // Runtime config (self-host OAuth client_id overrides)
 // ─────────────────────────────────────────────────────────
 //
-// Fired once from main.js, then awaited by the scheduler so its first
-// refresh attempt sees the override map (rather than racing against an
-// unresolved fetch and hitting `invalid_client` with the maintainer's
-// clientId paired with the self-hoster's secret).
-//
-// Bounded by RUNTIME_CONFIG_TIMEOUT_MS so a slow / down /api/proxy can't
-// stall the scheduler indefinitely — on timeout we fall back to whatever
-// the adapter registry has hardcoded (i.e. the hosted-user behavior).
+// The scheduler waits briefly for OAuth overrides; Settings may await the
+// full request so slow config still enables rows. A longer fetch timeout
+// releases a hung attempt so reopening Settings can retry.
 
 const RUNTIME_CONFIG_TIMEOUT_MS = 1500;
+const RUNTIME_CONFIG_FETCH_TIMEOUT_MS = 10000;
 /** @type {Promise<void> | null} */ let _runtimeConfigFetchPromise = null;
 /** @type {Promise<void> | null} */ let _runtimeConfigPromise = null;
 /** @param {{ waitForFetch?: boolean }} [options] @returns {Promise<void>} */
 export function loadWearableRuntimeConfig(options = {}) {
   if (!_runtimeConfigFetchPromise) {
     let loaded = false;
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), RUNTIME_CONFIG_FETCH_TIMEOUT_MS);
     _runtimeConfigFetchPromise = (async () => {
       try {
         const res = await fetch('/api/proxy', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ wearable_runtime_config: true }),
+          signal: controller.signal,
         });
         if (!res.ok) return;
         const data = await res.json();
@@ -767,6 +766,7 @@ export function loadWearableRuntimeConfig(options = {}) {
         loaded = true;
       } catch { /* offline / proxy missing — silently fall back to hardcoded */ }
     })().finally(() => {
+      clearTimeout(timeoutId);
       if (!loaded) _runtimeConfigFetchPromise = _runtimeConfigPromise = null;
     });
     // Race the fetch against a soft timeout so the scheduler never blocks

--- a/js/wearables-settings-panel.js
+++ b/js/wearables-settings-panel.js
@@ -506,6 +506,19 @@ async function _updateManualCounts() {
   } catch { /* non-fatal */ }
 }
 
+function _oauthClientConfigFingerprint() {
+  return visibleAdapters(Object.keys(listConnectedSources()))
+    .filter(adapter => adapter.authType === 'oauth2')
+    .map(adapter => `${adapter.id}:${getOAuthClientId(adapter) || ''}`)
+    .join('|');
+}
+
+async function _refreshAfterWearableRuntimeConfig() {
+  const before = _oauthClientConfigFingerprint();
+  await loadWearableRuntimeConfig({ waitForFetch: true });
+  if (before !== _oauthClientConfigFingerprint()) refreshSettingsWearables();
+}
+
 // Fire when the details element opens (delegated — the Settings section is
 // re-rendered on demand so we can't bind once at module load).
 document.addEventListener('toggle', (e) => {
@@ -522,6 +535,10 @@ document.addEventListener('toggle', (e) => {
 document.addEventListener('settings:wearables-rendered', () => {
   // Slightly defer so the [data-role="manual-counts"] element is in the DOM.
   queueMicrotask(_updateManualCounts);
+  // A fresh profile has no connected OAuth source, so startup maintenance
+  // does not load the public client-id map. Start it when Settings opens and
+  // re-render only if the returned configuration changed an adapter row.
+  void _refreshAfterWearableRuntimeConfig();
 });
 
 async function handleWearableConnect(adapterId) {

--- a/tests/playwright/wearables-settings-panel-browser-coverage.spec.js
+++ b/tests/playwright/wearables-settings-panel-browser-coverage.spec.js
@@ -10,10 +10,14 @@ test('wearables settings loads runtime credentials for a fresh unconnected profi
       import('/js/wearables-settings-panel.js'),
     ]);
     const originalFetch = window.fetch;
+    const originalSetTimeout = window.setTimeout;
     let runtimeConfigCalls = 0;
+    let hangingRequestAborted = false;
     adapters._resetOAuthOverrides();
     state.importedData = { wearableConnections: {} };
     document.getElementById('wearables-section')?.remove();
+    window.setTimeout = (handler, delay = 0, ...args) => originalSetTimeout(
+      handler, delay === 10000 ? 0 : delay, ...args);
 
     window.fetch = async (url, options = {}) => {
       if (String(url) === '/api/proxy') {
@@ -21,6 +25,12 @@ test('wearables settings loads runtime credentials for a fresh unconnected profi
         if (payload.wearable_runtime_config) {
           runtimeConfigCalls += 1;
           if (runtimeConfigCalls === 1) return new Response(null, { status: 503 });
+          if (runtimeConfigCalls === 2) return new Promise((_resolve, reject) => {
+            options.signal?.addEventListener('abort', () => {
+              hangingRequestAborted = true;
+              reject(new DOMException('Aborted', 'AbortError'));
+            }, { once: true });
+          });
           await new Promise(resolve => setTimeout(resolve, 25));
           return new Response(JSON.stringify({
             overrides: { google_health: 'hosted-google-health-client' },
@@ -45,6 +55,9 @@ test('wearables settings loads runtime credentials for a fresh unconnected profi
       const afterFailureStillWaiting = document.querySelector('[data-adapter="google_health"]')
         ?.textContent.includes('waiting on partner credentials');
       document.dispatchEvent(new Event('settings:wearables-rendered'));
+      while (!hangingRequestAborted) await new Promise(resolve => setTimeout(resolve, 10));
+      await new Promise(resolve => setTimeout(resolve, 0));
+      document.dispatchEvent(new Event('settings:wearables-rendered'));
       for (let attempt = 0; attempt < 80; attempt += 1) {
         const row = document.querySelector('[data-adapter="google_health"]');
         if (row?.textContent.includes('optional health hub')) break;
@@ -57,21 +70,24 @@ test('wearables settings loads runtime credentials for a fresh unconnected profi
         initiallyWaiting,
         initiallyHasConnect,
         afterFailureStillWaiting,
+        hangingRequestAborted,
         configuredText: configuredRow?.textContent || '',
         configuredHasConnect: Boolean(configuredRow
           ?.querySelector('[data-wearable-settings-action="connect"]')),
       };
     } finally {
       window.fetch = originalFetch;
+      window.setTimeout = originalSetTimeout;
       document.getElementById('wearables-section')?.remove();
     }
   });
 
   expect(result).toMatchObject({
-    runtimeConfigCalls: 2,
+    runtimeConfigCalls: 3,
     initiallyWaiting: true,
     initiallyHasConnect: false,
     afterFailureStillWaiting: true,
+    hangingRequestAborted: true,
     configuredHasConnect: true,
   });
   expect(result.configuredText).toContain('optional health hub');

--- a/tests/playwright/wearables-settings-panel-browser-coverage.spec.js
+++ b/tests/playwright/wearables-settings-panel-browser-coverage.spec.js
@@ -20,6 +20,7 @@ test('wearables settings loads runtime credentials for a fresh unconnected profi
         const payload = JSON.parse(String(options.body || '{}'));
         if (payload.wearable_runtime_config) {
           runtimeConfigCalls += 1;
+          if (runtimeConfigCalls === 1) return new Response(null, { status: 503 });
           await new Promise(resolve => setTimeout(resolve, 25));
           return new Response(JSON.stringify({
             overrides: { google_health: 'hosted-google-health-client' },
@@ -39,6 +40,11 @@ test('wearables settings loads runtime credentials for a fresh unconnected profi
         ?.querySelector('[data-wearable-settings-action="connect"]'));
 
       document.dispatchEvent(new Event('settings:wearables-rendered'));
+      while (runtimeConfigCalls < 1) await new Promise(resolve => setTimeout(resolve, 10));
+      await new Promise(resolve => setTimeout(resolve, 0));
+      const afterFailureStillWaiting = document.querySelector('[data-adapter="google_health"]')
+        ?.textContent.includes('waiting on partner credentials');
+      document.dispatchEvent(new Event('settings:wearables-rendered'));
       for (let attempt = 0; attempt < 80; attempt += 1) {
         const row = document.querySelector('[data-adapter="google_health"]');
         if (row?.textContent.includes('optional health hub')) break;
@@ -50,6 +56,7 @@ test('wearables settings loads runtime credentials for a fresh unconnected profi
         runtimeConfigCalls,
         initiallyWaiting,
         initiallyHasConnect,
+        afterFailureStillWaiting,
         configuredText: configuredRow?.textContent || '',
         configuredHasConnect: Boolean(configuredRow
           ?.querySelector('[data-wearable-settings-action="connect"]')),
@@ -61,9 +68,10 @@ test('wearables settings loads runtime credentials for a fresh unconnected profi
   });
 
   expect(result).toMatchObject({
-    runtimeConfigCalls: 1,
+    runtimeConfigCalls: 2,
     initiallyWaiting: true,
     initiallyHasConnect: false,
+    afterFailureStillWaiting: true,
     configuredHasConnect: true,
   });
   expect(result.configuredText).toContain('optional health hub');

--- a/tests/playwright/wearables-settings-panel-browser-coverage.spec.js
+++ b/tests/playwright/wearables-settings-panel-browser-coverage.spec.js
@@ -1,5 +1,75 @@
 import { expect, test } from './coverage-fixture.js';
 
+test('wearables settings loads runtime credentials for a fresh unconnected profile', async ({ page }) => {
+  await page.goto('/app', { waitUntil: 'load' });
+
+  const result = await page.evaluate(async () => {
+    const [{ state }, adapters, settings] = await Promise.all([
+      import('/js/state.js'),
+      import('/js/wearable-adapters.js'),
+      import('/js/wearables-settings-panel.js'),
+    ]);
+    const originalFetch = window.fetch;
+    let runtimeConfigCalls = 0;
+    adapters._resetOAuthOverrides();
+    state.importedData = { wearableConnections: {} };
+    document.getElementById('wearables-section')?.remove();
+
+    window.fetch = async (url, options = {}) => {
+      if (String(url) === '/api/proxy') {
+        const payload = JSON.parse(String(options.body || '{}'));
+        if (payload.wearable_runtime_config) {
+          runtimeConfigCalls += 1;
+          await new Promise(resolve => setTimeout(resolve, 25));
+          return new Response(JSON.stringify({
+            overrides: { google_health: 'hosted-google-health-client' },
+          }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+        }
+      }
+      return originalFetch(url, options);
+    };
+
+    try {
+      document.body.insertAdjacentHTML('beforeend', `
+        <section id="wearables-section">${settings.renderWearablesSettingsSection()}</section>
+      `);
+      const initialRow = document.querySelector('[data-adapter="google_health"]');
+      const initiallyWaiting = initialRow?.textContent.includes('waiting on partner credentials');
+      const initiallyHasConnect = Boolean(initialRow
+        ?.querySelector('[data-wearable-settings-action="connect"]'));
+
+      document.dispatchEvent(new Event('settings:wearables-rendered'));
+      for (let attempt = 0; attempt < 80; attempt += 1) {
+        const row = document.querySelector('[data-adapter="google_health"]');
+        if (row?.textContent.includes('optional health hub')) break;
+        await new Promise(resolve => setTimeout(resolve, 25));
+      }
+
+      const configuredRow = document.querySelector('[data-adapter="google_health"]');
+      return {
+        runtimeConfigCalls,
+        initiallyWaiting,
+        initiallyHasConnect,
+        configuredText: configuredRow?.textContent || '',
+        configuredHasConnect: Boolean(configuredRow
+          ?.querySelector('[data-wearable-settings-action="connect"]')),
+      };
+    } finally {
+      window.fetch = originalFetch;
+      document.getElementById('wearables-section')?.remove();
+    }
+  });
+
+  expect(result).toMatchObject({
+    runtimeConfigCalls: 1,
+    initiallyWaiting: true,
+    initiallyHasConnect: false,
+    configuredHasConnect: true,
+  });
+  expect(result.configuredText).toContain('optional health hub');
+  expect(result.configuredText).not.toContain('waiting on partner credentials');
+});
+
 test('wearables settings panel browser coverage renders rows, counts, and navigation toggles', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
   await page.waitForSelector('#notification-container', { state: 'attached' });


### PR DESCRIPTION
## What changed

- load the hosted wearable OAuth client configuration whenever the Wearables settings section renders
- retain the scheduler's bounded 1.5-second wait while allowing Settings to await a slower configuration response
- re-render provider rows only when their public client configuration changes
- add browser coverage for a fresh profile with no existing wearable connection

## Why

Fresh hosted users had no connected OAuth source, so startup maintenance skipped the runtime configuration request. Google Health consequently remained stuck on “Waiting for partner credentials” even though Vercel had the required credentials.

## Impact

Configured Google Health rows become connectable as soon as the runtime configuration arrives. Existing direct integrations and scheduler behavior are unchanged.

## Validation

- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run typecheck:strict-null`
- `npm run quality`
- `npm run architecture:check`
- `npm run production:check`
- `node tests/test-wearables.js` (603 passed)
- `node tests/test-wearables-connect-runtime.js` (6 passed)
- `npx playwright test tests/playwright/wearables-settings-panel-browser-coverage.spec.js --workers=1` (3 passed)
- `git diff --check`