### PR TITLE
Fix cross-device restore and Agent Access data flow

### DIFF
--- a/css/settings.css
+++ b/css/settings.css
@@ -1658,15 +1658,15 @@
   background: color-mix(in srgb, var(--green) 10%, transparent);
   color: var(--green);
 }
-.sync-settings-toggle {
+label.sync-settings-toggle {
   display: inline-flex;
   align-items: center;
   min-width: 32px;
   min-height: 28px;
   cursor: pointer;
 }
-.sync-settings-toggle input { display: none; }
-.sync-settings-toggle-slider {
+label.sync-settings-toggle input { display: none; }
+label.sync-settings-toggle .sync-settings-toggle-slider {
   position: relative;
   display: block;
   width: 32px;
@@ -1675,7 +1675,7 @@
   background: var(--border);
   transition: background .2s ease;
 }
-.sync-settings-toggle-slider::before {
+label.sync-settings-toggle .sync-settings-toggle-slider::before {
   content: '';
   position: absolute;
   top: 2px;
@@ -1686,9 +1686,9 @@
   background: var(--bg-primary);
   transition: transform .2s ease;
 }
-.sync-settings-toggle input:checked + .sync-settings-toggle-slider { background: var(--accent); }
-.sync-settings-toggle input:checked + .sync-settings-toggle-slider::before { transform: translateX(14px); }
-.sync-settings-toggle input:disabled + .sync-settings-toggle-slider { opacity: .45; cursor: not-allowed; }
+label.sync-settings-toggle input:checked + .sync-settings-toggle-slider { background: var(--accent); }
+label.sync-settings-toggle input:checked + .sync-settings-toggle-slider::before { transform: translateX(14px); }
+label.sync-settings-toggle input:disabled + .sync-settings-toggle-slider { opacity: .45; cursor: not-allowed; }
 .sync-setup-actions,
 .sync-management-actions {
   display: grid;

--- a/js/changelog-impl.js
+++ b/js/changelog-impl.js
@@ -11,6 +11,16 @@ const changelogDelegateRoots = new WeakSet();
 
 const CHANGELOG = [
   {
+    version: '1.13.1', date: '2026-08-08', title: 'Safer sync and complete Agent Access',
+    forceShow: true,
+    items: [
+      '<b>Joining an existing Sync identity now works end to end.</b> After you enter the 24 words, the new device completes setup and downloads the existing data from the relay instead of only appearing to be connected.',
+      '<b>Your genome and other profile data are better protected.</b> If a saved profile cannot be read, sync now stops safely instead of treating that profile as empty and sending a blank replacement to your other devices.',
+      '<b>Agent Access is ready when you open Settings.</b> Sync and Agent Access controls finish loading automatically, and the Agent Access on/off slider is visible again.',
+      '<b>AI agents receive your complete health context.</b> The redesigned Context-card answers now reach both in-app AI and encrypted external agents, including skin type and explicit digestive answers such as “none” or “normal”.',
+    ]
+  },
+  {
     version: '1.13.0', date: '2026-08-08', title: 'A completely redesigned Chat',
     items: [
       '<b>Chat has been redesigned from the ground up.</b> The message box grows for longer prompts, drafts stay with their conversations, and the experience works more naturally across desktop and mobile.',

--- a/js/changelog.js
+++ b/js/changelog.js
@@ -15,6 +15,7 @@ let useChangelogRetryUrl = false;
 // Keep this compact gate metadata aligned with forceShow entries in the lazy
 // archive. Source tests enforce exact coverage in both directions.
 const FORCE_SHOW_VERSIONS = [
+  '1.13.1',
   '1.11.1',
   '1.10.177',
   '1.10.169',

--- a/js/lab-context.js
+++ b/js/lab-context.js
@@ -594,13 +594,17 @@ function _buildLabContextInner(/** @type {LabContextOptions} */ { skipGroupFilte
     const dParts = [];
     if (diet.bowelFrequency) dParts.push(`Bowel frequency: ${diet.bowelFrequency}`);
     if (diet.stoolConsistency) dParts.push(`Stool consistency: ${diet.stoolConsistency}`);
-    if (diet.bloating && diet.bloating !== 'none') dParts.push(`Bloating: ${diet.bloating}`);
-    if (diet.gas && diet.gas !== 'none') dParts.push(`Gas: ${diet.gas}`);
-    if (diet.acidReflux && diet.acidReflux !== 'none') dParts.push(`Acid reflux: ${diet.acidReflux}`);
-    if (diet.burping && diet.burping !== 'none') dParts.push(`Burping: ${diet.burping}`);
-    if (diet.nausea && diet.nausea !== 'none') dParts.push(`Nausea: ${diet.nausea}`);
-    if (diet.appetite && diet.appetite !== 'normal') dParts.push(`Appetite: ${diet.appetite}`);
-    if (diet.abdominalPain && diet.abdominalPain !== 'none') dParts.push(`Abdominal pain: ${diet.abdominalPain}`);
+    // A selected negative answer is still useful clinical context. `null`
+    // means unanswered, while `none` / `normal` means the user explicitly
+    // ruled the symptom out; do not silently collapse those two states for AI
+    // chat or the encrypted Agent Access projection.
+    if (diet.bloating) dParts.push(`Bloating: ${diet.bloating}`);
+    if (diet.gas) dParts.push(`Gas: ${diet.gas}`);
+    if (diet.acidReflux) dParts.push(`Acid reflux: ${diet.acidReflux}`);
+    if (diet.burping) dParts.push(`Burping: ${diet.burping}`);
+    if (diet.nausea) dParts.push(`Nausea: ${diet.nausea}`);
+    if (diet.appetite) dParts.push(`Appetite: ${diet.appetite}`);
+    if (diet.abdominalPain) dParts.push(`Abdominal pain: ${diet.abdominalPain}`);
     if (diet.foodSensitivities && diet.foodSensitivities.length) dParts.push(`Food sensitivities: ${diet.foodSensitivities.join(', ')}`);
     if (dParts.length) ctx += dParts.join('. ') + '\n';
     if (diet.note) ctx += `Notes: ${diet.note}\n`;
@@ -666,6 +670,7 @@ function _buildLabContextInner(/** @type {LabContextOptions} */ { skipGroupFilte
       if (lc.amLight) parts.push(`Morning light: ${lc.amLight}`);
       if (lc.daytime) parts.push(`Daytime outdoor: ${lc.daytime}`);
       if (lc.uvExposure) parts.push(`UV exposure: ${lc.uvExposure}`);
+      if (lc.skinType) parts.push(`Skin type: ${lc.skinType}`);
       if (lc.evening && lc.evening.length) parts.push(`Evening light: ${lc.evening.join(', ')}`);
       if (lc.screenTime) parts.push(`Daily screen time: ${lc.screenTime}`);
       if (lc.techEnv && lc.techEnv.length) parts.push(`Tech environment: ${lc.techEnv.join(', ')}`);

--- a/js/lab-context.js
+++ b/js/lab-context.js
@@ -594,10 +594,7 @@ function _buildLabContextInner(/** @type {LabContextOptions} */ { skipGroupFilte
     const dParts = [];
     if (diet.bowelFrequency) dParts.push(`Bowel frequency: ${diet.bowelFrequency}`);
     if (diet.stoolConsistency) dParts.push(`Stool consistency: ${diet.stoolConsistency}`);
-    // A selected negative answer is still useful clinical context. `null`
-    // means unanswered, while `none` / `normal` means the user explicitly
-    // ruled the symptom out; do not silently collapse those two states for AI
-    // chat or the encrypted Agent Access projection.
+    // Preserve explicit negatives: `null` is unanswered; `none` / `normal` means ruled out.
     if (diet.bloating) dParts.push(`Bloating: ${diet.bloating}`);
     if (diet.gas) dParts.push(`Gas: ${diet.gas}`);
     if (diet.acidReflux) dParts.push(`Acid reflux: ${diet.acidReflux}`);

--- a/js/settings-agent-access-panel.js
+++ b/js/settings-agent-access-panel.js
@@ -128,9 +128,9 @@ export function renderMessengerSection() {
         <div class="settings-copy-title">Agent Access</div>
         <div class="settings-copy-desc">Let AI agents query your labs and context via MCP, Hermes Agent, or OpenClaw</div>
       </div>
-      <label class="chat-websearch-toggle-label" style="display:flex" aria-label="Toggle Agent Access">
-        <input type="checkbox" ${enabled ? 'checked' : ''} data-sync-action="toggle-messenger" style="display:none" ${toggleDisabled ? 'disabled' : ''}>
-        <span class="chat-toggle-slider"></span>
+      <label class="chat-websearch-toggle-label sync-settings-toggle" aria-label="Toggle Agent Access">
+        <input type="checkbox" ${enabled ? 'checked' : ''} data-sync-action="toggle-messenger" ${toggleDisabled ? 'disabled' : ''}>
+        <span class="chat-toggle-slider sync-settings-toggle-slider"></span>
       </label>
     </div>
     ${enabled && token ? `

--- a/js/settings-sync-panel.js
+++ b/js/settings-sync-panel.js
@@ -25,6 +25,18 @@ const settingsSyncPanelDeps = {
   updateSyncIndicator,
 };
 
+/** @param {SettingsSyncPanelModule} module */
+function replaceSettingsSyncPanelPlaceholders(module) {
+  const syncSection = document.getElementById('sync-section');
+  if (syncSection?.querySelector('[data-settings-sync-placeholder="sync"]')) {
+    syncSection.innerHTML = module.renderSyncSection();
+  }
+  const messengerSection = document.getElementById('messenger-section');
+  if (messengerSection?.querySelector('[data-settings-sync-placeholder="messenger"]')) {
+    messengerSection.innerHTML = module.renderMessengerSection();
+  }
+}
+
 export function isSettingsSyncPanelLoaded() {
   return settingsSyncPanelModule !== null;
 }
@@ -45,6 +57,11 @@ export function loadSettingsSyncPanelModule() {
       .then(module => {
         settingsSyncPanelModule = module;
         module.configureSettingsSyncPanelDeps(settingsSyncPanelDeps);
+        // renderSyncSection/renderMessengerSection return placeholders on a
+        // cold Settings open. Once the lazy module arrives, replace those
+        // placeholders in place so users get the real controls without
+        // closing and reopening Settings.
+        replaceSettingsSyncPanelPlaceholders(module);
         return module;
       })
       .catch(err => {
@@ -105,13 +122,13 @@ function runSettingsSyncPanelAction(name, args, shouldLoad = true) {
 export function renderSyncSection() {
   if (settingsSyncPanelModule) return settingsSyncPanelModule.renderSyncSection();
   void loadSettingsSyncPanelModule().catch(() => {});
-  return '<div class="settings-loading-placeholder">Loading sync settings…</div>';
+  return '<div class="settings-loading-placeholder" data-settings-sync-placeholder="sync">Loading sync settings…</div>';
 }
 
 export function renderMessengerSection() {
   if (settingsSyncPanelModule) return settingsSyncPanelModule.renderMessengerSection();
   void loadSettingsSyncPanelModule().catch(() => {});
-  return '<div class="settings-loading-placeholder">Loading Agent Access…</div>';
+  return '<div class="settings-loading-placeholder" data-settings-sync-placeholder="messenger">Loading Agent Access…</div>';
 }
 
 export function showSyncSetupModal() {

--- a/js/sync-actions.js
+++ b/js/sync-actions.js
@@ -164,6 +164,9 @@ async function flushDirtyProfilesForRelayCompaction(profiles) {
       if (_isSyncing()) throw new Error('Sync is still busy; wait for it to finish and retry compaction');
 
       const importedData = await readProfileImportedData(profileId);
+      if (!importedData) {
+        throw new Error(`Could not read local data for profile ${profileId.slice(0, 8)}; compaction stopped safely`);
+      }
       const result = await _pushProfile(profileId, importedData);
       if (!result?.ok) {
         throw new Error(`Could not commit pending changes for profile ${profileId.slice(0, 8)}`);

--- a/js/sync-identity.js
+++ b/js/sync-identity.js
@@ -187,7 +187,18 @@ export async function restoreFromMnemonic(mnemonic, options = {}) {
   const normalizedMnemonic = normalizeMnemonic(mnemonic);
   setRestoreNotice(options?.seedLocal ? 'seed-local' : 'join');
   try {
-    await evolu.restoreAppOwner(normalizedMnemonic);
+    if (options?.seedLocal) {
+      await evolu.restoreAppOwner(normalizedMnemonic);
+    } else {
+      // Evolu defaults restoreAppOwner to reload immediately from inside its
+      // worker. That navigation happens before the returned promise resolves,
+      // so none of the join-finalization below would run. In particular, a
+      // first-time join starts with persist:false and would reload with sync
+      // still disabled, leaving the restored owner unable to pull relay data.
+      // Keep the reset in this page long enough to commit our application
+      // state, then use the controlled reload at the end of this function.
+      await evolu.restoreAppOwner(normalizedMnemonic, { reload: false });
+    }
     // First-time joins initialize Evolu provisionally. Persist sync only once
     // the requested identity has actually been accepted.
     setSyncEnabled(true);

--- a/js/sync-push.js
+++ b/js/sync-push.js
@@ -81,6 +81,13 @@ export async function pushProfile(profileId, importedData, opts = {}) {
   const profileQuery = _getProfileQuery();
   if (!evolu || !_isSyncEnabled()) return;
   if (!profileId || typeof profileId !== 'string') return;
+  // Never turn a failed profile-storage read into an authoritative empty
+  // relay update. Callers that intentionally create an empty profile pass an
+  // explicit default object; null/undefined/arrays are always invalid here.
+  if (!importedData || typeof importedData !== 'object' || Array.isArray(importedData)) {
+    console.warn(`[sync] pushProfile skipped ${profileId.slice(0, 8)} — imported profile data is unavailable`);
+    return { ok: false, skipped: true, reason: 'missing-profile-data' };
+  }
   // _syncing was a guard against concurrent pushes, but if a previous push
   // hangs (Evolu's onComplete never fires) _syncing stays true and every
   // subsequent push (including manual Sync now / Reload-and-retry) silently

--- a/js/sync-save-hooks.js
+++ b/js/sync-save-hooks.js
@@ -4,7 +4,7 @@
 import { getErrorMessage } from './caught-error.js';
 import { state } from './state.js';
 import { profileStorageKey } from './profile-storage-key.js';
-import { getEncryptionEnabled, encryptedGetItem } from './crypto.js';
+import { encryptedGetItem } from './crypto.js';
 import { markChatDataLocal, markCustomPersonalityDataLocal } from './sync-chat-apply.js';
 import { pushContextToGateway } from './sync-messenger.js';
 import { addUtilsRuntimeListener } from './utils-runtime.js';
@@ -115,14 +115,19 @@ export async function readProfileImportedData(profileId, fallback = null) {
   if (!profileId) return _createDefaultProfileData();
   try {
     const storageKey = profileStorageKey(profileId, 'imported');
-    const raw = getEncryptionEnabled()
-      ? await encryptedGetItem(storageKey)
-      : localStorage.getItem(storageKey);
+    // Imported profile blobs live in IndexedDB regardless of whether their
+    // contents are encrypted. encryptedGetItem owns that routing (and the
+    // legacy localStorage migration), so bypassing it when encryption is off
+    // makes every inactive profile look empty.
+    const raw = await encryptedGetItem(storageKey);
     if (raw) return normalize(JSON.parse(raw));
   } catch (e) {
     console.warn('[sync] Could not read profile importedData for profile sync:', getErrorMessage(e, e));
   }
-  return _createDefaultProfileData();
+  // A named profile whose persisted blob is absent or unreadable must not be
+  // replaced on the relay with a freshly-created empty profile. New profiles
+  // pass their default data explicitly through the fallback argument.
+  return null;
 }
 
 /** @param {string} profileId
@@ -130,6 +135,12 @@ export async function readProfileImportedData(profileId, fallback = null) {
  * @param {number} [attempt]
  */
 function scheduleProfilePush(profileId, data, attempt = 0) {
+  // Fail closed when profile storage could not be read. Publishing null here
+  // can turn a transient local read problem into permanent cross-device loss.
+  if (!data || typeof data !== 'object') {
+    _profileSyncTimers.delete(profileId);
+    return;
+  }
   if (!_isSyncEnabled()) {
     _profileSyncTimers.delete(profileId);
     return;

--- a/scripts/dom-sink-policy.json
+++ b/scripts/dom-sink-policy.json
@@ -3,7 +3,7 @@
   "scope": "Every non-generated JavaScript module under js/",
   "reviewRule": "Any added or modified HTML-writing sink requires security review and a policy refresh.",
   "scannedFiles": 579,
-  "sinkCount": 487,
+  "sinkCount": 489,
   "files": {
     "js/backup.js": {
       "count": 1,
@@ -715,6 +715,13 @@
       "digest": "bac271bca60a413d6cde0ba957871058b0c6660fb2f608ccf690f7525773071b",
       "kinds": {
         "innerHTML": 8
+      }
+    },
+    "js/settings-sync-panel.js": {
+      "count": 2,
+      "digest": "5cac7d5517fd9b9dab0e4c68df5b2c622ed8f4b928c4e9ea40297999588d2aca",
+      "kinds": {
+        "innerHTML": 2
       }
     },
     "js/settings-sync-restore-ui.js": {

--- a/tests/playwright/changelog-loader-browser-coverage.spec.js
+++ b/tests/playwright/changelog-loader-browser-coverage.spec.js
@@ -38,12 +38,12 @@ test('changelog archive stays cold for first visits and ordinary patch updates, 
   });
 
   const outcomes = await page.evaluate(async url => {
-    window.APP_VERSION = '1.11.2';
+    window.APP_VERSION = '1.13.2';
     const facade = await import(url);
     localStorage.removeItem('labcharts-changelog-seen');
     const firstVisitResult = facade.maybeShowChangelog();
     const firstVisitSeen = localStorage.getItem('labcharts-changelog-seen');
-    localStorage.setItem('labcharts-changelog-seen', '1.11.1');
+    localStorage.setItem('labcharts-changelog-seen', '1.13.1');
     const patchResult = facade.maybeShowChangelog();
     const cold = !facade.isChangelogModuleLoaded();
     facade.closeChangelog();
@@ -68,10 +68,10 @@ test('changelog archive stays cold for first visits and ordinary patch updates, 
   expect(implementationRequests).toHaveLength(1);
   expect(outcomes).toEqual({
     firstVisitResult: undefined,
-    firstVisitSeen: '1.11.2',
+    firstVisitSeen: '1.13.2',
     patchResult: undefined,
     cold: true,
-    coldCloseSeen: '1.11.2',
+    coldCloseSeen: '1.13.2',
     sharedPromise: true,
     loaded: true,
     opened: 'opened:true',

--- a/tests/playwright/changelog.spec.js
+++ b/tests/playwright/changelog.spec.js
@@ -18,6 +18,8 @@ test('changelog modal opens, closes, and marks the current version as seen', asy
   await expect(overlay).toHaveClass(SHOW_CLASS_TOKEN);
   await expect(modal.locator('.modal-close')).toHaveCount(1);
   await expect(modal).toContainText("What's New");
+  await expect(modal).toContainText('Safer sync and complete Agent Access');
+  await expect(modal).toContainText('Your genome and other profile data are better protected.');
 
   await page.evaluate(async () => {
     const { closeChangelog } = await import('/js/changelog.js');
@@ -37,7 +39,7 @@ test('changelog forceShow entries auto-open until the latest version is seen', a
     const overlay = document.getElementById('changelog-modal-overlay');
     if (!overlay) throw new Error('changelog overlay unavailable');
 
-    localStorage.setItem('labcharts-changelog-seen', '1.7.0');
+    localStorage.setItem('labcharts-changelog-seen', '1.13.0');
     overlay.classList.remove('show');
     await maybeShowChangelog();
     const opensWhenForceShowIsNewer = overlay.classList.contains('show') === true;

--- a/tests/playwright/context-card-medical-history-editor-loader-browser-coverage.spec.js
+++ b/tests/playwright/context-card-medical-history-editor-loader-browser-coverage.spec.js
@@ -294,6 +294,11 @@ test('medical-history edits stay in a draft until Save and Cancel discards them'
 });
 
 test('medical-history Clear requires confirmation before deleting saved context', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('labcharts-default-onboarded', 'profile-set');
+    localStorage.setItem('labcharts-default-emptyTour', 'completed');
+    localStorage.setItem('labcharts-default-tour', 'completed');
+  });
   await page.goto('/app', { waitUntil: 'load' });
 
   await page.evaluate(async () => {

--- a/tests/playwright/settings-loader-browser-coverage.spec.js
+++ b/tests/playwright/settings-loader-browser-coverage.spec.js
@@ -255,4 +255,13 @@ test('returning-user startup defers Settings until a shell action opens it', asy
   await expect.poll(() => page.evaluate(async () => (
     (await import('/js/settings-sync-panel.js')).isSettingsSyncPanelLoaded()
   ))).toBe(true);
+  await expect(page.locator('#messenger-section [data-sync-action="toggle-messenger"]')).toHaveCount(1);
+  await expect(page.locator('#settings-modal [data-settings-sync-placeholder]')).toHaveCount(0);
+  await page.locator('[data-settings-tab="agent"]').click();
+  const agentAccessSlider = page.locator(
+    '#messenger-section [data-sync-action="toggle-messenger"] + .sync-settings-toggle-slider',
+  );
+  await expect(agentAccessSlider).toBeVisible();
+  await expect(agentAccessSlider).toHaveCSS('width', '32px');
+  await expect(agentAccessSlider).toHaveCSS('height', '18px');
 });

--- a/tests/playwright/settings-sync-panel-loader-browser-coverage.spec.js
+++ b/tests/playwright/settings-sync-panel-loader-browser-coverage.spec.js
@@ -123,6 +123,60 @@ test('Settings sync panel stays cold, single-flights, and applies stored configu
   });
 });
 
+test('cold Settings placeholders hydrate into interactive sync and Agent Access panels', async ({ page }) => {
+  await page.goto('/settings-sync-panel-loader-coverage');
+  await page.route('**/js/settings-sync-panel-impl.js*', route => route.fulfill({
+    contentType: 'text/javascript',
+    body: syntheticSettingsSyncPanel,
+  }));
+
+  const outcomes = await page.evaluate(async url => {
+    document.body.insertAdjacentHTML('beforeend', `
+      <section id="sync-section"></section>
+      <section id="messenger-section"></section>
+    `);
+    const facade = await import(url);
+    const syncSection = document.getElementById('sync-section');
+    const messengerSection = document.getElementById('messenger-section');
+    syncSection.innerHTML = facade.renderSyncSection();
+    messengerSection.innerHTML = facade.renderMessengerSection();
+    const cold = {
+      sync: syncSection.textContent,
+      messenger: messengerSection.textContent,
+    };
+
+    await facade.hydrateSettingsSyncPanel();
+
+    return {
+      cold,
+      hydrated: {
+        sync: syncSection.textContent,
+        messenger: messengerSection.textContent,
+      },
+      placeholdersRemaining: document.querySelectorAll('[data-settings-sync-placeholder]').length,
+      implementationCalls: window.__settingsSyncPanelLoaderCalls || [],
+    };
+  }, facadeUrl());
+
+  expect(outcomes).toEqual({
+    cold: {
+      sync: 'Loading sync settings…',
+      messenger: 'Loading Agent Access…',
+    },
+    hydrated: {
+      sync: 'sync markup',
+      messenger: 'messenger markup',
+    },
+    placeholdersRemaining: 0,
+    implementationCalls: [
+      ['configure', 'applyPendingTombstone,listPendingTombstones,pushContextToGateway,rejectPendingTombstone,updateSyncIndicator'],
+      ['renderSyncSection'],
+      ['renderMessengerSection'],
+      ['hydrateSettingsSyncPanel'],
+    ],
+  });
+});
+
 test('Settings sync panel retries with a fixed URL and reports the first failure', async ({ page }) => {
   await page.goto('/settings-sync-panel-loader-coverage');
   const implementationRequests = [];

--- a/tests/playwright/sync-actions-browser-coverage.spec.js
+++ b/tests/playwright/sync-actions-browser-coverage.spec.js
@@ -7,17 +7,32 @@ function moduleUrl(path) {
 test('sync save hooks and messenger cover debounce and gateway paths', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
 
-  const results = await page.evaluate(async ({ saveHooksUrl, messengerUrl }) => {
-    const [{ state }, saveHooks, messenger] = await Promise.all([
+  const results = await page.evaluate(async ({ saveHooksUrl, messengerUrl, labContextUrl }) => {
+    const [{ state }, saveHooks, messenger, labContext] = await Promise.all([
       import('/js/state.js'),
       import(saveHooksUrl),
       import(messengerUrl),
+      import(labContextUrl),
     ]);
     const outcomes = {};
     const pushes = [];
     const fetches = [];
     const debugCalls = [];
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
+    const decodeBase64 = value => {
+      const binary = atob(value);
+      return Uint8Array.from(binary, char => char.charCodeAt(0));
+    };
+    const decryptAgentContext = async envelope => {
+      const rawKey = Uint8Array.from({ length: 32 }, (_, index) => index);
+      const key = await crypto.subtle.importKey('raw', rawKey, { name: 'AES-GCM' }, false, ['decrypt']);
+      const plaintext = await crypto.subtle.decrypt({
+        name: 'AES-GCM',
+        iv: decodeBase64(envelope.iv),
+        additionalData: new TextEncoder().encode(`getbased-agent-context-v2:${profileId}`),
+      }, key, decodeBase64(envelope.ciphertext));
+      return new TextDecoder().decode(plaintext);
+    };
     const profileId = 'sync-hooks-active';
     const storageKeys = [
       'labcharts-messenger-enabled',
@@ -79,7 +94,136 @@ test('sync save hooks and messenger cover debounce and gateway paths', async ({ 
         });
       };
       state.currentProfile = profileId;
-      state.importedData = { entries: [{ date: '2026-06-09', markers: { metabolic: { glucose: 4.9 } } }] };
+      state.importedData = {
+        entries: [{ date: '2026-06-09', markers: { metabolic: { glucose: 4.9 } } }],
+        contextSourceSettings: {
+          'insight-cards': false,
+          'light-sun': false,
+        },
+        healthGoals: [
+          { severity: 'major', text: 'Restore stable morning energy' },
+          { severity: 'mild', text: 'Improve training recovery' },
+        ],
+        diagnoses: {
+          conditions: [{ name: 'Hashimoto thyroiditis', severity: 'moderate', status: 'controlled', since: '2021' }],
+          familyHistory: [{ relative: 'maternal_grandmother', condition: 'Type 2 diabetes', onsetAge: 55, note: 'required insulin' }],
+          proceduresNote: 'Appendectomy in 2019',
+          flags: {
+            lowMuscleMass: true,
+            hormoneTherapy: true,
+            postmenopause: true,
+            intenseTrainingRecent: true,
+            acuteIllnessNearDraw: true,
+          },
+          note: 'Medical-history agent sentinel',
+        },
+        diet: {
+          type: 'mediterranean',
+          pattern: '3 meals/day',
+          proteinIntake: '1.2–1.6 g/kg/day',
+          hydration: '2–3 L/day',
+          restrictions: ['gluten-free'],
+          alcohol: 'none',
+          caffeine: 'none',
+          caffeineTiming: 'morning only',
+          recentChanges: ['recent major diet change'],
+          breakfast: 'Greek yogurt and berries',
+          breakfastTime: '07:30',
+          lunch: 'Lentil salad',
+          lunchTime: '12:30',
+          dinner: 'Salmon and vegetables',
+          dinnerTime: '18:15',
+          snacks: 'Walnuts',
+          snacksTime: '15:00',
+          bowelFrequency: '1x/day',
+          stoolConsistency: 'smooth',
+          bloating: 'none',
+          gas: 'none',
+          acidReflux: 'none',
+          burping: 'none',
+          nausea: 'none',
+          appetite: 'normal',
+          abdominalPain: 'none',
+          foodSensitivities: ['histamine'],
+          note: 'Diet agent sentinel',
+        },
+        exercise: {
+          frequency: '3-4x/week',
+          types: ['strength', 'physiotherapy / rehab'],
+          intensity: 'moderate',
+          duration: '60-90 min',
+          dailyMovement: 'some walking',
+          muscleContext: 'muscular',
+          limitations: ['poor recovery'],
+          note: 'Exercise agent sentinel',
+        },
+        sleepRest: {
+          duration: '7-8h',
+          quality: 'good',
+          daytimeSleepiness: 'sometimes',
+          apneaStatus: 'not suspected',
+          papUse: 'not applicable',
+          naps: 'none',
+          schedule: 'consistent',
+          roomTemp: 'cool (18-20°C / 65-68°F)',
+          issues: ['waking at night'],
+          environment: ['blackout curtains'],
+          practices: ['evening magnesium'],
+          note: 'Sleep agent sentinel',
+        },
+        lightCircadian: {
+          amLight: 'sunrise outdoor (10+ min)',
+          daytime: '1-2h outdoor',
+          uvExposure: 'midday sun when possible',
+          skinType: 'III — medium',
+          evening: ['dim lights after sunset'],
+          screenTime: '4-8h',
+          techEnv: ['phone in bedroom'],
+          cold: 'cold shower',
+          grounding: 'barefoot occasionally',
+          mealTiming: ['early dinner (before 6pm)'],
+          note: 'Light agent sentinel',
+        },
+        stress: {
+          level: 'moderate',
+          duration: '6-12 months',
+          trend: 'improving',
+          sources: ['work'],
+          management: ['nature'],
+          note: 'Stress agent sentinel',
+        },
+        loveLife: {
+          status: 'married',
+          relationship: 'supportive & secure',
+          satisfaction: 'satisfied',
+          libido: 'normal',
+          libidoChange: 'unchanged',
+          frequency: 'weekly',
+          orgasm: 'usually',
+          concerns: ['mismatched libido'],
+          reproductiveGoals: ['pregnancy planning'],
+          note: 'Love-life agent sentinel',
+        },
+        environment: {
+          setting: 'urban residential',
+          climate: 'temperate',
+          altitude: 'moderate altitude (1,500-2,500 m)',
+          inhaledExposures: ['secondhand smoke'],
+          occupationalExposures: ['solvents'],
+          water: 'glacier water',
+          waterConcerns: ['unknown source quality'],
+          emf: ['WiFi router nearby'],
+          emfMitigation: ['WiFi off at night'],
+          homeLight: 'mostly LED lighting',
+          air: ['agricultural area / crop spraying nearby'],
+          toxins: ['mold exposure'],
+          building: 'old building (pre-1970)',
+          note: 'Environment agent sentinel',
+        },
+        interpretiveLens: 'Prioritize mechanistic circadian interpretation.',
+        contextNotes: 'Additional-context agent sentinel',
+      };
+      labContext.invalidateLabContextCache();
       localStorage.setItem('labcharts-messenger-enabled', 'false');
       localStorage.removeItem('labcharts-messenger-token');
       sessionStorage.removeItem('labcharts-chat-local-lock-until');
@@ -163,12 +307,16 @@ test('sync save hooks and messenger cover debounce and gateway paths', async ({ 
       localStorage.setItem('labcharts-agent-context-key', 'gbctx_v1_AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8');
       const testOwner = { id: 'MDEyMzQ1Njc4OWFiY2RlZg', writeKey: new Uint8Array(32).fill(7) };
       messenger.migrateLocalAgentAccessToProfile();
-      messenger.configureSyncMessenger({ getAppOwner: () => testOwner });
+      messenger.configureSyncMessenger({
+        getAppOwner: () => testOwner,
+        buildLabContext: labContext.buildLabContext,
+      });
       messenger.pushContextToGateway();
       await runPendingTimers();
       const defaultGateway = fetches.at(-1);
       const defaultGatewayBody = JSON.parse(defaultGateway.options?.body || '{}');
       const defaultGatewayContext = JSON.parse(defaultGatewayBody.context || '{}');
+      const decryptedAgentContext = await decryptAgentContext(defaultGatewayContext.encryptedContext);
       outcomes.messengerDefaultRelayPushesEncryptedContext = defaultGateway?.url === 'https://sync.getbased.health/api/context'
         && defaultGateway.options?.headers?.Authorization === 'Bearer aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
         && defaultGatewayBody.profileId === profileId
@@ -185,6 +333,106 @@ test('sync save hooks and messenger cover debounce and gateway paths', async ({ 
         && typeof defaultGatewayContext.encryptedContext?.iv === 'string'
         && typeof defaultGatewayContext.encryptedContext?.ciphertext === 'string'
         && !defaultGatewayContext.encryptedContext.ciphertext.includes('2026-06-09');
+      const redesignedContextFragments = [
+        '[section:healthGoals]',
+        'Restore stable morning energy',
+        'Improve training recovery',
+        'Prioritize mechanistic circadian interpretation.',
+        'Hashimoto thyroiditis (moderate, controlled, since 2021)',
+        'maternal grandmother: Type 2 diabetes, onset age 55 — required insulin',
+        'Appendectomy in 2019',
+        'Low muscle mass / creatinine may be unreliable',
+        'Hormone therapy / TRT / hormonal contraception',
+        'Postmenopause / no active cycle',
+        'Recent intense training near blood draw',
+        'Acute illness / infection / injury near blood draw',
+        'Medical-history agent sentinel',
+        'Protein intake: 1.2–1.6 g/kg/day',
+        'Daily fluid intake: 2–3 L/day',
+        'Alcohol: none',
+        'Caffeine: none',
+        'Latest caffeine: morning only',
+        'Recent changes: recent major diet change',
+        'Greek yogurt and berries',
+        'Lentil salad',
+        'Salmon and vegetables',
+        'Walnuts',
+        'Bowel frequency: 1x/day',
+        'Stool consistency: smooth',
+        'Bloating: none',
+        'Gas: none',
+        'Acid reflux: none',
+        'Burping: none',
+        'Nausea: none',
+        'Appetite: normal',
+        'Abdominal pain: none',
+        'Food sensitivities: histamine',
+        'Diet agent sentinel',
+        'Frequency: 3-4x/week',
+        'Types: strength, physiotherapy / rehab',
+        'Intensity: moderate',
+        'Typical session: 60-90 min',
+        'Daily movement: some walking',
+        'Muscle context: muscular',
+        'Limitations / recovery: poor recovery',
+        'Exercise agent sentinel',
+        'Duration: 7-8h',
+        'Quality: good',
+        'Daytime sleepiness: sometimes',
+        'Sleep apnea: not suspected',
+        'PAP / CPAP: not applicable',
+        'Naps: none',
+        'Schedule: consistent',
+        'Room temp: cool (18-20°C / 65-68°F)',
+        'Issues: waking at night',
+        'Environment: blackout curtains',
+        'Practices: evening magnesium',
+        'Sleep agent sentinel',
+        'Morning light: sunrise outdoor (10+ min)',
+        'Daytime outdoor: 1-2h outdoor',
+        'UV exposure: midday sun when possible',
+        'Skin type: III — medium',
+        'Evening light: dim lights after sunset',
+        'Daily screen time: 4-8h',
+        'Tech environment: phone in bedroom',
+        'Cold exposure: cold shower',
+        'Grounding: barefoot occasionally',
+        'Meal timing: early dinner (before 6pm)',
+        'Light agent sentinel',
+        'Level: moderate',
+        'Duration: 6-12 months',
+        'Trend: improving',
+        'Sources: work',
+        'Management: nature',
+        'Stress agent sentinel',
+        'Status: married',
+        'Relationship quality: supportive & secure',
+        'Satisfaction: satisfied',
+        'Libido: normal',
+        'Libido change: unchanged',
+        'Sexual frequency: weekly',
+        'Orgasm: usually',
+        'Concerns: mismatched libido',
+        'Reproductive goals: pregnancy planning',
+        'Love-life agent sentinel',
+        'Setting: urban residential',
+        'Climate: temperate',
+        'Altitude exposure: moderate altitude (1,500-2,500 m)',
+        'Smoking / inhaled exposure: secondhand smoke',
+        'Work / hobby exposures: solvents',
+        'Water: glacier water',
+        'Water concerns: unknown source quality',
+        'EMF exposure: WiFi router nearby',
+        'EMF mitigation: WiFi off at night',
+        'Home lighting: mostly LED lighting',
+        'Air quality: agricultural area / crop spraying nearby',
+        'Toxin exposure: mold exposure',
+        'Building: old building (pre-1970)',
+        'Environment agent sentinel',
+        'Additional-context agent sentinel',
+      ];
+      outcomes.messengerEncryptedPayloadCarriesEveryRedesignedContextField =
+        redesignedContextFragments.every(fragment => decryptedAgentContext.includes(fragment));
 
       messenger.configureSyncMessenger({
         getSyncRelay: () => 'ws://relay.local',
@@ -213,6 +461,7 @@ test('sync save hooks and messenger cover debounce and gateway paths', async ({ 
       });
       saveHooks.clearSyncSaveTimers();
       messenger.configureSyncMessenger({ getSyncRelay: () => 'wss://sync.getbased.health', debug: () => {} });
+      labContext.invalidateLabContextCache();
       state.currentProfile = saved.currentProfile;
       state.importedData = saved.importedData;
       for (const { type, listener, options } of boundListeners) {
@@ -235,6 +484,7 @@ test('sync save hooks and messenger cover debounce and gateway paths', async ({ 
   }, {
     saveHooksUrl: moduleUrl('/js/sync-save-hooks.js'),
     messengerUrl: moduleUrl('/js/sync-messenger.js'),
+    labContextUrl: moduleUrl('/js/lab-context.js'),
   });
 
   for (const [name, passed] of Object.entries(results)) {

--- a/tests/playwright/sync-identity-browser-coverage.spec.js
+++ b/tests/playwright/sync-identity-browser-coverage.spec.js
@@ -187,7 +187,7 @@ test('sync identity browser coverage handles libraries getters pending restore a
       const restoreCalls = [];
       let seedCalls = 0;
       const evolu = {
-        restoreAppOwner: async mnemonic => { restoreCalls.push(mnemonic); },
+        restoreAppOwner: async (mnemonic, options) => { restoreCalls.push({ mnemonic, options }); },
       };
       identity.configureSyncIdentity({
         getEvolu: () => evolu,
@@ -197,7 +197,8 @@ test('sync identity browser coverage handles libraries getters pending restore a
       clearNotifications();
       const joinResult = await identity.restoreFromMnemonic('  JOIN   OWNER\nMNEMONIC  ');
       outcomes.restoreJoinClearsSyncStorageAndMarksPending = joinResult === true
-        && restoreCalls[0] === 'join owner mnemonic'
+        && restoreCalls[0]?.mnemonic === 'join owner mnemonic'
+        && restoreCalls[0]?.options?.reload === false
         && localStorage.getItem('labcharts-sync-enabled') === 'true'
         && seedCalls === 0
         && identity.isRestoreJoinPending() === true
@@ -213,7 +214,8 @@ test('sync identity browser coverage handles libraries getters pending restore a
       scheduledDelays.length = 0;
       const seededResult = await identity.restoreFromMnemonic('seed local mnemonic', { seedLocal: true });
       outcomes.restoreSeedLocalClearsPendingAndSeeds = seededResult === true
-        && restoreCalls[1] === 'seed local mnemonic'
+        && restoreCalls[1]?.mnemonic === 'seed local mnemonic'
+        && restoreCalls[1]?.options === undefined
         && seedCalls === 1
         && identity.isRestoreJoinPending() === false
         && scheduledDelays.includes(500)

--- a/tests/playwright/sync-relay-transport-e2e.spec.js
+++ b/tests/playwright/sync-relay-transport-e2e.spec.js
@@ -99,7 +99,9 @@ async function enableNewIdentity(page) {
 async function joinIdentity(page, mnemonic, ownerId) {
   await page.evaluate(async () => {
     const { enableSync } = await import('/js/sync.js');
-    await enableSync({ skipPush: true });
+    // Match the Settings "Join existing device" path: the throwaway owner is
+    // intentionally provisional until restoreFromMnemonic accepts the seed.
+    await enableSync({ skipPush: true, persist: false });
   });
   await waitForOwner(page);
 

--- a/tests/sync-actions.test.js
+++ b/tests/sync-actions.test.js
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   configureSyncActions, prepareRelayCompaction, pushAllProfiles, rebuildOwnerRelayState, syncNow,
 } from '../js/sync-actions.js';
+import { encryptedRemoveItem, encryptedSetItem } from '../js/crypto.js';
 import { state } from '../js/state.js';
 import {
   clearSyncProfileDirty, getSyncDirtyToken, markSyncProfileDirty,
@@ -31,6 +32,38 @@ describe('sync action profile dependencies', () => {
     } finally {
       state.currentProfile = previousProfile;
       state.importedData = previousImportedData;
+      configureSyncActions({
+        pushProfile: async () => {},
+        getProfiles: () => [],
+        createDefaultProfileData: () => ({ entries: [] }),
+      });
+    }
+  });
+
+  it('skips an inactive profile whose persisted data is unavailable', async () => {
+    const previousProfile = state.currentProfile;
+    const profileId = 'unavailable-seed-profile';
+    const storageKey = profileStorageKey(profileId, 'imported');
+    const pushProfile = vi.fn().mockResolvedValue({ ok: true });
+    await encryptedRemoveItem(storageKey);
+    state.currentProfile = 'different-active-profile';
+    configureSyncActions({
+      pushProfile,
+      getProfiles: () => [{ id: profileId }],
+      createDefaultProfileData: () => ({ entries: [] }),
+    });
+
+    try {
+      await expect(pushAllProfiles()).resolves.toEqual({
+        total: 1,
+        succeeded: 0,
+        failed: 0,
+        skipped: 1,
+      });
+      expect(pushProfile).not.toHaveBeenCalled();
+    } finally {
+      state.currentProfile = previousProfile;
+      await encryptedRemoveItem(storageKey);
       configureSyncActions({
         pushProfile: async () => {},
         getProfiles: () => [],
@@ -140,7 +173,7 @@ describe('sync action profile dependencies', () => {
     const order = [];
     state.currentProfile = activeId;
     state.importedData = { entries: [], contextNotes: 'fresh active edit' };
-    localStorage.setItem(inactiveKey, JSON.stringify({ entries: [], contextNotes: 'fresh inactive edit' }));
+    await encryptedSetItem(inactiveKey, JSON.stringify({ entries: [], contextNotes: 'fresh inactive edit' }));
     markSyncProfileDirty(activeId);
     markSyncProfileDirty(inactiveId);
     configureSyncActions({
@@ -164,7 +197,7 @@ describe('sync action profile dependencies', () => {
         'pull',
       ]);
     } finally {
-      localStorage.removeItem(inactiveKey);
+      await encryptedRemoveItem(inactiveKey);
       localStorage.removeItem(`labcharts-${activeId}-sync-dirty`);
       localStorage.removeItem(`labcharts-${inactiveId}-sync-dirty`);
       state.currentProfile = previousProfile;
@@ -180,13 +213,15 @@ describe('sync action profile dependencies', () => {
     }
   });
 
-  it('fails compaction before pulling when an inactive dirty profile cannot commit', async () => {
+  it('fails compaction before pulling or pushing when inactive dirty profile data is unavailable', async () => {
     const inactiveId = 'compact-dirty-failed';
     const forcePull = vi.fn();
+    const pushProfile = vi.fn(async () => ({ ok: true }));
+    await encryptedRemoveItem(profileStorageKey(inactiveId, 'imported'));
     markSyncProfileDirty(inactiveId);
     configureSyncActions({
       forcePull,
-      pushProfile: async () => ({ ok: false, reason: 'timeout' }),
+      pushProfile,
       isSyncEnabled: () => true,
       isEvoluReady: () => true,
       isSyncing: () => false,
@@ -194,9 +229,11 @@ describe('sync action profile dependencies', () => {
     });
 
     try {
-      await expect(prepareRelayCompaction()).rejects.toThrow('Could not commit pending changes');
+      await expect(prepareRelayCompaction()).rejects.toThrow('Could not read local data');
       expect(forcePull).not.toHaveBeenCalled();
+      expect(pushProfile).not.toHaveBeenCalled();
     } finally {
+      await encryptedRemoveItem(profileStorageKey(inactiveId, 'imported'));
       localStorage.removeItem(`labcharts-${inactiveId}-sync-dirty`);
       configureSyncActions({
         forcePull: async () => {},

--- a/tests/sync-runtime.test.js
+++ b/tests/sync-runtime.test.js
@@ -689,6 +689,23 @@ describe('sync push runtime behavior', () => {
     }
   });
 
+  it('rejects unavailable profile data before writing any relay rows', async () => {
+    const fake = makeEvolu();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    configureRuntimeDeps(fake);
+
+    await expect(pushProfile(PROFILE_ID, null)).resolves.toEqual({
+      ok: false,
+      skipped: true,
+      reason: 'missing-profile-data',
+    });
+
+    expect(fake.calls.insert).toHaveLength(0);
+    expect(fake.calls.update).toHaveLength(0);
+    expect(isSyncPushInFlight()).toBe(false);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('imported profile data is unavailable'));
+  });
+
   it('inserts and updates profile rows only after a committed push and records local commit state', async () => {
     const fake = makeEvolu();
     const debug = vi.fn();

--- a/tests/sync-save-hooks.test.js
+++ b/tests/sync-save-hooks.test.js
@@ -1,12 +1,22 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { encryptedRemoveItem, encryptedSetItem } from '../js/crypto.js';
+import { profileStorageKey } from '../js/profile-storage-key.js';
+import { state } from '../js/state.js';
 import {
+  clearSyncSaveTimers,
   configureSyncSaveHooks,
+  onProfileSaved,
   readProfileImportedData,
 } from '../js/sync-save-hooks.js';
 
 describe('sync save-hook profile data dependencies', () => {
-  it('normalizes fallback data and creates missing profile data through configured helpers', async () => {
+  afterEach(() => {
+    clearSyncSaveTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('normalizes explicit fallback data but fails closed for a missing named profile', async () => {
     const fallback = { entries: [] };
     const createDefaultProfileData = vi.fn(() => ({ entries: [], created: true }));
     const migrateProfileData = vi.fn(data => {
@@ -21,13 +31,81 @@ describe('sync save-hook profile data dependencies', () => {
       expect(migrateProfileData).toHaveBeenCalledWith(fallback);
 
       localStorage.removeItem('labcharts-missing-profile-imported');
-      await expect(readProfileImportedData('missing-profile')).resolves.toEqual({
+      await expect(readProfileImportedData('missing-profile')).resolves.toBeNull();
+      expect(createDefaultProfileData).not.toHaveBeenCalled();
+
+      await expect(readProfileImportedData(null)).resolves.toEqual({
         entries: [],
         created: true,
       });
       expect(createDefaultProfileData).toHaveBeenCalledOnce();
     } finally {
       configureSyncSaveHooks(previous);
+    }
+  });
+
+  it('reads an inactive unencrypted profile blob from IndexedDB, including genome data', async () => {
+    const profileId = 'inactive-genome-profile';
+    const storageKey = profileStorageKey(profileId, 'imported');
+    const previousCurrentProfile = state.currentProfile;
+    const previousImportedData = state.importedData;
+    const previousEncryptionEnabled = localStorage.getItem('labcharts-encryption-enabled');
+    const stored = {
+      entries: [],
+      genetics: {
+        snps: [
+          { rsid: 'rs123', chromosome: '1', position: 12345, genotype: 'AG' },
+        ],
+      },
+    };
+
+    localStorage.removeItem('labcharts-encryption-enabled');
+    await encryptedRemoveItem(storageKey);
+    await encryptedSetItem(storageKey, JSON.stringify(stored));
+    state.currentProfile = 'different-active-profile';
+    state.importedData = { entries: [] };
+
+    try {
+      // The imported blob is intentionally absent from localStorage; it is
+      // always IDB-backed even when encryption itself is disabled.
+      expect(localStorage.getItem(storageKey)).toBeNull();
+      await expect(readProfileImportedData(profileId)).resolves.toEqual(stored);
+    } finally {
+      state.currentProfile = previousCurrentProfile;
+      state.importedData = previousImportedData;
+      if (previousEncryptionEnabled === null) localStorage.removeItem('labcharts-encryption-enabled');
+      else localStorage.setItem('labcharts-encryption-enabled', previousEncryptionEnabled);
+      await encryptedRemoveItem(storageKey);
+    }
+  });
+
+  it('does not publish a blank replacement when an inactive profile blob is unavailable', async () => {
+    const profileId = 'unavailable-inactive-profile';
+    const storageKey = profileStorageKey(profileId, 'imported');
+    const previousCurrentProfile = state.currentProfile;
+    const previousImportedData = state.importedData;
+    const pushProfile = vi.fn(async () => ({}));
+    const previous = configureSyncSaveHooks({
+      pushProfile,
+      isSyncEnabled: () => true,
+      isEvoluReady: () => true,
+      isSyncing: () => false,
+    });
+
+    await encryptedRemoveItem(storageKey);
+    state.currentProfile = 'different-active-profile';
+    state.importedData = { entries: [] };
+
+    try {
+      onProfileSaved(profileId);
+      await new Promise(resolve => setTimeout(resolve, 300));
+      expect(pushProfile).not.toHaveBeenCalled();
+    } finally {
+      configureSyncSaveHooks(previous);
+      state.currentProfile = previousCurrentProfile;
+      state.importedData = previousImportedData;
+      localStorage.removeItem(`labcharts-${profileId}-sync-dirty`);
+      await encryptedRemoveItem(storageKey);
     }
   });
 });

--- a/tests/test-changelog.js
+++ b/tests/test-changelog.js
@@ -128,6 +128,14 @@ assert('version.js sets APP_VERSION', versionMatch !== null, versionMatch ? `'${
 assert('APP_VERSION is semver', versionMatch && /^\d+\.\d+\.\d+/.test(versionMatch[1]), versionMatch ? versionMatch[1] : '');
 const latestChangelogVersion = changelogSrc.match(/version:\s*'([^']+)'/)?.[1] || '';
 assert('APP_VERSION is at least latest changelog entry', appVersion && latestChangelogVersion && semverGte(appVersion, latestChangelogVersion), `${appVersion} < ${latestChangelogVersion}`);
+assert('latest changelog explains sync safety and complete Agent Access in user-readable terms',
+  /version:\s*'1\.13\.1'[\s\S]{0,500}Safer sync and complete Agent Access/.test(changelogSrc)
+    && /version:\s*'1\.13\.1'[\s\S]{0,1800}works end to end/.test(changelogSrc)
+    && /version:\s*'1\.13\.1'[\s\S]{0,1800}genome and other profile data are better protected/.test(changelogSrc)
+    && /version:\s*'1\.13\.1'[\s\S]{0,1800}stops safely/.test(changelogSrc)
+    && /version:\s*'1\.13\.1'[\s\S]{0,1800}Agent Access is ready when you open Settings/.test(changelogSrc)
+    && /version:\s*'1\.13\.1'[\s\S]{0,1800}complete health context/.test(changelogSrc)
+    && /version:\s*'1\.13\.1'[\s\S]{0,1800}forceShow:\s*true/.test(changelogSrc));
 assert('latest changelog gives a readable overview of the redesigned health context release',
   /version:\s*'1\.12\.0'[\s\S]{0,500}A completely redesigned health context/.test(changelogSrc)
     && /version:\s*'1\.12\.0'[\s\S]{0,1600}redesigned from the ground up/.test(changelogSrc)

--- a/tests/test-settings-sync-delegated-actions.js
+++ b/tests/test-settings-sync-delegated-actions.js
@@ -99,6 +99,9 @@ assert('Delegated setup acknowledgment updates Done state',
   /action === 'setup-ack'[\s\S]*updateSyncSetupAck\(actionEl\)/.test(src));
 assert('Delegated Agent Access toggle calls toggleMessenger',
   /action === 'toggle-messenger'[\s\S]*toggleMessenger\(actionEl\.checked\)/.test(src));
+assert('Agent Access toggle uses Settings-owned visible slider styles',
+  /data-sync-action="toggle-messenger"[\s\S]{0,180}class="chat-toggle-slider sync-settings-toggle-slider"/.test(agentSrc)
+    && /class="chat-websearch-toggle-label sync-settings-toggle"/.test(agentSrc));
 assert('Agent Access enable checks saveImportedData result before pushing context or success',
   /const saved = await saveImportedData\(\{ reason: 'agent-access-enable' \}\);[\s\S]*if \(saved === false\) throw new Error\('saveImportedData returned false while enabling Agent Access'\);[\s\S]*pushContextToGateway\(\);[\s\S]*showNotification\('Agent Access enabled', 'success'\)/.test(agentSrc));
 assert('Agent Access disable checks saveImportedData result before success',

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -942,6 +942,15 @@ await import('../js/settings.js');
       && syncSaveHooksSrc.includes('const _profileSyncTimers = new Map()')
       && syncSaveHooksSrc.includes('readProfileImportedData(profileId, importedData)')
       && exportBlockIncludes(syncSrc, ['onProfileSaved']));
+  assert('inactive profile sync reads imported blobs through their canonical storage wrapper',
+    syncSaveHooksSrc.includes('const raw = await encryptedGetItem(storageKey)')
+      && !syncSaveHooksSrc.includes('localStorage.getItem(storageKey)'));
+  assert('missing inactive profile data is not replaced with an empty relay payload',
+    /readProfileImportedData[\s\S]{0,1800}return null;/.test(syncSaveHooksSrc)
+      && /scheduleProfilePush[\s\S]{0,500}!data \|\| typeof data !== 'object'/.test(syncSaveHooksSrc));
+  assert('pushProfile rejects unavailable imported data before constructing a relay payload',
+    /pushProfile[\s\S]{0,700}reason:\s*'missing-profile-data'/.test(syncPushSrc)
+      && /pushProfile[\s\S]{0,700}Array\.isArray\(importedData\)/.test(syncPushSrc));
   assert('profile metadata sync retries while Evolu is busy or not ready',
     syncSaveHooksSrc.includes('function scheduleProfilePush')
       && /scheduleProfilePush[\s\S]{0,600}attempt < 60/.test(syncSaveHooksSrc)
@@ -1396,9 +1405,12 @@ await import('../js/settings.js');
       && syncDisableCleanupSrc.includes('localStorage.removeItem(key)'));
   assert('restoreFromMnemonic normalizes the seed before calling evolu.restoreAppOwner',
     syncIdentitySrc.includes("normalize('NFKD')")
-      && syncIdentitySrc.includes('evolu.restoreAppOwner(normalizedMnemonic)'));
+      && syncIdentitySrc.includes('evolu.restoreAppOwner(normalizedMnemonic, { reload: false })'));
+  assert('restoreFromMnemonic defers Evolu reload until join state is persisted',
+    syncIdentitySrc.includes('evolu.restoreAppOwner(normalizedMnemonic, { reload: false })')
+      && syncIdentitySrc.includes('scheduleSyncRuntimeReload(500)'));
   // Verify timestamps are cleared AFTER restoreAppOwner within restoreFromMnemonic (not before)
-  const restoreIdx = syncIdentitySrc.indexOf('evolu.restoreAppOwner(normalizedMnemonic)');
+  const restoreIdx = syncIdentitySrc.indexOf('evolu.restoreAppOwner(normalizedMnemonic, { reload: false })');
   const clearTsInRestore = syncIdentitySrc.indexOf('clearSyncDisableStorage();', restoreIdx);
   assert('Sync-ts cleared after restoreAppOwner (not before)', restoreIdx > 0 && clearTsInRestore > restoreIdx,
     `restoreAppOwner at ${restoreIdx}, sync-ts clear at ${clearTsInRestore}`);
@@ -1502,10 +1514,10 @@ await import('../js/settings.js');
   assert('pushAllProfiles forwards force/seed options to profile pushes',
     /export async function pushAllProfiles\(options = \{\}\)/.test(syncActionsSrc)
       && /_pushProfile\(p\.id,\s*dataJson,\s*options\)/.test(syncActionsSrc));
-  assert('pushAllProfiles pushes metadata-only profiles with default data',
+  assert('pushAllProfiles defaults only the active profile and skips unreadable inactive profiles',
     syncActionsSrc.includes('createDefaultProfileData()')
       && /pushAllProfiles[\s\S]{0,800}readProfileImportedData\(p\.id\)/.test(syncActionsSrc)
-      && !/pushAllProfiles[\s\S]{0,800}if \(!raw\) continue/.test(syncActionsSrc));
+      && /pushAllProfiles[\s\S]{0,800}if \(!dataJson\)/.test(syncActionsSrc));
   assert('restore-as-source seeds the new owner before reload',
     /restoreFromMnemonic\(mnemonic,\s*options = \{\}\)/.test(syncIdentitySrc)
       && /options\?\.seedLocal[\s\S]{0,400}await _seedLocalProfiles\(\)/.test(syncIdentitySrc)
@@ -1563,6 +1575,11 @@ await import('../js/settings.js');
 
   assert('Settings imports sync panel', settingsSrc.includes("from './settings-sync-panel.js'"));
   assert('Settings hydrates sync panel on open', settingsSrc.includes('hydrateSettingsSyncPanel()'));
+  assert('lazy Settings sync panel replaces both cold placeholders after loading',
+    settingsSyncPanelSrc.includes('replaceSettingsSyncPanelPlaceholders(module)')
+      && settingsSyncPanelSrc.includes('data-settings-sync-placeholder="sync"')
+      && settingsSyncPanelSrc.includes('data-settings-sync-placeholder="messenger"')
+      && /replaceSettingsSyncPanelPlaceholders[\s\S]{0,700}renderSyncSection\(\)[\s\S]{0,400}renderMessengerSection\(\)/.test(settingsSyncPanelSrc));
   assert('settings-sync-panel imports sync functions', settingsSyncPanelSrc.includes("from './sync.js'"));
   assert('renderSyncSection exists', settingsSyncPanelSrc.includes('function renderSyncSection'));
   assert('Sync section in Data tab', settingsSrc.includes('Cross-Device Sync'));
@@ -2533,10 +2550,10 @@ await import('../js/settings.js');
     disableSyncSrc.includes('clearSyncDisableStorage();')
       && /isSyncDisableCleanupKey[\s\S]{0,300}-sync-cutover-v2/.test(syncDisableCleanupSrc));
   assert('restoreFromMnemonic clears delta snapshots',
-    /restoreFromMnemonic[\s\S]{0,1500}clearSyncDisableStorage\(\)/.test(syncIdentitySrc)
+    /restoreFromMnemonic[\s\S]{0,2200}clearSyncDisableStorage\(\)/.test(syncIdentitySrc)
       && /isSyncDisableCleanupKey[\s\S]{0,300}key\.includes\('-delta-'\)/.test(syncDisableCleanupSrc));
   assert('restoreFromMnemonic clears cutover flag',
-    /restoreFromMnemonic[\s\S]{0,1500}clearSyncDisableStorage\(\)/.test(syncIdentitySrc)
+    /restoreFromMnemonic[\s\S]{0,2200}clearSyncDisableStorage\(\)/.test(syncIdentitySrc)
       && /isSyncDisableCleanupKey[\s\S]{0,300}-sync-cutover-v2/.test(syncDisableCleanupSrc));
 
   // Live: proto-pollution defence — verify a malicious key is rejected
@@ -2714,10 +2731,10 @@ await import('../js/settings.js');
     disableSyncSrc.includes('clearSyncDisableStorage();')
       && /isSyncDisableCleanupKey[\s\S]{0,300}key\s*===\s*'labcharts-relay-quota-warned'/.test(syncDisableCleanupSrc));
   assert('restoreFromMnemonic clears -relay-bytes- keys',
-    /restoreFromMnemonic[\s\S]{0,1500}clearSyncDisableStorage\(\)/.test(syncIdentitySrc)
+    /restoreFromMnemonic[\s\S]{0,2200}clearSyncDisableStorage\(\)/.test(syncIdentitySrc)
       && /isSyncDisableCleanupKey[\s\S]{0,300}key\.includes\('-relay-bytes-'\)/.test(syncDisableCleanupSrc));
   assert('restoreFromMnemonic clears legacy global quota-warned key',
-    /restoreFromMnemonic[\s\S]{0,1500}clearSyncDisableStorage\(\)/.test(syncIdentitySrc)
+    /restoreFromMnemonic[\s\S]{0,2200}clearSyncDisableStorage\(\)/.test(syncIdentitySrc)
       && /isSyncDisableCleanupKey[\s\S]{0,300}key\s*===\s*'labcharts-relay-quota-warned'/.test(syncDisableCleanupSrc));
 
   // P2: warned-marker key now owner-scoped

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.13.0';
+self.APP_VERSION = '1.13.1';


### PR DESCRIPTION
## High-level overview

This PR makes cross-device Sync and Agent Access reliable again, especially on a newly installed device.

It fixes the full path from joining an existing recovery phrase, through safely loading every profile, to sharing the redesigned Context-card data with in-app AI and external agents such as Hermes over the relay. The changes are designed to preserve existing data and require no migration or settings reset. It ships as version 1.13.1 and appears in the application's What's New screen.

## Simple changelog

- Fixed joining an existing Sync recovery phrase so the new device finishes setup and actually downloads relay data.
- Protected genome data and other profile information from being replaced with an empty profile when local storage cannot be read.
- Restored the Agent Access on/off slider in Settings.
- Fixed Sync and Agent Access controls that could remain stuck as loading text the first time Settings was opened.
- Ensured the redesigned Context-card information reaches both in-app AI and external agents.
- Included previously missing skin type and explicit digestive answers such as “none” or “normal” in agent context.
- Added regression tests for recovery-phrase joins, profile-data safety, Settings loading, the Agent Access slider, and encrypted agent context.
- Added the full release summary to the in-app What's New screen as version 1.13.1.

## Technical summary

- Complete existing-mnemonic joins before the controlled reload so the restored Sync owner can pull relay data.
- Read inactive profile blobs through the canonical IndexedDB-backed storage path.
- Fail closed when profile data is unavailable instead of publishing an empty replacement to the relay.
- Stop relay compaction safely if a pending profile cannot be read.
- Hydrate lazy Cross-device Sync and Agent Access settings in place.
- Carry every redesigned Context-card field into shared AI context and the encrypted Agent Access payload.

## Root cause

Evolu's default owner restore could reload before getbased persisted the completed join. A first-time join could therefore appear successful while Sync remained disabled and no relay data was pulled.

Separately, inactive unencrypted profile reads bypassed the storage wrapper even though large imported blobs—including genome data—live in IndexedDB. A failed read could then look like an authoritative empty profile and be pushed to the relay.

The lazy Settings facade returned loading placeholders without replacing them after its implementation loaded, and two stored Context-card signals were omitted by the shared formatter.

## User impact

Joining an existing Sync identity now proceeds to the relay pull. Inactive profiles cannot be blanked by transient or incorrectly routed reads. Agent Access controls appear on a fresh Settings open, and Hermes or other MCP agents receive the same complete redesigned context as the in-app AI.

## Validation

- `npm test -- tests/sync-actions.test.js tests/sync-save-hooks.test.js tests/sync-runtime.test.js` — 59 passed
- `node tests/test-sync.js` — 844 passed
- `node tests/test-settings-sync-delegated-actions.js` — 51 passed
- Focused Chromium specs for Sync, Agent Access, and Settings — 14 passed
- `npm run typecheck:checkjs`
- `npm run quality` — 17 guardrails passed
- `git diff --check`
- `node tests/test-changelog.js` — 97 passed
- Focused What's New Chromium specs — 6 passed

The disposable real-relay transport spec remains CI-guarded and was not enabled locally.