### PR TITLE
Add shadow profile migration registry

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -9,8 +9,8 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 
 | Metric | Current |
 | --- | ---: |
-| Modules | 582 |
-| Internal import edges | 2502 |
+| Modules | 583 |
+| Internal import edges | 2503 |
 | Dynamic internal edges | 72 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -679,7 +679,7 @@ Native browser modules shipped with the static application.
 
 </details>
 
-<details><summary><code>profile</code> family — 11 modules</summary>
+<details><summary><code>profile</code> family — 12 modules</summary>
 
 - [`js/profile-context.js`](js/profile-context.js) → [`js/context-source-registry.js`](js/context-source-registry.js), [`js/state.js`](js/state.js)
 - [`js/profile-data-migrations.js`](js/profile-data-migrations.js) → [`js/adapters.js`](js/adapters.js), [`js/context-source-registry.js`](js/context-source-registry.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/light-env-evening.js`](js/light-env-evening.js), [`js/profile-marker-migrations.js`](js/profile-marker-migrations.js), [`js/schema.js`](js/schema.js)
@@ -687,6 +687,7 @@ Native browser modules shipped with the static application.
 - [`js/profile-list-store.js`](js/profile-list-store.js) → [`js/crypto.js`](js/crypto.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/profile-marker-migrations.js`](js/profile-marker-migrations.js) → [`js/adapters.js`](js/adapters.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/profile-fatty-acid-migrations.js`](js/profile-fatty-acid-migrations.js), [`js/schema.js`](js/schema.js)
 - [`js/profile-runtime.js`](js/profile-runtime.js) → [`js/chat-loader.js`](js/chat-loader.js), [`js/state.js`](js/state.js), [`js/wearables-connect.js`](js/wearables-connect.js) *(dynamic)*
+- [`js/profile-schema-migrations.js`](js/profile-schema-migrations.js) → [`js/profile-data-migrations.js`](js/profile-data-migrations.js)
 - [`js/profile-share-loader.js`](js/profile-share-loader.js) → [`js/profile-share.js`](js/profile-share.js) *(dynamic)*, [`js/utils-runtime.js`](js/utils-runtime.js), [`js/utils.js`](js/utils.js)
 - [`js/profile-share.js`](js/profile-share.js) → [`js/caught-error.js`](js/caught-error.js), [`js/export.js`](js/export.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils-runtime.js`](js/utils-runtime.js), [`js/utils.js`](js/utils.js)
 - [`js/profile-storage-cleanup.js`](js/profile-storage-cleanup.js) → [`js/blob-storage.js`](js/blob-storage.js), [`js/crypto.js`](js/crypto.js), [`js/cycle-store.js`](js/cycle-store.js), [`js/profile-storage-key.js`](js/profile-storage-key.js), [`js/wearables-store.js`](js/wearables-store.js)

