### PR TITLE
Fix Local AI import timeouts and add phase-aware progress

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -10,7 +10,7 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | Metric | Current |
 | --- | ---: |
 | Modules | 598 |
-| Internal import edges | 2584 |
+| Internal import edges | 2586 |
 | Dynamic internal edges | 72 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -581,7 +581,7 @@ Native browser modules shipped with the static application.
 - [`js/local-ai-lifecycle.js`](js/local-ai-lifecycle.js) → [`js/api-provider-storage.js`](js/api-provider-storage.js), [`js/local-ai-discovery.js`](js/local-ai-discovery.js), [`js/local-ai-provider-registry.js`](js/local-ai-provider-registry.js), [`js/local-ai-provider-shared.js`](js/local-ai-provider-shared.js)
 - [`js/local-ai-provider-lmstudio.js`](js/local-ai-provider-lmstudio.js) → [`js/api-transport.js`](js/api-transport.js), [`js/local-ai-provider-shared.js`](js/local-ai-provider-shared.js)
 - [`js/local-ai-provider-ollama.js`](js/local-ai-provider-ollama.js) → [`js/api-transport.js`](js/api-transport.js), [`js/caught-error.js`](js/caught-error.js), [`js/local-ai-provider-shared.js`](js/local-ai-provider-shared.js)
-- [`js/local-ai-provider-openai-compatible.js`](js/local-ai-provider-openai-compatible.js) → [`js/api-openai-compatible.js`](js/api-openai-compatible.js), [`js/local-ai-provider-shared.js`](js/local-ai-provider-shared.js)
+- [`js/local-ai-provider-openai-compatible.js`](js/local-ai-provider-openai-compatible.js) → [`js/api-openai-compatible.js`](js/api-openai-compatible.js), [`js/api-transport.js`](js/api-transport.js), [`js/local-ai-provider-shared.js`](js/local-ai-provider-shared.js)
 - [`js/local-ai-provider-registry.js`](js/local-ai-provider-registry.js) → [`js/local-ai-provider-lmstudio.js`](js/local-ai-provider-lmstudio.js), [`js/local-ai-provider-ollama.js`](js/local-ai-provider-ollama.js), [`js/local-ai-provider-openai-compatible.js`](js/local-ai-provider-openai-compatible.js), [`js/local-ai-provider-shared.js`](js/local-ai-provider-shared.js)
 - [`js/local-ai-provider-shared.js`](js/local-ai-provider-shared.js) → no in-scope imports
 
@@ -657,7 +657,7 @@ Native browser modules shipped with the static application.
 
 <details><summary><code>pdf</code> family — 13 modules</summary>
 
-- [`js/pdf-import-ai-utils.js`](js/pdf-import-ai-utils.js) → [`js/api.js`](js/api.js), [`js/utils.js`](js/utils.js)
+- [`js/pdf-import-ai-utils.js`](js/pdf-import-ai-utils.js) → [`js/api-provider-storage.js`](js/api-provider-storage.js), [`js/api.js`](js/api.js), [`js/utils.js`](js/utils.js)
 - [`js/pdf-import-commit.js`](js/pdf-import-commit.js) → [`js/adapters.js`](js/adapters.js), [`js/crypto.js`](js/crypto.js), [`js/data-merge.js`](js/data-merge.js), [`js/data.js`](js/data.js), [`js/import-benchmarks.js`](js/import-benchmarks.js), [`js/lab-entry-mutations.js`](js/lab-entry-mutations.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/pdf-import-marker-mapping.js`](js/pdf-import-marker-mapping.js), [`js/pdf-import-persistence.js`](js/pdf-import-persistence.js), [`js/pdf-import-review.js`](js/pdf-import-review.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/unique-id.js`](js/unique-id.js), [`js/utils.js`](js/utils.js)
 - [`js/pdf-import-file-handlers.js`](js/pdf-import-file-handlers.js) → [`js/api.js`](js/api.js), [`js/caught-error.js`](js/caught-error.js), [`js/import-benchmarks.js`](js/import-benchmarks.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/pdf-import-ai-utils.js`](js/pdf-import-ai-utils.js), [`js/pdf-import-file-utils.js`](js/pdf-import-file-utils.js), [`js/pdf-import-preflight.js`](js/pdf-import-preflight.js), [`js/pdf-import-progress.js`](js/pdf-import-progress.js), [`js/pdf-import-review.js`](js/pdf-import-review.js), [`js/pdf-import-spreadsheet.js`](js/pdf-import-spreadsheet.js), [`js/pii.js`](js/pii.js), [`js/privacy-safe-diagnostics.js`](js/privacy-safe-diagnostics.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/pdf-import-file-utils.js`](js/pdf-import-file-utils.js) → [`js/pdf-import-spreadsheet.js`](js/pdf-import-spreadsheet.js), [`js/pdfjs-loader.js`](js/pdfjs-loader.js)

--- a/css/import.css
+++ b/css/import.css
@@ -462,6 +462,10 @@ select.import-unit-input {
   text-align: center; font-size: 13px; font-weight: 600; color: var(--text-secondary);
   margin-bottom: 12px; font-variant-numeric: tabular-nums;
 }
