### PR TITLE
Prevent proxy traffic from exhausting profile Blob quota

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -87,14 +87,16 @@ UVDATA_BEARER=
 # a 90-day Ultrahuman backfill) and bound the entire upstream response
 # lifecycle to 180 seconds.
 #
-# Hosted Vercel deployments require a shared Vercel Blob store for the proxy
-# rate limit and fail closed when neither token is available. Prefer a
-# dedicated private Blob token in PROXY_RATE_LIMIT_BLOB_TOKEN; when blank, the
-# existing BLOB_READ_WRITE_TOKEN used by encrypted profile sharing is reused.
+# Hosted Vercel deployments require an explicitly configured limiter and fail
+# closed when none is available. PROXY_RATE_LIMIT_BLOB_TOKEN enables the
+# cross-instance limiter, but its per-request markers consume Blob Advanced
+# Operations. BLOB_READ_WRITE_TOKEN is reserved for encrypted profile sharing
+# and is never reused by the proxy limiter.
 #
 # Non-Vercel/self-host development uses a bounded in-process fallback. Set
-# PROXY_ALLOW_INSTANCE_RATE_LIMIT=1 only when a Vercel self-host knowingly
-# accepts that weaker per-instance limit.
+# PROXY_ALLOW_INSTANCE_RATE_LIMIT=1 on Vercel only when the deployment
+# knowingly accepts that weaker per-instance limit, ideally with a Vercel
+# Firewall rule as the outer abuse-control boundary.
 
 PROXY_RATE_LIMIT_MAX=
 PROXY_RATE_LIMIT_WINDOW_MS=