--- a/js/profile-schema-migrations.js
+++ b/js/profile-schema-migrations.js
@@ -1,0 +1,389 @@
+// @ts-check
+// profile-schema-migrations.js — Copy-on-write, sequential profile migrations.
+
+import { migrateProfileData } from './profile-data-migrations.js';
+
+/** @typedef {Record<string, any>} ProfileObject */
+/**
+ * @typedef {{
+ *   id: string,
+ *   fromVersion: number,
+ *   toVersion: number,
+ *   migrate: (draft: ProfileObject) => void,
+ * }} ProfileMigrationStep
+ */
+/**
+ * @typedef {{
+ *   ok: false,
+ *   mode: 'shadow',
+ *   targetVersion: number,
+ *   error: { code: string, message: string, [key: string]: unknown },
+ * }} ProfileMigrationFailure
+ */
+/**
+ * @typedef {{
+ *   ok: true,
+ *   mode: 'shadow',
+ *   fromVersion: number,
+ *   toVersion: number,
+ *   changed: boolean,
+ *   appliedMigrations: Array<{ id: string, fromVersion: number, toVersion: number }>,
+ *   validation: { counts: Record<string, number>, identifiedRecords: number },
+ *   data: ProfileObject,
+ * }} ProfileMigrationSuccess
+ */
+/** @typedef {ProfileMigrationFailure | ProfileMigrationSuccess} ProfileMigrationResult */
+
+export const LEGACY_PROFILE_SCHEMA_VERSION = 0;
+export const CURRENT_PROFILE_SCHEMA_VERSION = 1;
+
+const REQUIRED_COLLECTIONS = Object.freeze([
+  'entries',
+  'notes',
+  'supplements',
+  'healthGoals',
+  'changeHistory',
+  'importSnapshots',
+  'sunSessions',
+  'deviceSessions',
+  'lightDevices',
+  'lightMeasurements',
+  'lightAudits',
+]);
+
+const REQUIRED_MAPS = Object.freeze([
+  'customMarkers',
+  'markerNotes',
+  'markerValueNotes',
+  'biologyScoreAI',
+  'contextSourceSettings',
+]);
+
+// These roots are the complete mutation surface of the existing migration
+// chain and its marker-repair helpers. Any other existing root must compare
+// equal after a migration.
+const CONTENT_MUTABLE_ROOTS = new Set([
+  'sleepCircadian',
+  'sleepRest',
+  'lightCircadian',
+  'circadian',
+  'sleep',
+  'fieldExperts',
+  'fieldLens',
+  'interpretiveLens',
+  'diagnoses',
+  'diet',
+  'exercise',
+  'customMarkers',
+  'entries',
+  'manualValues',
+  'markerLabels',
+  'markerNotes',
+  'markerValueNotes',
+  'refOverrides',
+  'importSnapshots',
+  'emfAssessment',
+  'contextSourceSettings',
+  'lightEnvironment',
+  'sunDefaults',
+]);
+
+// These fields may be added when absent, but an existing value may not be
+// rewritten unless the root also appears in CONTENT_MUTABLE_ROOTS.
+const INITIALIZED_ROOTS = new Set([
+  'entries',
+  'notes',
+  'supplements',
+  'healthGoals',
+  'sleepRest',
+  'lightCircadian',
+  'stress',
+  'loveLife',
+  'environment',
+  'interpretiveLens',
+  'contextNotes',
+  'customMarkers',
+  'menstrualCycle',
+  'emfAssessment',
+  'genetics',
+  'markerNotes',
+  'markerValueNotes',
+  'biologyScoreAI',
+  'contextSourceSettings',
+  'changeHistory',
+  'importSnapshots',
+  'biometrics',
+  'sunSessions',
+  'deviceSessions',
+  'lightDevices',
+  'lightEnvironment',
+  'lightMeasurements',
+  'lightAudits',
+  'sunCorrelations',
+  'lifelightProfile',
+  'sunDefaults',
+]);
+
+/** @param {unknown} value */
+function isPlainObject(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+/**
+ * @param {unknown} value
+ * @param {Set<object>} [ancestors]
+ * @returns {string | null}
+ */
+function findUnsupportedProfileValue(value, ancestors = new Set()) {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return null;
+  if (typeof value === 'number') return Number.isFinite(value) ? null : 'NON_FINITE_NUMBER';
+  if (typeof value !== 'object') return 'NON_JSON_VALUE';
+  if (ancestors.has(/** @type {object} */ (value))) return 'CYCLIC_VALUE';
+  if (!Array.isArray(value) && !isPlainObject(value)) return 'NON_PLAIN_OBJECT';
+
+  ancestors.add(/** @type {object} */ (value));
+  const children = Array.isArray(value) ? value : Object.values(value);
+  for (const child of children) {
+    const issue = findUnsupportedProfileValue(child, ancestors);
+    if (issue) return issue;
+  }
+  ancestors.delete(/** @type {object} */ (value));
+  return null;
+}
+
+/** @param {ProfileObject} value */
+function cloneProfileObject(value) {
+  return /** @type {ProfileObject} */ (JSON.parse(JSON.stringify(value)));
+}
+
+/** @param {unknown} left @param {unknown} right */
+function jsonEqual(left, right) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+/** @param {unknown} value */
+function profileSchemaVersion(value) {
+  if (
+    !isPlainObject(value)
+    || !Object.hasOwn(/** @type {object} */ (value), 'schemaVersion')
+  ) {
+    return LEGACY_PROFILE_SCHEMA_VERSION;
+  }
+  return /** @type {ProfileObject} */ (value).schemaVersion;
+}
+
+/** @param {ProfileObject} draft */
+function migrateLegacyProfileToV1(draft) {
+  if (draft.entries === undefined) draft.entries = [];
+  if (draft.notes === undefined) draft.notes = [];
+  if (draft.supplements === undefined) draft.supplements = [];
+  migrateProfileData(/** @type {import('../types/app-state.js').ProfileData} */ (draft));
+  draft.schemaVersion = 1;
+}
+
+/** @type {readonly ProfileMigrationStep[]} */
+export const PROFILE_MIGRATION_REGISTRY = Object.freeze([
+  Object.freeze({
+    id: 'profile-v0-to-v1-normalize',
+    fromVersion: 0,
+    toVersion: 1,
+    migrate: migrateLegacyProfileToV1,
+  }),
+]);
+
+/**
+ * @param {unknown} registry
+ * @returns {{ ok: true, stepsByVersion: Map<number, ProfileMigrationStep> } | { ok: false, reason: string }}
+ */
+function compileMigrationRegistry(registry) {
+  if (!Array.isArray(registry)) return { ok: false, reason: 'REGISTRY_NOT_ARRAY' };
+  const stepsByVersion = new Map();
+  for (const candidate of registry) {
+    if (!isPlainObject(candidate)) return { ok: false, reason: 'STEP_NOT_OBJECT' };
+    const step = /** @type {ProfileMigrationStep} */ (candidate);
+    if (!/^[a-z0-9][a-z0-9-]{2,80}$/.test(step.id || '')) {
+      return { ok: false, reason: 'STEP_ID_INVALID' };
+    }
+    if (!Number.isInteger(step.fromVersion) || step.fromVersion < 0) {
+      return { ok: false, reason: 'STEP_FROM_VERSION_INVALID' };
+    }
+    if (step.toVersion !== step.fromVersion + 1) {
+      return { ok: false, reason: 'STEP_NOT_SEQUENTIAL' };
+    }
+    if (typeof step.migrate !== 'function') return { ok: false, reason: 'STEP_MIGRATOR_INVALID' };
+    if (stepsByVersion.has(step.fromVersion)) return { ok: false, reason: 'STEP_DUPLICATE_SOURCE' };
+    stepsByVersion.set(step.fromVersion, step);
+  }
+  return { ok: true, stepsByVersion };
+}
+
+/**
+ * Check registry structure without executing a migration.
+ * @param {unknown} [registry]
+ * @returns {{ ok: true } | { ok: false, reason: string }}
+ */
+export function validateProfileMigrationRegistry(registry = PROFILE_MIGRATION_REGISTRY) {
+  const compiled = compileMigrationRegistry(registry);
+  return compiled.ok ? { ok: true } : compiled;
+}
+
+/** @param {ProfileObject} data */
+function collectionSummary(data) {
+  const counts = /** @type {Record<string, number>} */ ({});
+  let identifiedRecords = 0;
+  for (const field of REQUIRED_COLLECTIONS) {
+    const collection = data[field];
+    if (!Array.isArray(collection)) continue;
+    counts[field] = collection.length;
+    identifiedRecords += collection.filter(item => (
+      isPlainObject(item)
+      && Object.hasOwn(/** @type {ProfileObject} */ (item), 'id')
+    )).length;
+  }
+  return { counts, identifiedRecords };
+}
+
+/** @param {ProfileObject} data @param {string} field */
+function collectionIdentitySignature(data, field) {
+  const collection = data[field];
+  if (!Array.isArray(collection)) return null;
+  return collection.map(item => {
+    if (!isPlainObject(item) || !Object.hasOwn(item, 'id')) return null;
+    const id = /** @type {ProfileObject} */ (item).id;
+    return typeof id === 'string' || typeof id === 'number' ? `${typeof id}:${id}` : null;
+  });
+}
+
+/**
+ * @param {ProfileObject} before
+ * @param {ProfileObject} after
+ * @param {number} targetVersion
+ * @returns {{ ok: true, summary: ReturnType<typeof collectionSummary> } | { ok: false, reason: string, field?: string }}
+ */
+function validateMigratedProfile(before, after, targetVersion) {
+  if (!isPlainObject(after)) return { ok: false, reason: 'PROFILE_NOT_OBJECT' };
+  if (after.schemaVersion !== targetVersion) return { ok: false, reason: 'VERSION_STAMP_MISMATCH' };
+
+  for (const field of REQUIRED_COLLECTIONS) {
+    if (!Array.isArray(after[field])) return { ok: false, reason: 'REQUIRED_COLLECTION_INVALID', field };
+    if (Array.isArray(before[field]) && before[field].length !== after[field].length) {
+      return { ok: false, reason: 'COLLECTION_COUNT_CHANGED', field };
+    }
+    const beforeIds = collectionIdentitySignature(before, field);
+    const afterIds = collectionIdentitySignature(after, field);
+    if (beforeIds && !jsonEqual(beforeIds, afterIds)) {
+      return { ok: false, reason: 'COLLECTION_IDENTITY_CHANGED', field };
+    }
+  }
+
+  for (const field of REQUIRED_MAPS) {
+    if (!isPlainObject(after[field])) return { ok: false, reason: 'REQUIRED_MAP_INVALID', field };
+  }
+
+  const allRoots = new Set([...Object.keys(before), ...Object.keys(after)]);
+  for (const field of allRoots) {
+    if (field === 'schemaVersion' || CONTENT_MUTABLE_ROOTS.has(field)) continue;
+    if (!Object.hasOwn(before, field) && INITIALIZED_ROOTS.has(field)) continue;
+    if (!Object.hasOwn(before, field) || !Object.hasOwn(after, field)) {
+      return { ok: false, reason: 'PROTECTED_ROOT_SET_CHANGED', field };
+    }
+    if (!jsonEqual(before[field], after[field])) {
+      return { ok: false, reason: 'PROTECTED_ROOT_VALUE_CHANGED', field };
+    }
+  }
+
+  return { ok: true, summary: collectionSummary(after) };
+}
+
+/**
+ * Run profile migrations against a detached copy. This function never writes
+ * storage and never mutates the caller's value.
+ *
+ * @param {unknown} input
+ * @param {{ targetVersion?: number, registry?: readonly ProfileMigrationStep[] }} [options]
+ * @returns {ProfileMigrationResult}
+ */
+export function runProfileMigrationsInShadow(input, options = {}) {
+  const targetVersion = options.targetVersion ?? CURRENT_PROFILE_SCHEMA_VERSION;
+  /**
+   * @param {string} code
+   * @param {string} message
+   * @param {Record<string, unknown>} [extra]
+   * @returns {ProfileMigrationFailure}
+   */
+  const fail = (code, message, extra = {}) => ({
+    ok: false,
+    mode: 'shadow',
+    targetVersion,
+    error: { code, message, ...extra },
+  });
+
+  if (!isPlainObject(input)) {
+    return fail('PROFILE_INPUT_INVALID', 'Profile data must be a plain object.');
+  }
+  const unsupported = findUnsupportedProfileValue(input);
+  if (unsupported) {
+    return fail('PROFILE_INPUT_UNSERIALIZABLE', 'Profile data is not safely serializable.', { reason: unsupported });
+  }
+  if (!Number.isInteger(targetVersion) || targetVersion < 1 || targetVersion > CURRENT_PROFILE_SCHEMA_VERSION) {
+    return fail('PROFILE_TARGET_VERSION_INVALID', 'Requested profile schema version is unsupported.');
+  }
+
+  const fromVersion = profileSchemaVersion(input);
+  if (!Number.isInteger(fromVersion) || fromVersion < 0) {
+    return fail('PROFILE_SCHEMA_VERSION_INVALID', 'Stored profile schema version is invalid.');
+  }
+  if (fromVersion > CURRENT_PROFILE_SCHEMA_VERSION) {
+    return fail('PROFILE_SCHEMA_VERSION_FUTURE', 'This profile requires a newer GetBased version.', { fromVersion });
+  }
+  if (fromVersion > targetVersion) {
+    return fail('PROFILE_DOWNGRADE_UNSUPPORTED', 'Profile schema downgrades are not supported.', { fromVersion });
+  }
+
+  const compiled = compileMigrationRegistry(options.registry ?? PROFILE_MIGRATION_REGISTRY);
+  if ('reason' in compiled) {
+    return fail('MIGRATION_REGISTRY_INVALID', 'Profile migration registry is invalid.', { reason: compiled.reason });
+  }
+
+  const before = cloneProfileObject(/** @type {ProfileObject} */ (input));
+  const draft = cloneProfileObject(before);
+  const appliedMigrations = [];
+  let version = fromVersion;
+  while (version < targetVersion) {
+    const step = compiled.stepsByVersion.get(version);
+    if (!step) {
+      return fail('MIGRATION_STEP_MISSING', 'A required profile migration step is unavailable.', { fromVersion: version });
+    }
+    try {
+      step.migrate(draft);
+    } catch {
+      return fail('MIGRATION_STEP_FAILED', 'A profile migration step failed safely.', { migrationId: step.id });
+    }
+    if (draft.schemaVersion !== step.toVersion) {
+      return fail('MIGRATION_VERSION_NOT_ADVANCED', 'A profile migration did not stamp its target version.', { migrationId: step.id });
+    }
+    appliedMigrations.push({ id: step.id, fromVersion: step.fromVersion, toVersion: step.toVersion });
+    version = step.toVersion;
+  }
+
+  const validation = validateMigratedProfile(before, draft, targetVersion);
+  if ('reason' in validation) {
+    return fail('PROFILE_VALIDATION_FAILED', 'Shadow-migrated profile data failed validation.', {
+      reason: validation.reason,
+      ...('field' in validation && validation.field ? { field: validation.field } : {}),
+    });
+  }
+
+  return {
+    ok: true,
+    mode: 'shadow',
+    fromVersion,
+    toVersion: targetVersion,
+    changed: !jsonEqual(before, draft),
+    appliedMigrations,
+    validation: validation.summary,
+    data: draft,
+  };
+}

--- a/scripts/dom-sink-policy.json
+++ b/scripts/dom-sink-policy.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "scope": "Every non-generated JavaScript module under js/",
   "reviewRule": "Any added or modified HTML-writing sink requires security review and a policy refresh.",
-  "scannedFiles": 563,
+  "scannedFiles": 564,
   "sinkCount": 483,
   "files": {
     "js/backup.js": {

--- a/tests/profile-schema-migrations.test.js
+++ b/tests/profile-schema-migrations.test.js
@@ -1,0 +1,195 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import {
+  CURRENT_PROFILE_SCHEMA_VERSION,
+  PROFILE_MIGRATION_REGISTRY,
+  runProfileMigrationsInShadow,
+  validateProfileMigrationRegistry,
+} from '../js/profile-schema-migrations.js';
+
+const FIXTURE_NAMES = [
+  'pre-v1.6.json',
+  'v1.7-structured-context.json',
+  'current-unversioned.json',
+];
+
+function loadProfileFixture(name = 'current-unversioned.json') {
+  const fixtureUrl = new URL(`./fixtures/profile-migrations/${name}`, import.meta.url);
+  return JSON.parse(readFileSync(fileURLToPath(fixtureUrl), 'utf8')).profile;
+}
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+describe('profile schema migration registry', () => {
+  it('defines a valid sequential registry through the current schema', () => {
+    expect(validateProfileMigrationRegistry()).toEqual({ ok: true });
+    expect(PROFILE_MIGRATION_REGISTRY).toHaveLength(CURRENT_PROFILE_SCHEMA_VERSION);
+    expect(PROFILE_MIGRATION_REGISTRY[0]).toMatchObject({
+      fromVersion: 0,
+      toVersion: 1,
+    });
+  });
+
+  it('rejects duplicate and non-sequential registry steps', () => {
+    const migrate = () => {};
+    expect(validateProfileMigrationRegistry([
+      { id: 'invalid-jump', fromVersion: 0, toVersion: 2, migrate },
+    ])).toEqual({ ok: false, reason: 'STEP_NOT_SEQUENTIAL' });
+    expect(validateProfileMigrationRegistry([
+      { id: 'first-step', fromVersion: 0, toVersion: 1, migrate },
+      { id: 'duplicate-step', fromVersion: 0, toVersion: 1, migrate },
+    ])).toEqual({ ok: false, reason: 'STEP_DUPLICATE_SOURCE' });
+  });
+});
+
+describe('shadow profile migrations', () => {
+  it.each(FIXTURE_NAMES)('validates the %s historical profile through the registry', name => {
+    const profile = loadProfileFixture(name);
+    const original = clone(profile);
+    const result = runProfileMigrationsInShadow(profile);
+
+    expect(result.ok).toBe(true);
+    expect(profile).toEqual(original);
+    expect(result.data.schemaVersion).toBe(CURRENT_PROFILE_SCHEMA_VERSION);
+    expect(result.validation.counts.entries).toBe(original.entries.length);
+    expect(result.validation.counts.notes).toBe(original.notes.length);
+  });
+
+  it('migrates an unversioned profile on a detached copy', () => {
+    const profile = loadProfileFixture();
+    const original = clone(profile);
+    const result = runProfileMigrationsInShadow(profile);
+
+    expect(result.ok).toBe(true);
+    expect(profile).toEqual(original);
+    expect(result.data).not.toBe(profile);
+    expect(result.data.schemaVersion).toBe(CURRENT_PROFILE_SCHEMA_VERSION);
+    expect(result.appliedMigrations).toEqual([
+      { id: 'profile-v0-to-v1-normalize', fromVersion: 0, toVersion: 1 },
+    ]);
+    expect(result.validation.counts.entries).toBe(1);
+    expect(result.validation.counts.notes).toBe(1);
+    expect(result.data.currentUnknownSurface).toEqual(original.currentUnknownSurface);
+  });
+
+  it('is deterministic and idempotent without reusing object references', () => {
+    const profile = loadProfileFixture();
+    const first = runProfileMigrationsInShadow(profile);
+    const independent = runProfileMigrationsInShadow(profile);
+    const repeated = runProfileMigrationsInShadow(first.data);
+
+    expect(first).toEqual(independent);
+    expect(repeated.ok).toBe(true);
+    expect(repeated.changed).toBe(false);
+    expect(repeated.appliedMigrations).toEqual([]);
+    expect(repeated.data).toEqual(first.data);
+    expect(repeated.data).not.toBe(first.data);
+  });
+
+  it('fills only missing baseline collections and preserves existing identities', () => {
+    const profile = loadProfileFixture();
+    delete profile.supplements;
+    const result = runProfileMigrationsInShadow(profile);
+
+    expect(result.ok).toBe(true);
+    expect(result.data.supplements).toEqual([]);
+    expect(result.data.entries[0].id).toBe('entry_current_001');
+    expect(result.data.notes[0].id).toBe('note_current_001');
+    expect(result.validation.identifiedRecords).toBe(2);
+  });
+
+  it('fails closed for invalid and future schema versions', () => {
+    const invalid = runProfileMigrationsInShadow({ ...loadProfileFixture(), schemaVersion: -1 });
+    const future = runProfileMigrationsInShadow({ ...loadProfileFixture(), schemaVersion: 99 });
+    const legacyTarget = runProfileMigrationsInShadow(loadProfileFixture(), { targetVersion: 0 });
+
+    expect(invalid).toMatchObject({ ok: false, error: { code: 'PROFILE_SCHEMA_VERSION_INVALID' } });
+    expect(future).toMatchObject({ ok: false, error: { code: 'PROFILE_SCHEMA_VERSION_FUTURE' } });
+    expect(legacyTarget).toMatchObject({ ok: false, error: { code: 'PROFILE_TARGET_VERSION_INVALID' } });
+    expect(invalid).not.toHaveProperty('data');
+    expect(future).not.toHaveProperty('data');
+  });
+
+  it('fails closed when a sequential migration step is missing', () => {
+    const result = runProfileMigrationsInShadow(loadProfileFixture(), { registry: [] });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: { code: 'MIGRATION_STEP_MISSING', fromVersion: 0 },
+    });
+    expect(result).not.toHaveProperty('data');
+  });
+
+  it('discards a failed migration draft without mutating the input', () => {
+    const profile = loadProfileFixture();
+    const original = clone(profile);
+    const result = runProfileMigrationsInShadow(profile, {
+      registry: [{
+        id: 'throwing-step',
+        fromVersion: 0,
+        toVersion: 1,
+        migrate(draft) {
+          draft.notes = [];
+          throw new Error('synthetic failure');
+        },
+      }],
+    });
+
+    expect(result).toMatchObject({ ok: false, error: { code: 'MIGRATION_STEP_FAILED' } });
+    expect(result).not.toHaveProperty('data');
+    expect(profile).toEqual(original);
+  });
+
+  it('rejects record loss even when a migration stamps the expected version', () => {
+    const profile = loadProfileFixture();
+    const result = runProfileMigrationsInShadow(profile, {
+      registry: [{
+        id: 'lossy-step',
+        fromVersion: 0,
+        toVersion: 1,
+        migrate(draft) {
+          draft.entries.pop();
+          draft.schemaVersion = 1;
+        },
+      }],
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: 'PROFILE_VALIDATION_FAILED',
+        reason: 'COLLECTION_COUNT_CHANGED',
+        field: 'entries',
+      },
+    });
+    expect(result).not.toHaveProperty('data');
+  });
+
+  it('rejects changes outside the declared migration surface', () => {
+    const profile = loadProfileFixture();
+    const result = runProfileMigrationsInShadow(profile, {
+      registry: [{
+        id: 'overbroad-step',
+        fromVersion: 0,
+        toVersion: 1,
+        migrate(draft) {
+          draft.currentUnknownSurface = { preserve: [] };
+          draft.schemaVersion = 1;
+        },
+      }],
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: 'PROFILE_VALIDATION_FAILED',
+        reason: 'PROTECTED_ROOT_VALUE_CHANGED',
+        field: 'currentUnknownSurface',
+      },
+    });
+  });
+});

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -515,6 +515,7 @@
     "js/notes.js",
     "js/profile-list-store.js",
     "js/profile-context.js",
