### PR TITLE
Group wearable integrations by setup path

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -9,8 +9,8 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 
 | Metric | Current |
 | --- | ---: |
-| Modules | 580 |
-| Internal import edges | 2501 |
+| Modules | 581 |
+| Internal import edges | 2502 |
 | Dynamic internal edges | 72 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -1024,7 +1024,7 @@ Native browser modules shipped with the static application.
 
 </details>
 
-<details><summary><code>wearables</code> family — 36 modules</summary>
+<details><summary><code>wearables</code> family — 37 modules</summary>
 
 - [`js/wearables-apple-health-runtime.js`](js/wearables-apple-health-runtime.js) → no in-scope imports
 - [`js/wearables-apple-health.js`](js/wearables-apple-health.js) → [`js/caught-error.js`](js/caught-error.js), [`js/data.js`](js/data.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js), [`js/wearable-adapters.js`](js/wearable-adapters.js), [`js/wearables-apple-health-runtime.js`](js/wearables-apple-health-runtime.js), [`js/wearables-connect.js`](js/wearables-connect.js) *(dynamic)*, [`js/wearables-store.js`](js/wearables-store.js), [`js/wearables-summary.js`](js/wearables-summary.js)
@@ -1050,7 +1050,8 @@ Native browser modules shipped with the static application.
 - [`js/wearables-polar-auth.js`](js/wearables-polar-auth.js) → [`js/utils.js`](js/utils.js), [`js/wearables-auth-runtime.js`](js/wearables-auth-runtime.js)
 - [`js/wearables-polar.js`](js/wearables-polar.js) → [`js/caught-error.js`](js/caught-error.js), [`js/utils.js`](js/utils.js)
 - [`js/wearables-runtime.js`](js/wearables-runtime.js) → [`js/emf-runtime.js`](js/emf-runtime.js), [`js/settings-runtime-bridge.js`](js/settings-runtime-bridge.js), [`js/utils.js`](js/utils.js)
-- [`js/wearables-settings-panel.js`](js/wearables-settings-panel.js) → [`js/brand-assets.js`](js/brand-assets.js), [`js/caught-error.js`](js/caught-error.js), [`js/data.js`](js/data.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js), [`js/wearable-adapters.js`](js/wearable-adapters.js), [`js/wearables-apple-health.js`](js/wearables-apple-health.js) *(dynamic)*, [`js/wearables-connect.js`](js/wearables-connect.js), [`js/wearables-manual.js`](js/wearables-manual.js), [`js/wearables-settings-runtime.js`](js/wearables-settings-runtime.js), [`js/wearables-store.js`](js/wearables-store.js), [`js/wearables-summary.js`](js/wearables-summary.js)
+- [`js/wearables-settings-groups.js`](js/wearables-settings-groups.js) → no in-scope imports
+- [`js/wearables-settings-panel.js`](js/wearables-settings-panel.js) → [`js/brand-assets.js`](js/brand-assets.js), [`js/caught-error.js`](js/caught-error.js), [`js/data.js`](js/data.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js), [`js/wearable-adapters.js`](js/wearable-adapters.js), [`js/wearables-apple-health.js`](js/wearables-apple-health.js) *(dynamic)*, [`js/wearables-connect.js`](js/wearables-connect.js), [`js/wearables-manual.js`](js/wearables-manual.js), [`js/wearables-settings-groups.js`](js/wearables-settings-groups.js), [`js/wearables-settings-runtime.js`](js/wearables-settings-runtime.js), [`js/wearables-store.js`](js/wearables-store.js), [`js/wearables-summary.js`](js/wearables-summary.js)
 - [`js/wearables-settings-runtime.js`](js/wearables-settings-runtime.js) → [`js/settings-runtime-bridge.js`](js/settings-runtime-bridge.js), [`js/utils.js`](js/utils.js)
 - [`js/wearables-store.js`](js/wearables-store.js) → no in-scope imports
 - [`js/wearables-strip-actions.js`](js/wearables-strip-actions.js) → [`js/caught-error.js`](js/caught-error.js), [`js/data.js`](js/data.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js), [`js/wearable-adapters.js`](js/wearable-adapters.js), [`js/wearables-connect.js`](js/wearables-connect.js), [`js/wearables-detail-modal.js`](js/wearables-detail-modal.js), [`js/wearables-manual-form-ui.js`](js/wearables-manual-form-ui.js), [`js/wearables-manual.js`](js/wearables-manual.js), [`js/wearables-runtime.js`](js/wearables-runtime.js), [`js/wearables-summary.js`](js/wearables-summary.js)

