### PR TITLE
Establish Gate 0 migration integrity baseline

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -9,7 +9,7 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 
 | Metric | Current |
 | --- | ---: |
-| Modules | 581 |
+| Modules | 582 |
 | Internal import edges | 2502 |
 | Dynamic internal edges | 72 |
 | Modules participating in cycles | 0 |
@@ -807,6 +807,12 @@ Native browser modules shipped with the static application.
 <details><summary><code>state</code> family — 1 module</summary>
 
 - [`js/state.js`](js/state.js) → no in-scope imports
+
+</details>
+
+<details><summary><code>storage</code> family — 1 module</summary>
+
+- [`js/storage-integrity-manifest.js`](js/storage-integrity-manifest.js) → no in-scope imports
 
 </details>
 

--- a/js/storage-integrity-manifest.js
+++ b/js/storage-integrity-manifest.js
@@ -1,0 +1,276 @@
+// @ts-check
+// Privacy-safe, read-only storage integrity manifests for migration checks.
+// Raw keys and values are never included. A manifest session keeps its HMAC
+// key in memory so before/after captures can be compared without making
+// health data, credentials, wallet state, or storage identifiers recoverable
+// from exported diagnostics.
+
+export const STORAGE_INTEGRITY_MANIFEST_VERSION = 1;
+
+export const STORAGE_CATEGORIES = Object.freeze({
+  PROFILE_DATA: 'profile-data',
+  PROFILE_METADATA: 'profile-metadata',
+  PROFILE_PREFERENCES: 'profile-preferences',
+  RAW_HEALTH: 'raw-health',
+  DERIVED: 'derived',
+  CREDENTIALS: 'credentials',
+  WALLET: 'wallet',
+  SYNC: 'sync',
+  BACKUP: 'backup',
+  APP_CACHE: 'app-cache',
+  MIGRATION: 'migration',
+  SETTINGS: 'settings',
+  UNKNOWN: 'unknown',
+});
+
+const PROFILE_DATA_KEY_RE = /^labcharts-[A-Za-z0-9_-]+-(?:imported|chat|chat-threads|chat-t_.+)$/;
+const PROFILE_PREFERENCE_KEY_RE = /^labcharts-[A-Za-z0-9_-]+-(?:units|rangeMode|showAltUnits|suppOverlay|noteOverlay|phaseOverlay|chatPersonality|chatPersonalityCustom|chatRailOpen)$/;
+const WALLET_KEY_RE = /(?:cashu|routstr|wallet|ppq-credit)/i;
+const SYNC_KEY_RE = /(?:sync|relay|evolu|agent-access)/i;
+const CREDENTIAL_KEY_RE = /(?:encryption|credential|oauth|api[-_]?key|(?:^|-)key$|token)/i;
+const BACKUP_KEY_RE = /(?:backup|imported-corrupt|recovery)/i;
+const DERIVED_KEY_RE = /(?:cache|fingerprint|biology-score|correlation|benchmark)/i;
+
+function normalizeCategory(category) {
+  return Object.values(STORAGE_CATEGORIES).includes(category)
+    ? category
+    : STORAGE_CATEGORIES.UNKNOWN;
+}
+
+export function classifyLocalStorageKey(key) {
+  const value = String(key || '');
+  if (/^labcharts-migration-/.test(value)) return STORAGE_CATEGORIES.MIGRATION;
+  if (BACKUP_KEY_RE.test(value)) return STORAGE_CATEGORIES.BACKUP;
+  if (WALLET_KEY_RE.test(value)) return STORAGE_CATEGORIES.WALLET;
+  if (SYNC_KEY_RE.test(value)) return STORAGE_CATEGORIES.SYNC;
+  if (CREDENTIAL_KEY_RE.test(value)) return STORAGE_CATEGORIES.CREDENTIALS;
+  if (value === 'labcharts-profiles' || value === 'labcharts-active-profile') {
+    return STORAGE_CATEGORIES.PROFILE_METADATA;
+  }
+  if (PROFILE_DATA_KEY_RE.test(value)) return STORAGE_CATEGORIES.PROFILE_DATA;
+  if (PROFILE_PREFERENCE_KEY_RE.test(value)) return STORAGE_CATEGORIES.PROFILE_PREFERENCES;
+  if (DERIVED_KEY_RE.test(value)) return STORAGE_CATEGORIES.DERIVED;
+  if (value.startsWith('labcharts-')) return STORAGE_CATEGORIES.SETTINGS;
+  return STORAGE_CATEGORIES.UNKNOWN;
+}
+
+export function classifyDatabaseName(name) {
+  const value = String(name || '');
+  if (value === 'labcharts-blobs') return STORAGE_CATEGORIES.PROFILE_DATA;
+  if (value === 'getbased-cashu') return STORAGE_CATEGORIES.WALLET;
+  if (value === 'labcharts-backups') return STORAGE_CATEGORIES.BACKUP;
+  if (value.startsWith('labcharts-wearables-') || value.startsWith('labcharts-cycle-')) {
+    return STORAGE_CATEGORIES.RAW_HEALTH;
+  }
+  if (/evolu|sync/i.test(value)) return STORAGE_CATEGORIES.SYNC;
+  if (/migration/i.test(value)) return STORAGE_CATEGORIES.MIGRATION;
+  return STORAGE_CATEGORIES.UNKNOWN;
+}
+
+export function classifyCacheName(name) {
+  const value = String(name || '');
+  if (value.startsWith('labcharts-v')) return STORAGE_CATEGORIES.APP_CACHE;
+  if (/transformers|model|lens/i.test(value)) return STORAGE_CATEGORIES.DERIVED;
+  return STORAGE_CATEGORIES.UNKNOWN;
+}
+
+function canonicalValue(value, seen = new WeakSet()) {
+  if (value === undefined) return { $type: 'undefined' };
+  if (typeof value === 'bigint') return { $type: 'bigint', value: String(value) };
+  if (typeof value === 'number' && !Number.isFinite(value)) {
+    return { $type: 'number', value: String(value) };
+  }
+  if (!value || typeof value !== 'object') return value;
+  if (value instanceof Date) return { $type: 'date', value: value.toISOString() };
+  if (value instanceof ArrayBuffer) {
+    return { $type: 'array-buffer', value: Array.from(new Uint8Array(value)) };
+  }
+  if (ArrayBuffer.isView(value)) {
+    return {
+      $type: value.constructor?.name || 'typed-array',
+      value: Array.from(new Uint8Array(value.buffer, value.byteOffset, value.byteLength)),
+    };
+  }
+  if (seen.has(value)) throw new TypeError('Storage integrity values must not contain cycles.');
+  seen.add(value);
+  if (Array.isArray(value)) {
+    const result = value.map(item => canonicalValue(item, seen));
+    seen.delete(value);
+    return result;
+  }
+  const result = {};
+  for (const key of Object.keys(value).sort()) {
+    result[key] = canonicalValue(value[key], seen);
+  }
+  seen.delete(value);
+  return result;
+}
+
+function canonicalString(value) {
+  return JSON.stringify(canonicalValue(value));
+}
+
+async function createEphemeralFingerprinter() {
+  if (!globalThis.crypto?.subtle) {
+    throw new Error('WebCrypto is required for privacy-safe storage integrity manifests.');
+  }
+  const key = await globalThis.crypto.subtle.generateKey(
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const encoder = new TextEncoder();
+  return async value => {
+    const signature = await globalThis.crypto.subtle.sign('HMAC', key, encoder.encode(value));
+    return Array.from(new Uint8Array(signature), byte => byte.toString(16).padStart(2, '0')).join('');
+  };
+}
+
+async function fingerprintEntry(fingerprint, namespace, value) {
+  return fingerprint(`${namespace}\u0000${canonicalString(value)}`);
+}
+
+function categoryCounts(entries) {
+  const counts = {};
+  for (const entry of entries) counts[entry.category] = (counts[entry.category] || 0) + 1;
+  return Object.fromEntries(Object.entries(counts).sort(([a], [b]) => a.localeCompare(b)));
+}
+
+async function buildLocalStorageManifest(entries, fingerprint) {
+  const manifestEntries = [];
+  for (const entry of entries || []) {
+    const category = normalizeCategory(entry.category || classifyLocalStorageKey(entry.key));
+    manifestEntries.push({
+      category,
+      keyFingerprint: await fingerprintEntry(fingerprint, 'local-key', String(entry.key || '')),
+      valueFingerprint: await fingerprintEntry(fingerprint, 'local-value', entry.value),
+    });
+  }
+  manifestEntries.sort((a, b) => a.keyFingerprint.localeCompare(b.keyFingerprint));
+  return {
+    entryCount: manifestEntries.length,
+    categories: categoryCounts(manifestEntries),
+    entries: manifestEntries,
+  };
+}
+
+async function buildDatabaseManifest(databases, fingerprint) {
+  const output = [];
+  for (const database of databases || []) {
+    const category = normalizeCategory(database.category || classifyDatabaseName(database.name));
+    const stores = [];
+    for (const store of database.stores || []) {
+      const records = [];
+      for (const record of store.records || []) {
+        records.push({
+          keyFingerprint: await fingerprintEntry(fingerprint, 'idb-record-key', record.key),
+          valueFingerprint: await fingerprintEntry(fingerprint, 'idb-record-value', record.value),
+        });
+      }
+      records.sort((a, b) => a.keyFingerprint.localeCompare(b.keyFingerprint));
+      stores.push({
+        nameFingerprint: await fingerprintEntry(fingerprint, 'idb-store-name', String(store.name || '')),
+        count: Number.isSafeInteger(store.count) && store.count >= 0 ? store.count : records.length,
+        records,
+      });
+    }
+    stores.sort((a, b) => a.nameFingerprint.localeCompare(b.nameFingerprint));
+    output.push({
+      category,
+      nameFingerprint: await fingerprintEntry(fingerprint, 'idb-name', String(database.name || '')),
+      stores,
+    });
+  }
+  output.sort((a, b) => a.nameFingerprint.localeCompare(b.nameFingerprint));
+  return {
+    databaseCount: output.length,
+    categories: categoryCounts(output),
+    databases: output,
+  };
+}
+
+async function buildCacheManifest(caches, fingerprint) {
+  const output = [];
+  for (const cache of caches || []) {
+    const category = normalizeCategory(cache.category || classifyCacheName(cache.name));
+    const requestFingerprints = [];
+    for (const request of cache.requests || []) {
+      requestFingerprints.push(await fingerprintEntry(fingerprint, 'cache-request', request));
+    }
+    requestFingerprints.sort();
+    output.push({
+      category,
+      nameFingerprint: await fingerprintEntry(fingerprint, 'cache-name', String(cache.name || '')),
+      requestCount: Number.isSafeInteger(cache.requestCount) && cache.requestCount >= 0
+        ? cache.requestCount
+        : requestFingerprints.length,
+      requestFingerprints,
+    });
+  }
+  output.sort((a, b) => a.nameFingerprint.localeCompare(b.nameFingerprint));
+  return {
+    cacheCount: output.length,
+    categories: categoryCounts(output),
+    caches: output,
+  };
+}
+
+async function buildManifest(snapshot, fingerprint) {
+  return {
+    version: STORAGE_INTEGRITY_MANIFEST_VERSION,
+    localStorage: await buildLocalStorageManifest(snapshot?.localStorage, fingerprint),
+    indexedDB: await buildDatabaseManifest(snapshot?.indexedDB, fingerprint),
+    caches: await buildCacheManifest(snapshot?.caches, fingerprint),
+  };
+}
+
+export async function createStorageIntegritySession(options = {}) {
+  const fingerprint = options.fingerprint || await createEphemeralFingerprinter();
+  if (typeof fingerprint !== 'function') throw new TypeError('A fingerprint function is required.');
+  return Object.freeze({
+    capture: snapshot => buildManifest(snapshot, fingerprint),
+  });
+}
+
+function flattenManifest(manifest, allowedCategories) {
+  const entries = new Map();
+  for (const entry of manifest?.localStorage?.entries || []) {
+    if (allowedCategories.has(entry.category)) continue;
+    entries.set(`local:${entry.keyFingerprint}`, canonicalString(entry));
+  }
+  for (const database of manifest?.indexedDB?.databases || []) {
+    if (allowedCategories.has(database.category)) continue;
+    for (const store of database.stores || []) {
+      entries.set(
+        `idb:${database.nameFingerprint}:${store.nameFingerprint}`,
+        canonicalString({ category: database.category, ...store }),
+      );
+    }
+  }
+  for (const cache of manifest?.caches?.caches || []) {
+    if (allowedCategories.has(cache.category)) continue;
+    entries.set(`cache:${cache.nameFingerprint}`, canonicalString(cache));
+  }
+  return entries;
+}
+
+export function compareStorageIntegrityManifests(before, after, options = {}) {
+  if (before?.version !== STORAGE_INTEGRITY_MANIFEST_VERSION
+      || after?.version !== STORAGE_INTEGRITY_MANIFEST_VERSION) {
+    throw new Error('Unsupported storage integrity manifest version.');
+  }
+  const allowedCategories = new Set(options.allowedCategories || []);
+  const previous = flattenManifest(before, allowedCategories);
+  const next = flattenManifest(after, allowedCategories);
+  const changes = [];
+  for (const id of Array.from(new Set([...previous.keys(), ...next.keys()])).sort()) {
+    const previousValue = previous.get(id) || null;
+    const nextValue = next.get(id) || null;
+    if (previousValue === nextValue) continue;
+    changes.push({
+      id,
+      change: previousValue === null ? 'added' : nextValue === null ? 'removed' : 'changed',
+    });
+  }
+  return { unchanged: changes.length === 0, changes };
+}

--- a/scripts/dom-sink-policy.json
+++ b/scripts/dom-sink-policy.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "scope": "Every non-generated JavaScript module under js/",
   "reviewRule": "Any added or modified HTML-writing sink requires security review and a policy refresh.",
-  "scannedFiles": 562,
+  "scannedFiles": 563,
   "sinkCount": 483,
   "files": {
     "js/backup.js": {

--- a/tests/fixtures/profile-migrations/current-unversioned.json
+++ b/tests/fixtures/profile-migrations/current-unversioned.json
@@ -1,0 +1,93 @@
+{
+  "fixtureSchema": 1,
+  "releaseRange": "current-unversioned",
+  "description": "Synthetic current profile used to prove no-op stability before schema versions are introduced.",
+  "profile": {
+    "entries": [
+      {
+        "id": "entry_current_001",
+        "date": "2026-07-01",
+        "markers": {
+          "biochemistry.glucose": 4.9
+        },
+        "updatedAt": 1782864000000
+      }
+    ],
+    "notes": [
+      {
+        "id": "note_current_001",
+        "date": "2026-07-02",
+        "text": "Synthetic current note",
+        "updatedAt": 1782950400000
+      }
+    ],
+    "supplements": [],
+    "healthGoals": [],
+    "diagnoses": null,
+    "diet": null,
+    "exercise": null,
+    "sleepRest": null,
+    "lightCircadian": null,
+    "stress": null,
+    "loveLife": null,
+    "environment": null,
+    "interpretiveLens": "",
+    "contextNotes": "",
+    "menstrualCycle": null,
+    "emfAssessment": null,
+    "genetics": null,
+    "customMarkers": {},
+    "markerNotes": {},
+    "markerValueNotes": {},
+    "biologyScoreAI": {},
+    "contextSourceSettings": {
+      "lab-markers": true,
+      "wearables": false
+    },
+    "changeHistory": [],
+    "importSnapshots": [],
+    "biometrics": null,
+    "manualValues": {},
+    "sunSessions": [],
+    "deviceSessions": [],
+    "lightDevices": [],
+    "lightEnvironment": null,
+    "lightMeasurements": [],
+    "lightAudits": [],
+    "sunCorrelations": null,
+    "lifelightProfile": null,
+    "sunDefaults": null,
+    "currentUnknownSurface": {
+      "preserve": [
+        "alpha",
+        "beta"
+      ]
+    }
+  },
+  "expect": {
+    "removedPaths": [],
+    "preservedPaths": [
+      "entries",
+      "notes",
+      "contextSourceSettings",
+      "currentUnknownSurface"
+    ],
+    "arrayCounts": {
+      "entries": 1,
+      "notes": 1,
+      "supplements": 0,
+      "healthGoals": 0,
+      "sunSessions": 0,
+      "lightDevices": 0
+    },
+    "expectedPaths": {
+      "/entries/0/id": "entry_current_001",
+      "/entries/0/markers/biochemistry.glucose": 4.9,
+      "/notes/0/id": "note_current_001",
+      "contextSourceSettings": {
+        "lab-markers": true,
+        "wearables": false
+      }
+    }
+  }
+}

--- a/tests/fixtures/profile-migrations/pre-v1.6.json
+++ b/tests/fixtures/profile-migrations/pre-v1.6.json
@@ -1,0 +1,92 @@
+{
+  "fixtureSchema": 1,
+  "releaseRange": "pre-v1.6",
+  "description": "Synthetic legacy profile covering the oldest context and laboratory migrations still supported by GetBased.",
+  "profile": {
+    "entries": [
+      {
+        "date": "2024-01-15",
+        "markers": {
+          "hematology.hematocrit": 0.42
+        }
+      }
+    ],
+    "notes": [
+      {
+        "date": "2024-01-16",
+        "text": "Synthetic historical note"
+      }
+    ],
+    "supplements": [
+      {
+        "name": "Synthetic mineral",
+        "startDate": "2024-01-01"
+      }
+    ],
+    "healthGoals": [
+      {
+        "text": "Improve sleep",
+        "severity": "medium"
+      }
+    ],
+    "sleepCircadian": "Usually seven hours with an inconsistent bedtime.",
+    "circadian": "Morning outdoor light when possible.",
+    "sleep": "Legacy sleep note.",
+    "fieldExperts": "Synthetic expert context.",
+    "fieldLens": "Synthetic interpretive context.",
+    "diagnoses": "Synthetic migraine history.",
+    "diet": "Synthetic mixed diet.",
+    "exercise": "Synthetic daily walking.",
+    "customMarkers": {},
+    "markerNotes": {
+      "hematology.hematocrit": "Historical marker note"
+    },
+    "markerValueNotes": {},
+    "refOverrides": {
+      "hematology.hematocrit": {
+        "refMin": 0.36,
+        "refMax": 0.46,
+        "optimalMin": 0.39,
+        "optimalMax": 0.44
+      }
+    },
+    "legacyUnknownSurface": {
+      "preserve": true,
+      "label": "unknown fields must survive"
+    }
+  },
+  "expect": {
+    "removedPaths": [
+      "sleepCircadian",
+      "circadian",
+      "sleep",
+      "fieldExperts",
+      "fieldLens"
+    ],
+    "preservedPaths": [
+      "notes",
+      "supplements",
+      "healthGoals",
+      "markerNotes",
+      "legacyUnknownSurface"
+    ],
+    "arrayCounts": {
+      "entries": 1,
+      "notes": 1,
+      "supplements": 1,
+      "healthGoals": 1
+    },
+    "expectedPaths": {
+      "/entries/0/markers/hematology.hematocrit": 42,
+      "diagnoses.note": "Synthetic migraine history.",
+      "diet.note": "Synthetic mixed diet.",
+      "exercise.note": "Synthetic daily walking.",
+      "sleepRest.note": "Usually seven hours with an inconsistent bedtime.",
+      "interpretiveLens": "Synthetic expert context.\n\nSynthetic interpretive context.",
+      "/refOverrides/hematology.hematocrit/refMin": 36,
+      "/refOverrides/hematology.hematocrit/refMax": 46,
+      "/refOverrides/hematology.hematocrit/optimalMin": 39,
+      "/refOverrides/hematology.hematocrit/optimalMax": 44
+    }
+  }
+}

--- a/tests/fixtures/profile-migrations/v1.7-structured-context.json
+++ b/tests/fixtures/profile-migrations/v1.7-structured-context.json
@@ -1,0 +1,127 @@
+{
+  "fixtureSchema": 1,
+  "releaseRange": "v1.7-era",
+  "description": "Synthetic structured-context profile covering later context, light, EMF, and sun-default migrations.",
+  "profile": {
+    "entries": [
+      {
+        "date": "2025-02-01",
+        "markers": {
+          "biochemistry.glucose": 5.1
+        }
+      }
+    ],
+    "notes": [],
+    "supplements": [],
+    "healthGoals": [],
+    "diagnoses": {
+      "conditions": [
+        "Synthetic condition"
+      ],
+      "note": "",
+      "familyHistory": null
+    },
+    "diet": {
+      "type": "omnivore",
+      "restrictions": [],
+      "pattern": null,
+      "note": ""
+    },
+    "exercise": {
+      "frequency": "3x weekly",
+      "types": [
+        "walking"
+      ],
+      "intensity": "moderate",
+      "dailyMovement": null,
+      "note": ""
+    },
+    "sleepRest": {
+      "duration": "7h",
+      "quality": "fair",
+      "schedule": null,
+      "issues": [],
+      "note": ""
+    },
+    "lightCircadian": {
+      "timing": "legacy",
+      "practices": [
+        "morning sunlight",
+        "blue light blockers",
+        "no screens before bed",
+        "red light therapy",
+        "UVB exposure"
+      ],
+      "mealTiming": [
+        "early dinner"
+      ],
+      "note": ""
+    },
+    "emfAssessment": {
+      "legacy": true
+    },
+    "contextSourceSettings": {
+      "wearables": false,
+      "lab-group-biochemistry": true,
+      "not-a-real-source": true,
+      "light-sun": "yes"
+    },
+    "sunDefaults": {
+      "location": {
+        "lat": 50.0755,
+        "lon": 14.4378,
+        "label": "Synthetic Prague"
+      }
+    },
+    "customMarkers": {},
+    "markerNotes": {},
+    "markerValueNotes": {},
+    "structuredUnknownSurface": {
+      "nested": {
+        "preserve": "yes"
+      }
+    }
+  },
+  "expect": {
+    "removedPaths": [
+      "lightCircadian.timing",
+      "lightCircadian.practices",
+      "sunDefaults.location"
+    ],
+    "preservedPaths": [
+      "entries",
+      "diagnoses.conditions",
+      "structuredUnknownSurface"
+    ],
+    "arrayCounts": {
+      "entries": 1,
+      "notes": 0,
+      "supplements": 0,
+      "healthGoals": 0
+    },
+    "expectedPaths": {
+      "diagnoses.familyHistory": [],
+      "lightCircadian.amLight": "morning outdoor (after sunrise)",
+      "lightCircadian.uvExposure": "UVB lamp",
+      "lightCircadian.evening": [
+        "blue blockers after sunset",
+        "no screens 1-2h before bed"
+      ],
+      "lightCircadian.mealTiming": [
+        "early dinner"
+      ],
+      "lightCircadian.note": "red light therapy",
+      "emfAssessment": null,
+      "contextSourceSettings": {
+        "wearables": false,
+        "lab-group-biochemistry": true
+      },
+      "sunDefaults.coords": {
+        "lat": 50.0755,
+        "lon": 14.4378,
+        "source": "profile-precise",
+        "label": "Synthetic Prague"
+      }
+    }
+  }
+}

--- a/tests/profile-migration-characterization.test.js
+++ b/tests/profile-migration-characterization.test.js
@@ -1,0 +1,83 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+import { migrateProfileData } from '../js/profile-data-migrations.js';
+
+const FIXTURE_FILES = [
+  'pre-v1.6.json',
+  'v1.7-structured-context.json',
+  'current-unversioned.json',
+];
+
+function readFixture(filename) {
+  return JSON.parse(readFileSync(
+    new URL(`./fixtures/profile-migrations/${filename}`, import.meta.url),
+    'utf8',
+  ));
+}
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function canonicalize(value) {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (!value || typeof value !== 'object') return value;
+  return Object.fromEntries(
+    Object.keys(value).sort().map(key => [key, canonicalize(value[key])]),
+  );
+}
+
+function readPath(root, path) {
+  const segments = path.startsWith('/') ? path.slice(1).split('/') : path.split('.');
+  return segments.reduce((value, segment) => value?.[segment], root);
+}
+
+function hasPath(root, path) {
+  const segments = path.split('.');
+  let value = root;
+  for (const segment of segments) {
+    if (!value || typeof value !== 'object' || !Object.hasOwn(value, segment)) return false;
+    value = value[segment];
+  }
+  return true;
+}
+
+describe('historical profile migration characterization', () => {
+  for (const filename of FIXTURE_FILES) {
+    const fixture = readFixture(filename);
+
+    it(`${fixture.releaseRange} migrates deterministically without losing unrelated data`, () => {
+      expect(fixture.fixtureSchema).toBe(1);
+      const original = clone(fixture.profile);
+      const first = migrateProfileData(clone(original));
+      const independentlyMigrated = migrateProfileData(clone(original));
+
+      expect(canonicalize(first)).toEqual(canonicalize(independentlyMigrated));
+
+      for (const path of fixture.expect.removedPaths) {
+        expect(hasPath(first, path), `expected ${path} to be removed`).toBe(false);
+      }
+      for (const path of fixture.expect.preservedPaths) {
+        expect(readPath(first, path), `expected ${path} to be preserved`)
+          .toEqual(readPath(original, path));
+      }
+      for (const [path, count] of Object.entries(fixture.expect.arrayCounts)) {
+        expect(readPath(first, path), `expected ${path} to remain an array`).toHaveLength(count);
+      }
+      for (const [path, expected] of Object.entries(fixture.expect.expectedPaths)) {
+        expect(readPath(first, path), `unexpected migrated value at ${path}`).toEqual(expected);
+      }
+    });
+
+    it(`${fixture.releaseRange} is idempotent after the first migration`, () => {
+      const migrated = migrateProfileData(clone(fixture.profile));
+      const once = canonicalize(migrated);
+
+      migrateProfileData(migrated);
+
+      expect(canonicalize(migrated)).toEqual(once);
+    });
+  }
+});

--- a/tests/storage-integrity-manifest.test.js
+++ b/tests/storage-integrity-manifest.test.js
@@ -1,0 +1,115 @@
+import { createHash } from 'node:crypto';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  STORAGE_CATEGORIES,
+  classifyCacheName,
+  classifyDatabaseName,
+  classifyLocalStorageKey,
+  compareStorageIntegrityManifests,
+  createStorageIntegritySession,
+} from '../js/storage-integrity-manifest.js';
+
+function testFingerprint(value) {
+  return Promise.resolve(createHash('sha256').update(`test-only-key\u0000${value}`).digest('hex'));
+}
+
+function storageSnapshot({ profileValue = 'encrypted-profile-v1', walletValue = 'encrypted-wallet-v1' } = {}) {
+  return {
+    localStorage: [
+      { key: 'labcharts-profile_alpha-imported', value: profileValue },
+      { key: 'labcharts-openrouter-key', value: 'sk-user-secret' },
+      { key: 'labcharts-sync-enabled', value: 'true' },
+      { key: 'labcharts-routstr-key', value: walletValue },
+    ],
+    indexedDB: [
+      {
+        name: 'labcharts-blobs',
+        stores: [{
+          name: 'kv',
+          count: 1,
+          records: [{ key: 'labcharts-profile_alpha-imported', value: profileValue }],
+        }],
+      },
+      {
+        name: 'getbased-cashu',
+        stores: [
+          { name: 'proofs', count: 2 },
+          { name: 'meta', count: 3 },
+        ],
+      },
+    ],
+    caches: [
+      {
+        name: 'labcharts-v1.11.0',
+        requests: ['/app', '/js/main.js'],
+      },
+    ],
+  };
+}
+
+describe('storage integrity policy', () => {
+  it('classifies migration-sensitive and protected surfaces', () => {
+    expect(classifyLocalStorageKey('labcharts-profile_alpha-imported'))
+      .toBe(STORAGE_CATEGORIES.PROFILE_DATA);
+    expect(classifyLocalStorageKey('labcharts-openrouter-key'))
+      .toBe(STORAGE_CATEGORIES.CREDENTIALS);
+    expect(classifyLocalStorageKey('labcharts-routstr-key'))
+      .toBe(STORAGE_CATEGORIES.WALLET);
+    expect(classifyLocalStorageKey('labcharts-sync-enabled'))
+      .toBe(STORAGE_CATEGORIES.SYNC);
+    expect(classifyDatabaseName('getbased-cashu')).toBe(STORAGE_CATEGORIES.WALLET);
+    expect(classifyDatabaseName('labcharts-wearables-profile_alpha'))
+      .toBe(STORAGE_CATEGORIES.RAW_HEALTH);
+    expect(classifyCacheName('labcharts-v1.11.0')).toBe(STORAGE_CATEGORIES.APP_CACHE);
+  });
+});
+
+describe('privacy-safe storage integrity manifests', () => {
+  it('produces stable comparisons without exposing raw identifiers or values', async () => {
+    const session = await createStorageIntegritySession({ fingerprint: testFingerprint });
+    const first = await session.capture(storageSnapshot());
+    const second = await session.capture(storageSnapshot());
+
+    expect(second).toEqual(first);
+    expect(compareStorageIntegrityManifests(first, second)).toEqual({
+      unchanged: true,
+      changes: [],
+    });
+
+    const serialized = JSON.stringify(first);
+    for (const sensitiveText of [
+      'profile_alpha',
+      'sk-user-secret',
+      'encrypted-profile-v1',
+      'encrypted-wallet-v1',
+      '/js/main.js',
+    ]) {
+      expect(serialized).not.toContain(sensitiveText);
+    }
+  });
+
+  it('allows the migration target while detecting protected-store changes', async () => {
+    const session = await createStorageIntegritySession({ fingerprint: testFingerprint });
+    const before = await session.capture(storageSnapshot());
+    const profileChanged = await session.capture(storageSnapshot({
+      profileValue: 'encrypted-profile-v2',
+    }));
+    const protectedChange = await session.capture(storageSnapshot({
+      walletValue: 'encrypted-wallet-v2',
+    }));
+
+    expect(compareStorageIntegrityManifests(before, profileChanged, {
+      allowedCategories: [STORAGE_CATEGORIES.PROFILE_DATA],
+    })).toEqual({ unchanged: true, changes: [] });
+
+    const comparison = compareStorageIntegrityManifests(before, protectedChange, {
+      allowedCategories: [STORAGE_CATEGORIES.PROFILE_DATA],
+    });
+    expect(comparison.unchanged).toBe(false);
+    expect(comparison.changes).toHaveLength(1);
+    expect(comparison.changes[0].change).toBe('changed');
+    expect(JSON.stringify(comparison)).not.toContain('encrypted-wallet-v2');
+  });
+});

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -515,6 +515,7 @@
     "js/notes.js",
     "js/profile-list-store.js",
     "js/profile-context.js",
+    "js/storage-integrity-manifest.js",
     "js/provider-local-ai-runtime.js",
     "js/provider-local-ai-controls.js",
     "js/provider-panel-delegates.js",


### PR DESCRIPTION
## Summary

- add three synthetic historical profile fixtures covering pre-v1.6, v1.7-era, and current unversioned shapes
- characterize the existing migration path for deterministic output, idempotence, expected legacy transformations, array-count preservation, and unknown-field preservation
- add a privacy-safe storage integrity manifest core with categories for profile data, metadata, preferences, raw health stores, credentials, wallets, sync, backups, caches, derived data, and migration state
- compare before/after manifests while explicitly allowing only the intended migration category
- fingerprint every storage identifier and value with a session-scoped HMAC so diagnostics contain neither raw keys nor raw values
- regenerate the architecture map for the new leaf module

## Why

GetBased currently applies a versionless, in-place profile migration during load, save, import, and sync. Before introducing schema versions or changing persistence behavior, Gate 0 needs a stable behavioral baseline and a way to prove that protected stores remain untouched.

This PR establishes those foundations without wiring any new production storage reads or writes.

## User impact

None. The new module is not imported by the application yet, and the fixtures are synthetic. No existing profile, credential, wallet, sync state, backup, or cache behavior changes.

## Validation

- `npm test -- tests/profile-migration-characterization.test.js tests/storage-integrity-manifest.test.js` — 9 passed
- `npm test -- tests/profile-data-boundaries.test.js` — 2 passed
- `npm run typecheck:checkjs`
- `npm run quality`
- `npm run architecture:build` — 582 modules, 0 cycles
