### PR TITLE
Patch nested Undici security alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1064,9 +1064,9 @@
       }
     },
     "node_modules/@vercel/blob/node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
       "elliptic": "$elliptic"
     },
     "@vercel/blob": {
-      "undici": "6.27.0"
+      "undici": "6.28.0"
     }
   }
 }

--- a/tests/proxy-entrypoint-runtime.test.js
+++ b/tests/proxy-entrypoint-runtime.test.js
@@ -55,7 +55,7 @@ describe('proxy production entrypoint', () => {
     expect(packageJson.dependencies['@vercel/blob']).toBe('2.4.0');
     expect(packageLock.packages['node_modules/@vercel/blob'].version).toBe('2.4.0');
     expect(packageLock.packages['node_modules/@vercel/blob/node_modules/undici'].version)
-      .toBe('6.27.0');
+      .toBe('6.28.0');
   });
 
   it('answers preflight and method probes without initializing Blob storage', async () => {


### PR DESCRIPTION
## What changed

- update the `@vercel/blob` Undici override from 6.27.0 to 6.28.0
- regenerate the npm lockfile
- update the exact runtime-artifact assertion

## Why

Undici 6.27.0 is affected by three moderate-severity Dependabot alerts. Version 6.28.0 is the first patched 6.x release and keeps the existing `@vercel/blob` integration on the same major line.

## Impact

This removes the remaining known npm vulnerabilities after the direct Undici 7.29.0 update, without changing the Blob SDK or proxy behavior.

## Verification

- `npm ci` — 0 vulnerabilities
- `npm test -- tests/proxy-network.test.js tests/proxy-upstream.test.js tests/proxy-entrypoint-runtime.test.js tests/proxy-rate-limit.test.js` — 21 passed
- `npm run typecheck:server`
- `npm run supply-chain:check`