### PR TITLE
Fix joining existing sync identities

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -9,8 +9,8 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 
 | Metric | Current |
 | --- | ---: |
-| Modules | 586 |
-| Internal import edges | 2533 |
+| Modules | 587 |
+| Internal import edges | 2536 |
 | Dynamic internal edges | 72 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -60,7 +60,7 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 | [`js/state.js`](js/state.js) | 175 | [`js/app-light-sun-modules.js`](js/app-light-sun-modules.js) | 36 |
 | [`js/caught-error.js`](js/caught-error.js) | 83 | [`js/sync-configure.js`](js/sync-configure.js) | 27 |
 | [`js/data.js`](js/data.js) | 77 | [`js/pdf-import.js`](js/pdf-import.js) | 26 |
-| [`js/modal-lifecycle.js`](js/modal-lifecycle.js) | 71 | [`js/settings.js`](js/settings.js) | 26 |
+| [`js/modal-lifecycle.js`](js/modal-lifecycle.js) | 72 | [`js/settings.js`](js/settings.js) | 26 |
 | [`js/api.js`](js/api.js) | 65 | [`js/wearables-connect.js`](js/wearables-connect.js) | 25 |
 | [`js/profile.js`](js/profile.js) | 48 | [`js/chat-send.js`](js/chat-send.js) | 23 |
 | [`js/schema.js`](js/schema.js) | 34 | [`js/views.js`](js/views.js) | 22 |
@@ -759,7 +759,7 @@ Native browser modules shipped with the static application.
 
 </details>
 