--- a/css/wearables.css
+++ b/css/wearables.css
@@ -519,14 +519,50 @@
 
 /* Settings — wearable adapter list (Slack/Notion-style integrations row).
    Each vendor gets one row; connected vendors expand a details drawer. */
+.wearables-adapter-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  margin-top: 16px;
+}
+.wearables-adapter-group-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 0 2px;
+}
+.wearables-adapter-group-title {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 650;
+  line-height: 1.4;
+}
+.wearables-adapter-group-hint {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.4;
+  text-align: right;
+}
 .wearables-adapter-list {
   display: flex;
   flex-direction: column;
-  margin-top: 10px;
+  margin-top: 8px;
   border: 1px solid var(--border);
   border-radius: 10px;
   overflow: hidden;
   background: var(--bg-primary);
+}
+@media (max-width: 600px) {
+  .wearables-adapter-group-heading {
+    display: block;
+  }
+  .wearables-adapter-group-hint {
+    margin-top: 2px;
+    text-align: left;
+  }
 }
 .wearable-row {
   border-bottom: 1px solid var(--border);

--- a/js/changelog-impl.js
+++ b/js/changelog-impl.js
@@ -17,6 +17,7 @@ const CHANGELOG = [
       '<b>The official hosted app stays focused on integrations it can support.</b> WHOOP and Ultrahuman are hidden there unless the deployment is fully configured; localhost shows disabled setup rows so developers can discover and prepare them.',
       '<b>WHOOP sign-in now keeps its client secret on the server.</b> Token exchange and refresh follow WHOOP\'s confidential OAuth flow instead of treating the browser as a public client.',
       '<b>Existing connections stay manageable.</b> If an operator later disables one of these integrations, syncing pauses while the user can still remove the local connection.',
+      '<b>Wearable Settings is easier to scan.</b> Connected sources and migration warnings appear first, followed by available providers, self-host integrations, and import or manual-entry options.',
     ]
   },
   {

--- a/js/wearables-settings-groups.js
+++ b/js/wearables-settings-groups.js
@@ -1,0 +1,66 @@
+// @ts-check
+// Pure presentation grouping for Settings → Wearables. Keeping ordering rules
+// separate from the renderer makes the hosted/self-host layout easy to test
+// without coupling it to connection actions or DOM state.
+
+export const WEARABLE_GROUP_COPY = Object.freeze({
+  connected: {
+    title: 'Connected',
+    hint: 'Connections needing action appear first.',
+  },
+  available: {
+    title: 'Available integrations',
+    hint: 'Connect a supported provider directly.',
+  },
+  self_host: {
+    title: 'Self-host integrations',
+    hint: 'These use this deployment\'s own developer credentials. Experimental providers are labeled.',
+  },
+  local: {
+    title: 'Import or enter data',
+    hint: 'Import an Apple Health export or record key biometrics manually.',
+  },
+});
+
+/** @type {Readonly<Record<string, number>>} */
+const SELF_HOST_ADAPTER_ORDER = Object.freeze({
+  google_health: 0,
+  whoop: 1,
+  ultrahuman: 2,
+});
+
+/**
+ * @param {Array<any>} adapters
+ * @param {object} connected
+ * @param {(adapter: any) => boolean} needsAttention
+ */
+export function groupWearableAdapters(adapters, connected, needsAttention) {
+  /** @type {Record<string, Array<any>>} */
+  const grouped = { connected: [], available: [], self_host: [], local: [] };
+  const registryIndex = new Map(adapters.map((adapter, index) => [adapter.id, index]));
+
+  for (const adapter of adapters) {
+    if (Object.prototype.hasOwnProperty.call(connected, adapter.id)) grouped.connected.push(adapter);
+    else if (adapter.authType === 'manual' || adapter.authType === 'file-import') grouped.local.push(adapter);
+    else if (adapter.hostConfiguredOnly || adapter.experimentalSelfHost || adapter.integrationKind === 'aggregator') grouped.self_host.push(adapter);
+    else grouped.available.push(adapter);
+  }
+
+  grouped.connected.sort((a, b) => {
+    const attention = Number(Boolean(needsAttention(b))) - Number(Boolean(needsAttention(a)));
+    return attention || (registryIndex.get(a.id) ?? 0) - (registryIndex.get(b.id) ?? 0);
+  });
+  grouped.self_host.sort((a, b) => {
+    const aRank = SELF_HOST_ADAPTER_ORDER[a.id] ?? Number.MAX_SAFE_INTEGER;
+    const bRank = SELF_HOST_ADAPTER_ORDER[b.id] ?? Number.MAX_SAFE_INTEGER;
+    return aRank - bRank || (registryIndex.get(a.id) ?? 0) - (registryIndex.get(b.id) ?? 0);
+  });
+  grouped.local.sort((a, b) => {
+    const typeOrder = Number(a.authType === 'manual') - Number(b.authType === 'manual');
+    return typeOrder || (registryIndex.get(a.id) ?? 0) - (registryIndex.get(b.id) ?? 0);
+  });
+
+  return Object.entries(grouped)
+    .filter(([, items]) => items.length)
+    .map(([id, items]) => ({ id, items, ...WEARABLE_GROUP_COPY[id] }));
+}

--- a/js/wearables-settings-panel.js
+++ b/js/wearables-settings-panel.js
@@ -13,6 +13,7 @@ import {
   isOAuthAdapterConfigured,
 } from './wearable-adapters.js';
 import { brandMarkMono } from './brand-assets.js';
+import { groupWearableAdapters } from './wearables-settings-groups.js';
 import {
   beginConnectOAuth,
   backfillWearable,
@@ -200,8 +201,12 @@ function vendorIcon(adapterId, opts = {}) {
 
 export function renderWearablesSettingsSection() {
   const connected = listConnectedSources();
-  const rows = visibleAdapters(Object.keys(connected))
-    .map(a => renderAdapterRow(a, !!connected[a.id])).join('');
+  const groups = groupWearableAdapters(
+    visibleAdapters(Object.keys(connected)),
+    connected,
+    connectedAdapterNeedsAttention,
+  );
+  const groupMarkup = groups.map(group => renderAdapterGroup(group, connected)).join('');
   const hidden = isWearableStripHidden();
   // BETA badge moves out of every row to a single section-level note. Every
   // wearable adapter is currently beta — the per-row chip was redundant.
@@ -216,10 +221,29 @@ export function renderWearablesSettingsSection() {
     </label>
   </div>
   <div class="settings-section-header" style="display:block">
-    <div class="settings-section-title" style="display:block;margin-bottom:4px">Connected devices</div>
-    <div class="settings-section-hint" style="display:block">Imported history is stored on this device; a compact summary + anomaly events sync to your other devices. Connecting a cloud provider contacts that provider's API. All integrations are <em>beta</em> — please report issues.</div>
+    <div class="settings-section-title" style="display:block;margin-bottom:4px">Health data sources</div>
+    <div class="settings-section-hint" style="display:block">Connected sources appear first; other providers are grouped by setup path. Imported history is stored on this device, while connecting a cloud provider contacts that provider's API. All integrations are <em>beta</em> — please report issues.</div>
   </div>
-  <div class="wearables-adapter-list">${rows}</div>`;
+  <div class="wearables-adapter-groups">${groupMarkup}</div>`;
+}
+
+function connectedAdapterNeedsAttention(adapter) {
+  const connection = getConnection(adapter.id);
+  return adapter.legacyMigrationOnly
+    || connection?.needsReauth
+    || (adapter.hostConfiguredOnly && !isOAuthAdapterConfigured(adapter));
+}
+
+function renderAdapterGroup(group, connected) {
+  const headingId = `wearables-group-${group.id}`;
+  const rows = group.items.map(adapter => renderAdapterRow(adapter, !!connected[adapter.id])).join('');
+  return `<section class="wearables-adapter-group" data-wearable-group="${escapeAttr(group.id)}" aria-labelledby="${headingId}">
+    <div class="wearables-adapter-group-heading">
+      <h3 class="wearables-adapter-group-title" id="${headingId}">${escapeHTML(group.title)}</h3>
+      <p class="wearables-adapter-group-hint">${escapeHTML(group.hint)}</p>
+    </div>
+    <div class="wearables-adapter-list">${rows}</div>
+  </section>`;
 }
 
 // Each adapter renders as a single horizontal row:

--- a/scripts/dom-sink-policy.json
+++ b/scripts/dom-sink-policy.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "scope": "Every non-generated JavaScript module under js/",
   "reviewRule": "Any added or modified HTML-writing sink requires security review and a policy refresh.",
-  "scannedFiles": 561,
+  "scannedFiles": 562,
   "sinkCount": 483,
   "files": {
     "js/backup.js": {

--- a/service-worker.js
+++ b/service-worker.js
@@ -516,6 +516,7 @@ const APP_SHELL = [
   '/js/wearables-runtime.js',
   '/js/wearables-auth-runtime.js',
   '/js/wearables-settings-runtime.js',
+  '/js/wearables-settings-groups.js',
   '/js/wearables-settings-panel.js',
   '/js/wearables-store.js',
   '/js/wearables-summary.js',

--- a/tests/playwright/wearables-settings-panel-browser-coverage.spec.js
+++ b/tests/playwright/wearables-settings-panel-browser-coverage.spec.js
@@ -70,6 +70,9 @@ test('wearables settings loads runtime credentials for a fresh unconnected profi
       }
 
       const configuredRow = document.querySelector('[data-adapter="google_health"]');
+      const adapterIdsInGroup = groupId => Array.from(document.querySelectorAll(
+        `[data-wearable-group="${groupId}"] [data-adapter]`,
+      )).map(row => row.getAttribute('data-adapter'));
       return {
         runtimeConfigCalls,
         initiallySelfHostOnly,
@@ -85,6 +88,11 @@ test('wearables settings loads runtime credentials for a fresh unconnected profi
         whoopConfigured: document.querySelector('[data-adapter="whoop"]')
           ?.textContent.includes('experimental · self-hosted')
           && Boolean(document.querySelector('[data-adapter="whoop"] [data-wearable-settings-action="connect"]')),
+        groupIds: Array.from(document.querySelectorAll('[data-wearable-group]'))
+          .map(group => group.getAttribute('data-wearable-group')),
+        availableOrder: adapterIdsInGroup('available'),
+        selfHostOrder: adapterIdsInGroup('self_host'),
+        localOrder: adapterIdsInGroup('local'),
       };
     } finally {
       window.fetch = originalFetch;
@@ -105,6 +113,10 @@ test('wearables settings loads runtime credentials for a fresh unconnected profi
   });
   expect(result.configuredText).toContain('optional health hub');
   expect(result.configuredText).not.toContain('waiting on partner credentials');
+  expect(result.groupIds).toEqual(['available', 'self_host', 'local']);
+  expect(result.availableOrder).toEqual(['oura', 'withings', 'polar']);
+  expect(result.selfHostOrder).toEqual(['google_health', 'whoop', 'ultrahuman']);
+  expect(result.localOrder).toEqual(['apple_health', 'manual']);
 });
 
 test('wearables settings panel browser coverage renders rows, counts, and navigation toggles', async ({ page }) => {
@@ -234,8 +246,17 @@ test('wearables settings panel browser coverage renders rows, counts, and naviga
       const manualRow = section.querySelector('[data-adapter="manual"]');
       const appleRow = section.querySelector('[data-adapter="apple_health"]');
       const manualCounts = section.querySelector('[data-role="manual-counts"]')?.textContent || '';
+      const connectedOrder = Array.from(section.querySelectorAll(
+        '[data-wearable-group="connected"] [data-adapter]',
+      )).map(row => row.getAttribute('data-adapter'));
 
       check('strip visible toggle starts checked', toggle?.checked === true);
+      check('connected group puts the migration warning before healthy connections',
+        connectedOrder.join(',') === 'fitbit,oura,manual,apple_health', connectedOrder.join(','));
+      check('connected sources are removed from the setup groups',
+        !section.querySelector('[data-wearable-group="available"] [data-adapter="oura"]')
+        && !section.querySelector('[data-wearable-group="local"] [data-adapter="manual"]')
+        && !section.querySelector('[data-wearable-group="local"] [data-adapter="apple_health"]'));
       check('connected OAuth row renders status and identity',
         ouraRow?.textContent.includes('connected') && ouraRow?.textContent.includes('oura@example.test'));
       check('legacy Fitbit reauth state explains self-host Google Health migration',

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -527,6 +527,7 @@ const wearablesWorkflowCheckJsModules = [
   'js/wearables-polar.js',
   'js/wearables-runtime.js',
   'js/wearables-settings-runtime.js',
+  'js/wearables-settings-groups.js',
   'js/wearables-settings-panel.js',
   'js/wearables-store.js',
   'js/wearables-summary.js',

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -70,6 +70,7 @@
     '/js/wearables-runtime.js',
     '/js/wearables-auth-runtime.js',
     '/js/wearables-settings-runtime.js',
+    '/js/wearables-settings-groups.js',
     '/js/wearables-connect-runtime.js',
     '/js/settings-runtime-bridge.js',
     '/js/settings-sync-panel.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -354,6 +354,7 @@
     "js/wearables-polar.js",
     "js/wearables-runtime.js",
     "js/wearables-settings-runtime.js",
+    "js/wearables-settings-groups.js",
     "js/wearables-settings-panel.js",
     "js/wearables-store.js",
     "js/wearables-strip-actions.js",


### PR DESCRIPTION
## What changed

- replace the flat Wearables integration list with conditional Connected, Available integrations, Self-host integrations, and Import or enter data groups
- keep connected sources at the top and prioritize migration, reauthentication, or disabled-host warnings within that group
- order self-host integrations as Google Health, WHOOP, and Ultrahuman, while preserving hosted visibility rules
- move Apple Health import ahead of manual entry and add responsive, accessible group headings
- include the grouping helper in the PWA precache and architecture map
- add a high-level note to the existing 1.11.2 changelog entry

## Why

The previous registry-driven order placed experimental WHOOP and Ultrahuman rows beside production integrations and labeled the entire mixed list “Connected devices.” That made setup availability, self-host requirements, and existing connection state difficult to scan.

## User impact

Users see connected sources and warnings first, then supported direct providers, self-host-only options, and local import/manual paths. Hosted deployments still hide unconfigured WHOOP and Ultrahuman; localhost and configured self-hosts retain their setup rows.

## Checks

- `node tests/test-wearables.js` — 603 passed
- `node tests/test-changelog.js` — 93 passed
- `node tests/verify-modules.js` — 160 passed
- `npm run typecheck:checkjs`
- `npm run architecture:check`
- `npm run production:check`
- `npm run quality` — 17 passed
- `PORT=8011 npx playwright test tests/playwright/wearables-settings-panel-browser-coverage.spec.js --workers=1` — 3 passed
