### PR TITLE
Add encrypted migration recovery storage

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -10,7 +10,7 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | Metric | Current |
 | --- | ---: |
 | Modules | 584 |
-| Internal import edges | 2504 |
+| Internal import edges | 2506 |
 | Dynamic internal edges | 72 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -66,7 +66,7 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 | [`js/schema.js`](js/schema.js) | 34 | [`js/views.js`](js/views.js) | 22 |
 | [`js/crypto.js`](js/crypto.js) | 31 | [`js/dashboard-view-composition.js`](js/dashboard-view-composition.js) | 20 |
 | [`js/data-merge.js`](js/data-merge.js) | 30 | [`js/biology-scores.js`](js/biology-scores.js) | 19 |
-| [`js/constants.js`](js/constants.js) | 21 | [`js/export.js`](js/export.js) | 17 |
+| [`js/constants.js`](js/constants.js) | 21 | [`js/export.js`](js/export.js) | 18 |
 | [`js/utils-runtime.js`](js/utils-runtime.js) | 20 | [`js/lab-context.js`](js/lab-context.js) | 17 |
 | [`js/marker-analysis.js`](js/marker-analysis.js) | 19 | [`js/marker-detail-modal-impl.js`](js/marker-detail-modal-impl.js) | 17 |
 | [`js/chat-runtime.js`](js/chat-runtime.js) | 17 | [`js/sun.js`](js/sun.js) | 17 |
@@ -362,7 +362,7 @@ Native browser modules shipped with the static application.
 - [`js/data-merge-lab-entries.js`](js/data-merge-lab-entries.js) → [`js/lab-entry.js`](js/lab-entry.js)
 - [`js/data-merge.js`](js/data-merge.js) → [`js/data-merge-lab-entries.js`](js/data-merge-lab-entries.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/sync-delta-id.js`](js/sync-delta-id.js), [`js/sync-delta-surface-config.js`](js/sync-delta-surface-config.js)
 - [`js/data-view-controls.js`](js/data-view-controls.js) → [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils-runtime.js`](js/utils-runtime.js), [`js/utils.js`](js/utils.js)
-- [`js/data-wipe.js`](js/data-wipe.js) → no in-scope imports
+- [`js/data-wipe.js`](js/data-wipe.js) → [`js/migration-recovery-store.js`](js/migration-recovery-store.js)
 - [`js/data.js`](js/data.js) → [`js/crypto.js`](js/crypto.js), [`js/data-view-controls.js`](js/data-view-controls.js), [`js/lab-date-range.js`](js/lab-date-range.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/marker-analysis.js`](js/marker-analysis.js), [`js/profile-context.js`](js/profile-context.js), [`js/profile.js`](js/profile.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/sync-save-hooks.js`](js/sync-save-hooks.js), [`js/sync.js`](js/sync.js), [`js/utils.js`](js/utils.js)
 
 </details>
@@ -399,7 +399,7 @@ Native browser modules shipped with the static application.
 - [`js/export-report-html.js`](js/export-report-html.js) → [`js/export-report.js`](js/export-report.js), [`js/marker-analysis.js`](js/marker-analysis.js), [`js/state.js`](js/state.js), [`js/supplement-impact.js`](js/supplement-impact.js), [`js/utils.js`](js/utils.js)
 - [`js/export-report.js`](js/export-report.js) → [`js/api.js`](js/api.js), [`js/cycle.js`](js/cycle.js), [`js/data.js`](js/data.js), [`js/marker-analysis.js`](js/marker-analysis.js), [`js/profile.js`](js/profile.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/export-runtime.js`](js/export-runtime.js) → [`js/cashu-wallet.js`](js/cashu-wallet.js) *(dynamic)*, [`js/crypto.js`](js/crypto.js), [`js/state.js`](js/state.js)
-- [`js/export.js`](js/export.js) → [`js/biology-score-context-ai.js`](js/biology-score-context-ai.js) *(dynamic)*, [`js/caught-error.js`](js/caught-error.js), [`js/context-cards.js`](js/context-cards.js) *(dynamic)*, [`js/crypto.js`](js/crypto.js), [`js/data.js`](js/data.js), [`js/export-import.js`](js/export-import.js) *(dynamic)*, [`js/export-report-builder.js`](js/export-report-builder.js) *(dynamic)*, [`js/export-report-html.js`](js/export-report-html.js), [`js/export-report.js`](js/export-report.js), [`js/export-runtime.js`](js/export-runtime.js), [`js/lab-entry-mutations.js`](js/lab-entry-mutations.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/nostr-discovery.js`](js/nostr-discovery.js), [`js/profile-storage-cleanup.js`](js/profile-storage-cleanup.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
+- [`js/export.js`](js/export.js) → [`js/biology-score-context-ai.js`](js/biology-score-context-ai.js) *(dynamic)*, [`js/caught-error.js`](js/caught-error.js), [`js/context-cards.js`](js/context-cards.js) *(dynamic)*, [`js/crypto.js`](js/crypto.js), [`js/data.js`](js/data.js), [`js/export-import.js`](js/export-import.js) *(dynamic)*, [`js/export-report-builder.js`](js/export-report-builder.js) *(dynamic)*, [`js/export-report-html.js`](js/export-report-html.js), [`js/export-report.js`](js/export-report.js), [`js/export-runtime.js`](js/export-runtime.js), [`js/lab-entry-mutations.js`](js/lab-entry-mutations.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/migration-recovery-store.js`](js/migration-recovery-store.js), [`js/nostr-discovery.js`](js/nostr-discovery.js), [`js/profile-storage-cleanup.js`](js/profile-storage-cleanup.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 
 </details>
 

--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -9,8 +9,8 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 
 | Metric | Current |
 | --- | ---: |
-| Modules | 583 |
-| Internal import edges | 2503 |
+| Modules | 584 |
+| Internal import edges | 2504 |
 | Dynamic internal edges | 72 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -598,6 +598,12 @@ Native browser modules shipped with the static application.
 - [`js/marker-detail-modal.js`](js/marker-detail-modal.js) → [`js/health-data-loader.js`](js/health-data-loader.js), [`js/marker-detail-actions.js`](js/marker-detail-actions.js), [`js/marker-detail-modal-impl.js`](js/marker-detail-modal-impl.js) *(dynamic)*, [`js/marker-detail-runtime.js`](js/marker-detail-runtime.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/modal-trigger-memory.js`](js/modal-trigger-memory.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/marker-detail-runtime.js`](js/marker-detail-runtime.js) → [`js/dna-runtime-bridge.js`](js/dna-runtime-bridge.js), [`js/emf-runtime.js`](js/emf-runtime.js), [`js/recommendations-runtime.js`](js/recommendations-runtime.js), [`js/utils.js`](js/utils.js), [`js/wearables-runtime.js`](js/wearables-runtime.js)
 - [`js/marker-detail-store.js`](js/marker-detail-store.js) → [`js/data.js`](js/data.js), [`js/lab-entry-mutations.js`](js/lab-entry-mutations.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/state.js`](js/state.js)
+
+</details>
+
+<details><summary><code>migration</code> family — 1 module</summary>
+
+- [`js/migration-recovery-store.js`](js/migration-recovery-store.js) → [`js/blob-storage.js`](js/blob-storage.js)
 
 </details>
 

--- a/js/blob-storage.js
+++ b/js/blob-storage.js
@@ -77,6 +77,53 @@ export async function setBlob(key, value) {
 }
 
 /**
+ * Replace a profile blob only if it still matches the value the caller read.
+ * IndexedDB serializes read-write transactions, so this remains safe when
+ * Navigator Locks is unavailable or another tab writes between shadow
+ * validation and commit.
+ *
+ * @param {string} key
+ * @param {string} expectedValue
+ * @param {string} nextValue
+ * @returns {Promise<void>}
+ */
+export async function compareAndSetBlob(key, expectedValue, nextValue) {
+  if (!shouldUseBlob(key)) throw new Error('Compare-and-set requires an IndexedDB profile blob key.');
+  if (typeof expectedValue !== 'string' || typeof nextValue !== 'string') {
+    throw new TypeError('Compare-and-set profile values must be strings.');
+  }
+  const db = await _openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    const store = tx.objectStore(STORE_NAME);
+    let conflict = false;
+    const read = store.get(key);
+    read.onsuccess = () => {
+      if (read.result !== expectedValue) {
+        conflict = true;
+        tx.abort();
+        return;
+      }
+      store.put(nextValue, key);
+    };
+    read.onerror = () => reject(read.error);
+    tx.oncomplete = () => resolve();
+    tx.onabort = () => {
+      if (conflict) {
+        const error = /** @type {Error & { code?: string }} */ (
+          new Error('Profile data changed before migration commit.')
+        );
+        error.code = 'blob_conflict';
+        reject(error);
+      } else {
+        reject(tx.error || new Error('Profile blob transaction was aborted.'));
+      }
+    };
+    tx.onerror = () => {};
+  });
+}
+
+/**
  * @param {string} key
  * @param {{ throwOnError?: boolean }} [options]
  */