-<details><summary><code>settings</code> family — 18 modules</summary>
+<details><summary><code>settings</code> family — 19 modules</summary>
 
 - [`js/settings-agent-access-panel.js`](js/settings-agent-access-panel.js) → [`js/data.js`](js/data.js), [`js/state.js`](js/state.js), [`js/sync.js`](js/sync.js), [`js/utils-runtime.js`](js/utils-runtime.js), [`js/utils.js`](js/utils.js)
 - [`js/settings-data.js`](js/settings-data.js) → [`js/api.js`](js/api.js), [`js/import-benchmarks.js`](js/import-benchmarks.js), [`js/import-loader.js`](js/import-loader.js), [`js/import-reference-benchmark.js`](js/import-reference-benchmark.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
@@ -771,8 +771,9 @@ Native browser modules shipped with the static application.
 - [`js/settings-provider-bridge.js`](js/settings-provider-bridge.js) → [`js/api.js`](js/api.js), [`js/provider-panels.js`](js/provider-panels.js) *(dynamic)*
 - [`js/settings-runtime-bridge.js`](js/settings-runtime-bridge.js) → no in-scope imports
 - [`js/settings-runtime.js`](js/settings-runtime.js) → [`js/settings-runtime-bridge.js`](js/settings-runtime-bridge.js), [`js/sun-uvdata-config.js`](js/sun-uvdata-config.js)
-- [`js/settings-sync-panel-impl.js`](js/settings-sync-panel-impl.js) → [`js/caught-error.js`](js/caught-error.js), [`js/data.js`](js/data.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/settings-agent-access-panel.js`](js/settings-agent-access-panel.js), [`js/settings-runtime-bridge.js`](js/settings-runtime-bridge.js), [`js/state.js`](js/state.js), [`js/sync.js`](js/sync.js), [`js/utils.js`](js/utils.js)
+- [`js/settings-sync-panel-impl.js`](js/settings-sync-panel-impl.js) → [`js/caught-error.js`](js/caught-error.js), [`js/data.js`](js/data.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/settings-agent-access-panel.js`](js/settings-agent-access-panel.js), [`js/settings-runtime-bridge.js`](js/settings-runtime-bridge.js), [`js/settings-sync-restore-ui.js`](js/settings-sync-restore-ui.js), [`js/state.js`](js/state.js), [`js/sync.js`](js/sync.js), [`js/utils.js`](js/utils.js)
 - [`js/settings-sync-panel.js`](js/settings-sync-panel.js) → [`js/settings-sync-panel-impl.js`](js/settings-sync-panel-impl.js) *(dynamic)*, [`js/sync.js`](js/sync.js), [`js/utils.js`](js/utils.js)
+- [`js/settings-sync-restore-ui.js`](js/settings-sync-restore-ui.js) → [`js/modal-lifecycle.js`](js/modal-lifecycle.js)
 - [`js/settings-tweaks.js`](js/settings-tweaks.js) → [`js/charts.js`](js/charts.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/settings-event-target.js`](js/settings-event-target.js), [`js/settings-runtime.js`](js/settings-runtime.js), [`js/theme.js`](js/theme.js), [`js/utils.js`](js/utils.js)
 - [`js/settings-voice-hardware.js`](js/settings-voice-hardware.js) → [`js/voice-local-engine.js`](js/voice-local-engine.js), [`js/voice-model-catalog.js`](js/voice-model-catalog.js)
 - [`js/settings-voice-model-controller.js`](js/settings-voice-model-controller.js) → [`js/caught-error.js`](js/caught-error.js), [`js/settings-voice-hardware.js`](js/settings-voice-hardware.js), [`js/utils.js`](js/utils.js), [`js/voice-local-engine.js`](js/voice-local-engine.js), [`js/voice-model-catalog.js`](js/voice-model-catalog.js), [`js/voice-settings-storage.js`](js/voice-settings-storage.js)
@@ -909,7 +910,7 @@ Native browser modules shipped with the static application.
 - [`js/sync-disable-cleanup.js`](js/sync-disable-cleanup.js) → no in-scope imports
 - [`js/sync-environment.js`](js/sync-environment.js) → [`js/utils-runtime.js`](js/utils-runtime.js)
 - [`js/sync-identity.js`](js/sync-identity.js) → [`js/sync-disable-cleanup.js`](js/sync-disable-cleanup.js), [`js/sync-runtime.js`](js/sync-runtime.js), [`js/utils.js`](js/utils.js)
-- [`js/sync-init.js`](js/sync-init.js) → [`js/sync-environment.js`](js/sync-environment.js), [`js/sync-recovery.js`](js/sync-recovery.js), [`js/sync-relay-health.js`](js/sync-relay-health.js), [`js/sync-runtime.js`](js/sync-runtime.js), [`js/sync-schema.js`](js/sync-schema.js), [`js/sync-settings-state.js`](js/sync-settings-state.js), [`js/sync-subscriptions.js`](js/sync-subscriptions.js), [`js/utils.js`](js/utils.js)
+- [`js/sync-init.js`](js/sync-init.js) → [`js/sync-environment.js`](js/sync-environment.js), [`js/sync-identity.js`](js/sync-identity.js), [`js/sync-recovery.js`](js/sync-recovery.js), [`js/sync-relay-health.js`](js/sync-relay-health.js), [`js/sync-runtime.js`](js/sync-runtime.js), [`js/sync-schema.js`](js/sync-schema.js), [`js/sync-settings-state.js`](js/sync-settings-state.js), [`js/sync-subscriptions.js`](js/sync-subscriptions.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-lifecycle.js`](js/sync-lifecycle.js) → [`js/sync-actions.js`](js/sync-actions.js), [`js/sync-disable-cleanup.js`](js/sync-disable-cleanup.js), [`js/sync-environment.js`](js/sync-environment.js), [`js/sync-init.js`](js/sync-init.js), [`js/sync-pull.js`](js/sync-pull.js), [`js/sync-runtime.js`](js/sync-runtime.js), [`js/sync-save-hooks.js`](js/sync-save-hooks.js), [`js/sync-settings-state.js`](js/sync-settings-state.js), [`js/sync-state.js`](js/sync-state.js), [`js/sync-subscriptions.js`](js/sync-subscriptions.js), [`js/sync-ui.js`](js/sync-ui.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-messenger.js`](js/sync-messenger.js) → [`js/state.js`](js/state.js), [`js/utils-runtime.js`](js/utils-runtime.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-origin-state.js`](js/sync-origin-state.js) → no in-scope imports

--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -10,7 +10,7 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | Metric | Current |
 | --- | ---: |
 | Modules | 587 |
-| Internal import edges | 2536 |
+| Internal import edges | 2537 |
 | Dynamic internal edges | 72 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -909,7 +909,7 @@ Native browser modules shipped with the static application.
 - [`js/sync-dirty-state.js`](js/sync-dirty-state.js) → no in-scope imports
 - [`js/sync-disable-cleanup.js`](js/sync-disable-cleanup.js) → no in-scope imports
 - [`js/sync-environment.js`](js/sync-environment.js) → [`js/utils-runtime.js`](js/utils-runtime.js)
-- [`js/sync-identity.js`](js/sync-identity.js) → [`js/sync-disable-cleanup.js`](js/sync-disable-cleanup.js), [`js/sync-runtime.js`](js/sync-runtime.js), [`js/utils.js`](js/utils.js)
+- [`js/sync-identity.js`](js/sync-identity.js) → [`js/sync-disable-cleanup.js`](js/sync-disable-cleanup.js), [`js/sync-runtime.js`](js/sync-runtime.js), [`js/sync-settings-state.js`](js/sync-settings-state.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-init.js`](js/sync-init.js) → [`js/sync-environment.js`](js/sync-environment.js), [`js/sync-identity.js`](js/sync-identity.js), [`js/sync-recovery.js`](js/sync-recovery.js), [`js/sync-relay-health.js`](js/sync-relay-health.js), [`js/sync-runtime.js`](js/sync-runtime.js), [`js/sync-schema.js`](js/sync-schema.js), [`js/sync-settings-state.js`](js/sync-settings-state.js), [`js/sync-subscriptions.js`](js/sync-subscriptions.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-lifecycle.js`](js/sync-lifecycle.js) → [`js/sync-actions.js`](js/sync-actions.js), [`js/sync-disable-cleanup.js`](js/sync-disable-cleanup.js), [`js/sync-environment.js`](js/sync-environment.js), [`js/sync-init.js`](js/sync-init.js), [`js/sync-pull.js`](js/sync-pull.js), [`js/sync-runtime.js`](js/sync-runtime.js), [`js/sync-save-hooks.js`](js/sync-save-hooks.js), [`js/sync-settings-state.js`](js/sync-settings-state.js), [`js/sync-state.js`](js/sync-state.js), [`js/sync-subscriptions.js`](js/sync-subscriptions.js), [`js/sync-ui.js`](js/sync-ui.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-messenger.js`](js/sync-messenger.js) → [`js/state.js`](js/state.js), [`js/utils-runtime.js`](js/utils-runtime.js), [`js/utils.js`](js/utils.js)

--- a/css/settings.css
+++ b/css/settings.css
@@ -1707,6 +1707,18 @@
   border-color: color-mix(in srgb, var(--red) 55%, var(--border));
   color: var(--red);
 }
+.sync-setup-restore-actions {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: stretch;
+  gap: 8px;
+}
+.sync-setup-restore-actions .import-btn,
+.sync-setup-restore-actions .confirm-btn {
+  min-height: 38px;
+  white-space: nowrap;
+}
+.sync-setup-restore-cancel { min-width: 76px; }
 .sync-management-help {
   margin-top: 6px;
   color: var(--text-muted);
@@ -1771,6 +1783,17 @@
   .sync-identity-code { font-size: 15px; letter-spacing: .05em; }
   .sync-setup-actions,
   .sync-management-actions { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 480px) {
+  .sync-setup-restore-actions { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .sync-setup-restore-actions #sync-setup-restore-go { grid-column: 1 / -1; }
+  .sync-setup-restore-actions .import-btn,
+  .sync-setup-restore-actions .confirm-btn {
+    width: 100%;
+    min-width: 0;
+    min-height: 40px;
+  }
 }
 
 @media (max-width: 720px) {

--- a/js/changelog-impl.js
+++ b/js/changelog-impl.js
@@ -11,6 +11,14 @@ const changelogDelegateRoots = new WeakSet();
 
 const CHANGELOG = [
   {
+    version: '1.12.2', date: '2026-08-07', title: 'Easier, more reliable sync setup',
+    items: [
+      '<b>Joining an existing sync identity now keeps you informed.</b> You can see when sync is starting, when the 24 words are being checked, and whether the device is reloading or needs you to try again.',
+      '<b>Entering a sync identity works better on mobile.</b> Seed phrases are protected from autocorrect and normalized for capitalization, spacing, and pasted line breaks.',
+      '<b>A clear confirmation appears after the reload.</b> You can immediately tell that this device joined the existing identity and is syncing its data.',
+    ]
+  },
+  {
     version: '1.12.0', date: '2026-08-07', title: 'A completely redesigned health context',
     items: [
       '<b>Health context has been redesigned from the ground up.</b> The cards are cleaner, easier to scan and edit, work better on mobile, and explain why each area matters.',

--- a/js/settings-sync-panel-impl.js
+++ b/js/settings-sync-panel-impl.js
@@ -24,6 +24,14 @@ import {
   updateSyncIndicator,
 } from './sync.js';
 import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
+import {
+  closeRestoreMnemonicDialog,
+  openRestoreMnemonicDialog,
+  setSyncSetupRestoreBusy,
+  setSyncSetupRestoreReloading,
+  updateRestoreMnemonicDialogState,
+  updateSyncSetupRestoreState,
+} from './settings-sync-restore-ui.js';
 import { getSettingsModuleFunction } from './settings-runtime-bridge.js';
 import { saveImportedData } from './data.js';
 import { state } from './state.js';
@@ -40,7 +48,7 @@ import {
   toggleMessengerToken,
 } from './settings-agent-access-panel.js';
 
-export { renderMessengerSection };
+export { closeRestoreMnemonicDialog, renderMessengerSection };
 // Agent Access UI implementation moved to settings-agent-access-panel.js.
 // Facade breadcrumbs kept for source-inspection tests/backward ownership:
 // renderMessengerSection · OpenClaw · GETBASED_AGENT_CONTEXT_KEY · messenger-token · data-masked
@@ -85,6 +93,7 @@ let settingsSyncDelegatesInstalled = false;
 const SETTINGS_SYNC_STATE_ACTIONS = new Set([
   'toggle-sync',
   'setup-ack',
+  'setup-restore-input',
   'restore-dialog-input',
   'toggle-messenger',
   'set-agent-wearable-series-days',
@@ -215,9 +224,11 @@ async function handleSettingsSyncChange(event) {
 }
 
 function handleSettingsSyncInput(event) {
-  const actionEl = closestSettingsSyncAction(event, '[data-sync-action]');
-  if (!actionEl || actionEl.dataset.syncAction !== 'restore-dialog-input') return;
-  if (actionEl instanceof HTMLTextAreaElement) updateRestoreMnemonicDialogState(actionEl);
+  const actionEl = closestSettingsSyncAction(event);
+  if (!(actionEl instanceof HTMLTextAreaElement)) return;
+  const action = actionEl.dataset.syncAction || actionEl.dataset.syncSetupAction;
+  if (action === 'restore-dialog-input') updateRestoreMnemonicDialogState(actionEl);
+  else if (action === 'setup-restore-input') updateSyncSetupRestoreState(actionEl, _syncRestoreInProgress);
 }
 
 function installSettingsSyncDelegates() {
@@ -396,8 +407,8 @@ export function showSyncSetupModal() {
     overlay.className = 'confirm-overlay';
     document.body.appendChild(overlay);
   }
-  overlay.innerHTML = `<div class="confirm-dialog" role="dialog" aria-modal="true" aria-label="Sync setup" style="max-width:480px">
-    <h3 style="margin:0 0 6px;font-size:16px;color:var(--text-primary)">Set up sync</h3>
+  overlay.innerHTML = `<div class="confirm-dialog sync-setup-dialog" role="dialog" aria-modal="true" aria-labelledby="sync-setup-title" style="max-width:480px">
+    <h3 id="sync-setup-title" style="margin:0 0 6px;font-size:16px;color:var(--text-primary)">Set up sync</h3>
     <p style="font-size:13px;color:var(--text-muted);margin:0 0 20px;line-height:1.5">Your data is encrypted with a 24-word mnemonic. The relay server only sees ciphertext.</p>
     <div id="sync-setup-choices">
       <button class="import-btn import-btn-primary" style="width:100%;padding:12px 16px;font-size:13px;margin-bottom:10px;text-align:left" data-sync-setup-action="setup-new">
@@ -411,13 +422,15 @@ export function showSyncSetupModal() {
     </div>
     <div id="sync-setup-new" style="display:none"></div>
     <div id="sync-setup-restore" style="display:none">
-      <textarea id="sync-setup-restore-input" style="font-size:12px;width:100%;height:70px;resize:vertical;border-radius:8px;background:var(--bg-secondary);color:var(--text-primary);border:1px solid var(--border);padding:10px 12px;font-family:var(--font-mono, monospace);box-sizing:border-box;margin-bottom:10px" placeholder="Paste your 24-word mnemonic here..."></textarea>
-      <div style="display:flex;gap:8px">
-        <button class="import-btn import-btn-primary" style="flex:1;padding:8px 16px;font-size:13px" data-sync-setup-action="setup-do-restore">Restore</button>
-        <button class="import-btn import-btn-secondary" style="padding:8px 16px;font-size:13px" data-sync-setup-action="setup-back">Back</button>
+      <textarea id="sync-setup-restore-input" aria-label="24-word mnemonic" aria-describedby="sync-setup-restore-msg" data-sync-setup-action="setup-restore-input" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" style="font-size:12px;width:100%;height:70px;resize:vertical;border-radius:8px;background:var(--bg-secondary);color:var(--text-primary);border:1px solid var(--border);padding:10px 12px;font-family:var(--font-mono, monospace);box-sizing:border-box" placeholder="Paste your 24-word mnemonic here..."></textarea>
+      <div id="sync-setup-restore-msg" role="status" aria-live="polite" style="font-size:11px;color:var(--text-muted);margin:6px 0 10px;min-height:14px"></div>
+      <div class="sync-setup-restore-actions">
+        <button id="sync-setup-restore-go" class="import-btn import-btn-primary" style="flex:1;padding:8px 16px;font-size:13px" data-sync-setup-action="setup-do-restore" disabled>Join &amp; reload</button>
+        <button id="sync-setup-restore-back" class="import-btn import-btn-secondary" style="padding:8px 16px;font-size:13px" data-sync-setup-action="setup-back">Back</button>
+        <button class="confirm-btn confirm-btn-cancel sync-setup-restore-cancel" data-sync-setup-action="setup-cancel">Cancel</button>
       </div>
     </div>
-    <div style="margin-top:16px;text-align:right">
+    <div class="sync-setup-choice-footer" style="margin-top:16px;text-align:right">
       <button class="confirm-btn confirm-btn-cancel" data-sync-setup-action="setup-cancel">Cancel</button>
     </div>
   </div>`;
@@ -425,6 +438,11 @@ export function showSyncSetupModal() {
 }
 
 export async function closeSyncSetup() {
+  if (_syncRestoreInProgress) {
+    showNotification('Joining the existing sync identity…', 'info');
+    nudgeSyncSetupDialog();
+    return false;
+  }
   try {
     closeModalOverlay('sync-setup-overlay');
     // If sync was started during setup but user cancelled, clean up
@@ -442,9 +460,11 @@ export async function closeSyncSetup() {
     if (el) el.innerHTML = renderSyncSection();
     _releaseSyncToggle();
   }
+  return true;
 }
 
 let _syncSetupInProgress = false;
+let _syncRestoreInProgress = false;
 async function syncSetupNew() {
   if (_syncSetupInProgress) return;
   const choicesEl = document.getElementById('sync-setup-choices');
@@ -517,8 +537,13 @@ function syncSetupRestore() {
   if (!choicesEl || !restoreEl) return;
   choicesEl.style.display = 'none';
   restoreEl.style.display = 'block';
-  const input = document.getElementById('sync-setup-restore-input');
-  if (input) input.focus();
+  const title = document.getElementById('sync-setup-title');
+  if (title) title.textContent = 'Join existing sync';
+  const choiceFooter = /** @type {HTMLElement | null} */ (document.querySelector('#sync-setup-overlay .sync-setup-choice-footer'));
+  if (choiceFooter) choiceFooter.hidden = true;
+  const input = /** @type {HTMLTextAreaElement | null} */ (document.getElementById('sync-setup-restore-input'));
+  updateSyncSetupRestoreState(input);
+  input?.focus();
 }
 
 function syncSetupBack() {
@@ -529,10 +554,17 @@ function syncSetupBack() {
   choicesEl.style.display = '';
   restoreEl.style.display = 'none';
   newEl.style.display = 'none';
+  const title = document.getElementById('sync-setup-title');
+  if (title) title.textContent = 'Set up sync';
+  const choiceFooter = /** @type {HTMLElement | null} */ (document.querySelector('#sync-setup-overlay .sync-setup-choice-footer'));
+  if (choiceFooter) choiceFooter.hidden = false;
 }
 
 async function syncSetupDoRestore() {
-  if (_syncSetupInProgress) return;
+  if (_syncSetupInProgress) {
+    showNotification('Sync setup is already in progress…', 'info');
+    return;
+  }
   const input = /** @type {HTMLTextAreaElement | null} */ (document.getElementById('sync-setup-restore-input'));
   if (!input) return;
   const raw = (input.value || '').trim();
@@ -549,21 +581,33 @@ async function syncSetupDoRestore() {
   }
 
   _syncSetupInProgress = true;
+  _syncRestoreInProgress = true;
+  let restored = false;
+  setSyncSetupRestoreBusy(true, 'Starting encrypted sync…');
   try {
     // Enable sync (generates throwaway identity) then immediately restore
-    await enableSync({ skipPush: true });
+    const enabled = await enableSync({ skipPush: true });
+    if (enabled !== true) {
+      throw new Error(getMnemonicResolutionError() || 'Sync could not initialize in this browser');
+    }
+    setSyncSetupRestoreBusy(true, 'Sync is ready. Checking the 24-word identity…');
     const result = await restoreFromMnemonic(mnemonic);
     if (!result) {
-      // Restore failed — clean up the throwaway identity
-      await disableSync();
-      const el = document.getElementById('sync-section');
-      if (el) el.innerHTML = renderSyncSection();
-      _releaseSyncToggle();
+      setSyncSetupRestoreBusy(false, 'Could not join. Verify all 24 words and try again.');
       return;
     }
+    restored = true;
+    setSyncSetupRestoreReloading();
     // restoreFromMnemonic triggers reload, so nothing else needed
+  } catch (e) {
+    console.error('[sync] join existing device failed:', e);
+    const reason = getErrorMessage(e, e);
+    setSyncSetupRestoreBusy(false, `Could not join: ${reason}`);
+    showNotification(`Could not join existing sync: ${reason}`, 'error');
   } finally {
     _syncSetupInProgress = false;
+    _syncRestoreInProgress = false;
+    if (!restored) setSyncSetupRestoreBusy(false);
   }
 }
 
@@ -675,65 +719,6 @@ function copySyncIdentityCode() {
   });
 }
 
-/**
- * Single-step restore modal — replaces the old two-button flow that confused
- * users into clicking the outer "Restore from mnemonic" button (which only
- * revealed a textarea) and waiting for something to happen. Now the modal
- * contains the seed input + a single Restore action button + Cancel, all
- * in one place. Same pattern as the sync setup wizard so users don't have
- * to learn two different shapes.
- */
-function openRestoreMnemonicDialog() {
-  let overlay = document.getElementById('sync-restore-overlay');
-  if (!overlay) {
-    overlay = document.createElement('div');
-    overlay.id = 'sync-restore-overlay';
-    overlay.className = 'confirm-overlay';
-    document.body.appendChild(overlay);
-  }
-  overlay.innerHTML = `<div class="confirm-dialog" role="dialog" aria-modal="true" aria-labelledby="sync-restore-title" style="max-width:480px">
-    <h3 id="sync-restore-title" style="margin:0 0 6px;font-size:16px;color:var(--text-primary)">Restore from mnemonic</h3>
-    <p style="font-size:13px;color:var(--text-muted);margin:0 0 14px;line-height:1.5">Paste your 24-word seed from another device. This replaces your current sync identity — anything synced under the old identity will no longer reach this device.</p>
-    <textarea id="sync-restore-dialog-input" autofocus aria-label="24-word mnemonic" data-sync-action="restore-dialog-input" style="font-size:12px;width:100%;height:90px;resize:vertical;border-radius:8px;background:var(--bg-secondary);color:var(--text-primary);border:1px solid var(--border);padding:10px 12px;font-family:var(--font-mono, monospace);box-sizing:border-box" placeholder="word word word word word word word word word word word word word word word word word word word word word word word word"></textarea>
-    <div id="sync-restore-dialog-msg" style="font-size:11px;color:var(--text-muted);margin-top:6px;min-height:14px"></div>
-    <div style="display:flex;gap:8px;justify-content:flex-end;margin-top:12px">
-      <button class="confirm-btn confirm-btn-cancel" data-sync-action="close-restore-dialog">Cancel</button>
-      <button id="sync-restore-dialog-go" class="import-btn import-btn-primary" style="padding:8px 16px;font-size:13px" data-sync-action="confirm-restore">Restore &amp; reload</button>
-    </div>
-  </div>`;
-  openModalOverlay(overlay, { initialFocus: '#sync-restore-dialog-input', focusDelay: 50 });
-  // Live word count + button enable so the user gets immediate feedback as
-  // they paste — much friendlier than only finding out on submit.
-  const input = document.getElementById('sync-restore-dialog-input');
-  if (input) {
-    updateRestoreMnemonicDialogState(input instanceof HTMLTextAreaElement ? input : null);
-  }
-}
-
-function updateRestoreMnemonicDialogState(input = /** @type {HTMLTextAreaElement | null} */ (document.getElementById('sync-restore-dialog-input'))) {
-  const msg = document.getElementById('sync-restore-dialog-msg');
-  const btn = /** @type {HTMLButtonElement | null} */ (document.getElementById('sync-restore-dialog-go'));
-  if (!input) return;
-  const raw = (input.value || '').trim();
-  if (!raw) {
-    if (msg) { msg.textContent = ''; msg.style.color = 'var(--text-muted)'; }
-    if (btn) btn.disabled = true;
-    return;
-  }
-  const words = raw.split(/\s+/);
-  if (words.length === 24) {
-    if (msg) { msg.textContent = '✓ 24 words detected'; msg.style.color = 'var(--green, #22c55e)'; }
-    if (btn) btn.disabled = false;
-  } else {
-    if (msg) { msg.textContent = `${words.length} word${words.length === 1 ? '' : 's'} so far — need exactly 24`; msg.style.color = '#fbbf24'; }
-    if (btn) btn.disabled = true;
-  }
-}
-
-export function closeRestoreMnemonicDialog() {
-  closeModalOverlay('sync-restore-overlay');
-}
-
 async function confirmRestoreMnemonic() {
   const input = /** @type {HTMLTextAreaElement | null} */ (document.getElementById('sync-restore-dialog-input'));
   const btn = /** @type {HTMLButtonElement | null} */ (document.getElementById('sync-restore-dialog-go'));
@@ -746,13 +731,26 @@ async function confirmRestoreMnemonic() {
     return;
   }
   if (btn) { btn.disabled = true; btn.textContent = 'Restoring…'; }
+  const msg = document.getElementById('sync-restore-dialog-msg');
+  if (msg) { msg.textContent = 'Checking the 24-word identity…'; msg.style.color = 'var(--text-muted)'; }
   // No second confirm dialog — the modal already explains what restore
   // does, and the action button is explicit ("Restore & reload"). Adding
   // a second confirm pile-up was the friction users complained about.
-  const result = await restoreFromMnemonic(raw);
-  if (!result) {
+  try {
+    const result = await restoreFromMnemonic(raw);
+    if (!result) {
+      if (btn) { btn.disabled = false; btn.textContent = 'Restore & reload'; }
+      if (msg) { msg.textContent = 'Could not restore. Verify all 24 words and try again.'; msg.style.color = 'var(--red)'; }
+      if (!isSyncEnabled()) showNotification('Sync not initialized — enable sync first, then restore', 'error');
+      return;
+    }
+    if (msg) { msg.textContent = 'Identity accepted. Reloading this device…'; msg.style.color = 'var(--green, #22c55e)'; }
+  } catch (e) {
+    const reason = getErrorMessage(e, e);
+    console.error('[sync] restore identity failed:', e);
     if (btn) { btn.disabled = false; btn.textContent = 'Restore & reload'; }
-    if (!isSyncEnabled()) showNotification('Sync not initialized — enable sync first, then restore', 'error');
+    if (msg) { msg.textContent = `Could not restore: ${reason}`; msg.style.color = 'var(--red)'; }
+    showNotification(`Could not restore sync identity: ${reason}`, 'error');
   }
   // On success: restoreFromMnemonic triggers reload (Evolu auto-reloads),
   // so we don't need to close this modal — the page replaces itself.

--- a/js/settings-sync-panel-impl.js
+++ b/js/settings-sync-panel-impl.js
@@ -427,11 +427,10 @@ export function showSyncSetupModal() {
       <div class="sync-setup-restore-actions">
         <button id="sync-setup-restore-go" class="import-btn import-btn-primary" style="flex:1;padding:8px 16px;font-size:13px" data-sync-setup-action="setup-do-restore" disabled>Join &amp; reload</button>
         <button id="sync-setup-restore-back" class="import-btn import-btn-secondary" style="padding:8px 16px;font-size:13px" data-sync-setup-action="setup-back">Back</button>
-        <button class="confirm-btn confirm-btn-cancel sync-setup-restore-cancel" data-sync-setup-action="setup-cancel">Cancel</button>
       </div>
     </div>
     <div class="sync-setup-choice-footer" style="margin-top:16px;text-align:right">
-      <button class="confirm-btn confirm-btn-cancel" data-sync-setup-action="setup-cancel">Cancel</button>
+      <button id="sync-setup-cancel" class="confirm-btn confirm-btn-cancel sync-setup-restore-cancel" data-sync-setup-action="setup-cancel">Cancel</button>
     </div>
   </div>`;
   openModalOverlay(overlay, { initialFocus: '[data-sync-setup-action="setup-new"]', focusDelay: 50 });
@@ -540,6 +539,9 @@ function syncSetupRestore() {
   const title = document.getElementById('sync-setup-title');
   if (title) title.textContent = 'Join existing sync';
   const choiceFooter = /** @type {HTMLElement | null} */ (document.querySelector('#sync-setup-overlay .sync-setup-choice-footer'));
+  const restoreActions = document.querySelector('#sync-setup-overlay .sync-setup-restore-actions');
+  const cancel = document.getElementById('sync-setup-cancel');
+  if (restoreActions && cancel) restoreActions.append(cancel);
   if (choiceFooter) choiceFooter.hidden = true;
   const input = /** @type {HTMLTextAreaElement | null} */ (document.getElementById('sync-setup-restore-input'));
   updateSyncSetupRestoreState(input);
@@ -557,6 +559,8 @@ function syncSetupBack() {
   const title = document.getElementById('sync-setup-title');
   if (title) title.textContent = 'Set up sync';
   const choiceFooter = /** @type {HTMLElement | null} */ (document.querySelector('#sync-setup-overlay .sync-setup-choice-footer'));
+  const cancel = document.getElementById('sync-setup-cancel');
+  if (choiceFooter && cancel) choiceFooter.append(cancel);
   if (choiceFooter) choiceFooter.hidden = false;
 }
 

--- a/js/settings-sync-panel-impl.js
+++ b/js/settings-sync-panel-impl.js
@@ -589,8 +589,9 @@ async function syncSetupDoRestore() {
   let restored = false;
   setSyncSetupRestoreBusy(true, 'Starting encrypted sync…');
   try {
-    // Enable sync (generates throwaway identity) then immediately restore
-    const enabled = await enableSync({ skipPush: true });
+    // Initialize a throwaway identity without persisting it. The restored
+    // identity becomes durable only after Evolu accepts the supplied seed.
+    const enabled = await enableSync({ skipPush: true, persist: false });
     if (enabled !== true) {
       throw new Error(getMnemonicResolutionError() || 'Sync could not initialize in this browser');
     }

--- a/js/settings-sync-restore-ui.js
+++ b/js/settings-sync-restore-ui.js
@@ -1,0 +1,102 @@
+// @ts-check
+// settings-sync-restore-ui.js — mnemonic restore progress and validation UI.
+
+import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
+
+/** @param {HTMLTextAreaElement | null} [input]
+ * @param {boolean} [busy]
+ */
+export function updateSyncSetupRestoreState(
+  input = /** @type {HTMLTextAreaElement | null} */ (document.getElementById('sync-setup-restore-input')),
+  busy = false,
+) {
+  const msg = document.getElementById('sync-setup-restore-msg');
+  const btn = /** @type {HTMLButtonElement | null} */ (document.getElementById('sync-setup-restore-go'));
+  if (!input || busy) return;
+  const raw = (input.value || '').trim();
+  const words = raw ? raw.split(/\s+/) : [];
+  if (msg) {
+    msg.textContent = raw
+      ? (words.length === 24 ? '✓ 24 words detected' : `${words.length} word${words.length === 1 ? '' : 's'} so far — need exactly 24`)
+      : 'Paste the 24 words from the device that already has sync.';
+    msg.style.color = words.length === 24 ? 'var(--green, #22c55e)' : (raw ? '#fbbf24' : 'var(--text-muted)');
+  }
+  if (btn) btn.disabled = words.length !== 24;
+}
+
+export function setSyncSetupRestoreBusy(busy, message = '') {
+  const restoreEl = document.getElementById('sync-setup-restore');
+  const input = /** @type {HTMLTextAreaElement | null} */ (document.getElementById('sync-setup-restore-input'));
+  const msg = document.getElementById('sync-setup-restore-msg');
+  const btn = /** @type {HTMLButtonElement | null} */ (document.getElementById('sync-setup-restore-go'));
+  const back = /** @type {HTMLButtonElement | null} */ (document.getElementById('sync-setup-restore-back'));
+  const cancelButtons = document.querySelectorAll('#sync-setup-overlay [data-sync-setup-action="setup-cancel"]');
+  if (restoreEl) restoreEl.setAttribute('aria-busy', busy ? 'true' : 'false');
+  if (input) input.disabled = busy;
+  if (btn) {
+    btn.disabled = busy;
+    btn.textContent = busy ? 'Joining…' : 'Join & reload';
+  }
+  if (back) back.disabled = busy;
+  cancelButtons.forEach(cancel => { if (cancel instanceof HTMLButtonElement) cancel.disabled = busy; });
+  if (msg && message) {
+    msg.textContent = message;
+    msg.style.color = busy ? 'var(--text-muted)' : 'var(--red)';
+  }
+}
+
+export function setSyncSetupRestoreReloading() {
+  setSyncSetupRestoreBusy(true, 'Identity accepted. Reloading this device…');
+  const btn = /** @type {HTMLButtonElement | null} */ (document.getElementById('sync-setup-restore-go'));
+  if (btn) btn.textContent = 'Reloading…';
+}
+
+export function openRestoreMnemonicDialog() {
+  let overlay = document.getElementById('sync-restore-overlay');
+  if (!overlay) {
+    overlay = document.createElement('div');
+    overlay.id = 'sync-restore-overlay';
+    overlay.className = 'confirm-overlay';
+    document.body.appendChild(overlay);
+  }
+  overlay.innerHTML = `<div class="confirm-dialog" role="dialog" aria-modal="true" aria-labelledby="sync-restore-title" style="max-width:480px">
+    <h3 id="sync-restore-title" style="margin:0 0 6px;font-size:16px;color:var(--text-primary)">Restore from mnemonic</h3>
+    <p style="font-size:13px;color:var(--text-muted);margin:0 0 14px;line-height:1.5">Paste your 24-word seed from another device. This replaces your current sync identity — anything synced under the old identity will no longer reach this device.</p>
+    <textarea id="sync-restore-dialog-input" autofocus aria-label="24-word mnemonic" aria-describedby="sync-restore-dialog-msg" data-sync-action="restore-dialog-input" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" style="font-size:12px;width:100%;height:90px;resize:vertical;border-radius:8px;background:var(--bg-secondary);color:var(--text-primary);border:1px solid var(--border);padding:10px 12px;font-family:var(--font-mono, monospace);box-sizing:border-box" placeholder="word word word word word word word word word word word word word word word word word word word word word word word word"></textarea>
+    <div id="sync-restore-dialog-msg" role="status" aria-live="polite" style="font-size:11px;color:var(--text-muted);margin-top:6px;min-height:14px"></div>
+    <div style="display:flex;gap:8px;justify-content:flex-end;margin-top:12px">
+      <button class="confirm-btn confirm-btn-cancel" data-sync-action="close-restore-dialog">Cancel</button>
+      <button id="sync-restore-dialog-go" class="import-btn import-btn-primary" style="padding:8px 16px;font-size:13px" data-sync-action="confirm-restore">Restore &amp; reload</button>
+    </div>
+  </div>`;
+  openModalOverlay(overlay, { initialFocus: '#sync-restore-dialog-input', focusDelay: 50 });
+  const input = document.getElementById('sync-restore-dialog-input');
+  updateRestoreMnemonicDialogState(input instanceof HTMLTextAreaElement ? input : null);
+}
+
+/** @param {HTMLTextAreaElement | null} [input] */
+export function updateRestoreMnemonicDialogState(
+  input = /** @type {HTMLTextAreaElement | null} */ (document.getElementById('sync-restore-dialog-input')),
+) {
+  const msg = document.getElementById('sync-restore-dialog-msg');
+  const btn = /** @type {HTMLButtonElement | null} */ (document.getElementById('sync-restore-dialog-go'));
+  if (!input) return;
+  const raw = (input.value || '').trim();
+  if (!raw) {
+    if (msg) { msg.textContent = ''; msg.style.color = 'var(--text-muted)'; }
+    if (btn) btn.disabled = true;
+    return;
+  }
+  const words = raw.split(/\s+/);
+  if (words.length === 24) {
+    if (msg) { msg.textContent = '✓ 24 words detected'; msg.style.color = 'var(--green, #22c55e)'; }
+    if (btn) btn.disabled = false;
+  } else {
+    if (msg) { msg.textContent = `${words.length} word${words.length === 1 ? '' : 's'} so far — need exactly 24`; msg.style.color = '#fbbf24'; }
+    if (btn) btn.disabled = true;
+  }
+}
+
+export function closeRestoreMnemonicDialog() {
+  closeModalOverlay('sync-restore-overlay');
+}

--- a/js/sync-identity.js
+++ b/js/sync-identity.js
@@ -22,6 +22,30 @@ let _getEvolu = () => null;
 let _seedLocalProfiles = async () => {};
 
 export const RESTORE_JOIN_PENDING_KEY = 'labcharts-sync-restore-join-pending';
+export const RESTORE_NOTICE_KEY = 'labcharts-sync-restore-notice';
+
+function setRestoreNotice(kind) {
+  try { sessionStorage.setItem(RESTORE_NOTICE_KEY, kind); } catch {}
+}
+
+function clearRestoreNotice() {
+  try { sessionStorage.removeItem(RESTORE_NOTICE_KEY); } catch {}
+}
+
+export function consumeSyncRestoreNotice() {
+  let kind = '';
+  try {
+    kind = sessionStorage.getItem(RESTORE_NOTICE_KEY) || '';
+    sessionStorage.removeItem(RESTORE_NOTICE_KEY);
+  } catch {}
+  if (kind === 'seed-local') return 'Sync identity restored and this device’s data was republished.';
+  if (kind === 'join') return 'Joined existing sync identity. Syncing data from your other device…';
+  return null;
+}
+
+function normalizeMnemonic(mnemonic) {
+  return String(mnemonic || '').normalize('NFKD').trim().toLowerCase().split(/\s+/).join(' ');
+}
 
 /** @param {{
  *   getAppOwner?: () => SyncAppOwner | null,
@@ -155,9 +179,14 @@ export async function resetLocalSyncHistoryForRelayRebuild() {
  */
 export async function restoreFromMnemonic(mnemonic, options = {}) {
   const evolu = currentEvolu();
-  if (!evolu) return false;
+  if (!evolu) {
+    showNotification('Sync is still starting. Wait a moment and try again.', 'error');
+    return false;
+  }
+  const normalizedMnemonic = normalizeMnemonic(mnemonic);
+  setRestoreNotice(options?.seedLocal ? 'seed-local' : 'join');
   try {
-    await evolu.restoreAppOwner(mnemonic);
+    await evolu.restoreAppOwner(normalizedMnemonic);
     // sessionStorage survives the reload below. Locks created under the old
     // owner must not veto provider settings pulled from the restored owner.
     sessionStorage.removeItem('labcharts-ai-settings-local-lock-until');
@@ -182,6 +211,7 @@ export async function restoreFromMnemonic(mnemonic, options = {}) {
     scheduleSyncRuntimeReload(500);
     return true;
   } catch (e) {
+    clearRestoreNotice();
     console.error('[sync] Restore failed:', e);
     showNotification('Invalid mnemonic', 'error');
     return false;

--- a/js/sync-identity.js
+++ b/js/sync-identity.js
@@ -6,6 +6,7 @@ import {
   clearSyncDisableStorage,
 } from './sync-disable-cleanup.js';
 import { scheduleSyncRuntimeReload } from './sync-runtime.js';
+import { setSyncEnabled } from './sync-settings-state.js';
 
 /** @typedef {{ id?: unknown, mnemonic?: string }} SyncAppOwner */
 /** @typedef {{ restoreAppOwner: (mnemonic: string, options?: { reload?: boolean }) => unknown }} SyncEvolu */
@@ -187,6 +188,9 @@ export async function restoreFromMnemonic(mnemonic, options = {}) {
   setRestoreNotice(options?.seedLocal ? 'seed-local' : 'join');
   try {
     await evolu.restoreAppOwner(normalizedMnemonic);
+    // First-time joins initialize Evolu provisionally. Persist sync only once
+    // the requested identity has actually been accepted.
+    setSyncEnabled(true);
     // sessionStorage survives the reload below. Locks created under the old
     // owner must not veto provider settings pulled from the restored owner.
     sessionStorage.removeItem('labcharts-ai-settings-local-lock-until');

--- a/js/sync-init.js
+++ b/js/sync-init.js
@@ -1,13 +1,14 @@
 // @ts-check
 // sync-init.js - Evolu initialization and startup reconciliation.
 
-import { isDebugMode } from './utils.js';
+import { isDebugMode, showNotification } from './utils.js';
 import { createSyncQueries, createSyncSchema } from './sync-schema.js';
 import { getSyncBlocker, getSyncRelay } from './sync-environment.js';
 import { primeSyncState, setSyncEnabled } from './sync-settings-state.js';
 import { bindSyncRecoveryEvents } from './sync-recovery.js';
 import { bindSyncSubscriptions, startRelayProbe } from './sync-subscriptions.js';
 import { scheduleOwnerStorageRefresh } from './sync-relay-health.js';
+import { consumeSyncRestoreNotice } from './sync-identity.js';
 import {
   getSyncAppOwner, getSyncEvolu, getSyncReloadUrlRuntime,
   setSyncAppOwner, setSyncAppOwnerError, setSyncEvolu,
@@ -87,6 +88,8 @@ export async function initSync() {
     const readyPromise = evolu.appOwner.then(owner => {
       setSyncAppOwner(owner);
       setSyncAppOwnerError(null);
+      const restoreNotice = consumeSyncRestoreNotice();
+      if (restoreNotice) showNotification(restoreNotice, 'success', 6000);
       scheduleOwnerStorageRefresh(0);
       dbg('Owner resolved');
     }).catch(e => {

--- a/js/sync-lifecycle.js
+++ b/js/sync-lifecycle.js
@@ -25,7 +25,7 @@ export async function enableSync({ skipPush = false } = {}) {
   const blocker = getSyncBlocker();
   if (blocker) {
     showNotification(`Sync unavailable in this browser: ${blocker}`, 'error');
-    return;
+    return false;
   }
   setSyncEnabled(true);
   setSyncAppOwnerError(null);
@@ -36,7 +36,7 @@ export async function enableSync({ skipPush = false } = {}) {
     // load failure. Already logged by initSync; surface a toast so the user
     // doesn't sit staring at a Resolving... spinner.
     showNotification(`Sync failed to initialize. ${getSyncAppOwnerError() || 'Check console for [sync] errors.'}`, 'error');
-    return;
+    return false;
   }
   // Race the owner-resolution promise against a 30s ceiling. A stuck
   // OPFS handle or a Web Lock that never resolves can leave Evolu's
@@ -47,7 +47,7 @@ export async function enableSync({ skipPush = false } = {}) {
   if (result === '__timeout__' || !getSyncAppOwner()) {
     const reason = getSyncAppOwnerError() || 'Evolu owner did not resolve within 30s';
     showNotification(`Sync init failed: ${reason}`, 'error');
-    return;
+    return false;
   }
   const queryLoaded = getSyncQueryLoadedPromise();
   if (queryLoaded) {
@@ -60,6 +60,7 @@ export async function enableSync({ skipPush = false } = {}) {
   }
   showNotification('Sync enabled', 'success');
   renderSyncIndicator();
+  return true;
 }
 
 export async function disableSync() {

--- a/js/sync-lifecycle.js
+++ b/js/sync-lifecycle.js
@@ -18,8 +18,8 @@ import {
   setSyncAppOwnerError,
 } from './sync-runtime.js';
 
-/** @param {{ skipPush?: boolean }} [options] */
-export async function enableSync({ skipPush = false } = {}) {
+/** @param {{ skipPush?: boolean, persist?: boolean }} [options] */
+export async function enableSync({ skipPush = false, persist = true } = {}) {
   // Reject early if the webview can't actually run Evolu - no point flipping
   // the persisted flag and starting init only to time out at 30s.
   const blocker = getSyncBlocker();
@@ -27,7 +27,8 @@ export async function enableSync({ skipPush = false } = {}) {
     showNotification(`Sync unavailable in this browser: ${blocker}`, 'error');
     return false;
   }
-  setSyncEnabled(true);
+  if (persist) setSyncEnabled(true);
+  else setSyncEnabled(true, { persist: false });
   setSyncAppOwnerError(null);
   await initSync();
   const readyPromise = getSyncReadyPromise();
@@ -58,8 +59,10 @@ export async function enableSync({ skipPush = false } = {}) {
     try { await forcePull(); } catch (e) { console.warn('[sync] initial pull failed:', e); }
     try { await pushAllProfiles(); } catch (e) { console.warn('[sync] initial push failed:', e); }
   }
-  showNotification('Sync enabled', 'success');
-  renderSyncIndicator();
+  if (persist) {
+    showNotification('Sync enabled', 'success');
+    renderSyncIndicator();
+  }
   return true;
 }
 

--- a/scripts/dom-sink-policy.json
+++ b/scripts/dom-sink-policy.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "scope": "Every non-generated JavaScript module under js/",
   "reviewRule": "Any added or modified HTML-writing sink requires security review and a policy refresh.",
-  "scannedFiles": 567,
-  "sinkCount": 483,
+  "scannedFiles": 568,
+  "sinkCount": 482,
   "files": {
     "js/backup.js": {
       "count": 1,
@@ -696,10 +696,17 @@
       }
     },
     "js/settings-sync-panel-impl.js": {
-      "count": 10,
-      "digest": "168562e833c3dfe0fbee1be611130de771b195fbaef9ba91ceefd9c10a138a6c",
+      "count": 8,
+      "digest": "114b2c24e492718cdb9643475be43fc8d30ce4304eb0c2927e0967b6a872e4df",
       "kinds": {
-        "innerHTML": 10
+        "innerHTML": 8
+      }
+    },
+    "js/settings-sync-restore-ui.js": {
+      "count": 1,
+      "digest": "e48ce39b90c18ab76221daf781b2aa73b25b166d37982a4a2d8c8d10ded7d549",
+      "kinds": {
+        "innerHTML": 1
       }
     },
     "js/settings-tweaks.js": {

--- a/scripts/dom-sink-policy.json
+++ b/scripts/dom-sink-policy.json
@@ -697,7 +697,7 @@
     },
     "js/settings-sync-panel-impl.js": {
       "count": 8,
-      "digest": "114b2c24e492718cdb9643475be43fc8d30ce4304eb0c2927e0967b6a872e4df",
+      "digest": "bac271bca60a413d6cde0ba957871058b0c6660fb2f608ccf690f7525773071b",
       "kinds": {
         "innerHTML": 8
       }

--- a/service-worker.js
+++ b/service-worker.js
@@ -285,6 +285,7 @@ const APP_SHELL = [
   '/js/settings-runtime-bridge.js',
   '/js/settings-sync-panel.js',
   '/js/settings-sync-panel-impl.js',
+  '/js/settings-sync-restore-ui.js',
   '/js/settings-tweaks.js',
   '/js/voice-audio.js',
   '/js/voice-catalog-storage.js',

--- a/tests/playwright/settings-sync-setup-browser-coverage.spec.js
+++ b/tests/playwright/settings-sync-setup-browser-coverage.spec.js
@@ -10,6 +10,12 @@ async function openIsolatedSyncSetupPage(page) {
     contentType: 'text/html',
     body: `<!doctype html>
       <html>
+        <head>
+          <link rel="stylesheet" href="/styles.css">
+          <link rel="stylesheet" href="/css/app-shell.css">
+          <link rel="stylesheet" href="/css/modal-shared.css">
+          <link rel="stylesheet" href="/css/settings.css">
+        </head>
         <body>
           <div id="notification-container"></div>
           <section id="sync-section"></section>
@@ -24,6 +30,10 @@ async function openIsolatedSyncSetupPage(page) {
       export function isSyncEnabled() { return !!stub.enabled; }
       export async function enableSync(options = {}) {
         stub.calls.push({ fn: 'enableSync', skipPush: options.skipPush === true });
+        if (stub.enableResult === false) {
+          stub.enabled = false;
+          return false;
+        }
         stub.enabled = true;
         return true;
       }
@@ -140,6 +150,7 @@ test('settings sync setup browser coverage exercises mnemonic setup restore and 
       mnemonic,
       fingerprint: 'A94F-2C71-B803',
       restoreResult: true,
+      enableResult: true,
       relay: 'wss://relay.example',
     };
 
@@ -231,19 +242,55 @@ test('settings sync setup browser coverage exercises mnemonic setup restore and 
       syncPanel.showSyncSetupModal();
       document.querySelector('[data-sync-setup-action="setup-restore"]')?.click();
       const setupRestoreInput = document.getElementById('sync-setup-restore-input');
-      if (!(setupRestoreInput instanceof HTMLTextAreaElement)) {
-        throw new Error('setup restore input missing');
+      const setupRestoreButton = document.getElementById('sync-setup-restore-go');
+      const setupRestoreMessage = document.getElementById('sync-setup-restore-msg');
+      if (!(setupRestoreInput instanceof HTMLTextAreaElement) || !(setupRestoreButton instanceof HTMLButtonElement)) {
+        throw new Error('setup restore controls missing');
       }
+      setupRestoreInput.value = mnemonic.split(' ').slice(0, 23).join(' ');
+      setupRestoreInput.dispatchEvent(new Event('input', { bubbles: true }));
+      const incompleteSeedStaysDisabled = setupRestoreButton.disabled
+        && setupRestoreMessage?.textContent.includes('23 words');
       setupRestoreInput.value = mnemonic;
-      document.querySelector('[data-sync-setup-action="setup-do-restore"]')?.click();
+      setupRestoreInput.dispatchEvent(new Event('input', { bubbles: true }));
+      outcomes.setupRestoreValidatesInputWithoutMobileTextMutation =
+        incompleteSeedStaysDisabled
+        && setupRestoreButton.disabled === false
+        && setupRestoreMessage?.textContent.includes('24 words detected') === true
+        && setupRestoreInput.autocapitalize === 'none'
+        && setupRestoreInput.spellcheck === false;
+
+      window.__settingsSyncSetupStub.enableResult = false;
+      setupRestoreButton.click();
+      await waitFor(() => setupRestoreButton.textContent === 'Join & reload', 'failed initialization reset');
+      outcomes.setupRestoreSurfacesInitializationFailure =
+        setupRestoreMessage?.textContent.includes('Could not join') === true
+        && window.__settingsSyncSetupStub.calls.filter(call => call.fn === 'restoreFromMnemonic').length === 0;
+
+      window.__settingsSyncSetupStub.enableResult = true;
+      window.__settingsSyncSetupStub.restoreResult = false;
+      setupRestoreButton.click();
       await waitFor(() => window.__settingsSyncSetupStub.calls
         .filter(call => call.fn === 'restoreFromMnemonic').length >= 1, 'setup restore call');
+      await waitFor(() => setupRestoreButton.textContent === 'Join & reload', 'failed restore reset');
+      outcomes.setupRestoreFailureStaysVisibleAndRetryable =
+        setupRestoreMessage?.textContent.includes('Could not join') === true
+        && setupRestoreButton.disabled === false
+        && !window.__settingsSyncSetupStub.calls.some(call => call.fn === 'disableSync');
+
+      window.__settingsSyncSetupStub.restoreResult = true;
+      setupRestoreButton.click();
+      await waitFor(() => window.__settingsSyncSetupStub.calls
+        .filter(call => call.fn === 'restoreFromMnemonic').length >= 2, 'setup restore retry');
       outcomes.setupRestoreEnablesThrowawayIdentityThenRestores =
         window.__settingsSyncSetupStub.calls.some(call => call.fn === 'enableSync' && call.skipPush === true)
-        && window.__settingsSyncSetupStub.calls.some(call => call.fn === 'restoreFromMnemonic' && call.mnemonic === mnemonic);
+        && window.__settingsSyncSetupStub.calls.some(call => call.fn === 'restoreFromMnemonic' && call.mnemonic === mnemonic)
+        && setupRestoreButton.textContent === 'Reloading…'
+        && setupRestoreMessage?.textContent.includes('Identity accepted') === true;
 
       window.__settingsSyncSetupStub.restoreResult = false;
       window.__settingsSyncSetupStub.enabled = true;
+      document.getElementById('sync-setup-overlay')?.remove();
       syncSection.innerHTML = syncPanel.renderSyncSection();
       document.querySelector('[data-sync-action="open-restore-dialog"]')?.click();
       await waitFor(() => !!document.getElementById('sync-restore-dialog-input'), 'restore dialog');
@@ -259,8 +306,11 @@ test('settings sync setup browser coverage exercises mnemonic setup restore and 
       await waitFor(() => dialogButton.textContent === 'Restore & reload', 'restore button reset');
       outcomes.confirmRestoreHandlesFailedRestore =
         window.__settingsSyncSetupStub.calls
-          .filter(call => call.fn === 'restoreFromMnemonic' && call.mnemonic === mnemonic).length >= 2
+          .filter(call => call.fn === 'restoreFromMnemonic' && call.mnemonic === mnemonic).length >= 3
         && dialogButton.disabled === false
+        && document.getElementById('sync-restore-dialog-msg')?.textContent.includes('Could not restore') === true
+        && dialogInput.autocapitalize === 'none'
+        && dialogInput.spellcheck === false
         && toasts().some(text => text.includes('Sync not initialized'));
     } finally {
       document.getElementById('sync-setup-overlay')?.remove();
@@ -283,4 +333,60 @@ test('settings sync setup browser coverage exercises mnemonic setup restore and 
   for (const [name, passed] of Object.entries(results)) {
     expect(passed, name).toBe(true);
   }
+});
+
+test('join existing sync modal keeps all actions usable on a narrow phone', async ({ page }) => {
+  await page.setViewportSize({ width: 320, height: 568 });
+  await openIsolatedSyncSetupPage(page);
+
+  const layout = await page.evaluate(async ({ syncPanelUrl }) => {
+    window.__settingsSyncSetupStub = {
+      calls: [],
+      enabled: false,
+      enableResult: true,
+      restoreResult: true,
+      mnemonic: Array.from({ length: 24 }, (_, index) => `word${index + 1}`).join(' '),
+    };
+    const syncPanel = await import(syncPanelUrl);
+    syncPanel.showSyncSetupModal();
+    document.querySelector('[data-sync-setup-action="setup-restore"]')?.click();
+
+    const dialog = document.querySelector('#sync-setup-overlay .confirm-dialog');
+    const actions = document.querySelector('.sync-setup-restore-actions');
+    const join = document.getElementById('sync-setup-restore-go');
+    const back = document.getElementById('sync-setup-restore-back');
+    const cancel = document.querySelector('.sync-setup-restore-cancel');
+    const rect = element => element?.getBoundingClientRect();
+    const dialogRect = rect(dialog);
+    const actionsRect = rect(actions);
+    const joinRect = rect(join);
+    const backRect = rect(back);
+    const cancelRect = rect(cancel);
+    const result = {
+      title: document.getElementById('sync-setup-title')?.textContent,
+      choiceFooterHidden: document.querySelector('.sync-setup-choice-footer')?.hidden === true,
+      usesResponsiveGrid: actions ? getComputedStyle(actions).display === 'grid' : false,
+      dialogFitsViewport: !!dialogRect && dialogRect.left >= 0 && dialogRect.right <= innerWidth
+        && dialogRect.top >= 0 && dialogRect.bottom <= innerHeight,
+      primaryOwnsFirstRow: !!actionsRect && !!joinRect
+        && Math.abs(joinRect.width - actionsRect.width) < 1
+        && joinRect.height >= 40,
+      secondaryActionsShareRow: !!joinRect && !!backRect && !!cancelRect
+        && backRect.top > joinRect.top
+        && Math.abs(backRect.top - cancelRect.top) < 1
+        && Math.abs(backRect.width - cancelRect.width) < 1
+        && cancelRect.right <= dialogRect.right,
+    };
+
+    back?.click();
+    result.backRestoresSetup = document.getElementById('sync-setup-title')?.textContent === 'Set up sync'
+      && document.querySelector('.sync-setup-choice-footer')?.hidden === false
+      && getComputedStyle(document.getElementById('sync-setup-choices')).display !== 'none';
+    document.getElementById('sync-setup-overlay')?.remove();
+    return result;
+  }, {
+    syncPanelUrl: moduleUrl('/js/settings-sync-panel-impl.js'),
+  });
+
+  expect(Object.entries(layout).filter(([, value]) => value !== true && value !== 'Join existing sync')).toEqual([]);
 });

--- a/tests/playwright/settings-sync-setup-browser-coverage.spec.js
+++ b/tests/playwright/settings-sync-setup-browser-coverage.spec.js
@@ -29,7 +29,11 @@ async function openIsolatedSyncSetupPage(page) {
       const stub = window.__settingsSyncSetupStub;
       export function isSyncEnabled() { return !!stub.enabled; }
       export async function enableSync(options = {}) {
-        stub.calls.push({ fn: 'enableSync', skipPush: options.skipPush === true });
+        stub.calls.push({
+          fn: 'enableSync',
+          skipPush: options.skipPush === true,
+          persist: options.persist !== false,
+        });
         if (stub.enableResult === false) {
           stub.enabled = false;
           return false;
@@ -283,7 +287,9 @@ test('settings sync setup browser coverage exercises mnemonic setup restore and 
       await waitFor(() => window.__settingsSyncSetupStub.calls
         .filter(call => call.fn === 'restoreFromMnemonic').length >= 2, 'setup restore retry');
       outcomes.setupRestoreEnablesThrowawayIdentityThenRestores =
-        window.__settingsSyncSetupStub.calls.some(call => call.fn === 'enableSync' && call.skipPush === true)
+        window.__settingsSyncSetupStub.calls.some(call =>
+          call.fn === 'enableSync' && call.skipPush === true && call.persist === false
+        )
         && window.__settingsSyncSetupStub.calls.some(call => call.fn === 'restoreFromMnemonic' && call.mnemonic === mnemonic)
         && setupRestoreButton.textContent === 'Reloading…'
         && setupRestoreMessage?.textContent.includes('Identity accepted') === true;

--- a/tests/playwright/sync-identity-browser-coverage.spec.js
+++ b/tests/playwright/sync-identity-browser-coverage.spec.js
@@ -198,6 +198,7 @@ test('sync identity browser coverage handles libraries getters pending restore a
       const joinResult = await identity.restoreFromMnemonic('  JOIN   OWNER\nMNEMONIC  ');
       outcomes.restoreJoinClearsSyncStorageAndMarksPending = joinResult === true
         && restoreCalls[0] === 'join owner mnemonic'
+        && localStorage.getItem('labcharts-sync-enabled') === 'true'
         && seedCalls === 0
         && identity.isRestoreJoinPending() === true
         && cleanupKeysClearedByJoinRestore.every(key => localStorage.getItem(key) === null)

--- a/tests/playwright/sync-identity-browser-coverage.spec.js
+++ b/tests/playwright/sync-identity-browser-coverage.spec.js
@@ -79,6 +79,7 @@ test('sync identity browser coverage handles libraries getters pending restore a
     const hadQRCode = Object.prototype.hasOwnProperty.call(window, 'qrcode');
     const savedQRCode = window.qrcode;
     const savedSetTimeout = window.setTimeout;
+    const savedRestoreNotice = sessionStorage.getItem(identity.RESTORE_NOTICE_KEY);
     const savedBody = document.body.innerHTML;
     const savedScripts = Array.from(document.scripts).map(script => script.getAttribute('src')).filter(Boolean);
     const notifications = () => document.getElementById('notification-container')?.textContent || '';
@@ -98,7 +99,8 @@ test('sync identity browser coverage handles libraries getters pending restore a
 
       outcomes.defaultInjectedDepsReturnEmpty = identity.getMnemonic() === null
         && identity.getMnemonicResolutionError() === null
-        && await identity.restoreFromMnemonic('missing evolu') === false;
+        && await identity.restoreFromMnemonic('missing evolu') === false
+        && notifications().includes('Sync is still starting');
 
       identity.configureSyncIdentity({
         getEvolu: () => ({ restoreAppOwner: async () => {} }),
@@ -109,7 +111,8 @@ test('sync identity browser coverage handles libraries getters pending restore a
       outcomes.defaultSeedLocalDependencyIsCallable = defaultSeedResult === true
         && identity.isRestoreJoinPending() === false
         && scheduledDelays.includes(500)
-        && notifications().includes('seeded this device');
+        && notifications().includes('seeded this device')
+        && identity.consumeSyncRestoreNotice()?.includes('data was republished') === true;
 
       window.bip39 = { existing: true };
       outcomes.ensureBip39UsesExistingGlobal = await identity.ensureBip39() === window.bip39;
@@ -192,7 +195,7 @@ test('sync identity browser coverage handles libraries getters pending restore a
       });
 
       clearNotifications();
-      const joinResult = await identity.restoreFromMnemonic('join owner mnemonic');
+      const joinResult = await identity.restoreFromMnemonic('  JOIN   OWNER\nMNEMONIC  ');
       outcomes.restoreJoinClearsSyncStorageAndMarksPending = joinResult === true
         && restoreCalls[0] === 'join owner mnemonic'
         && seedCalls === 0
@@ -202,7 +205,8 @@ test('sync identity browser coverage handles libraries getters pending restore a
         && localStorage.getItem(identity.RESTORE_JOIN_PENDING_KEY) !== 'remove-me'
         && localStorage.getItem('coverage-keep-key') === 'keep-me'
         && scheduledDelays.includes(500)
-        && notifications().includes('Restored from mnemonic');
+        && notifications().includes('Restored from mnemonic')
+        && identity.consumeSyncRestoreNotice()?.includes('Joined existing sync identity') === true;
 
       clearNotifications();
       scheduledDelays.length = 0;
@@ -212,7 +216,8 @@ test('sync identity browser coverage handles libraries getters pending restore a
         && seedCalls === 1
         && identity.isRestoreJoinPending() === false
         && scheduledDelays.includes(500)
-        && notifications().includes('seeded this device');
+        && notifications().includes('seeded this device')
+        && identity.consumeSyncRestoreNotice()?.includes('data was republished') === true;
 
       clearNotifications();
       identity.configureSyncIdentity({
@@ -220,10 +225,13 @@ test('sync identity browser coverage handles libraries getters pending restore a
       });
       const failureResult = await identity.restoreFromMnemonic('bad mnemonic');
       outcomes.restoreFailureNotifiesAndReturnsFalse = failureResult === false
-        && notifications().includes('Invalid mnemonic');
+        && notifications().includes('Invalid mnemonic')
+        && identity.consumeSyncRestoreNotice() === null;
 
+      clearNotifications();
       identity.configureSyncIdentity({ getEvolu: () => null });
-      outcomes.restoreWithoutEvoluReturnsFalse = await identity.restoreFromMnemonic('missing evolu') === false;
+      outcomes.restoreWithoutEvoluReturnsFalse = await identity.restoreFromMnemonic('missing evolu') === false
+        && notifications().includes('Sync is still starting');
     } finally {
       window.setTimeout = savedSetTimeout;
       if (hadBip39) window.bip39 = savedBip39;
@@ -237,6 +245,8 @@ test('sync identity browser coverage handles libraries getters pending restore a
         seedLocalProfiles: async () => {},
       });
       localStorage.clear();
+      if (savedRestoreNotice == null) sessionStorage.removeItem(identity.RESTORE_NOTICE_KEY);
+      else sessionStorage.setItem(identity.RESTORE_NOTICE_KEY, savedRestoreNotice);
       for (const [key, value] of storage) {
         if (key && value != null) localStorage.setItem(key, value);
       }

--- a/tests/playwright/sync-init-browser-coverage.spec.js
+++ b/tests/playwright/sync-init-browser-coverage.spec.js
@@ -190,11 +190,12 @@ test('sync init browser coverage creates Evolu runtime subscriptions and debug g
   await openSyncInitPage(page, '/sync-init-success-browser-coverage', evoluBundleBody());
 
   const results = await page.evaluate(async ({ initUrl }) => {
-    const [init, runtime, settings, subscriptions] = await Promise.all([
+    const [init, runtime, settings, subscriptions, identity] = await Promise.all([
       import(initUrl),
       import('/js/sync-runtime.js'),
       import('/js/sync-settings-state.js'),
       import('/js/sync-subscriptions.js'),
+      import('/js/sync-identity.js'),
     ]);
     const outcomes = {};
     const original = {
@@ -215,6 +216,7 @@ test('sync init browser coverage creates Evolu runtime subscriptions and debug g
       settings.setSyncEnabled(true, { persist: false });
       localStorage.setItem('labcharts-debug', 'true');
       localStorage.setItem('labcharts-sync-relay', 'wss://relay.example/ws');
+      sessionStorage.setItem(identity.RESTORE_NOTICE_KEY, 'join');
       window.__syncInitTrace = { rows: [{ profileId: 'debug-profile' }] };
       init.configureSyncInit({
         reconcileLocalStorageWithEvolu: async () => {
@@ -264,6 +266,10 @@ test('sync init browser coverage creates Evolu runtime subscriptions and debug g
         && runtime.getSyncAppOwner()?.id === 'owner-init'
         && runtime.getSyncAppOwnerError() === null;
 
+      outcomes.restoreReloadShowsDurableJoinConfirmation =
+        document.getElementById('notification-container')?.textContent.includes('Joined existing sync identity') === true
+        && sessionStorage.getItem(identity.RESTORE_NOTICE_KEY) === null;
+
       outcomes.runsConfiguredReconciliationAfterReady = trace.reconciledCount === 1;
 
       outcomes.bindsSubscriptionsAndRelayProbe =
@@ -291,6 +297,7 @@ test('sync init browser coverage creates Evolu runtime subscriptions and debug g
       localStorage.removeItem(settings.SYNC_STORAGE_KEY);
       localStorage.removeItem('labcharts-debug');
       localStorage.removeItem('labcharts-sync-relay');
+      sessionStorage.removeItem(identity.RESTORE_NOTICE_KEY);
       delete window._syncDebug;
       delete window.__syncInitTrace;
       delete window.__syncInitResolveOwner;

--- a/tests/playwright/sync-lifecycle-browser-coverage.spec.js
+++ b/tests/playwright/sync-lifecycle-browser-coverage.spec.js
@@ -47,9 +47,10 @@ test('sync lifecycle browser coverage handles enable guards success and disable 
         configurable: true,
         value: undefined,
       });
-      await lifecycle.enableSync();
+      const blockedEnableResult = await lifecycle.enableSync();
       outcomes.enableGuardShowsUnsupportedNotification =
-        notificationText().includes('Sync unavailable in this browser: navigator.locks not available');
+        blockedEnableResult === false
+        && notificationText().includes('Sync unavailable in this browser: navigator.locks not available');
       outcomes.enableGuardDoesNotPersistEnabled = localStorage.getItem(settings.SYNC_STORAGE_KEY) === null;
 
       if (hadOwnLocks && ownLocksDescriptor) {
@@ -67,9 +68,10 @@ test('sync lifecycle browser coverage handles enable guards success and disable 
       runtime.setSyncReadyPromise(Promise.resolve());
       runtime.setSyncQueryLoadedPromise(Promise.resolve().then(() => { queryLoaded = true; }));
       syncUi.configureSyncUI({ isSyncEnabled: settings.isSyncEnabled });
-      await lifecycle.enableSync({ skipPush: true });
+      const successfulEnableResult = await lifecycle.enableSync({ skipPush: true });
 
-      outcomes.enableSuccessPersistsFlag = localStorage.getItem(settings.SYNC_STORAGE_KEY) === 'true';
+      outcomes.enableSuccessPersistsFlag = successfulEnableResult === true
+        && localStorage.getItem(settings.SYNC_STORAGE_KEY) === 'true';
       outcomes.enableSuccessClearsOwnerError = runtime.getSyncAppOwnerError() === null;
       outcomes.enableSuccessWaitsForQueryLoaded = queryLoaded;
       outcomes.enableSuccessShowsToast = notificationText().includes('Sync enabled');

--- a/tests/playwright/sync-lifecycle-browser-coverage.spec.js
+++ b/tests/playwright/sync-lifecycle-browser-coverage.spec.js
@@ -78,6 +78,17 @@ test('sync lifecycle browser coverage handles enable guards success and disable 
       outcomes.enableSuccessRendersIndicator =
         !!document.getElementById('sync-indicator-slot')?.querySelector('#sync-indicator-btn');
 
+      settings.setSyncEnabled(false, { persist: false });
+      localStorage.removeItem(settings.SYNC_STORAGE_KEY);
+      document.getElementById('notification-container').innerHTML = '';
+      document.getElementById('sync-indicator-slot').innerHTML = '';
+      const provisionalEnableResult = await lifecycle.enableSync({ skipPush: true, persist: false });
+      outcomes.provisionalEnableStaysMemoryOnlyAndSilent = provisionalEnableResult === true
+        && settings.isSyncEnabled() === true
+        && localStorage.getItem(settings.SYNC_STORAGE_KEY) === null
+        && !notificationText().includes('Sync enabled')
+        && document.getElementById('sync-indicator-slot')?.innerHTML === '';
+
       document.getElementById('notification-container').innerHTML = '';
       syncState.updateSyncStatus({ push: 'pending', pull: 'pulling', relay: 'unreachable' });
       for (const key of cleanupKeys) localStorage.setItem(key, 'delete-me');
@@ -139,7 +150,7 @@ test('sync lifecycle browser coverage handles enable guards success and disable 
     }
     if (thrownError) throw thrownError;
 
-    outcomes.allLifecycleOutcomesReached = Object.keys(outcomes).length === 15;
+    outcomes.allLifecycleOutcomesReached = Object.keys(outcomes).length === 16;
     return outcomes;
   }, {
     lifecycleUrl: moduleUrl('/js/sync-lifecycle.js'),

--- a/tests/sync-lifecycle-runtime.test.js
+++ b/tests/sync-lifecycle-runtime.test.js
@@ -133,6 +133,20 @@ describe('sync lifecycle runtime behavior', () => {
     expect(deps.renderSyncIndicator).toHaveBeenCalled();
   });
 
+  it('initializes a provisional identity without persisting or announcing sync', async () => {
+    const deps = installLifecycleMocks();
+    const { enableSync } = await loadLifecycle();
+
+    const result = await enableSync({ skipPush: true, persist: false });
+
+    expect(result).toBe(true);
+    expect(deps.setSyncEnabled).toHaveBeenCalledWith(true, { persist: false });
+    expect(deps.forcePull).not.toHaveBeenCalled();
+    expect(deps.pushAllProfiles).not.toHaveBeenCalled();
+    expect(deps.showNotification).not.toHaveBeenCalledWith('Sync enabled', 'success');
+    expect(deps.renderSyncIndicator).not.toHaveBeenCalled();
+  });
+
   it('surfaces init failures without running initial data movement', async () => {
     const deps = installLifecycleMocks({
       getSyncEvolu: vi.fn(() => null),

--- a/tests/test-modal-lifecycle-integrations.js
+++ b/tests/test-modal-lifecycle-integrations.js
@@ -65,6 +65,7 @@ const recommendationsSrc = fs.readFileSync(path.join(root, 'js/recommendations.j
 const settingsSrc = fs.readFileSync(path.join(root, 'js/settings.js'), 'utf8');
 const settingsTweaksSrc = fs.readFileSync(path.join(root, 'js/settings-tweaks.js'), 'utf8');
 const settingsSyncPanelSrc = fs.readFileSync(path.join(root, 'js/settings-sync-panel-impl.js'), 'utf8');
+const settingsSyncRestoreUiSrc = fs.readFileSync(path.join(root, 'js/settings-sync-restore-ui.js'), 'utf8');
 const serviceWorkerSrc = fs.readFileSync(path.join(root, 'service-worker.js'), 'utf8');
 const supplementsSrc = fs.readFileSync(path.join(root, 'js/supplements.js'), 'utf8');
 const sunSrc = fs.readFileSync(path.join(root, 'js/sun.js'), 'utf8');
@@ -191,12 +192,13 @@ assert('mobile sidebar uses shared scroll lock lifecycle helpers',
 
 assert('sync setup and restore dialogs use shared lifecycle helpers',
   settingsSyncPanelSrc.includes("from './modal-lifecycle.js'") &&
+    settingsSyncRestoreUiSrc.includes("from './modal-lifecycle.js'") &&
     settingsSyncPanelSrc.includes("openModalOverlay(overlay, { initialFocus: '[data-sync-setup-action=\"setup-new\"]', focusDelay: 50 })") &&
-    settingsSyncPanelSrc.includes("openModalOverlay(overlay, { initialFocus: '#sync-restore-dialog-input', focusDelay: 50 })") &&
+    settingsSyncRestoreUiSrc.includes("openModalOverlay(overlay, { initialFocus: '#sync-restore-dialog-input', focusDelay: 50 })") &&
     (settingsSyncPanelSrc.match(/closeModalOverlay\('sync-setup-overlay'\)/g) || []).length >= 2 &&
-    settingsSyncPanelSrc.includes("closeModalOverlay('sync-restore-overlay')") &&
-    !settingsSyncPanelSrc.includes("overlay.classList.add('show')") &&
-    !settingsSyncPanelSrc.includes("overlay.classList.remove('show')"));
+    settingsSyncRestoreUiSrc.includes("closeModalOverlay('sync-restore-overlay')") &&
+    !`${settingsSyncPanelSrc}\n${settingsSyncRestoreUiSrc}`.includes("overlay.classList.add('show')") &&
+    !`${settingsSyncPanelSrc}\n${settingsSyncRestoreUiSrc}`.includes("overlay.classList.remove('show')"));
 
 assert('global focus trap top-overlay check includes confirm overlays',
   appEventsSrc.includes("'.modal-overlay.show, .confirm-overlay.show'"));

--- a/tests/test-settings-sync-delegated-actions.js
+++ b/tests/test-settings-sync-delegated-actions.js
@@ -8,6 +8,8 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
 const src = fs.readFileSync(path.join(root, 'js/settings-sync-panel-impl.js'), 'utf8');
+const restoreUiSrc = fs.readFileSync(path.join(root, 'js/settings-sync-restore-ui.js'), 'utf8');
+const syncUiSrc = `${src}\n${restoreUiSrc}`;
 const agentSrc = fs.readFileSync(path.join(root, 'js/settings-agent-access-panel.js'), 'utf8');
 
 let passed = 0;
@@ -29,7 +31,7 @@ const inlineHandlerRe = /\bon(?:click|change|input|submit|keydown|keyup)=/;
 const directAssignmentRe = /\.(?:onclick|onchange|oninput)\s*=/;
 
 assert('settings-sync-panel implementation has no inline event attributes',
-  !inlineHandlerRe.test(src));
+  !inlineHandlerRe.test(syncUiSrc));
 assert('settings-sync-panel implementation avoids direct event property assignment',
   !directAssignmentRe.test(src));
 assert('Settings sync delegates click events',
@@ -76,7 +78,7 @@ assert('Click delegate lets state controls reach change/input events',
   'regenerate-messenger-context-key',
   'set-agent-wearable-series-days',
 ].forEach(action => {
-  assert(`Sync action ${action} is rendered`, src.includes(`data-sync-action="${action}"`));
+  assert(`Sync action ${action} is rendered`, syncUiSrc.includes(`data-sync-action="${action}"`));
 });
 
 [

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -131,6 +131,7 @@ await import('../js/settings.js');
     await fetchWithRetry('js/settings-sync-panel.js'),
     await fetchWithRetry('js/settings-sync-panel-impl.js'),
   ].join('\n');
+  const settingsSyncRestoreUiSrc = await fetchWithRetry('js/settings-sync-restore-ui.js');
   const dataSrc = await fetchWithRetry('js/data.js');
   const startupOrchestratorSrc = await fetchWithRetry('js/startup-orchestrator.js');
   const startupUiSrc = await fetchWithRetry('js/startup-ui.js');
@@ -444,6 +445,8 @@ await import('../js/settings.js');
     serviceWorkerSrc.includes("'/js/settings-sync-panel.js'"));
   assert('service worker precaches settings-sync-panel-impl.js',
     serviceWorkerSrc.includes("'/js/settings-sync-panel-impl.js'"));
+  assert('service worker precaches settings-sync-restore-ui.js',
+    serviceWorkerSrc.includes("'/js/settings-sync-restore-ui.js'"));
   assert('pushContextToGateway treats gateway HTTP errors as failures with relay error detail',
     /const\s+res\s*=\s*await\s+fetch\(`\$\{relay\}\/api\/context`/.test(syncMessengerSrc)
       && syncMessengerSrc.includes('await res.text()')
@@ -1391,9 +1394,11 @@ await import('../js/settings.js');
     syncIdentitySrc.includes('clearSyncDisableStorage();')
       && syncDisableCleanupSrc.includes("key.endsWith('-sync-ts')")
       && syncDisableCleanupSrc.includes('localStorage.removeItem(key)'));
-  assert('restoreFromMnemonic calls evolu.restoreAppOwner', syncIdentitySrc.includes('evolu.restoreAppOwner(mnemonic)'));
+  assert('restoreFromMnemonic normalizes the seed before calling evolu.restoreAppOwner',
+    syncIdentitySrc.includes("normalize('NFKD')")
+      && syncIdentitySrc.includes('evolu.restoreAppOwner(normalizedMnemonic)'));
   // Verify timestamps are cleared AFTER restoreAppOwner within restoreFromMnemonic (not before)
-  const restoreIdx = syncIdentitySrc.indexOf('evolu.restoreAppOwner(mnemonic)');
+  const restoreIdx = syncIdentitySrc.indexOf('evolu.restoreAppOwner(normalizedMnemonic)');
   const clearTsInRestore = syncIdentitySrc.indexOf('clearSyncDisableStorage();', restoreIdx);
   assert('Sync-ts cleared after restoreAppOwner (not before)', restoreIdx > 0 && clearTsInRestore > restoreIdx,
     `restoreAppOwner at ${restoreIdx}, sync-ts clear at ${clearTsInRestore}`);
@@ -1570,7 +1575,9 @@ await import('../js/settings.js');
       && settingsSyncPanelSrc.includes('same 24-word Data Sync identity')
       && settingsSyncPanelSrc.includes('this code doesn’t grant access to your data')
       && syncIdentitySrc.includes('getSyncIdentityFingerprint'));
-  assert('Restore from mnemonic button', settingsSyncPanelSrc.includes('Restore from mnemonic'));
+  assert('Restore from mnemonic button',
+    settingsSyncPanelSrc.includes('Restore / switch identity')
+      && settingsSyncRestoreUiSrc.includes('Restore from mnemonic'));
   assert('Relay input under Advanced', settingsSyncPanelSrc.includes('sync-relay-input') && settingsSyncPanelSrc.includes('Advanced'));
   assert('Relay validation rejects non-wss and non-ws', settingsSyncPanelSrc.includes("!url.startsWith('wss://')") && settingsSyncPanelSrc.includes("!url.startsWith('ws://')"));
   assert('toggleSync function', settingsSyncPanelSrc.includes('async function toggleSync'));
@@ -1590,9 +1597,18 @@ await import('../js/settings.js');
   assert('Done button has disabled styling', settingsSyncPanelSrc.includes("opacity:0.45") || settingsSyncPanelSrc.includes("opacity: 0.45"));
   assert('syncSetupRestore shows textarea', settingsSyncPanelSrc.includes('function syncSetupRestore'));
   assert('syncSetupDoRestore validates 24 words', settingsSyncPanelSrc.includes("words.length !== 24"));
-  assert('syncSetupDoRestore cleans up on failure', settingsSyncPanelSrc.includes('await disableSync()') && settingsSyncPanelSrc.includes('Restore failed'));
-  assert('syncSetupDoRestore restore failure releases watchdog timer',
-    /if \(!result\)[\s\S]{0,300}_releaseSyncToggle\(\)/.test(settingsSyncPanelSrc));
+  const syncSetupRestoreFlowSrc = settingsSyncPanelSrc.slice(
+    settingsSyncPanelSrc.indexOf('async function syncSetupDoRestore'),
+    settingsSyncPanelSrc.indexOf('async function updateRelayStatus'),
+  );
+  assert('syncSetupDoRestore keeps a failed join visible and retryable',
+    syncSetupRestoreFlowSrc.includes('Could not join. Verify all 24 words and try again.')
+      && syncSetupRestoreFlowSrc.includes('setSyncSetupRestoreBusy(false)')
+      && !syncSetupRestoreFlowSrc.includes('await disableSync()'));
+  assert('syncSetupRestore protects mnemonic entry from mobile text mutation',
+    settingsSyncPanelSrc.includes('autocapitalize="none"')
+      && settingsSyncPanelSrc.includes('autocorrect="off"')
+      && settingsSyncPanelSrc.includes('spellcheck="false"'));
   assert('syncSetupBack returns to choices', settingsSyncPanelSrc.includes('function syncSetupBack'));
   assert('closeSyncSetup disables sync if started', settingsSyncPanelSrc.includes('async function closeSyncSetup') && settingsSyncPanelSrc.includes('disableSync'));
   assert('closeSyncSetup releases _syncToggling', settingsSyncPanelSrc.includes('_syncToggling = false'));

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -2533,10 +2533,10 @@ await import('../js/settings.js');
     disableSyncSrc.includes('clearSyncDisableStorage();')
       && /isSyncDisableCleanupKey[\s\S]{0,300}-sync-cutover-v2/.test(syncDisableCleanupSrc));
   assert('restoreFromMnemonic clears delta snapshots',
-    /restoreFromMnemonic[\s\S]{0,1000}clearSyncDisableStorage\(\)/.test(syncIdentitySrc)
+    /restoreFromMnemonic[\s\S]{0,1500}clearSyncDisableStorage\(\)/.test(syncIdentitySrc)
       && /isSyncDisableCleanupKey[\s\S]{0,300}key\.includes\('-delta-'\)/.test(syncDisableCleanupSrc));
   assert('restoreFromMnemonic clears cutover flag',
-    /restoreFromMnemonic[\s\S]{0,1000}clearSyncDisableStorage\(\)/.test(syncIdentitySrc)
+    /restoreFromMnemonic[\s\S]{0,1500}clearSyncDisableStorage\(\)/.test(syncIdentitySrc)
       && /isSyncDisableCleanupKey[\s\S]{0,300}-sync-cutover-v2/.test(syncDisableCleanupSrc));
 
   // Live: proto-pollution defence — verify a malicious key is rejected

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -536,6 +536,7 @@
     "js/settings-provider-bridge.js",
     "js/settings-sync-panel.js",
     "js/settings-sync-panel-impl.js",
+    "js/settings-sync-restore-ui.js",
     "js/settings-agent-access-panel.js",
     "js/settings-voice-hardware.js",
     "js/settings-voice-model-controller.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.12.1';
+self.APP_VERSION = '1.12.2';


### PR DESCRIPTION
## Summary

- make joining an existing cross-device sync identity show clear progress, failure, retry, and reload states
- normalize pasted 24-word identities and protect mobile entry from autocorrect or capitalization changes
- show a durable success confirmation after the required reload
- polish the responsive join modal so its primary, Back, and Cancel actions fit cleanly on desktop and narrow phones
- ship the fix as version 1.12.2 with a user-readable release note

## Root cause and impact

The first-time join flow did not verify that sync initialization had actually succeeded before trying to restore the identity. Failed initialization or restore could immediately reload or reset the UI, making the button appear to do nothing. Mobile text correction could also alter a valid seed phrase.

The flow now checks readiness explicitly, leaves errors visible and retryable, normalizes the phrase before restore, and confirms success after reload. Existing synced data and encryption behavior are unchanged.

## Validation

- 839 cross-device sync assertions
- 27 focused lifecycle and service-worker unit tests
- focused Chromium coverage for setup, restore, initialization, lifecycle, reload confirmation, and narrow-phone layout
- JavaScript and TypeScript checks
- quality and architecture guardrails
- production build and PWA precache check