+.import-progress-stage {
+  text-align: center; font-size: 12px; color: var(--text-muted);
+  margin: -8px 0 12px; min-height: 15px;
+}
 .import-progress-filename {
   font-size: 12px; color: var(--text-muted); margin-top: 4px;
   align-self: center;

--- a/js/api-local.js
+++ b/js/api-local.js
@@ -6,19 +6,22 @@ import { prepareLocalAiRuntimeHandoff, rememberLocalAiRuntimeUse } from './local
 import { getLocalAiProviderAdapter } from './local-ai-provider-registry.js';
 import { discoverLocalAI, getCachedLocalAiModelDetail, markCachedLocalAiModelLoaded } from './local-ai-discovery.js';
 
-function contentTokenEstimate(content) {
-  if (typeof content === 'string') return content.length / 3.5;
+function contentTokenEstimate(content, charsPerToken) {
+  if (typeof content === 'string') return content.length / charsPerToken;
   if (!Array.isArray(content)) return 0;
   return content.reduce((total, block) => {
-    if (typeof block?.text === 'string') return total + block.text.length / 3.5;
+    if (typeof block?.text === 'string') return total + block.text.length / charsPerToken;
     if (block?.type === 'image' || block?.type === 'image_url') return total + 1600;
     return total;
   }, 0);
 }
 
-export function estimateLocalAiPromptTokens({ system, messages }) {
-  const contentTokens = String(system || '').length / 3.5
-    + (Array.isArray(messages) ? messages.reduce((total, message) => total + contentTokenEstimate(message?.content), 0) : 0);
+export function estimateLocalAiPromptTokens({ system, messages, promptCharsPerToken }) {
+  // 3.5 chars/token fits prose; dense numeric tables (lab reports) tokenize
+  // closer to 3, so callers with that input shape pass promptCharsPerToken.
+  const charsPerToken = Number(promptCharsPerToken) > 0 ? Number(promptCharsPerToken) : 3.5;
+  const contentTokens = String(system || '').length / charsPerToken
+    + (Array.isArray(messages) ? messages.reduce((total, message) => total + contentTokenEstimate(message?.content, charsPerToken), 0) : 0);
   const messageOverhead = (Array.isArray(messages) ? messages.length : 0) * 6 + (system ? 6 : 0);
   return Math.ceil(contentTokens) + messageOverhead;
 }
@@ -117,10 +120,38 @@ export async function callOpenAICompatibleLocalAPI(opts) {
     requiredContext,
     roundContextLength,
   }) || null;
-  const effectiveModelDetail = nativeRequest?.modelDetail || modelDetail;
+  let effectiveModelDetail = nativeRequest?.modelDetail || modelDetail;
+  let useNativeInfer = !!(nativeRequest && providerAdapter.infer);
+
+  // Prefer load-then-stream: (re)load the model at the target context via the
+  // lifecycle hook, then generate over the streaming compatible endpoint. The
+  // native chat endpoint is non-streaming, so long generations there would sit
+  // behind the initial-response timeout with no progress signal.
+  if (nativeRequest && providerAdapter.loadWithContext) {
+    try {
+      await providerAdapter.loadWithContext({
+        baseUrl: url,
+        apiKey: config.apiKey,
+        model,
+        modelDetail,
+        contextLength: nativeRequest.contextLength,
+      });
+      useNativeInfer = false;
+      // The server auto-fits context to available memory and may load less (or
+      // more) than requested — read back the real value and plan against it.
+      const discovery = await discoverLocalAI(url, config.apiKey, { force: true });
+      const loadedDetail = discovery.modelDetails?.find(detail => detail.name === model) || null;
+      if (loadedDetail) effectiveModelDetail = loadedDetail;
+      else effectiveModelDetail = nativeRequest.modelDetail || modelDetail;
+    } catch (error) {
+      // Older servers have no load route; keep the native chat fallback path.
+      if (Number(/** @type {any} */ (error)?.status) !== 404) throw error;
+    }
+  }
+
   const plan = planLocalAiRequest(opts, effectiveModelDetail);
 
-  if (nativeRequest && providerAdapter.infer) {
+  if (useNativeInfer && nativeRequest && providerAdapter.infer) {
     let nativeResult;
     try {
       nativeResult = await providerAdapter.infer({

--- a/js/api-local.js
+++ b/js/api-local.js
@@ -140,9 +140,14 @@ export async function callOpenAICompatibleLocalAPI(opts) {
       // The server auto-fits context to available memory and may load less (or
       // more) than requested — read back the real value and plan against it.
       const discovery = await discoverLocalAI(url, config.apiKey, { force: true });
-      const loadedDetail = discovery.modelDetails?.find(detail => detail.name === model) || null;
-      if (loadedDetail) effectiveModelDetail = loadedDetail;
-      else effectiveModelDetail = nativeRequest.modelDetail || modelDetail;
+      const loadedModelKey = modelDetail?.nativeModelKey || model;
+      const loadedDetail = discovery.modelDetails?.find(detail => detail.loaded
+        && Number(detail.contextLength) > 0
+        && (detail.name === model || detail.nativeModelKey === loadedModelKey)) || null;
+      if (!loadedDetail) {
+        throw new Error(`Local AI reloaded ${model}, but could not verify its active context length. Check the model state in the local server, then retry.`);
+      }
+      effectiveModelDetail = loadedDetail;
     } catch (error) {
       // Older servers have no load route; keep the native chat fallback path.
       if (Number(/** @type {any} */ (error)?.status) !== 404) throw error;

--- a/js/api-openai-compatible.js
+++ b/js/api-openai-compatible.js
@@ -49,6 +49,7 @@ const proxyFetch = createProxyFetch(useCustomApiProxy);
  *   useProxy?: boolean,
  *   extraBody?: Record<string, any>,
  *   fetchImpl?: typeof fetch | null,
+ *   firstReadStallMs?: number,
  * }} OpenAICompatibleTransportOptions
  */
 
@@ -100,7 +101,7 @@ function localAIReasoningControlRejected(res, errorText) {
   return (res.status === 400 || res.status === 422) && /reasoning[_ .-]?(?:effort|control)|invalid.*reasoning/i.test(errorText);
 }
 
-export async function callOpenAICompatibleAPI(endpoint, key, model, providerName, { system, messages, maxTokens, onStream, signal, requestTimeoutMs, jsonMode, jsonSchema, forceNonStream }, extraHeaders = {}, { useProxy = true, extraBody = {}, fetchImpl = null } = /** @type {OpenAICompatibleTransportOptions} */ ({})) {
+export async function callOpenAICompatibleAPI(endpoint, key, model, providerName, { system, messages, maxTokens, onStream, signal, requestTimeoutMs, jsonMode, jsonSchema, forceNonStream }, extraHeaders = {}, { useProxy = true, extraBody = {}, fetchImpl = null, firstReadStallMs = 0 } = /** @type {OpenAICompatibleTransportOptions} */ ({})) {
   const apiMessages = [];
   if (system) apiMessages.push({ role: 'system', content: system });
   for (const msg of messages) apiMessages.push({ role: msg.role, content: msg.content });
@@ -239,9 +240,14 @@ export async function callOpenAICompatibleAPI(endpoint, key, model, providerName
       }
     };
     const MAX_SSE_BUFFER = 4 * 1024 * 1024;
+    let receivedAnyChunk = false;
     while (true) {
-      const { done, value } = await readWithStallTimeout(reader, `${providerName} stream`);
+      // Before the first chunk, a local server may be prefilling the prompt
+      // (silence is progress); afterwards silence means a stalled stream.
+      const stallMs = !receivedAnyChunk && firstReadStallMs > 0 ? firstReadStallMs : undefined;
+      const { done, value } = await readWithStallTimeout(reader, `${providerName} stream`, stallMs);
       if (done) break;
+      receivedAnyChunk = true;
       buffer += decoder.decode(value, { stream: true });
       if (buffer.length > MAX_SSE_BUFFER) {
         try { reader.cancel(); } catch {}

--- a/js/api-openai-compatible.js
+++ b/js/api-openai-compatible.js
@@ -204,6 +204,7 @@ export async function callOpenAICompatibleAPI(endpoint, key, model, providerName
     let inputTokens = 0;
     let outputTokens = 0;
     let performance = null;
+    let receivedFirstToken = false;
     const handleSSELine = (line, boundary) => {
       if (!line.startsWith('data: ')) return;
       const data = line.slice(6);
@@ -216,10 +217,12 @@ export async function callOpenAICompatibleAPI(endpoint, key, model, providerName
         if (choice?.finish_reason) finishReason = choice.finish_reason;
         else if (choice?.native_finish_reason) finishReason = choice.native_finish_reason;
         if (delta?.content) {
+          receivedFirstToken = true;
           if (!hasContent) hasContent = true;
           fullText += delta.content;
           onStream(fullText);
         } else if (delta?.reasoning_content || delta?.reasoning) {
+          receivedFirstToken = true;
           if (!hasContent) reasoningBuf += delta.reasoning_content || delta.reasoning;
         }
         if (event.usage) {
@@ -240,14 +243,12 @@ export async function callOpenAICompatibleAPI(endpoint, key, model, providerName
       }
     };
     const MAX_SSE_BUFFER = 4 * 1024 * 1024;
-    let receivedAnyChunk = false;
     while (true) {
-      // Before the first chunk, a local server may be prefilling the prompt
-      // (silence is progress); afterwards silence means a stalled stream.
-      const stallMs = !receivedAnyChunk && firstReadStallMs > 0 ? firstReadStallMs : undefined;
+      // Metadata and role-only SSE events can arrive before prefill finishes;
+      // keep the extended allowance until an actual response token arrives.
+      const stallMs = !receivedFirstToken && firstReadStallMs > 0 ? firstReadStallMs : undefined;
       const { done, value } = await readWithStallTimeout(reader, `${providerName} stream`, stallMs);
       if (done) break;
-      receivedAnyChunk = true;
       buffer += decoder.decode(value, { stream: true });
       if (buffer.length > MAX_SSE_BUFFER) {
         try { reader.cancel(); } catch {}

--- a/js/api-transport.js
+++ b/js/api-transport.js
@@ -11,12 +11,18 @@ import { isDebugMode } from './utils.js';
 // silence instead of leaving the chat message stuck in "typing..." forever.
 // Cancels the reader on timeout so the connection releases.
 export const STREAM_STALL_TIMEOUT_MS = 30000;
-export function readWithStallTimeout(reader, label = 'AI stream') {
+// First-read allowance for local inference servers: prompt prefill legitimately
+// produces zero stream bytes for many minutes on long inputs (a dense 31B on
+// Apple silicon prefills ~11k tokens in ~5 minutes), which is silence the 30s
+// guard would misread as a dead connection. Connection-level failures are
+// still caught by the initial-response timeout, and the user can always Stop.
+export const LOCAL_AI_FIRST_TOKEN_STALL_MS = 900000;
+export function readWithStallTimeout(reader, label = 'AI stream', timeoutMs = STREAM_STALL_TIMEOUT_MS) {
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => {
       try { reader.cancel(); } catch (e) {}
-      reject(new Error(`${label} stalled — no data for ${Math.round(STREAM_STALL_TIMEOUT_MS / 1000)}s. Check your connection, tap Stop in the chat header, then try again.`));
-    }, STREAM_STALL_TIMEOUT_MS);
+      reject(new Error(`${label} stalled — no data for ${Math.round(timeoutMs / 1000)}s. Check your connection, tap Stop in the chat header, then try again.`));
+    }, timeoutMs);
     reader.read().then(
       (result) => { clearTimeout(timer); resolve(result); },
       (err) => { clearTimeout(timer); reject(err); },

--- a/js/import-reference-benchmark.js
+++ b/js/import-reference-benchmark.js
@@ -447,8 +447,8 @@ export async function runBundledImportReferenceBenchmark({ onProgress } = {}) {
       }, { persist: false });
       onProgress?.(15, 'Sending 68 results to the model');
       const analysisStartedAt = performance.now();
-      const result = await parseLabPDFWithAI(sourceText, manifest.fileName, pct => {
-        onProgress?.(Math.max(15, Math.min(90, Number(pct) || 15)), 'Model is reading the report');
+      const result = await parseLabPDFWithAI(sourceText, manifest.fileName, (pct, stageLabel) => {
+        onProgress?.(Math.max(15, Math.min(90, Number(pct) || 15)), stageLabel || 'Model is reading the report');
       }, { captureRawModelOutput: true, deterministicBenchmark: true });
       const analysisMs = Math.max(0, Math.round(performance.now() - analysisStartedAt));
       const provider = result?.provider || providerAtStart;

--- a/js/local-ai-provider-lmstudio.js
+++ b/js/local-ai-provider-lmstudio.js
@@ -328,9 +328,21 @@ export async function loadLMStudioModelWithContext({
   timeoutMs = LMSTUDIO_LOAD_TIMEOUT_MS,
 }) {
   if (modelDetail?.loaded) {
+    let unloaded = false;
     try {
-      await unloadLMStudioModel({ baseUrl, apiKey, model, modelDetail });
-    } catch { /* stale instance state — the load below is still authoritative */ }
+      unloaded = await unloadLMStudioModel({ baseUrl, apiKey, model, modelDetail });
+    } catch { unloaded = false; }
+    if (!unloaded) {
+      // A failed unload may just mean the instance already vanished (stale
+      // cached state). Only refuse when the server still reports it loaded —
+      // loading a second copy of a large model would exhaust unified memory.
+      const check = await discoverLMStudioProvider({ baseUrl, apiKey }).catch(() => null);
+      const stillLoaded = check?.modelDetails?.some(detail => detail.loaded
+        && (detail.name === model || (modelDetail.nativeModelKey && detail.nativeModelKey === modelDetail.nativeModelKey)));
+      if (stillLoaded) {
+        throw new Error(`LM Studio could not unload ${model} before reloading it with a larger context. Unload it manually in LM Studio, then retry.`);
+      }
+    }
   }
   const response = await fetch(`${baseUrl}/api/v1/models/load`, {
     method: 'POST',

--- a/js/local-ai-provider-lmstudio.js
+++ b/js/local-ai-provider-lmstudio.js
@@ -292,15 +292,6 @@ export async function inferWithLMStudioNativeProvider({ config, model, opts, pla
 }
 
 /**
- * @param {{
- *   baseUrl: string,
- *   apiKey?: string,
- *   model: string,
- *   modelDetail?: { loadedInstanceId?: string } | null,
- *   timeoutMs?: number,
- * }} context
- */
-/**
  * Load (or reload) a model with an explicit context length via the native
  * REST API, so generation can then run over the streaming OpenAI-compatible
  * endpoint instead of the non-streaming native chat call. Any loaded instance
@@ -334,9 +325,13 @@ export async function loadLMStudioModelWithContext({
     } catch { unloaded = false; }
     if (!unloaded) {
       // A failed unload may just mean the instance already vanished (stale
-      // cached state). Only refuse when the server still reports it loaded —
-      // loading a second copy of a large model would exhaust unified memory.
+      // cached state), but only an authoritative discovery response can prove
+      // that. Fail closed when residency cannot be verified: loading a second
+      // copy of a large model would exhaust unified memory.
       const check = await discoverLMStudioProvider({ baseUrl, apiKey }).catch(() => null);
+      if (!check?.available || !check.runningStatusKnown) {
+        throw new Error(`LM Studio could not verify that ${model} was unloaded before reloading it with a larger context. Check the model state in LM Studio, then retry.`);
+      }
       const stillLoaded = check?.modelDetails?.some(detail => detail.loaded
         && (detail.name === model || (modelDetail.nativeModelKey && detail.nativeModelKey === modelDetail.nativeModelKey)));
       if (stillLoaded) {
@@ -364,6 +359,15 @@ export async function loadLMStudioModelWithContext({
   return true;
 }
 
+/**
+ * @param {{
+ *   baseUrl: string,
+ *   apiKey?: string,
+ *   model: string,
+ *   modelDetail?: { loadedInstanceId?: string } | null,
+ *   timeoutMs?: number,
+ * }} context
+ */
 export async function unloadLMStudioModel({ baseUrl, apiKey = '', model, modelDetail = null, timeoutMs = 5000 }) {
   const instanceId = modelDetail?.loadedInstanceId || model;
   if (!instanceId) return false;

--- a/js/local-ai-provider-lmstudio.js
+++ b/js/local-ai-provider-lmstudio.js
@@ -15,6 +15,14 @@ import {
   unavailableLocalAiResult,
 } from './local-ai-provider-shared.js';
 
+// A 20GB model load takes 20-60s; leave headroom for memory-pressure stalls.
+const LMSTUDIO_LOAD_TIMEOUT_MS = 300000;
+// The native chat endpoint is non-streaming, so the initial-response timeout
+// spans the entire generation. Local generations legitimately run for many
+// minutes (long prompts at ~15 tok/s), so the streaming-oriented request
+// timeout must not apply here. The caller's abort signal still cancels.
+const LMSTUDIO_NATIVE_GENERATION_TIMEOUT_MS = 900000;
+
 export const lmStudioProviderAdapter = Object.freeze({
   id: 'lmstudio',
   label: 'LM Studio',
@@ -33,6 +41,7 @@ export const lmStudioProviderAdapter = Object.freeze({
   prepareNativeRequest: prepareLMStudioNativeRequest,
   infer: inferWithLMStudioNativeProvider,
   unload: unloadLMStudioModel,
+  loadWithContext: loadLMStudioModelWithContext,
 });
 
 function indexLMStudioModels(rawModels) {
@@ -227,7 +236,10 @@ export async function inferWithLMStudioNativeProvider({ config, model, opts, pla
     }),
     signal: opts.signal,
   };
-  const timeoutState = createInitialResponseTimeout(requestInit, opts.requestTimeoutMs || FETCH_REQUEST_TIMEOUT_MS);
+  const timeoutState = createInitialResponseTimeout(
+    requestInit,
+    Math.max(opts.requestTimeoutMs || FETCH_REQUEST_TIMEOUT_MS, LMSTUDIO_NATIVE_GENERATION_TIMEOUT_MS),
+  );
   let response;
   try {
     response = await fetch(`${String(config.url || '').replace(/\/+$/, '')}/api/v1/chat`, timeoutState.fetchOptions);
@@ -249,14 +261,21 @@ export async function inferWithLMStudioNativeProvider({ config, model, opts, pla
   if (!text) throw new Error('LM Studio returned no final response content.');
   if (opts.onStream) opts.onStream(text);
   const stats = data.stats || {};
+  const inputTokens = Number(stats.input_tokens) || 0;
+  const outputTokens = Number(stats.total_output_tokens) || 0;
+  // The native endpoint reports no finish reason. Infer truncation from the
+  // token accounting: generation that stopped at the output cap or filled the
+  // context window did not finish naturally.
+  const truncated = (plan.maxTokens > 0 && outputTokens >= plan.maxTokens)
+    || (contextLength > 0 && inputTokens + outputTokens >= contextLength - 1);
   return {
     text,
     usage: {
-      inputTokens: Number(stats.input_tokens) || 0,
-      outputTokens: Number(stats.total_output_tokens) || 0,
+      inputTokens,
+      outputTokens,
     },
-    finishReason: null,
-    truncated: false,
+    finishReason: truncated ? 'length' : null,
+    truncated,
     diagnostics: {
       providerApi: 'native',
       nativeContextOverride: true,
@@ -281,6 +300,58 @@ export async function inferWithLMStudioNativeProvider({ config, model, opts, pla
  *   timeoutMs?: number,
  * }} context
  */
+/**
+ * Load (or reload) a model with an explicit context length via the native
+ * REST API, so generation can then run over the streaming OpenAI-compatible
+ * endpoint instead of the non-streaming native chat call. Any loaded instance
+ * is unloaded first — LM Studio instances are additive, and two resident
+ * copies of a large model would exhaust unified memory.
+ *
+ * Throws with `status` set on HTTP failure; callers treat 404 (older builds
+ * without the load route) as "fall back to the native chat path".
+ *
+ * @param {{
+ *   baseUrl: string,
+ *   apiKey?: string,
+ *   model: string,
+ *   modelDetail?: { nativeModelKey?: string, loadedInstanceId?: string, loaded?: boolean } | null,
+ *   contextLength: number,
+ *   timeoutMs?: number,
+ * }} context
+ */
+export async function loadLMStudioModelWithContext({
+  baseUrl,
+  apiKey = '',
+  model,
+  modelDetail = null,
+  contextLength,
+  timeoutMs = LMSTUDIO_LOAD_TIMEOUT_MS,
+}) {
+  if (modelDetail?.loaded) {
+    try {
+      await unloadLMStudioModel({ baseUrl, apiKey, model, modelDetail });
+    } catch { /* stale instance state — the load below is still authoritative */ }
+  }
+  const response = await fetch(`${baseUrl}/api/v1/models/load`, {
+    method: 'POST',
+    headers: createLocalAiHeaders(apiKey, { json: true }),
+    body: JSON.stringify({
+      model: modelDetail?.nativeModelKey || model,
+      context_length: contextLength,
+    }),
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!response.ok) {
+    const body = await response.json().catch(() => null);
+    const detail = body?.error?.message || response.statusText;
+    const error = new Error(`LM Studio could not load ${model} (${response.status}): ${redactApiSecretText(detail, [apiKey])}`);
+    /** @type {any} */ (error).status = response.status;
+    throw error;
+  }
+  await response.json().catch(() => null);
+  return true;
+}
+
 export async function unloadLMStudioModel({ baseUrl, apiKey = '', model, modelDetail = null, timeoutMs = 5000 }) {
   const instanceId = modelDetail?.loadedInstanceId || model;
   if (!instanceId) return false;

--- a/js/local-ai-provider-ollama.js
+++ b/js/local-ai-provider-ollama.js
@@ -276,12 +276,14 @@ export async function inferWithOllamaNativeProvider({ config, model, opts, plan,
   let buffer = '';
   let fullText = '';
   let finalEvent = null;
+  let receivedFirstToken = false;
   const handleNdjsonLine = (line, boundary) => {
     if (!line.trim()) return;
     try {
       const event = JSON.parse(line);
       if (event.error) throw new Error(redactApiSecretText(event.error, [config.apiKey]));
       if (event.message?.content) {
+        receivedFirstToken = true;
         fullText += event.message.content;
         opts.onStream(fullText);
       }
@@ -292,13 +294,12 @@ export async function inferWithOllamaNativeProvider({ config, model, opts, plan,
     }
   };
   const maxBuffer = 4 * 1024 * 1024;
-  let receivedAnyChunk = false;
   while (true) {
-    // Prompt prefill emits no bytes; only treat silence as a stall mid-stream.
+    // Metadata-only events can precede the first generated token, so retain
+    // the prefill allowance until response content actually arrives.
     const { done, value } = await readWithStallTimeout(reader, 'Ollama stream',
-      receivedAnyChunk ? undefined : LOCAL_AI_FIRST_TOKEN_STALL_MS);
+      receivedFirstToken ? undefined : LOCAL_AI_FIRST_TOKEN_STALL_MS);
     if (done) break;
-    receivedAnyChunk = true;
     buffer += decoder.decode(value, { stream: true });
     if (buffer.length > maxBuffer) {
       try { reader.cancel(); } catch {}

--- a/js/local-ai-provider-ollama.js
+++ b/js/local-ai-provider-ollama.js
@@ -2,7 +2,7 @@
 // Ollama native discovery, lifecycle, context management, and inference adapter.
 
 import { getErrorMessage } from './caught-error.js';
-import { createInitialResponseTimeout, FETCH_REQUEST_TIMEOUT_MS, readWithStallTimeout } from './api-transport.js';
+import { createInitialResponseTimeout, FETCH_REQUEST_TIMEOUT_MS, LOCAL_AI_FIRST_TOKEN_STALL_MS, readWithStallTimeout } from './api-transport.js';
 import {
   createLocalAiHeaders,
   getLocalAiExecutionLocation,
@@ -292,9 +292,13 @@ export async function inferWithOllamaNativeProvider({ config, model, opts, plan,
     }
   };
   const maxBuffer = 4 * 1024 * 1024;
+  let receivedAnyChunk = false;
   while (true) {
-    const { done, value } = await readWithStallTimeout(reader, 'Ollama stream');
+    // Prompt prefill emits no bytes; only treat silence as a stall mid-stream.
+    const { done, value } = await readWithStallTimeout(reader, 'Ollama stream',
+      receivedAnyChunk ? undefined : LOCAL_AI_FIRST_TOKEN_STALL_MS);
     if (done) break;
+    receivedAnyChunk = true;
     buffer += decoder.decode(value, { stream: true });
     if (buffer.length > maxBuffer) {
       try { reader.cancel(); } catch {}

--- a/js/local-ai-provider-openai-compatible.js
+++ b/js/local-ai-provider-openai-compatible.js
@@ -2,6 +2,7 @@
 // Generic OpenAI-compatible Local AI adapter (Jan, llama.cpp, LocalAI, etc.).
 
 import { callOpenAICompatibleAPI } from './api-openai-compatible.js';
+import { LOCAL_AI_FIRST_TOKEN_STALL_MS } from './api-transport.js';
 import {
   createLocalAiHeaders,
   isLikelyEmbeddingModel,
@@ -79,7 +80,7 @@ export async function inferWithOpenAICompatibleProvider({ config, model, opts, p
     'Local AI',
     { ...opts, maxTokens: plan.maxTokens },
     {},
-    { useProxy: false, extraBody },
+    { useProxy: false, extraBody, firstReadStallMs: LOCAL_AI_FIRST_TOKEN_STALL_MS },
   );
   return {
     ...result,

--- a/js/local-ai-provider-registry.js
+++ b/js/local-ai-provider-registry.js
@@ -15,6 +15,7 @@ import { localAiDiscoveryError, unavailableLocalAiResult } from './local-ai-prov
  * @property {(context: any) => Promise<any>} [infer] Normalized inference entry point.
  * @property {(context: any) => any} [prepareNativeRequest] Optional native request planner.
  * @property {(context: any) => Promise<boolean>} [unload] Optional model lifecycle hook.
+ * @property {(context: any) => Promise<boolean>} [loadWithContext] Optional load-with-context-length lifecycle hook.
  */
 
 /** @type {ReadonlyArray<LocalAiProviderAdapter>} */

--- a/js/pdf-import-ai-utils.js
+++ b/js/pdf-import-ai-utils.js
@@ -80,6 +80,13 @@ function readImportAIPerf() {
   catch { return {}; }
 }
 
+/**
+ * @param {string} perfKey
+ * @param {{
+ *   usage?: ImportUsage,
+ *   diagnostics?: { performance?: { timeToFirstTokenMs?: number, tokensPerSecond?: number } }
+ * }} [result]
+ */
 export function saveImportAIPerf(perfKey, { usage, diagnostics } = {}) {
   if (!perfKey) return;
   const perf = diagnostics?.performance;
@@ -95,7 +102,9 @@ export function saveImportAIPerf(perfKey, { usage, diagnostics } = {}) {
   const keys = Object.keys(all);
   while (keys.length > 12) {
     keys.sort((a, b) => (all[a]?.at || 0) - (all[b]?.at || 0));
-    delete all[keys.shift()];
+    const oldestKey = keys.shift();
+    if (!oldestKey) break;
+    delete all[oldestKey];
   }
   try { localStorage.setItem(IMPORT_AI_PERF_KEY, JSON.stringify(all)); } catch {}
 }

--- a/js/pdf-import-ai-utils.js
+++ b/js/pdf-import-ai-utils.js
@@ -2,6 +2,7 @@
 // pdf-import-ai-utils.js - AI request retry, JSON parsing, and accounting helpers.
 
 import { callClaudeAPI, AI_IMPORT_REQUEST_TIMEOUT_MS } from './api.js';
+import { getAIProvider, getOllamaMainModel } from './api-provider-storage.js';
 import { isDebugMode } from './utils.js';
 
 export const IMPORT_JSON_SCHEMA = {
@@ -58,6 +59,94 @@ export function compactMarkerReference(markerRef) {
  *   outputTokens?: number
  * }} ImportUsage
  */
+
+// ── Phase-aware AI analysis progress ──
+// Before the first streamed token the model is prefilling ("reading") — a
+// dense local model can sit there for minutes with zero bytes. After the
+// first token it is generating ("writing"). Observed per-model performance is
+// persisted so later imports show a real time estimate during prefill.
+const IMPORT_AI_PERF_KEY = 'labcharts-import-ai-perf';
+const READING_PCT_START = 15;
+const READING_PCT_END = 40;
+const WRITING_PCT_END = 90;
+
+export function importAIPerfKey() {
+  const provider = getAIProvider();
+  return provider === 'ollama' ? `local:${getOllamaMainModel()}` : provider;
+}
+
+function readImportAIPerf() {
+  try { return JSON.parse(localStorage.getItem(IMPORT_AI_PERF_KEY) || '{}') || {}; }
+  catch { return {}; }
+}
+
+export function saveImportAIPerf(perfKey, { usage, diagnostics } = {}) {
+  if (!perfKey) return;
+  const perf = diagnostics?.performance;
+  const inputTokens = Number(usage?.inputTokens) || 0;
+  const ttftMs = Number(perf?.timeToFirstTokenMs) || 0;
+  const genTps = Number(perf?.tokensPerSecond) || 0;
+  if (!(inputTokens > 0 && ttftMs > 500) && !(genTps > 0)) return;
+  const all = readImportAIPerf();
+  const next = { ...(all[perfKey] || {}), at: Date.now() };
+  if (inputTokens > 0 && ttftMs > 500) next.prefillTps = Math.round(inputTokens / (ttftMs / 1000));
+  if (genTps > 0) next.genTps = Math.round(genTps * 10) / 10;
+  all[perfKey] = next;
+  const keys = Object.keys(all);
+  while (keys.length > 12) {
+    keys.sort((a, b) => (all[a]?.at || 0) - (all[b]?.at || 0));
+    delete all[keys.shift()];
+  }
+  try { localStorage.setItem(IMPORT_AI_PERF_KEY, JSON.stringify(all)); } catch {}
+}
+
+function remainingTimeLabel(ms) {
+  if (ms >= 90000) return `about ${Math.round(ms / 60000)} min left`;
+  if (ms > 0) return `about ${Math.max(5, Math.round(ms / 5000) * 5)}s left`;
+  return '';
+}
+
+export function createImportAIProgress({ perfKey, estimatedPromptTokens = 0, onProgress }) {
+  if (!onProgress) return { onStream: undefined, start() {}, finish() {} };
+  const perf = readImportAIPerf()[perfKey] || {};
+  const prefillEtaMs = perf.prefillTps > 0 && estimatedPromptTokens > 0
+    ? (estimatedPromptTokens / perf.prefillTps) * 1000
+    : 0;
+  let ticker = null;
+  let startedAt = 0;
+  let lastPct = 0;
+  const report = (pct, label) => {
+    pct = Math.round(Math.max(READING_PCT_START, Math.min(WRITING_PCT_END, pct)));
+    if (pct < lastPct) pct = lastPct;
+    lastPct = pct;
+    onProgress(pct, label);
+  };
+  const stopTicker = () => { if (ticker) { clearInterval(ticker); ticker = null; } };
+  return {
+    start() {
+      startedAt = Date.now();
+      report(READING_PCT_START, 'Model is reading the report');
+      const span = READING_PCT_END - READING_PCT_START;
+      ticker = setInterval(() => {
+        const elapsed = Date.now() - startedAt;
+        // A measured prefill rate makes the bar track real time; without one
+        // it creeps asymptotically so slow dense models never look stuck.
+        const frac = prefillEtaMs > 0
+          ? Math.min(elapsed / prefillEtaMs, 1)
+          : 1 - Math.exp(-elapsed / 90000);
+        const left = prefillEtaMs > 0 ? Math.max(prefillEtaMs - elapsed, 0) : 0;
+        report(READING_PCT_START + frac * span, `Model is reading the report${left > 3000 ? ' — ' + remainingTimeLabel(left) : ''}`);
+      }, 1000);
+    },
+    onStream(text) {
+      stopTicker();
+      // Output length is unknown up front; approach the ceiling asymptotically.
+      const frac = 1 - Math.exp(-text.length / 9000);
+      report(READING_PCT_END + frac * (WRITING_PCT_END - READING_PCT_END), 'Model is writing the results');
+    },
+    finish() { stopTicker(); },
+  };
+}
 
 export function isAIStreamAbortError(err) {
   const message = String(err?.message || err || '').toLowerCase();

--- a/js/pdf-import-progress.js
+++ b/js/pdf-import-progress.js
@@ -21,13 +21,15 @@ export function isImportRunning() {
   return importStatus.running;
 }
 
-export function updateImportProgressPct(pct) {
+export function updateImportProgressPct(pct, stageLabel) {
   const bar = document.querySelector('.import-progress-bar');
   const fill = /** @type {HTMLElement | null} */ (document.querySelector('.import-progress-bar-fill'));
   const label = document.querySelector('.import-progress-pct');
+  const stage = document.querySelector('.import-progress-stage');
   if (bar) bar.setAttribute('aria-valuenow', String(pct));
   if (fill) fill.style.width = pct + '%';
   if (label) label.textContent = pct + '%';
+  if (stage && stageLabel !== undefined) stage.textContent = stageLabel || '';
   if (importStatus.running) setImportStatus({ pct });
 }
 
@@ -35,6 +37,7 @@ function buildProgressHTML(step, fileName) {
   const pct = STEP_START_PCT[step] || 0;
   let html = `<div class="import-progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${pct}" aria-label="Import progress"><div class="import-progress-bar-fill" style="width:${pct}%"></div></div>`;
   html += `<div class="import-progress-pct">${pct}%</div>`;
+  html += '<div class="import-progress-stage"></div>';
   html += '<div class="import-progress">';
   for (let i = 0; i < IMPORT_STEPS.length; i++) {
     const isDone = i < step;

--- a/js/pdf-import.js
+++ b/js/pdf-import.js
@@ -14,8 +14,11 @@ import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 import {
   callImportAIWithStreamFallback,
   compactMarkerReference,
+  createImportAIProgress,
   getUsageTokens,
   IMPORT_JSON_SCHEMA,
+  importAIPerfKey,
+  saveImportAIPerf,
   tryParseJSON,
 } from './pdf-import-ai-utils.js';
 import { extractXLSXText, isCsvTextFile, isXlsxFile } from './pdf-import-spreadsheet.js';
@@ -194,7 +197,7 @@ export async function extractPDFText(file) {
 /**
  * @param {string} pdfText
  * @param {string} fileName
- * @param {((pct: number) => void) | undefined} onProgress
+ * @param {((pct: number, stageLabel?: string) => void) | undefined} onProgress
  * @param {{captureRawModelOutput?: boolean, deterministicBenchmark?: boolean}} [options]
  * @returns {Promise<any>}
  */
@@ -287,34 +290,45 @@ Return ONLY valid JSON in this exact format, no other text:
 
   const provider = getAIProvider();
   const maxTokens = 16384;
-  // Stream AI response to report real-time progress during analysis (15% → 90%)
-  let onStream;
-  if (onProgress) {
-    let lastPct = -1;
-    onStream = (text) => {
-      const pct = Math.min(15 + Math.round((text.length / (maxTokens * 3)) * 75), 90);
-      if (pct !== lastPct) { lastPct = pct; onProgress(pct); }
-    };
-  }
   // Include previously imported marker keys so the AI reuses consistent mappings
   const existingKeys = deterministicBenchmark ? new Set() : getExistingImportMarkerKeys();
   const existingKeysNote = existingKeys.size > 0
     ? `\n\nIMPORTANT — These marker keys were used in previous imports for this profile. Reuse them for the same biomarkers to ensure consistency:\n${[...existingKeys].join(', ')}`
     : '';
 
-  const { text: response, usage, diagnostics } = await callImportAIWithStreamFallback({
-    system: system + existingKeysNote,
-    messages: [{ role: 'user', content: `Extract all biomarker results from this lab report${fileName ? ' (file: ' + fileName + ')' : ''}:\n\n${pdfText}` }],
-    maxTokens,
-    onStream,
-    requestTimeoutMs: AI_IMPORT_REQUEST_TIMEOUT_MS,
-    jsonMode: true,
-    jsonSchema: IMPORT_JSON_SCHEMA,
-    reasoningEffort: 'none',
-    temperature: 0,
-    minOutputTokens: 2048,
-    preferNativeContext: true,
-  }, 'PDF text analysis');
+  // Phase-aware progress: "reading" until the first streamed token, then
+  // "writing" driven by generated length (15% → 90%).
+  const perfKey = importAIPerfKey();
+  const progress = createImportAIProgress({
+    perfKey,
+    estimatedPromptTokens: Math.ceil((system.length + pdfText.length) / 3),
+    onProgress,
+  });
+  let response, usage, diagnostics, truncated;
+  progress.start();
+  try {
+    ({ text: response, usage, diagnostics, truncated } = await callImportAIWithStreamFallback({
+      system: system + existingKeysNote,
+      messages: [{ role: 'user', content: `Extract all biomarker results from this lab report${fileName ? ' (file: ' + fileName + ')' : ''}:\n\n${pdfText}` }],
+      maxTokens,
+      onStream: progress.onStream,
+      requestTimeoutMs: AI_IMPORT_REQUEST_TIMEOUT_MS,
+      jsonMode: true,
+      jsonSchema: IMPORT_JSON_SCHEMA,
+      reasoningEffort: 'none',
+      temperature: 0,
+      minOutputTokens: 2048,
+      preferNativeContext: true,
+      promptCharsPerToken: 3,
+    }, 'PDF text analysis'));
+  } finally {
+    progress.finish();
+  }
+  saveImportAIPerf(perfKey, { usage, diagnostics });
+
+  if (truncated) {
+    throw new Error('The AI response was cut off before the marker list completed (output limit or context window reached). Increase the model’s context length, or split the report into smaller imports.');
+  }
 
   // Parse JSON from response (handle markdown code blocks, thinking tags, truncated output)
   let jsonStr = (response || '').trim();
@@ -471,14 +485,6 @@ Return ONLY valid JSON in this exact format:
 
   const provider = getAIProvider();
   const maxTokens = 16384;
-  let onStream;
-  if (onProgress) {
-    let lastPct = -1;
-    onStream = (text) => {
-      const pct = Math.min(15 + Math.round((text.length / (maxTokens * 3)) * 75), 90);
-      if (pct !== lastPct) { lastPct = pct; onProgress(pct); }
-    };
-  }
 
   // Build content array with image blocks + text instruction
   // All providers use OpenAI-compatible image format
@@ -490,19 +496,37 @@ Return ONLY valid JSON in this exact format:
     { type: 'text', text: `Extract all biomarker results from this lab report${fileName ? ' (file: ' + fileName + ')' : ''}. Read every page carefully.` }
   ];
 
-  const { text: response, usage, diagnostics } = await callImportAIWithStreamFallback({
-    system,
-    messages: [{ role: 'user', content }],
-    maxTokens,
-    onStream,
-    requestTimeoutMs: AI_IMPORT_REQUEST_TIMEOUT_MS,
-    jsonMode: true,
-    jsonSchema: IMPORT_JSON_SCHEMA,
-    reasoningEffort: 'none',
-    temperature: 0,
-    minOutputTokens: 2048,
-    preferNativeContext: true,
-  }, 'PDF image analysis');
+  const perfKey = importAIPerfKey();
+  const progress = createImportAIProgress({
+    perfKey,
+    estimatedPromptTokens: Math.ceil(system.length / 3) + images.length * 1600,
+    onProgress,
+  });
+  let response, usage, diagnostics, truncated;
+  progress.start();
+  try {
+    ({ text: response, usage, diagnostics, truncated } = await callImportAIWithStreamFallback({
+      system,
+      messages: [{ role: 'user', content }],
+      maxTokens,
+      onStream: progress.onStream,
+      requestTimeoutMs: AI_IMPORT_REQUEST_TIMEOUT_MS,
+      jsonMode: true,
+      jsonSchema: IMPORT_JSON_SCHEMA,
+      reasoningEffort: 'none',
+      temperature: 0,
+      minOutputTokens: 2048,
+      preferNativeContext: true,
+      promptCharsPerToken: 3,
+    }, 'PDF image analysis'));
+  } finally {
+    progress.finish();
+  }
+  saveImportAIPerf(perfKey, { usage, diagnostics });
+
+  if (truncated) {
+    throw new Error('The AI response was cut off before the marker list completed (output limit or context window reached). Increase the model’s context length, or import fewer pages at once.');
+  }
 
   let jsonStr = (response || '').trim();
   jsonStr = jsonStr.replace(/<think>[\s\S]*?<\/think>/gi, '').trim();

--- a/tests/api-provider-contracts.test.js
+++ b/tests/api-provider-contracts.test.js
@@ -638,6 +638,17 @@ describe('AI provider request contracts', () => {
     });
     expect(imageEstimate).toBeGreaterThan(1600);
 
+    // Dense numeric inputs (lab tables) opt into a lower chars-per-token ratio.
+    const proseEstimate = estimateLocalAiPromptTokens({
+      messages: [{ role: 'user', content: 'x'.repeat(3500) }],
+    });
+    const denseEstimate = estimateLocalAiPromptTokens({
+      messages: [{ role: 'user', content: 'x'.repeat(3500) }],
+      promptCharsPerToken: 3,
+    });
+    expect(proseEstimate).toBe(1006);
+    expect(denseEstimate).toBe(1173);
+
     globalThis.fetch = vi.fn(async url => {
       if (String(url).endsWith('/api/v1/models')) {
         return jsonResponse({ models: [
@@ -713,32 +724,40 @@ describe('AI provider request contracts', () => {
     });
   });
 
-  it('uses LM Studio native chat to expand context for a large import request', async () => {
+  it('reloads LM Studio with expanded context then streams a large import request', async () => {
     setAIProvider('ollama');
     setOllamaMainModel('thinkingcap-qwen3.6-27b');
+    let loadedCtx = 8192;
+    const lifecycle = [];
     globalThis.fetch = vi.fn(async (url, init = {}) => {
+      const href = String(url);
       if (init.method === 'POST') {
-        expect(String(url)).toBe('http://localhost:11434/api/v1/chat');
-        return jsonResponse({
-          output: [{ type: 'message', content: '{"markers":[]}' }],
-          stats: {
-            input_tokens: 7200,
-            total_output_tokens: 24,
-            tokens_per_second: 31.5,
-            reasoning_output_tokens: 0,
-          },
-        });
+        if (href.endsWith('/api/v1/models/unload')) {
+          lifecycle.push(['unload', JSON.parse(init.body)]);
+          return jsonResponse({ ok: true });
+        }
+        if (href.endsWith('/api/v1/models/load')) {
+          const body = JSON.parse(init.body);
+          lifecycle.push(['load', body]);
+          loadedCtx = body.context_length;
+          return jsonResponse({ ok: true });
+        }
+        if (href.endsWith('/v1/chat/completions')) {
+          lifecycle.push(['chat', JSON.parse(init.body)]);
+          return chatCompletionResponse('{"markers":[]}');
+        }
+        throw new Error(`Unexpected POST URL: ${href}`);
       }
-      if (String(url).endsWith('/api/v1/models')) {
+      if (href.endsWith('/api/v1/models')) {
         return jsonResponse({ models: [{
           type: 'llm',
           key: 'thinkingcap-qwen3.6-27b@q4_k_m',
-          loaded_instances: [{ id: 'thinkingcap-qwen3.6-27b', config: { context_length: 8192 } }],
+          loaded_instances: [{ id: 'thinkingcap-qwen3.6-27b', config: { context_length: loadedCtx } }],
           max_context_length: 262144,
           capabilities: { reasoning: { allowed_options: ['off', 'on'], default: 'on' } },
         }] });
       }
-      if (String(url).endsWith('/v1/models')) {
+      if (href.endsWith('/v1/models')) {
         return jsonResponse({ data: [{ id: 'thinkingcap-qwen3.6-27b' }] });
       }
       return jsonResponse({}, { status: 404 });
@@ -753,8 +772,68 @@ describe('AI provider request contracts', () => {
       preferNativeContext: true,
     }));
 
-    const postCall = globalThis.fetch.mock.calls.find(([, init]) => init?.method === 'POST');
-    const body = JSON.parse(postCall[1].body);
+    // Unload the small-context instance, reload at the planned context, then
+    // generate over the streaming-capable compatible endpoint.
+    expect(lifecycle.map(([action]) => action)).toEqual(['unload', 'load', 'chat']);
+    expect(lifecycle[0][1]).toEqual({ instance_id: 'thinkingcap-qwen3.6-27b' });
+    expect(lifecycle[1][1]).toEqual({
+      model: 'thinkingcap-qwen3.6-27b@q4_k_m',
+      context_length: 16384,
+    });
+    expect(lifecycle[2][1]).toMatchObject({ model: 'thinkingcap-qwen3.6-27b' });
+    expect(result).toMatchObject({
+      text: '{"markers":[]}',
+      diagnostics: {
+        providerApi: 'openai-compatible',
+        localPlan: { contextLength: 16384 },
+      },
+    });
+  });
+
+  it('falls back to LM Studio native chat when the load endpoint is missing', async () => {
+    setAIProvider('ollama');
+    setOllamaMainModel('thinkingcap-qwen3.6-27b');
+    globalThis.fetch = vi.fn(async (url, init = {}) => {
+      const href = String(url);
+      if (init.method === 'POST') {
+        if (href.endsWith('/api/v1/models/load')) return jsonResponse({ error: { message: 'Not found' } }, { status: 404 });
+        expect(href).toBe('http://localhost:11434/api/v1/chat');
+        return jsonResponse({
+          output: [{ type: 'message', content: '{"markers":[]}' }],
+          stats: {
+            input_tokens: 7200,
+            total_output_tokens: 24,
+            tokens_per_second: 31.5,
+            reasoning_output_tokens: 0,
+          },
+        });
+      }
+      if (href.endsWith('/api/v1/models')) {
+        return jsonResponse({ models: [{
+          type: 'llm',
+          key: 'thinkingcap-qwen3.6-27b@q4_k_m',
+          loaded_instances: [{ id: 'thinkingcap-qwen3.6-27b', config: { context_length: 8192 } }],
+          max_context_length: 262144,
+          capabilities: { reasoning: { allowed_options: ['off', 'on'], default: 'on' } },
+        }] });
+      }
+      if (href.endsWith('/v1/models')) {
+        return jsonResponse({ data: [{ id: 'thinkingcap-qwen3.6-27b' }] });
+      }
+      return jsonResponse({}, { status: 404 });
+    });
+
+    const result = await callClaudeAPI(baseChatOptions({
+      system: 'Extract the report as JSON.',
+      messages: [{ role: 'user', content: 'x'.repeat(25_000) }],
+      maxTokens: 4096,
+      jsonMode: true,
+      reasoningEffort: 'none',
+      preferNativeContext: true,
+    }));
+
+    const chatCall = globalThis.fetch.mock.calls.find(([url, init]) => init?.method === 'POST' && String(url).endsWith('/api/v1/chat'));
+    const body = JSON.parse(chatCall[1].body);
     expect(body).toMatchObject({
       model: 'thinkingcap-qwen3.6-27b',
       context_length: 16384,
@@ -765,6 +844,7 @@ describe('AI provider request contracts', () => {
     });
     expect(result).toMatchObject({
       text: '{"markers":[]}',
+      truncated: false,
       diagnostics: {
         nativeContextOverride: true,
         contextLength: 16384,
@@ -774,27 +854,78 @@ describe('AI provider request contracts', () => {
     });
   });
 
-  it('requests sufficient LM Studio context when switching to an unloaded model', async () => {
+  it('flags a native LM Studio response that stopped at the output or context cap as truncated', async () => {
+    globalThis.fetch = vi.fn(async () => jsonResponse({
+      output: [{ type: 'message', content: '{"markers":[{"rawName":"Potas' }],
+      stats: { input_tokens: 11057, total_output_tokens: 1854 },
+    }));
+    const result = await inferWithLMStudioNativeProvider({
+      config: { url: 'http://lmstudio.test', apiKey: '' },
+      model: 'local-model',
+      opts: { messages: [{ role: 'user', content: 'extract' }], requestTimeoutMs: 1000 },
+      plan: { maxTokens: 4096 },
+      contextLength: 12912,
+      modelDetail: null,
+    });
+    expect(result.truncated).toBe(true);
+    expect(result.finishReason).toBe('length');
+
+    const atOutputCap = await inferWithLMStudioNativeProvider({
+      config: { url: 'http://lmstudio.test', apiKey: '' },
+      model: 'local-model',
+      opts: { messages: [{ role: 'user', content: 'extract' }], requestTimeoutMs: 1000 },
+      plan: { maxTokens: 1854 },
+      contextLength: 65536,
+      modelDetail: null,
+    });
+    expect(atOutputCap.truncated).toBe(true);
+
+    const finishedNaturally = await inferWithLMStudioNativeProvider({
+      config: { url: 'http://lmstudio.test', apiKey: '' },
+      model: 'local-model',
+      opts: { messages: [{ role: 'user', content: 'extract' }], requestTimeoutMs: 1000 },
+      plan: { maxTokens: 4096 },
+      contextLength: 65536,
+      modelDetail: null,
+    });
+    expect(finishedNaturally.truncated).toBe(false);
+    expect(finishedNaturally.finishReason).toBe(null);
+  });
+
+  it('loads sufficient LM Studio context when switching to an unloaded model', async () => {
     setAIProvider('ollama');
     setOllamaMainModel('new-model-q4');
+    let loadedCtx = 0;
+    const lifecycle = [];
     globalThis.fetch = vi.fn(async (url, init = {}) => {
+      const href = String(url);
       if (init.method === 'POST') {
-        expect(String(url)).toBe('http://localhost:11434/api/v1/chat');
-        return jsonResponse({
-          output: [{ type: 'message', content: '{"markers":[]}' }],
-          stats: { input_tokens: 7200, total_output_tokens: 24 },
-        });
+        if (href.endsWith('/api/v1/models/unload')) {
+          lifecycle.push(['unload', JSON.parse(init.body)]);
+          return jsonResponse({ ok: true });
+        }
+        if (href.endsWith('/api/v1/models/load')) {
+          const body = JSON.parse(init.body);
+          lifecycle.push(['load', body]);
+          loadedCtx = body.context_length;
+          return jsonResponse({ ok: true });
+        }
+        if (href.endsWith('/v1/chat/completions')) {
+          lifecycle.push(['chat', JSON.parse(init.body)]);
+          return chatCompletionResponse('{"markers":[]}');
+        }
+        throw new Error(`Unexpected POST URL: ${href}`);
       }
-      if (String(url).endsWith('/api/v1/models')) {
+      if (href.endsWith('/api/v1/models')) {
         return jsonResponse({ models: [{
           type: 'llm',
           key: 'new-model-q4',
-          loaded_instances: [],
+          loaded_instances: loadedCtx > 0 ? [{ id: 'new-model-q4', config: { context_length: loadedCtx } }] : [],
           max_context_length: 131072,
           capabilities: { reasoning: { allowed_options: ['on'], default: 'on' } },
         }] });
       }
-      if (String(url).endsWith('/v1/models')) {
+      if (href.endsWith('/v1/models')) {
         return jsonResponse({ data: [] });
       }
       return jsonResponse({}, { status: 404 });
@@ -809,18 +940,18 @@ describe('AI provider request contracts', () => {
       preferNativeContext: true,
     }));
 
-    const postCall = globalThis.fetch.mock.calls.find(([, init]) => init?.method === 'POST');
-    const body = JSON.parse(postCall[1].body);
-    expect(body).toMatchObject({
+    // Nothing was loaded, so no unload call precedes the load.
+    expect(lifecycle.map(([action]) => action)).toEqual(['load', 'chat']);
+    expect(lifecycle[0][1]).toEqual({
       model: 'new-model-q4',
       context_length: 16384,
-      max_output_tokens: 4096,
     });
-    expect(body).not.toHaveProperty('reasoning');
-    expect(result.diagnostics).toMatchObject({
-      nativeContextOverride: true,
-      contextLength: 16384,
-      localPlan: { contextLength: 16384 },
+    expect(result).toMatchObject({
+      text: '{"markers":[]}',
+      diagnostics: {
+        providerApi: 'openai-compatible',
+        localPlan: { contextLength: 16384 },
+      },
     });
   });
 

--- a/tests/api-provider-contracts.test.js
+++ b/tests/api-provider-contracts.test.js
@@ -855,6 +855,43 @@ describe('AI provider request contracts', () => {
     });
   });
 
+  it('refuses inference when LM Studio cannot verify the context after loading', async () => {
+    setAIProvider('ollama');
+    setOllamaMainModel('thinkingcap-qwen3.6-27b');
+    let nativeDiscoveryCalls = 0;
+    let loaded = false;
+    globalThis.fetch = vi.fn(async (url, init = {}) => {
+      const href = String(url);
+      if (init.method === 'POST') {
+        if (href.endsWith('/api/v1/models/unload')) return jsonResponse({ ok: true });
+        if (href.endsWith('/api/v1/models/load')) { loaded = true; return jsonResponse({ ok: true }); }
+        if (href.endsWith('/v1/chat/completions')) throw new Error('Inference must not run with an unverified context.');
+      }
+      if (href.endsWith('/api/v1/models')) {
+        nativeDiscoveryCalls++;
+        if (nativeDiscoveryCalls > 1) return jsonResponse({ error: 'unavailable' }, { status: 503 });
+        return jsonResponse({ models: [{
+          type: 'llm',
+          key: 'thinkingcap-qwen3.6-27b@q4_k_m',
+          loaded_instances: [{ id: 'thinkingcap-qwen3.6-27b', config: { context_length: 8192 } }],
+          max_context_length: 262144,
+        }] });
+      }
+      if (href.endsWith('/v1/models')) return jsonResponse({ data: [{ id: 'thinkingcap-qwen3.6-27b' }] });
+      return jsonResponse({}, { status: 404 });
+    });
+
+    await expect(callClaudeAPI(baseChatOptions({
+      system: 'Extract the report as JSON.',
+      messages: [{ role: 'user', content: 'x'.repeat(25_000) }],
+      maxTokens: 4096,
+      jsonMode: true,
+      reasoningEffort: 'none',
+      preferNativeContext: true,
+    }))).rejects.toThrow(/could not verify its active context length/i);
+    expect(loaded).toBe(true);
+  });
+
   it('refuses to load a second copy when the prior LM Studio instance cannot be unloaded', async () => {
     const loadedDetail = { loaded: true, loadedInstanceId: 'big-model-1', nativeModelKey: 'big-model@q4' };
     const modelsBody = (loaded) => ({ models: [{
@@ -891,6 +928,20 @@ describe('AI provider request contracts', () => {
       modelDetail: loadedDetail,
       contextLength: 16384,
     })).resolves.toBe(true);
+
+    // Unload fails and discovery cannot verify residency → fail closed.
+    globalThis.fetch = vi.fn(async (url, init = {}) => {
+      if (String(url).endsWith('/api/v1/models/unload')) return jsonResponse({ error: 'busy' }, { status: 500 });
+      if (String(url).endsWith('/api/v1/models/load')) throw new Error('Load must not run without an authoritative residency check.');
+      if (String(url).endsWith('/api/v1/models')) return jsonResponse({ error: 'unavailable' }, { status: 503 });
+      return jsonResponse({}, { status: 404 });
+    });
+    await expect(loadLMStudioModelWithContext({
+      baseUrl: 'http://lmstudio.test',
+      model: 'big-model',
+      modelDetail: loadedDetail,
+      contextLength: 16384,
+    })).rejects.toThrow(/could not verify that big-model was unloaded/i);
   });
 
   it('flags a native LM Studio response that stopped at the output or context cap as truncated', async () => {

--- a/tests/api-provider-contracts.test.js
+++ b/tests/api-provider-contracts.test.js
@@ -59,7 +59,7 @@ import { updateKeyCache } from '../js/crypto.js';
 import { checkOpenAICompatible, clearLocalAiDiscovery, discoverLocalAI } from '../js/local-ai-discovery.js';
 import { estimateLocalAiPromptTokens } from '../js/api-local.js';
 import { LOCAL_AI_PROVIDER_ADAPTERS, getLocalAiProviderCapabilities } from '../js/local-ai-provider-registry.js';
-import { inferWithLMStudioNativeProvider } from '../js/local-ai-provider-lmstudio.js';
+import { inferWithLMStudioNativeProvider, loadLMStudioModelWithContext } from '../js/local-ai-provider-lmstudio.js';
 import { inferWithOllamaNativeProvider } from '../js/local-ai-provider-ollama.js';
 import { getLocalAiExecutionLocation, isLocalAiLoopbackUrl } from '../js/local-ai-provider-shared.js';
 import {
@@ -796,6 +796,7 @@ describe('AI provider request contracts', () => {
     globalThis.fetch = vi.fn(async (url, init = {}) => {
       const href = String(url);
       if (init.method === 'POST') {
+        if (href.endsWith('/api/v1/models/unload')) return jsonResponse({ ok: true });
         if (href.endsWith('/api/v1/models/load')) return jsonResponse({ error: { message: 'Not found' } }, { status: 404 });
         expect(href).toBe('http://localhost:11434/api/v1/chat');
         return jsonResponse({
@@ -852,6 +853,44 @@ describe('AI provider request contracts', () => {
         localPlan: { contextLength: 16384 },
       },
     });
+  });
+
+  it('refuses to load a second copy when the prior LM Studio instance cannot be unloaded', async () => {
+    const loadedDetail = { loaded: true, loadedInstanceId: 'big-model-1', nativeModelKey: 'big-model@q4' };
+    const modelsBody = (loaded) => ({ models: [{
+      type: 'llm',
+      key: 'big-model@q4',
+      loaded_instances: loaded ? [{ id: 'big-model-1', config: { context_length: 8192 } }] : [],
+      max_context_length: 131072,
+    }] });
+
+    // Unload fails and the server still reports the instance loaded → refuse.
+    globalThis.fetch = vi.fn(async (url, init = {}) => {
+      if (String(url).endsWith('/api/v1/models/unload')) return jsonResponse({ error: 'busy' }, { status: 500 });
+      if (String(url).endsWith('/api/v1/models/load')) throw new Error('Load must not run while the old instance is resident.');
+      if (String(url).endsWith('/api/v1/models')) return jsonResponse(modelsBody(true));
+      return jsonResponse({}, { status: 404 });
+    });
+    await expect(loadLMStudioModelWithContext({
+      baseUrl: 'http://lmstudio.test',
+      model: 'big-model',
+      modelDetail: loadedDetail,
+      contextLength: 16384,
+    })).rejects.toThrow(/could not unload big-model/i);
+
+    // Unload fails but the instance is already gone (stale state) → proceed.
+    globalThis.fetch = vi.fn(async (url, init = {}) => {
+      if (String(url).endsWith('/api/v1/models/unload')) return jsonResponse({ error: 'not found' }, { status: 404 });
+      if (String(url).endsWith('/api/v1/models/load')) return jsonResponse({ ok: true });
+      if (String(url).endsWith('/api/v1/models')) return jsonResponse(modelsBody(false));
+      return jsonResponse({}, { status: 404 });
+    });
+    await expect(loadLMStudioModelWithContext({
+      baseUrl: 'http://lmstudio.test',
+      model: 'big-model',
+      modelDetail: loadedDetail,
+      contextLength: 16384,
+    })).resolves.toBe(true);
   });
 
   it('flags a native LM Studio response that stopped at the output or context cap as truncated', async () => {

--- a/tests/api-transport.test.js
+++ b/tests/api-transport.test.js
@@ -199,3 +199,75 @@ describe('custom secure fetch request timeout lifecycle', () => {
     )).rejects.toThrow('stream ended without response content');
   });
 });
+
+describe('stream stall guard', () => {
+  it('gives the first read a longer stall window and reverts to the default afterwards', async () => {
+    const { readWithStallTimeout, STREAM_STALL_TIMEOUT_MS } = await import('../js/api-transport.js');
+    vi.useFakeTimers();
+    const neverResolves = () => new Promise(() => {});
+
+    // Default window: rejects at STREAM_STALL_TIMEOUT_MS.
+    const defaultReader = { read: neverResolves, cancel: vi.fn() };
+    const defaultRead = readWithStallTimeout(defaultReader, 'Test stream');
+    const defaultRejection = expect(defaultRead).rejects.toThrow(/stalled — no data for 30s/);
+    await vi.advanceTimersByTimeAsync(STREAM_STALL_TIMEOUT_MS + 1);
+    await defaultRejection;
+    expect(defaultReader.cancel).toHaveBeenCalled();
+
+    // Extended first-read window: still pending after the default deadline.
+    const { LOCAL_AI_FIRST_TOKEN_STALL_MS } = await import('../js/api-transport.js');
+    const slowReader = { read: neverResolves, cancel: vi.fn() };
+    const pending = readWithStallTimeout(slowReader, 'Test stream', LOCAL_AI_FIRST_TOKEN_STALL_MS);
+    const pendingRejection = expect(pending).rejects.toThrow(new RegExp(`no data for ${LOCAL_AI_FIRST_TOKEN_STALL_MS / 1000}s`));
+    await vi.advanceTimersByTimeAsync(STREAM_STALL_TIMEOUT_MS + 1);
+    expect(slowReader.cancel).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(LOCAL_AI_FIRST_TOKEN_STALL_MS);
+    await pendingRejection;
+    expect(slowReader.cancel).toHaveBeenCalled();
+  });
+
+  it('applies the first-read allowance to Local AI streams then guards subsequent reads', async () => {
+    const { LOCAL_AI_FIRST_TOKEN_STALL_MS, STREAM_STALL_TIMEOUT_MS } = await import('../js/api-transport.js');
+    vi.useFakeTimers();
+    const encoder = new TextEncoder();
+    let readCount = 0;
+    const chunks = [
+      'data: {"choices":[{"delta":{"content":"par"}}]}\n',
+      'data: {"choices":[{"delta":{"content":"tial"},"finish_reason":"stop"}]}\n\ndata: [DONE]\n',
+    ];
+    const stream = new ReadableStream({
+      async pull(controller) {
+        readCount++;
+        if (readCount === 1) {
+          // Simulate prompt prefill: first chunk arrives after the default
+          // stall window but inside the local first-token allowance.
+          await vi.advanceTimersByTimeAsync(STREAM_STALL_TIMEOUT_MS * 3);
+          controller.enqueue(encoder.encode(chunks[0]));
+          return;
+        }
+        controller.enqueue(encoder.encode(chunks[1]));
+        controller.close();
+      },
+    });
+    const result = await callOpenAICompatibleAPI(
+      'http://localhost:1234/v1/chat/completions',
+      '',
+      'local-model',
+      'Local AI',
+      {
+        messages: [{ role: 'user', content: 'long prompt' }],
+        maxTokens: 32,
+        onStream: vi.fn(),
+        requestTimeoutMs: 1000,
+      },
+      {},
+      {
+        useProxy: false,
+        firstReadStallMs: LOCAL_AI_FIRST_TOKEN_STALL_MS,
+        fetchImpl: async () => new Response(stream, { status: 200, headers: { 'Content-Type': 'text/event-stream' } }),
+      },
+    );
+    expect(result.text).toBe('partial');
+    expect(result.finishReason).toBe('stop');
+  });
+});

--- a/tests/api-transport.test.js
+++ b/tests/api-transport.test.js
@@ -232,20 +232,21 @@ describe('stream stall guard', () => {
     const encoder = new TextEncoder();
     let readCount = 0;
     const chunks = [
+      'data: {"choices":[{"delta":{"role":"assistant","content":""}}]}\n',
       'data: {"choices":[{"delta":{"content":"par"}}]}\n',
       'data: {"choices":[{"delta":{"content":"tial"},"finish_reason":"stop"}]}\n\ndata: [DONE]\n',
     ];
     const stream = new ReadableStream({
       async pull(controller) {
         readCount++;
-        if (readCount === 1) {
-          // Simulate prompt prefill: first chunk arrives after the default
-          // stall window but inside the local first-token allowance.
+        if (readCount <= 2) {
+          // Simulate a role-only metadata event, then continued prompt prefill:
+          // both reads need the first-token allowance.
           await vi.advanceTimersByTimeAsync(STREAM_STALL_TIMEOUT_MS * 3);
-          controller.enqueue(encoder.encode(chunks[0]));
+          controller.enqueue(encoder.encode(chunks[readCount - 1]));
           return;
         }
-        controller.enqueue(encoder.encode(chunks[1]));
+        controller.enqueue(encoder.encode(chunks[2]));
         controller.close();
       },
     });

--- a/tests/pdf-import-progress-phases.test.js
+++ b/tests/pdf-import-progress-phases.test.js
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createImportAIProgress, saveImportAIPerf } from '../js/pdf-import-ai-utils.js';
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('phase-aware import AI progress', () => {
+  it('reports a reading phase until the first token, then a writing phase', () => {
+    const calls = [];
+    const progress = createImportAIProgress({
+      perfKey: 'local:test-model',
+      estimatedPromptTokens: 10000,
+      onProgress: (pct, label) => calls.push([pct, label]),
+    });
+    progress.start();
+    expect(calls.at(-1)).toEqual([15, 'Model is reading the report']);
+
+    vi.advanceTimersByTime(30000);
+    const [readingPct, readingLabel] = calls.at(-1);
+    expect(readingLabel).toContain('reading');
+    expect(readingPct).toBeGreaterThanOrEqual(15);
+    expect(readingPct).toBeLessThanOrEqual(40);
+
+    progress.onStream('x'.repeat(4000));
+    const [writingPct, writingLabel] = calls.at(-1);
+    expect(writingLabel).toBe('Model is writing the results');
+    expect(writingPct).toBeGreaterThanOrEqual(40);
+    expect(writingPct).toBeLessThanOrEqual(90);
+
+    // Ticker no longer fires after streaming begins.
+    const countAfterStream = calls.length;
+    vi.advanceTimersByTime(5000);
+    expect(calls.length).toBe(countAfterStream);
+
+    // Progress is monotonic even if a smaller text length were reported.
+    progress.onStream('x'.repeat(20000));
+    const highPct = calls.at(-1)[0];
+    progress.onStream('x'.repeat(100));
+    expect(calls.at(-1)[0]).toBeGreaterThanOrEqual(highPct);
+    progress.finish();
+  });
+
+  it('uses persisted per-model prefill speed for a time-tracking reading phase', () => {
+    saveImportAIPerf('local:fast-model', {
+      usage: { inputTokens: 10000 },
+      diagnostics: { performance: { timeToFirstTokenMs: 10000, tokensPerSecond: 25 } },
+    });
+    const calls = [];
+    const progress = createImportAIProgress({
+      perfKey: 'local:fast-model',
+      estimatedPromptTokens: 10000, // at 1000 tok/s prefill → ~10s ETA
+      onProgress: (pct, label) => calls.push([pct, label]),
+    });
+    progress.start();
+    vi.advanceTimersByTime(5000); // halfway through the ETA
+    const [pct, label] = calls.at(-1);
+    expect(pct).toBeGreaterThanOrEqual(26);
+    expect(pct).toBeLessThanOrEqual(29);
+    expect(label).toMatch(/reading the report — about \d+s left/);
+    // At/after the ETA the reading phase parks at its ceiling.
+    vi.advanceTimersByTime(6000);
+    expect(calls.at(-1)[0]).toBe(40);
+    progress.finish();
+  });
+
+  it('does nothing without an onProgress callback and caps stored perf entries', () => {
+    const progress = createImportAIProgress({ perfKey: 'local:x', estimatedPromptTokens: 100 });
+    expect(progress.onStream).toBeUndefined();
+    progress.start();
+    progress.finish();
+
+    for (let i = 0; i < 15; i++) {
+      saveImportAIPerf(`local:model-${i}`, {
+        usage: { inputTokens: 1000 },
+        diagnostics: { performance: { timeToFirstTokenMs: 2000, tokensPerSecond: 10 } },
+      });
+    }
+    const stored = JSON.parse(localStorage.getItem('labcharts-import-ai-perf'));
+    expect(Object.keys(stored).length).toBeLessThanOrEqual(12);
+  });
+});


### PR DESCRIPTION
## Problem

Large PDF imports against LM Studio failed in three distinct ways, all traced live against a real LM Studio instance on Apple silicon:

1. **3-minute wall.** The LM Studio native `/api/v1/chat` path is non-streaming, so `AI_IMPORT_REQUEST_TIMEOUT_MS` (180s) bounded the *entire* generation. An 11k-token lab report needs model load + prefill + several thousand output tokens — the server log showed `Client disconnected. Stopping generation` at exactly +180s on every attempt while the model was mid-response.
2. **Stall guard vs prefill.** The 30s stream stall guard treats silence as a dead connection, but local prefill legitimately produces zero bytes for minutes (a dense 31B prefills 11k tokens in ~5 min at ~40 tok/s). Imports passed or failed depending on prompt-cache luck.
3. **Silent truncation.** When generation stopped at the output cap or filled the context window, the truncated JSON was salvaged into a silently-partial marker list (`truncated: false` was hardcoded on the native path).

## Fix

- **Load-then-stream**: when a context override is needed, (re)load the model via `POST /api/v1/models/load` (unloading the prior instance first so two copies of a ~19 GB model are never resident), force-rediscover to read back the **auto-fitted** context (LM Studio can fit above or below the request), re-plan the output budget against the real value, then generate over the streaming `/v1/chat/completions` endpoint where the timeout only covers time-to-first-token. Servers without the load route (404) keep the native path, now with a 15-minute ceiling.
- **First-token allowance**: local streams (LM Studio compatible path + Ollama native) get `LOCAL_AI_FIRST_TOKEN_STALL_MS` (15 min) for the first read; the 30s mid-stream guard is unchanged. Connection-level failures are still caught by the initial-response timeout.
- **Truncation detection**: the native path infers truncation from token accounting (`total_output_tokens >= max` or input+output filling the context); both import paths raise a clear "increase the model's context length" error instead of importing half a report.
- **Estimate calibration**: dense numeric lab tables tokenize at ~3 chars/token, not 3.5 (observed: 11,057 real vs ~6.5k estimated) — import requests pass `promptCharsPerToken: 3`.
- **Phase-aware progress**: import analysis now distinguishes "Model is reading the report" (prefill, 15→40%) from "Model is writing the results" (first streamed token onward, 40→90%). Per-model prefill/generation speed from stream stats is persisted (capped at 12 models), so repeat imports show a real "about X min left" during prefill instead of a bar stuck at 15%.

## Testing

- Unit: new coverage for the load→stream lifecycle contract (unload→load→chat order, 404 fallback to native chat), truncation flagging, stall-window behavior, and progress phases; existing native-path contract tests updated. Affected suites green: api-provider-contracts (40), api-transport (9), pdf-import-progress-phases (3), plus guardrails/audit/unit-import.
- Live E2E (Playwright driving the real app against LM Studio 1234): repeated full imports of a 35k-char synthetic panel, 38/38 markers extracted, including cold model load + cold prompt cache; observed request sequence matches design (`models/unload` → `models/load` → auto-fit readback → streaming completion). A 36-minute dense-31B generation completed end-to-end where the old code disconnected at 30s/180s.