+    "js/profile-schema-migrations.js",
     "js/storage-integrity-manifest.js",
     "js/provider-local-ai-runtime.js",
     "js/provider-local-ai-controls.js",

--- a/types/app-state.d.ts
+++ b/types/app-state.d.ts
@@ -1,4 +1,5 @@
 export interface ProfileData {
+  schemaVersion?: number;
   entries: Array<Record<string, any>>;
   notes: any[];
   supplements: any[];


### PR DESCRIPTION
## Summary

- introduce explicit legacy (`0`) and current (`1`) profile schema versions
- add a frozen, sequential migration registry with one `0 -> 1` normalization step
- run migrations only against a detached JSON-safe copy and never mutate caller-owned data
- return a typed success/failure result that exposes migrated data only after validation succeeds
- fail closed for invalid, future, downgrade, missing-step, throwing-step, and unstamped migrations
- validate required collections/maps, collection counts, record identities, and all profile roots outside the declared legacy migration surface
- exercise the registry across all three synthetic historical profile fixtures
- register the new module in checkJs, architecture, and DOM-sink inventories

## Why

Gate 0 needs explicit schema sequencing and shadow validation before any migration can be connected to live profile storage. The current versionless migrator mutates its input directly; this wrapper establishes a safe copy-on-write boundary while preserving the exact existing normalization implementation beneath it.

## User impact

None. No production module imports this runner yet. It performs no storage reads, writes, cache changes, sync changes, credential access, wallet access, or UI changes.

## Validation

- `npm test -- tests/profile-schema-migrations.test.js tests/profile-migration-characterization.test.js tests/profile-data-boundaries.test.js` — 21 passed
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run architecture:check` — 583 modules, 0 cycles
- `node scripts/dom-sink-audit.mjs` — 483 sinks unchanged across 564 modules
- `npm run quality` — 17 passed