--- a/js/data-wipe.js
+++ b/js/data-wipe.js
@@ -142,6 +142,7 @@ export async function eraseAllLocalAppData() {
       ...profileIds.flatMap(id => [`labcharts-wearables-${id}`, `labcharts-cycle-${id}`]),
       'labcharts-backups',
       'labcharts-blobs',
+      'labcharts-migration-recovery',
     ],
     errors,
   );

--- a/js/data-wipe.js
+++ b/js/data-wipe.js
@@ -1,6 +1,8 @@
 // @ts-check
 // data-wipe.js — destructive local storage cleanup helpers
 
+import { eraseMigrationRecoveryStorage } from './migration-recovery-store.js';
+
 const APP_SESSION_KEY_RE = /^(?:labcharts|chat-onboard-|or_|welcome-details-open$|(?:oura|withings|ultrahuman|polar|whoop|fitbit|google_health)-oauth-pending$)/;
 
 function failure(label, error) {
@@ -75,15 +77,16 @@ function removeStorageKeys(storage, keys, label, errors) {
   }
 }
 
-async function deleteIndexedDBDatabasesByPrefix(prefixes, fallbackNames, errors) {
+async function deleteIndexedDBDatabasesByPrefix(prefixes, fallbackNames, errors, excludedNames = []) {
   if (typeof indexedDB === 'undefined') return;
   const names = new Set(fallbackNames);
+  const excluded = new Set(excludedNames);
   if (typeof indexedDB.databases === 'function') {
     try {
       const databases = await indexedDB.databases();
       for (const database of databases || []) {
         const name = database?.name || '';
-        if (prefixes.some(prefix => name.startsWith(prefix))) names.add(name);
+        if (!excluded.has(name) && prefixes.some(prefix => name.startsWith(prefix))) names.add(name);
       }
     } catch (error) {
       errors.push(failure('Could not enumerate IndexedDB databases', error));
@@ -136,15 +139,20 @@ export async function eraseAllLocalAppData() {
 
   removeStorageKeys(globalThis.localStorage, localKeys, 'local storage', errors);
   removeStorageKeys(globalThis.sessionStorage, sessionKeys, 'session storage', errors);
+  try {
+    await eraseMigrationRecoveryStorage();
+  } catch (error) {
+    errors.push(failure('Could not delete migration recovery storage', error));
+  }
   await deleteIndexedDBDatabasesByPrefix(
     ['labcharts-'],
     [
       ...profileIds.flatMap(id => [`labcharts-wearables-${id}`, `labcharts-cycle-${id}`]),
       'labcharts-backups',
       'labcharts-blobs',
-      'labcharts-migration-recovery',
     ],
     errors,
+    ['labcharts-migration-recovery'],
   );
   for (const name of ['getbased-cashu']) {
     try {

--- a/js/export.js
+++ b/js/export.js
@@ -22,6 +22,7 @@ import {
 } from './profile.js';
 import { encryptedGetItem, encryptedRemoveItem } from './crypto.js';
 import { clearProfileStorage, listStoredProfileIds } from './profile-storage-cleanup.js';
+import { eraseMigrationRecoveryStorage } from './migration-recovery-store.js';
 import { findOrCreateLabEntry } from './lab-entry-mutations.js';
 import { setLabEntryMarker } from './lab-entry.js';
 import { getSelectedNodeUrl } from './nostr-discovery.js';
@@ -443,6 +444,7 @@ export async function clearAllData() {
       // Delete the wallet first. If it is blocked by another tab, preserve the
       // profile records and report the failure instead of claiming success.
       await destroyWalletRuntimeDB();
+      await eraseMigrationRecoveryStorage();
       const profileIds = await listStoredProfileIds(profiles.map(profile => profile.id));
       for (const id of profileIds) {
         await clearProfileStorage(id);

--- a/js/migration-recovery-store.js
+++ b/js/migration-recovery-store.js
@@ -38,6 +38,40 @@ let dbPromise = null;
 /** @type {Map<string, Promise<void>>} */
 const inMemoryLocks = new Map();
 
+/**
+ * Close this module's cached connection before deleting the recovery database.
+ * A generic deleteDatabase call can otherwise be blocked by the same page that
+ * requested the wipe after migration recovery has been used.
+ */
+export async function eraseMigrationRecoveryStorage() {
+  const openConnection = dbPromise;
+  dbPromise = null;
+  if (openConnection) {
+    try {
+      const db = await openConnection;
+      db.close();
+    } catch {
+      // A failed open has no live connection to close; deletion can still run.
+    }
+  }
+  if (typeof indexedDB === 'undefined') return;
+  if (typeof indexedDB.deleteDatabase !== 'function') {
+    throw new Error('IndexedDB deletion is unavailable.');
+  }
+  await new Promise((resolve, reject) => {
+    try {
+      const request = indexedDB.deleteDatabase(DB_NAME);
+      request.onsuccess = () => resolve(undefined);
+      request.onerror = () => reject(request.error || new Error('Migration recovery deletion failed.'));
+      request.onblocked = () => reject(
+        new Error('Migration recovery deletion is blocked by another open Get Based tab.'),
+      );
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
 function openRecoveryDB() {
   if (dbPromise) return dbPromise;
   if (typeof indexedDB === 'undefined') return Promise.reject(new Error('IndexedDB is unavailable.'));

--- a/js/migration-recovery-store.js
+++ b/js/migration-recovery-store.js
@@ -1,0 +1,537 @@
+// @ts-check
+// migration-recovery-store.js — Encrypted, crash-consistent profile rollback.
+
+import { compareAndSetBlob, getBlob, shouldUseBlob } from './blob-storage.js';
+
+const DB_NAME = 'labcharts-migration-recovery';
+const DB_VERSION = 1;
+const KEY_STORE = 'device-keys';
+const SNAPSHOT_STORE = 'snapshots';
+const PROFILE_INDEX = 'profileKey';
+const DEVICE_KEY_ID = 'migration-recovery-aes-key:v1';
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+export const MIGRATION_RECOVERY_FORMAT_VERSION = 1;
+export const MAX_MIGRATION_RECOVERY_SNAPSHOTS = 3;
+
+/** @typedef {'prepared' | 'committed' | 'rolled-back'} RecoveryStatus */
+/**
+ * @typedef {{
+ *   id: string,
+ *   formatVersion: number,
+ *   profileKey: string,
+ *   fromVersion: number,
+ *   toVersion: number,
+ *   createdAt: number,
+ *   status: RecoveryStatus,
+ *   previousBytes: number,
+ *   nextBytes: number,
+ *   envelope: { iv: Uint8Array, ciphertext: ArrayBuffer },
+ *   committedAt?: number,
+ *   rolledBackAt?: number,
+ * }} RecoveryRecord
+ */
+
+/** @type {Promise<IDBDatabase> | null} */
+let dbPromise = null;
+/** @type {Map<string, Promise<void>>} */
+const inMemoryLocks = new Map();
+
+function openRecoveryDB() {
+  if (dbPromise) return dbPromise;
+  if (typeof indexedDB === 'undefined') return Promise.reject(new Error('IndexedDB is unavailable.'));
+  dbPromise = new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(KEY_STORE)) db.createObjectStore(KEY_STORE);
+      if (!db.objectStoreNames.contains(SNAPSHOT_STORE)) {
+        const snapshots = db.createObjectStore(SNAPSHOT_STORE, { keyPath: 'id' });
+        snapshots.createIndex(PROFILE_INDEX, 'profileKey', { unique: false });
+      }
+    };
+    request.onsuccess = () => {
+      const db = request.result;
+      db.onversionchange = () => {
+        db.close();
+        dbPromise = null;
+      };
+      resolve(db);
+    };
+    request.onerror = () => {
+      dbPromise = null;
+      reject(request.error || new Error('Could not open migration recovery storage.'));
+    };
+    request.onblocked = () => {
+      dbPromise = null;
+      reject(new Error('Migration recovery storage upgrade is blocked.'));
+    };
+  });
+  dbPromise.catch(() => { dbPromise = null; });
+  return dbPromise;
+}
+
+/** @template T @param {IDBRequest<T>} request @returns {Promise<T>} */
+function requestResult(request) {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error || new Error('IndexedDB request failed.'));
+  });
+}
+
+/** @param {IDBTransaction} transaction */
+function transactionDone(transaction) {
+  return new Promise((resolve, reject) => {
+    transaction.oncomplete = () => resolve(undefined);
+    transaction.onabort = () => reject(transaction.error || new Error('IndexedDB transaction aborted.'));
+    transaction.onerror = () => {};
+  });
+}
+
+/** @param {unknown} value */
+function isRecoveryKey(value) {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = /** @type {CryptoKey} */ (value);
+  return candidate.type === 'secret'
+    && candidate.extractable === false
+    && candidate.algorithm?.name === 'AES-GCM';
+}
+
+async function readDeviceKey() {
+  const db = await openRecoveryDB();
+  const tx = db.transaction(KEY_STORE, 'readonly');
+  return requestResult(tx.objectStore(KEY_STORE).get(DEVICE_KEY_ID));
+}
+
+async function getOrCreateDeviceKey() {
+  const existing = await readDeviceKey();
+  if (isRecoveryKey(existing)) return /** @type {CryptoKey} */ (existing);
+  if (!globalThis.crypto?.subtle) throw new Error('Secure browser storage is unavailable.');
+  const generated = await globalThis.crypto.subtle.generateKey(
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt'],
+  );
+  try {
+    const db = await openRecoveryDB();
+    const tx = db.transaction(KEY_STORE, 'readwrite');
+    tx.objectStore(KEY_STORE).add(generated, DEVICE_KEY_ID);
+    await transactionDone(tx);
+    return generated;
+  } catch {
+    const winner = await readDeviceKey();
+    if (isRecoveryKey(winner)) return /** @type {CryptoKey} */ (winner);
+    throw new Error('Could not retain the migration recovery key.');
+  }
+}
+
+/** @param {Uint8Array | ArrayBuffer} value */
+function byteView(value) {
+  const source = value instanceof Uint8Array ? value : new Uint8Array(value);
+  return new Uint8Array(source);
+}
+
+/** @param {unknown} error */
+function caughtErrorCode(error) {
+  if (!error || typeof error !== 'object' || !('code' in error)) return '';
+  return String(error.code || '');
+}
+
+/** @param {ArrayBuffer} value */
+function hex(value) {
+  return Array.from(new Uint8Array(value), byte => byte.toString(16).padStart(2, '0')).join('');
+}
+
+/** @param {string} value */
+async function digest(value) {
+  const hashed = await globalThis.crypto.subtle.digest('SHA-256', encoder.encode(value));
+  return hex(hashed);
+}
+
+function createSnapshotId() {
+  if (typeof globalThis.crypto?.randomUUID === 'function') return globalThis.crypto.randomUUID();
+  const bytes = globalThis.crypto.getRandomValues(new Uint8Array(16));
+  return Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('');
+}
+
+/** @param {Pick<RecoveryRecord, 'id' | 'profileKey' | 'fromVersion' | 'toVersion' | 'createdAt'>} record */
+function additionalData(record) {
+  return encoder.encode([
+    'getbased-migration-recovery',
+    MIGRATION_RECOVERY_FORMAT_VERSION,
+    record.id,
+    record.profileKey,
+    record.fromVersion,
+    record.toVersion,
+    record.createdAt,
+  ].join('|'));
+}
+
+/**
+ * @param {string} previousValue
+ * @param {string} nextValue
+ */
+export function estimateMigrationRecoveryBytes(previousValue, nextValue) {
+  const previousBytes = encoder.encode(previousValue).byteLength;
+  const nextBytes = encoder.encode(nextValue).byteLength;
+  const requiredBytes = Math.ceil((previousBytes + nextBytes + 65536) * 1.25);
+  return { previousBytes, nextBytes, requiredBytes };
+}
+
+/**
+ * @param {string} previousValue
+ * @param {string} nextValue
+ * @param {{ estimate?: () => Promise<{ usage?: number, quota?: number }> }} [options]
+ */
+export async function preflightMigrationRecoveryStorage(previousValue, nextValue, options = {}) {
+  const sizes = estimateMigrationRecoveryBytes(previousValue, nextValue);
+  const estimate = options.estimate || globalThis.navigator?.storage?.estimate?.bind(globalThis.navigator.storage);
+  if (typeof estimate !== 'function') {
+    return { ok: true, supported: false, availableBytes: null, headroomBytes: null, ...sizes };
+  }
+  try {
+    const result = await estimate();
+    if (!Number.isFinite(result?.usage) || !Number.isFinite(result?.quota)) {
+      return { ok: true, supported: false, availableBytes: null, headroomBytes: null, ...sizes };
+    }
+    const availableBytes = Math.max(0, Number(result.quota) - Number(result.usage));
+    const headroomBytes = availableBytes - sizes.requiredBytes;
+    return {
+      ok: headroomBytes >= 0,
+      supported: true,
+      availableBytes,
+      headroomBytes,
+      ...sizes,
+    };
+  } catch {
+    return { ok: true, supported: false, availableBytes: null, headroomBytes: null, ...sizes };
+  }
+}
+
+/** @param {RecoveryRecord} record @param {string} previousValue @param {string} nextValue */
+async function encryptRecoveryRecord(record, previousValue, nextValue) {
+  const key = await getOrCreateDeviceKey();
+  const iv = globalThis.crypto.getRandomValues(new Uint8Array(12));
+  const plaintext = encoder.encode(JSON.stringify({
+    version: MIGRATION_RECOVERY_FORMAT_VERSION,
+    profileKey: record.profileKey,
+    previousValue,
+    nextDigest: await digest(nextValue),
+  }));
+  const ciphertext = await globalThis.crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv, additionalData: additionalData(record) },
+    key,
+    plaintext,
+  );
+  return { iv, ciphertext };
+}
+
+/** @param {RecoveryRecord} record */
+async function decryptRecoveryRecord(record) {
+  try {
+    const key = await readDeviceKey();
+    if (!isRecoveryKey(key)) return null;
+    const plaintext = await globalThis.crypto.subtle.decrypt(
+      {
+        name: 'AES-GCM',
+        iv: byteView(record.envelope.iv),
+        additionalData: additionalData(record),
+      },
+      /** @type {CryptoKey} */ (key),
+      record.envelope.ciphertext,
+    );
+    const payload = JSON.parse(decoder.decode(plaintext));
+    if (payload?.version !== MIGRATION_RECOVERY_FORMAT_VERSION
+        || payload?.profileKey !== record.profileKey
+        || typeof payload?.previousValue !== 'string'
+        || !/^[a-f0-9]{64}$/.test(payload?.nextDigest || '')) return null;
+    return payload;
+  } catch {
+    return null;
+  }
+}
+
+/** @param {RecoveryRecord} record */
+async function addRecoveryRecord(record) {
+  const db = await openRecoveryDB();
+  const tx = db.transaction(SNAPSHOT_STORE, 'readwrite');
+  tx.objectStore(SNAPSHOT_STORE).add(record);
+  await transactionDone(tx);
+}
+
+/** @param {string} id @returns {Promise<RecoveryRecord | null>} */
+async function getRecoveryRecord(id) {
+  const db = await openRecoveryDB();
+  const tx = db.transaction(SNAPSHOT_STORE, 'readonly');
+  const result = await requestResult(tx.objectStore(SNAPSHOT_STORE).get(id));
+  return result ? /** @type {RecoveryRecord} */ (result) : null;
+}
+
+/** @param {string} id */
+async function deleteRecoveryRecord(id) {
+  const db = await openRecoveryDB();
+  const tx = db.transaction(SNAPSHOT_STORE, 'readwrite');
+  tx.objectStore(SNAPSHOT_STORE).delete(id);
+  await transactionDone(tx);
+}
+
+/** @param {string} id @param {RecoveryStatus} status */
+async function setRecoveryStatus(id, status) {
+  const db = await openRecoveryDB();
+  const tx = db.transaction(SNAPSHOT_STORE, 'readwrite');
+  const store = tx.objectStore(SNAPSHOT_STORE);
+  const record = await requestResult(store.get(id));
+  if (!record) {
+    tx.abort();
+    throw new Error('Migration recovery snapshot was not found.');
+  }
+  const next = /** @type {RecoveryRecord} */ (record);
+  next.status = status;
+  if (status === 'committed') next.committedAt = Date.now();
+  if (status === 'rolled-back') next.rolledBackAt = Date.now();
+  store.put(next);
+  await transactionDone(tx);
+}
+
+/**
+ * @template T
+ * @param {string} profileKey
+ * @param {() => Promise<T>} callback
+ * @returns {Promise<T>}
+ */
+export async function withProfileMigrationLock(profileKey, callback) {
+  const lockName = `getbased-profile-migration:${profileKey}`;
+  const locks = globalThis.navigator?.locks;
+  if (locks && typeof locks.request === 'function') {
+    return locks.request(lockName, { mode: 'exclusive' }, callback);
+  }
+
+  const previous = inMemoryLocks.get(lockName) || Promise.resolve();
+  /** @type {() => void} */
+  let release = () => {};
+  const current = new Promise(resolve => { release = () => resolve(undefined); });
+  const tail = previous.then(() => current);
+  inMemoryLocks.set(lockName, tail);
+  await previous;
+  try {
+    return await callback();
+  } finally {
+    release();
+    if (inMemoryLocks.get(lockName) === tail) inMemoryLocks.delete(lockName);
+  }
+}
+
+/** @param {unknown} input */
+function isValidRecoveryInput(input) {
+  if (!input || typeof input !== 'object') return false;
+  const candidate = /** @type {Record<string, any>} */ (input);
+  return typeof candidate.profileKey === 'string'
+    && candidate.profileKey.endsWith('-imported')
+    && shouldUseBlob(candidate.profileKey)
+    && typeof candidate.previousValue === 'string'
+    && typeof candidate.nextValue === 'string'
+    && candidate.previousValue !== candidate.nextValue
+    && Number.isInteger(candidate.fromVersion)
+    && Number.isInteger(candidate.toVersion)
+    && candidate.fromVersion >= 0
+    && candidate.toVersion > candidate.fromVersion
+    && (candidate.estimate === undefined || typeof candidate.estimate === 'function');
+}
+
+/**
+ * @param {{
+ *   profileKey: string,
+ *   previousValue: string,
+ *   nextValue: string,
+ *   fromVersion: number,
+ *   toVersion: number,
+ *   estimate?: () => Promise<{ usage?: number, quota?: number }>,
+ * }} input
+ */
+export async function prepareMigrationRecoverySnapshot(input) {
+  if (!isValidRecoveryInput(input)) {
+    return { ok: false, error: { code: 'RECOVERY_INPUT_INVALID', message: 'Migration recovery input is invalid.' } };
+  }
+  const preflight = await preflightMigrationRecoveryStorage(
+    input.previousValue,
+    input.nextValue,
+    { ...(input.estimate ? { estimate: input.estimate } : {}) },
+  );
+  if (!preflight.ok) {
+    return {
+      ok: false,
+      preflight,
+      error: { code: 'RECOVERY_STORAGE_INSUFFICIENT', message: 'Not enough storage is available for a recovery snapshot.' },
+    };
+  }
+
+  const record = /** @type {RecoveryRecord} */ ({
+    id: createSnapshotId(),
+    formatVersion: MIGRATION_RECOVERY_FORMAT_VERSION,
+    profileKey: input.profileKey,
+    fromVersion: input.fromVersion,
+    toVersion: input.toVersion,
+    createdAt: Date.now(),
+    status: 'prepared',
+    previousBytes: preflight.previousBytes,
+    nextBytes: preflight.nextBytes,
+    envelope: null,
+  });
+  try {
+    record.envelope = await encryptRecoveryRecord(record, input.previousValue, input.nextValue);
+    await addRecoveryRecord(record);
+    return { ok: true, snapshotId: record.id, preflight };
+  } catch {
+    return {
+      ok: false,
+      preflight,
+      error: { code: 'RECOVERY_SNAPSHOT_WRITE_FAILED', message: 'The encrypted recovery snapshot could not be retained.' },
+    };
+  }
+}
+
+/** @param {string} profileKey */
+export async function listMigrationRecoverySnapshots(profileKey) {
+  const db = await openRecoveryDB();
+  const tx = db.transaction(SNAPSHOT_STORE, 'readonly');
+  const records = await requestResult(
+    tx.objectStore(SNAPSHOT_STORE).index(PROFILE_INDEX).getAll(profileKey),
+  );
+  return (records || [])
+    .map(record => ({
+      id: record.id,
+      formatVersion: record.formatVersion,
+      profileKey: record.profileKey,
+      fromVersion: record.fromVersion,
+      toVersion: record.toVersion,
+      createdAt: record.createdAt,
+      status: record.status,
+      previousBytes: record.previousBytes,
+      nextBytes: record.nextBytes,
+    }))
+    .sort((left, right) => right.createdAt - left.createdAt);
+}
+
+/** @param {string} profileKey */
+async function pruneSettledSnapshots(profileKey) {
+  const records = await listMigrationRecoverySnapshots(profileKey);
+  const settled = records.filter(record => record.status !== 'prepared');
+  for (const record of settled.slice(MAX_MIGRATION_RECOVERY_SNAPSHOTS)) {
+    await deleteRecoveryRecord(record.id);
+  }
+}
+
+/**
+ * Retain an encrypted snapshot first, then atomically replace the active blob
+ * only if it has not changed since shadow validation.
+ *
+ * @param {Parameters<typeof prepareMigrationRecoverySnapshot>[0]} input
+ */
+export async function commitProfileMigrationWithRecovery(input) {
+  if (!isValidRecoveryInput(input)) {
+    return { ok: false, error: { code: 'RECOVERY_INPUT_INVALID', message: 'Migration recovery input is invalid.' } };
+  }
+  return withProfileMigrationLock(input.profileKey, async () => {
+    const prepared = await prepareMigrationRecoverySnapshot(input);
+    if (!prepared.ok) return prepared;
+    try {
+      await compareAndSetBlob(input.profileKey, input.previousValue, input.nextValue);
+    } catch (error) {
+      try { await deleteRecoveryRecord(prepared.snapshotId); } catch {}
+      const code = caughtErrorCode(error);
+      return {
+        ok: false,
+        preflight: prepared.preflight,
+        error: {
+          code: code === 'blob_conflict' ? 'RECOVERY_COMMIT_CONFLICT' : 'RECOVERY_COMMIT_FAILED',
+          message: code === 'blob_conflict'
+            ? 'Profile data changed before migration commit.'
+            : 'The profile migration was not committed.',
+        },
+      };
+    }
+
+    let journalStatus = 'prepared';
+    try {
+      await setRecoveryStatus(prepared.snapshotId, 'committed');
+      journalStatus = 'committed';
+    } catch {
+      // The active write is valid and its prepared journal is recoverable.
+    }
+    if (journalStatus === 'committed') {
+      try { await pruneSettledSnapshots(input.profileKey); } catch {}
+    }
+    return {
+      ok: true,
+      snapshotId: prepared.snapshotId,
+      journalStatus,
+      preflight: prepared.preflight,
+    };
+  });
+}
+
+/** @param {string} snapshotId */
+export async function reconcileMigrationRecoverySnapshot(snapshotId) {
+  const record = await getRecoveryRecord(snapshotId);
+  if (!record) return { ok: false, error: { code: 'RECOVERY_NOT_FOUND', message: 'Recovery snapshot was not found.' } };
+  const payload = await decryptRecoveryRecord(record);
+  if (!payload) return { ok: false, error: { code: 'RECOVERY_DECRYPT_FAILED', message: 'Recovery snapshot could not be decrypted.' } };
+  return withProfileMigrationLock(record.profileKey, async () => {
+    const current = await getBlob(record.profileKey);
+    if (typeof current !== 'string') {
+      return { ok: false, error: { code: 'RECOVERY_ACTIVE_PROFILE_MISSING', message: 'Active profile data is unavailable.' } };
+    }
+    if (current === payload.previousValue) {
+      await setRecoveryStatus(record.id, 'rolled-back');
+      return { ok: true, outcome: 'rolled-back', snapshotId: record.id };
+    }
+    if (await digest(current) === payload.nextDigest) {
+      await setRecoveryStatus(record.id, 'committed');
+      return { ok: true, outcome: 'committed', snapshotId: record.id };
+    }
+    return {
+      ok: false,
+      error: { code: 'RECOVERY_RECONCILE_CONFLICT', message: 'Active profile data no longer matches the migration journal.' },
+    };
+  });
+}
+
+/** @param {string} snapshotId */
+export async function rollbackProfileMigration(snapshotId) {
+  const record = await getRecoveryRecord(snapshotId);
+  if (!record) return { ok: false, error: { code: 'RECOVERY_NOT_FOUND', message: 'Recovery snapshot was not found.' } };
+  const payload = await decryptRecoveryRecord(record);
+  if (!payload) return { ok: false, error: { code: 'RECOVERY_DECRYPT_FAILED', message: 'Recovery snapshot could not be decrypted.' } };
+  return withProfileMigrationLock(record.profileKey, async () => {
+    const current = await getBlob(record.profileKey);
+    if (typeof current !== 'string') {
+      return { ok: false, error: { code: 'RECOVERY_ACTIVE_PROFILE_MISSING', message: 'Active profile data is unavailable.' } };
+    }
+    if (current === payload.previousValue) {
+      await setRecoveryStatus(record.id, 'rolled-back');
+      return { ok: true, snapshotId: record.id, journalStatus: 'rolled-back' };
+    }
+    if (await digest(current) !== payload.nextDigest) {
+      return {
+        ok: false,
+        error: { code: 'RECOVERY_CURRENT_VALUE_CHANGED', message: 'Profile data changed after migration; automatic rollback was refused.' },
+      };
+    }
+    try {
+      await compareAndSetBlob(record.profileKey, current, payload.previousValue);
+    } catch (error) {
+      const code = caughtErrorCode(error);
+      return {
+        ok: false,
+        error: {
+          code: code === 'blob_conflict' ? 'RECOVERY_ROLLBACK_CONFLICT' : 'RECOVERY_ROLLBACK_FAILED',
+          message: 'The recovery snapshot was retained, but rollback was not applied.',
+        },
+      };
+    }
+    let journalStatus = 'rolled-back';
+    try { await setRecoveryStatus(record.id, 'rolled-back'); } catch { journalStatus = record.status; }
+    return { ok: true, snapshotId: record.id, journalStatus };
+  });
+}

--- a/js/migration-recovery-store.js
+++ b/js/migration-recovery-store.js
@@ -243,7 +243,11 @@ export async function preflightMigrationRecoveryStorage(previousValue, nextValue
   }
 }
 
-/** @param {RecoveryRecord} record @param {string} previousValue @param {string} nextValue */
+/**
+ * @param {Pick<RecoveryRecord, 'id' | 'profileKey' | 'fromVersion' | 'toVersion' | 'createdAt'>} record
+ * @param {string} previousValue
+ * @param {string} nextValue
+ */
 async function encryptRecoveryRecord(record, previousValue, nextValue) {
   const key = await getOrCreateDeviceKey();
   const iv = globalThis.crypto.getRandomValues(new Uint8Array(12));
@@ -400,7 +404,7 @@ export async function prepareMigrationRecoverySnapshot(input) {
     };
   }
 
-  const record = /** @type {RecoveryRecord} */ ({
+  const metadata = /** @type {Omit<RecoveryRecord, 'envelope'>} */ ({
     id: createSnapshotId(),
     formatVersion: MIGRATION_RECOVERY_FORMAT_VERSION,
     profileKey: input.profileKey,
@@ -410,10 +414,12 @@ export async function prepareMigrationRecoverySnapshot(input) {
     status: 'prepared',
     previousBytes: preflight.previousBytes,
     nextBytes: preflight.nextBytes,
-    envelope: null,
   });
   try {
-    record.envelope = await encryptRecoveryRecord(record, input.previousValue, input.nextValue);
+    const record = /** @type {RecoveryRecord} */ ({
+      ...metadata,
+      envelope: await encryptRecoveryRecord(metadata, input.previousValue, input.nextValue),
+    });
     await addRecoveryRecord(record);
     return { ok: true, snapshotId: record.id, preflight };
   } catch {
@@ -468,11 +474,12 @@ export async function commitProfileMigrationWithRecovery(input) {
   }
   return withProfileMigrationLock(input.profileKey, async () => {
     const prepared = await prepareMigrationRecoverySnapshot(input);
-    if (!prepared.ok) return prepared;
+    if (prepared.ok !== true || typeof prepared.snapshotId !== 'string') return prepared;
+    const snapshotId = prepared.snapshotId;
     try {
       await compareAndSetBlob(input.profileKey, input.previousValue, input.nextValue);
     } catch (error) {
-      try { await deleteRecoveryRecord(prepared.snapshotId); } catch {}
+      try { await deleteRecoveryRecord(snapshotId); } catch {}
       const code = caughtErrorCode(error);
       return {
         ok: false,
@@ -488,7 +495,7 @@ export async function commitProfileMigrationWithRecovery(input) {
 
     let journalStatus = 'prepared';
     try {
-      await setRecoveryStatus(prepared.snapshotId, 'committed');
+      await setRecoveryStatus(snapshotId, 'committed');
       journalStatus = 'committed';
     } catch {
       // The active write is valid and its prepared journal is recoverable.
@@ -498,7 +505,7 @@ export async function commitProfileMigrationWithRecovery(input) {
     }
     return {
       ok: true,
-      snapshotId: prepared.snapshotId,
+      snapshotId,
       journalStatus,
       preflight: prepared.preflight,
     };

--- a/scripts/dom-sink-policy.json
+++ b/scripts/dom-sink-policy.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "scope": "Every non-generated JavaScript module under js/",
   "reviewRule": "Any added or modified HTML-writing sink requires security review and a policy refresh.",
-  "scannedFiles": 564,
+  "scannedFiles": 565,
   "sinkCount": 483,
   "files": {
     "js/backup.js": {

--- a/service-worker.js
+++ b/service-worker.js
@@ -391,6 +391,7 @@ const APP_SHELL = [
   '/js/crypto.js',
   '/js/crypto-ui.js',
   '/js/data-wipe.js',
+  '/js/migration-recovery-store.js',
   '/js/backup-cycle.js',
   '/js/backup-serialization.js',
   '/js/backup.js',

--- a/tests/data-wipe.test.js
+++ b/tests/data-wipe.test.js
@@ -79,6 +79,7 @@ describe('eraseAllLocalAppData', () => {
       'labcharts-cycle-orphaned-profile',
       'labcharts-blobs',
       'labcharts-backups',
+      'labcharts-migration-recovery',
       'labcharts-future-store',
       'getbased-cashu',
     ];
@@ -126,6 +127,7 @@ describe('eraseAllLocalAppData', () => {
       'labcharts-blobs',
       'labcharts-cycle-active-profile',
       'labcharts-cycle-default',
+      'labcharts-migration-recovery',
       'labcharts-wearables-active-profile',
       'labcharts-wearables-default',
     ]);

--- a/tests/migration-recovery-store.test.js
+++ b/tests/migration-recovery-store.test.js
@@ -1,0 +1,248 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  compareAndSetBlob,
+  getBlob,
+  setBlob,
+} from '../js/blob-storage.js';
+import {
+  commitProfileMigrationWithRecovery,
+  estimateMigrationRecoveryBytes,
+  listMigrationRecoverySnapshots,
+  preflightMigrationRecoveryStorage,
+  prepareMigrationRecoverySnapshot,
+  reconcileMigrationRecoverySnapshot,
+  rollbackProfileMigration,
+  withProfileMigrationLock,
+} from '../js/migration-recovery-store.js';
+
+const ampleEstimate = async () => ({ usage: 1024, quota: 100 * 1024 * 1024 });
+
+function profileKey(label) {
+  return `labcharts-recovery-${label}-${crypto.randomUUID()}-imported`;
+}
+
+function requestResult(request) {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+async function readRawRecoveryStorage(snapshotId) {
+  const db = await requestResult(indexedDB.open('labcharts-migration-recovery'));
+  const snapshotTx = db.transaction('snapshots', 'readonly');
+  const snapshot = await requestResult(snapshotTx.objectStore('snapshots').get(snapshotId));
+  const keyTx = db.transaction('device-keys', 'readonly');
+  const key = await requestResult(
+    keyTx.objectStore('device-keys').get('migration-recovery-aes-key:v1'),
+  );
+  db.close();
+  return { snapshot, key };
+}
+
+describe('migration recovery storage preflight', () => {
+  it('budgets for the encrypted previous value, replacement value, and IDB overhead', () => {
+    const sizes = estimateMigrationRecoveryBytes('a'.repeat(1000), 'b'.repeat(2000));
+
+    expect(sizes.previousBytes).toBe(1000);
+    expect(sizes.nextBytes).toBe(2000);
+    expect(sizes.requiredBytes).toBeGreaterThan(3000);
+  });
+
+  it('refuses before writing when reported storage headroom is insufficient', async () => {
+    const key = profileKey('quota');
+    const previousValue = JSON.stringify({ secret: 'quota-old' });
+    const nextValue = JSON.stringify({ secret: 'quota-new' });
+    await setBlob(key, previousValue);
+
+    const preflight = await preflightMigrationRecoveryStorage(previousValue, nextValue, {
+      estimate: async () => ({ usage: 999_999, quota: 1_000_000 }),
+    });
+    const result = await commitProfileMigrationWithRecovery({
+      profileKey: key,
+      previousValue,
+      nextValue,
+      fromVersion: 0,
+      toVersion: 1,
+      estimate: async () => ({ usage: 999_999, quota: 1_000_000 }),
+    });
+
+    expect(preflight).toMatchObject({ ok: false, supported: true });
+    expect(result).toMatchObject({
+      ok: false,
+      error: { code: 'RECOVERY_STORAGE_INSUFFICIENT' },
+    });
+    expect(await getBlob(key)).toBe(previousValue);
+    expect(await listMigrationRecoverySnapshots(key)).toEqual([]);
+  });
+
+  it('rejects corrupt-copy keys and no-op replacements before storage access', async () => {
+    const value = JSON.stringify({ schemaVersion: 0 });
+    const corruptCopy = await prepareMigrationRecoverySnapshot({
+      profileKey: `${profileKey('invalid')}-corrupt`,
+      previousValue: value,
+      nextValue: JSON.stringify({ schemaVersion: 1 }),
+      fromVersion: 0,
+      toVersion: 1,
+      estimate: ampleEstimate,
+    });
+    const noOp = await commitProfileMigrationWithRecovery({
+      profileKey: profileKey('no-op'),
+      previousValue: value,
+      nextValue: value,
+      fromVersion: 0,
+      toVersion: 1,
+      estimate: ampleEstimate,
+    });
+
+    expect(corruptCopy).toMatchObject({ ok: false, error: { code: 'RECOVERY_INPUT_INVALID' } });
+    expect(noOp).toMatchObject({ ok: false, error: { code: 'RECOVERY_INPUT_INVALID' } });
+  });
+});
+
+describe('encrypted migration recovery lifecycle', () => {
+  it('commits with an encrypted non-extractable snapshot and rolls back exactly', async () => {
+    const key = profileKey('roundtrip');
+    const previousValue = JSON.stringify({ secret: 'private-before-value', schemaVersion: 0 });
+    const nextValue = JSON.stringify({ secret: 'private-after-value', schemaVersion: 1 });
+    await setBlob(key, previousValue);
+
+    const committed = await commitProfileMigrationWithRecovery({
+      profileKey: key,
+      previousValue,
+      nextValue,
+      fromVersion: 0,
+      toVersion: 1,
+      estimate: ampleEstimate,
+    });
+
+    expect(committed).toMatchObject({ ok: true, journalStatus: 'committed' });
+    expect(await getBlob(key)).toBe(nextValue);
+    const metadata = await listMigrationRecoverySnapshots(key);
+    expect(metadata).toHaveLength(1);
+    expect(metadata[0]).toMatchObject({
+      id: committed.snapshotId,
+      status: 'committed',
+      fromVersion: 0,
+      toVersion: 1,
+    });
+    expect(metadata[0]).not.toHaveProperty('envelope');
+
+    const raw = await readRawRecoveryStorage(committed.snapshotId);
+    expect(JSON.stringify(raw.snapshot)).not.toContain('private-before-value');
+    expect(JSON.stringify(raw.snapshot)).not.toContain('private-after-value');
+    expect(raw.key).toMatchObject({ type: 'secret', extractable: false });
+
+    const rolledBack = await rollbackProfileMigration(committed.snapshotId);
+    expect(rolledBack).toMatchObject({ ok: true, journalStatus: 'rolled-back' });
+    expect(await getBlob(key)).toBe(previousValue);
+    expect((await listMigrationRecoverySnapshots(key))[0].status).toBe('rolled-back');
+  });
+
+  it('refuses a stale commit without changing the active profile', async () => {
+    const key = profileKey('conflict');
+    const callerValue = JSON.stringify({ revision: 1 });
+    const concurrentValue = JSON.stringify({ revision: 2 });
+    const migratedValue = JSON.stringify({ revision: 1, schemaVersion: 1 });
+    await setBlob(key, concurrentValue);
+
+    const result = await commitProfileMigrationWithRecovery({
+      profileKey: key,
+      previousValue: callerValue,
+      nextValue: migratedValue,
+      fromVersion: 0,
+      toVersion: 1,
+      estimate: ampleEstimate,
+    });
+
+    expect(result).toMatchObject({ ok: false, error: { code: 'RECOVERY_COMMIT_CONFLICT' } });
+    expect(await getBlob(key)).toBe(concurrentValue);
+    expect(await listMigrationRecoverySnapshots(key)).toEqual([]);
+  });
+
+  it('reconciles both interrupted-before-write and interrupted-after-write journals', async () => {
+    const beforeKey = profileKey('prepared-before');
+    const beforeValue = JSON.stringify({ state: 'old-before' });
+    const beforeNext = JSON.stringify({ state: 'new-before' });
+    await setBlob(beforeKey, beforeValue);
+    const preparedBefore = await prepareMigrationRecoverySnapshot({
+      profileKey: beforeKey,
+      previousValue: beforeValue,
+      nextValue: beforeNext,
+      fromVersion: 0,
+      toVersion: 1,
+      estimate: ampleEstimate,
+    });
+
+    const beforeResult = await reconcileMigrationRecoverySnapshot(preparedBefore.snapshotId);
+    expect(beforeResult).toMatchObject({ ok: true, outcome: 'rolled-back' });
+    expect(await getBlob(beforeKey)).toBe(beforeValue);
+
+    const afterKey = profileKey('prepared-after');
+    const afterValue = JSON.stringify({ state: 'old-after' });
+    const afterNext = JSON.stringify({ state: 'new-after' });
+    await setBlob(afterKey, afterValue);
+    const preparedAfter = await prepareMigrationRecoverySnapshot({
+      profileKey: afterKey,
+      previousValue: afterValue,
+      nextValue: afterNext,
+      fromVersion: 0,
+      toVersion: 1,
+      estimate: ampleEstimate,
+    });
+    await compareAndSetBlob(afterKey, afterValue, afterNext);
+
+    const afterResult = await reconcileMigrationRecoverySnapshot(preparedAfter.snapshotId);
+    expect(afterResult).toMatchObject({ ok: true, outcome: 'committed' });
+    expect(await getBlob(afterKey)).toBe(afterNext);
+  });
+
+  it('refuses automatic rollback after a later profile edit', async () => {
+    const key = profileKey('later-edit');
+    const previousValue = JSON.stringify({ revision: 1 });
+    const migratedValue = JSON.stringify({ revision: 1, schemaVersion: 1 });
+    const laterValue = JSON.stringify({ revision: 2, schemaVersion: 1 });
+    await setBlob(key, previousValue);
+    const committed = await commitProfileMigrationWithRecovery({
+      profileKey: key,
+      previousValue,
+      nextValue: migratedValue,
+      fromVersion: 0,
+      toVersion: 1,
+      estimate: ampleEstimate,
+    });
+    await setBlob(key, laterValue);
+
+    const result = await rollbackProfileMigration(committed.snapshotId);
+    expect(result).toMatchObject({
+      ok: false,
+      error: { code: 'RECOVERY_CURRENT_VALUE_CHANGED' },
+    });
+    expect(await getBlob(key)).toBe(laterValue);
+  });
+});
+
+describe('profile migration lock fallback', () => {
+  it('serializes same-profile callbacks when Navigator Locks is unavailable', async () => {
+    const key = profileKey('lock');
+    const order = [];
+    let releaseFirst;
+    const firstGate = new Promise(resolve => { releaseFirst = resolve; });
+    const first = withProfileMigrationLock(key, async () => {
+      order.push('first-start');
+      await firstGate;
+      order.push('first-end');
+    });
+    await Promise.resolve();
+    const second = withProfileMigrationLock(key, async () => {
+      order.push('second');
+    });
+    await Promise.resolve();
+
+    expect(order).toEqual(['first-start']);
+    releaseFirst();
+    await Promise.all([first, second]);
+    expect(order).toEqual(['first-start', 'first-end', 'second']);
+  });
+});

--- a/tests/migration-recovery-store.test.js
+++ b/tests/migration-recovery-store.test.js
@@ -7,6 +7,7 @@ import {
 } from '../js/blob-storage.js';
 import {
   commitProfileMigrationWithRecovery,
+  eraseMigrationRecoveryStorage,
   estimateMigrationRecoveryBytes,
   listMigrationRecoverySnapshots,
   preflightMigrationRecoveryStorage,
@@ -220,6 +221,26 @@ describe('encrypted migration recovery lifecycle', () => {
       error: { code: 'RECOVERY_CURRENT_VALUE_CHANGED' },
     });
     expect(await getBlob(key)).toBe(laterValue);
+  });
+
+  it('closes its cached connection before complete erasure and can reopen cleanly', async () => {
+    const key = profileKey('erase');
+    const previousValue = JSON.stringify({ state: 'private-before' });
+    const nextValue = JSON.stringify({ state: 'private-after', schemaVersion: 1 });
+    await setBlob(key, previousValue);
+    const committed = await commitProfileMigrationWithRecovery({
+      profileKey: key,
+      previousValue,
+      nextValue,
+      fromVersion: 0,
+      toVersion: 1,
+      estimate: ampleEstimate,
+    });
+    expect(committed.ok).toBe(true);
+
+    await eraseMigrationRecoveryStorage();
+
+    expect(await listMigrationRecoverySnapshots(key)).toEqual([]);
   });
 });
 

--- a/tests/storage-integrity-manifest.test.js
+++ b/tests/storage-integrity-manifest.test.js
@@ -62,6 +62,8 @@ describe('storage integrity policy', () => {
     expect(classifyDatabaseName('getbased-cashu')).toBe(STORAGE_CATEGORIES.WALLET);
     expect(classifyDatabaseName('labcharts-wearables-profile_alpha'))
       .toBe(STORAGE_CATEGORIES.RAW_HEALTH);
+    expect(classifyDatabaseName('labcharts-migration-recovery'))
+      .toBe(STORAGE_CATEGORIES.MIGRATION);
     expect(classifyCacheName('labcharts-v1.11.0')).toBe(STORAGE_CATEGORIES.APP_CACHE);
   });
 });

--- a/tests/test-export-import.js
+++ b/tests/test-export-import.js
@@ -441,6 +441,9 @@ return (async function() {
     exportSrc.includes('await listStoredProfileIds(profiles.map(profile => profile.id))'));
   assert('Awaits centralized profile storage cleanup',
     /for \(const id of profileIds\)[\s\S]{0,200}await clearProfileStorage\(id\)/.test(exportSrc));
+  assert('Erases cross-profile migration recovery storage',
+    exportSrc.includes("import { eraseMigrationRecoveryStorage } from './migration-recovery-store.js'")
+    && exportSrc.includes('await eraseMigrationRecoveryStorage()'));
   assert('Awaits the profile-list reset', exportSrc.includes('await saveProfiles([{ id: defaultId'));
   assert('Resets state.importedData from the canonical factory',
     exportSrc.includes('state.importedData = createDefaultProfileData()'));

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -511,6 +511,7 @@
     "js/marker-analysis.js",
     "js/marker-detail-actions.js",
     "js/marker-detail-editing.js",
+    "js/migration-recovery-store.js",
     "js/notes-runtime.js",
     "js/notes.js",
     "js/profile-list-store.js",


### PR DESCRIPTION
## Summary

- add a dedicated `labcharts-migration-recovery` IndexedDB that old app versions safely ignore
- encrypt every pre-migration raw profile blob with a device-local, non-extractable AES-256-GCM key
- bind snapshot metadata as AES-GCM additional authenticated data
- preflight storage headroom for the encrypted prior value, replacement value, and conservative IDB overhead
- serialize same-profile migrations with Navigator Locks and an in-memory fallback
- add an IndexedDB compare-and-set primitive so concurrent writes fail instead of overwriting newer profile state
- commit through a crash-consistent `prepared -> committed -> rolled-back` journal
- reconcile interruptions before or after the active blob write
- refuse automatic rollback after any later profile edit
- retain at most three settled snapshots per profile while never pruning unresolved prepared journals
- include the recovery database in complete local-data erasure and classify it as migration state in integrity policy

## Compatibility and safety

The existing `labcharts-blobs` database remains at version 1. Recovery state lives in a separate database, so rolling the application code back to an older release does not cause IndexedDB `VersionError` or make existing profiles unreadable.

A recovery snapshot is durably written before the active profile compare-and-set. Snapshot/quota/crypto failure leaves the active blob untouched. If the active write succeeds but the journal-status update is interrupted, startup reconciliation can identify the result from the encrypted journal.

## User impact

No migration path calls this module yet. Profile load, save, import, and sync behavior remain unchanged. The only existing behavior change is that full local-data erasure also deletes the new recovery database.

## Validation

- `npm test -- tests/migration-recovery-store.test.js tests/data-wipe.test.js tests/storage-integrity-manifest.test.js tests/profile-schema-migrations.test.js` — 28 passed
- `node tests/test-blob-storage.js` — 22 passed
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run architecture:check` — 584 modules, 0 cycles
- `node scripts/dom-sink-audit.mjs` — 483 sinks unchanged across 565 modules
- `npm run quality` — 17 passed
