### PR TITLE
Stabilize context editor tour setup

### DIFF
--- a/tests/playwright/context-editor-stylesheet-browser-coverage.spec.js
+++ b/tests/playwright/context-editor-stylesheet-browser-coverage.spec.js
@@ -142,6 +142,7 @@ test('cold startup defers context editor presentation until a real editor opens'
 test('long context editors use accessible progressive disclosure on mobile', async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await page.addInitScript(() => {
+    localStorage.setItem('labcharts-default-emptyTour', 'completed');
     localStorage.setItem('labcharts-default-tour', 'completed');
   });
   await page.goto('/app', { waitUntil: 'load' });
@@ -155,6 +156,7 @@ test('long context editors use accessible progressive disclosure on mobile', asy
   });
 
   const modal = page.locator('#detail-modal');
+  await expect(page.locator('#tour-overlay')).toHaveCount(0);
   await expect(modal).toHaveAttribute('aria-label', 'Diet & Digestion');
   await expect(modal.locator('details.ctx-editor-section')).toHaveCount(3);
   await expect(modal.locator('details.ctx-editor-section[open]')).toHaveCount(0);


### PR DESCRIPTION
## What changed

- mark both the empty-profile and populated-profile guided tours complete in the mobile context-editor test setup
- assert that no tour overlay is present before interacting with the editor

## Why

The fresh-profile `emptyTour` can start shortly after `/app` loads. The test previously suppressed only the regular `tour`, so `#tour-overlay` could race the editor and intercept the `Typical meals` summary click. This flake appeared across unrelated dependency PRs and is not caused by Playwright 1.62.1.

## Verification

- `npx playwright test tests/playwright/context-editor-stylesheet-browser-coverage.spec.js` — 5 passed
- repeated the formerly flaky test 20 times with `--repeat-each=20` — 20 passed