--- a/api/share.js
+++ b/api/share.js
@@ -387,6 +387,24 @@ async function enforcePostRateLimit(req, options) {
 async function handlePost(req) {
   const options = blobOptions();
   if (!options) return jsonResponse(req, 503, { error: 'Profile sharing storage is not configured.' });
+  let body;
+  try {
+    body = await req.json();
+  } catch {
+    return jsonResponse(req, 400, { error: 'Invalid JSON body.' });
+  }
+  const id = validateId(body?.id);
+  if (!id) return jsonResponse(req, 400, { error: 'Invalid share id.' });
+  const manageTokenHash = String(body?.manageTokenHash || '');
+  if (!MANAGE_TOKEN_HASH_RE.test(manageTokenHash)) {
+    return jsonResponse(req, 400, { error: 'Invalid share management token.' });
+  }
+  const normalization = normalizeEnvelope(body.envelope);
+  if (normalization.error) return jsonResponse(req, 400, { error: normalization.error });
+  const normalized = normalization.value;
+  // Reject malformed or oversized input before touching Blob-backed abuse
+  // controls. Only a request that could create a share should consume an
+  // advanced Blob operation.
   let rateLimit;
   try {
     rateLimit = await enforcePostRateLimit(req, options);
@@ -404,21 +422,6 @@ async function handlePost(req) {
       { 'Retry-After': String(rateLimit.retryAfterSeconds) },
     );
   }
-  let body;
-  try {
-    body = await req.json();
-  } catch {
-    return jsonResponse(req, 400, { error: 'Invalid JSON body.' });
-  }
-  const id = validateId(body?.id);
-  if (!id) return jsonResponse(req, 400, { error: 'Invalid share id.' });
-  const manageTokenHash = String(body?.manageTokenHash || '');
-  if (!MANAGE_TOKEN_HASH_RE.test(manageTokenHash)) {
-    return jsonResponse(req, 400, { error: 'Invalid share management token.' });
-  }
-  const normalization = normalizeEnvelope(body.envelope);
-  if (normalization.error) return jsonResponse(req, 400, { error: normalization.error });
-  const normalized = normalization.value;
   try {
     if (await legacyShareIdExists(id, options)) {
       return jsonResponse(req, 409, { error: 'A shared profile with this id already exists.' });

--- a/lib/proxy-rate-limit.js
+++ b/lib/proxy-rate-limit.js
@@ -1,7 +1,7 @@
 // @ts-check
-// Shared proxy abuse control. Hosted Vercel deployments use atomic Vercel
-// Blob markers so the limit spans function instances. Local and explicitly
-// opted-in self-hosted deployments retain a bounded in-process fallback.
+// Shared proxy abuse control. Hosted Vercel deployments can use a dedicated
+// Vercel Blob store so the limit spans function instances. Local and
+// explicitly opted-in deployments retain a bounded in-process fallback.
 
 import {
   BlobPreconditionFailedError,
@@ -239,7 +239,10 @@ export async function enforceProxyRateLimit(req) {
   );
   const subject = getProxyRateLimitSubject(req);
   const env = typeof process !== 'undefined' ? process.env || {} : {};
-  const token = env.PROXY_RATE_LIMIT_BLOB_TOKEN || env.BLOB_READ_WRITE_TOKEN || '';
+  // Never reuse the profile-sharing store implicitly. Proxy and voice traffic
+  // is much higher volume and its per-request markers can otherwise exhaust
+  // the Blob operations needed to create and read encrypted profile shares.
+  const token = env.PROXY_RATE_LIMIT_BLOB_TOKEN || '';
 
   if (token) {
     const controller = new AbortController();

--- a/tests/api-network-runtime.test.js
+++ b/tests/api-network-runtime.test.js
@@ -306,7 +306,7 @@ describe('profile share API runtime behavior', () => {
 
   it('rejects invalid share payloads and reports a full rate-limit window', async () => {
     process.env.BLOB_READ_WRITE_TOKEN = 'vercel_blob_rw_store123_secret';
-    const { store } = installBlobStoreMock();
+    const { apiCalls, store } = installBlobStoreMock();
 
     const badId = await shareHandler(makeShareRequest('POST', {
       id: 'short',
@@ -335,8 +335,9 @@ describe('profile share API runtime behavior', () => {
     });
     const storedPaths = Array.from(store.keys());
     const rateLimitMarkersFromMalformedPosts = storedPaths.filter(path => path.startsWith('profile-share-rate/v2/'));
-    expect(rateLimitMarkersFromMalformedPosts).toHaveLength(3);
+    expect(rateLimitMarkersFromMalformedPosts).toEqual([]);
     expect(storedPaths.filter(path => path.startsWith('profile-shares/v2/'))).toEqual([]);
+    expect(apiCalls).toEqual([]);
 
     installBlobStoreMock({ conflictRateLimit: true });
     const limited = await shareHandler(makeShareRequest('POST', {
@@ -366,7 +367,7 @@ describe('profile share API runtime behavior', () => {
 
   it('dynamically enforces every encrypted-envelope boundary before storing a share', async () => {
     process.env.BLOB_READ_WRITE_TOKEN = 'vercel_blob_rw_store123_secret';
-    const { store } = installBlobStoreMock();
+    const { apiCalls, store } = installBlobStoreMock();
     const id = 'shareBoundaryId012345678';
     const manageTokenHash = 'a'.repeat(64);
     const cases = [
@@ -445,6 +446,7 @@ describe('profile share API runtime behavior', () => {
       expect(await responseJson(response), testCase.label).toEqual({ error: testCase.error });
     }
     expect(Array.from(store.keys()).filter(path => path.startsWith('profile-shares/v2/'))).toEqual([]);
+    expect(apiCalls).toEqual([]);
   });
 
   it('handles missing, expired, corrupt, duplicate, and unsupported-method records', async () => {

--- a/tests/proxy-rate-limit.test.js
+++ b/tests/proxy-rate-limit.test.js
@@ -203,12 +203,26 @@ describe('proxy distributed rate limit', () => {
     });
   });
 
-  it('propagates distributed storage failures so the route can return 503', async () => {
+  it('does not reuse the profile-sharing Blob token for proxy traffic', async () => {
     process.env.VERCEL = '1';
     process.env.BLOB_READ_WRITE_TOKEN = 'vercel_blob_rw_store_secret';
+
+    expect(await enforceProxyRateLimit(rateRequest('203.0.113.93'))).toEqual({
+      limited: false,
+      unavailable: true,
+      retryAfterSeconds: 60,
+      scope: 'unavailable',
+    });
+    expect(blobMock.list).not.toHaveBeenCalled();
+    expect(blobMock.put).not.toHaveBeenCalled();
+  });
+
+  it('propagates dedicated distributed storage failures so the route can return 503', async () => {
+    process.env.VERCEL = '1';
+    process.env.PROXY_RATE_LIMIT_BLOB_TOKEN = 'vercel_blob_rw_store_secret';
     blobMock.list.mockRejectedValueOnce(new Error('blob unavailable'));
 
-    await expect(enforceProxyRateLimit(rateRequest('203.0.113.93')))
+    await expect(enforceProxyRateLimit(rateRequest('203.0.113.98')))
       .rejects.toThrow('blob unavailable');
   });
 });


### PR DESCRIPTION
## Summary

- reserve `BLOB_READ_WRITE_TOKEN` exclusively for encrypted profile sharing
- require proxy and voice rate limiting to use either the explicit per-instance mode or a dedicated Blob token
- validate malformed, weak, expired, and oversized share payloads before any Blob-backed rate-limit operation
- update the production environment guidance and add regression coverage

## Root cause

The proxy limiter silently fell back to the profile-sharing Blob token. Ordinary proxy and voice requests therefore created and listed rate-limit markers in the same Blob-backed quota, consuming several Advanced Operations per request even when no profile was shared. Invalid profile-share POSTs also consumed Blob markers before their payloads were rejected.

## Impact

After deployment, normal proxy and voice traffic no longer consumes the Blob operations required by profile sharing. Invalid profile-share payloads also incur zero Blob API calls.

The production deployment should keep `BLOB_READ_WRITE_TOKEN`, leave `PROXY_RATE_LIMIT_BLOB_TOKEN` unset, and set `PROXY_ALLOW_INSTANCE_RATE_LIMIT=1`. A Vercel Firewall rate-limit rule for `POST /api/share` has been configured as the outer boundary.

## Validation

- `npm test -- tests/proxy-rate-limit.test.js tests/api-network-runtime.test.js tests/proxy-entrypoint-runtime.test.js` — 37 passed
- `node tests/test-profile-share.js` — 35 passed
- `npm run typecheck:server`
- `npm run architecture:check`
- `npm run quality`
