### PR TITLE
fix: keep the focus card usable on thinking models

### DIFF
--- a/js/focus-card.js
+++ b/js/focus-card.js
@@ -3,7 +3,7 @@
 
 import { state } from './state.js';
 import { trackUsage } from './schema.js';
-import { escapeAttr, hasCardContent, getStatus } from './utils.js';
+import { escapeAttr, escapeHTML, hasCardContent, getStatus } from './utils.js';
 import { getActiveData, getFocusCardFingerprint } from './data.js';
 import { getAllFlaggedMarkers } from './marker-analysis.js';
 import { profileStorageKey } from './profile.js';
@@ -239,6 +239,9 @@ export async function loadFocusCard(opts = {}) {
       system: focusSystem,
       messages: [{ role: 'user', content: ctx }],
       maxTokens: 500,
+      // A thinking model spends this 500-token cap on reasoning and finishes
+      // with `length` before writing any content, leaving the card empty.
+      reasoningEffort: 'none',
       onStream(text) {
         if (text.length < target.length) displayed = 0;
         target = text;
@@ -267,7 +270,12 @@ export async function loadFocusCard(opts = {}) {
       el.innerHTML = `<span class="focus-card-text" style="color:var(--text-muted)">No insight available</span>`;
     }
   } catch(e) {
-    el.innerHTML = `<span class="focus-card-text" style="color:var(--text-muted)">Could not load insight</span>`;
+    // Show why. The transport raises actionable messages here (e.g. a local
+    // model spending its output budget on reasoning); collapsing them all to
+    // "Could not load insight" sends people debugging the network instead.
+    console.error('Focus card insight failed:', e);
+    const reason = e instanceof Error && e.message ? e.message : '';
+    el.innerHTML = `<span class="focus-card-text" style="color:var(--text-muted)">Could not load insight${reason ? ` — ${escapeHTML(reason)}` : ''}</span>`;
   }
 }
 

--- a/tests/playwright/context-coverage-batch.spec.js
+++ b/tests/playwright/context-coverage-batch.spec.js
@@ -892,11 +892,17 @@ test('context health dots and focus card cover cache fallback and empty states',
       localStorage.removeItem('labcharts-ai-paused');
       localStorage.setItem('labcharts-ollama-model', 'context-test-model');
       const focusAiCalls = [];
+      let focusResponseMode = 'success';
       window.fetch = async (url, options = {}) => {
         const href = typeof url === 'string' ? url : url?.url || '';
         if (href === 'http://ollama.test/v1/chat/completions') {
           const body = JSON.parse(options.body || '{}');
           focusAiCalls.push(body);
+          if (focusResponseMode === 'failure') {
+            return new Response(JSON.stringify({
+              error: { message: '<img src=x onerror=alert(1)> model rejected request' },
+            }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+          }
           const stream = new ReadableStream({
             start(controller) {
               const encoder = new TextEncoder();
@@ -916,8 +922,19 @@ test('context health dots and focus card cover cache fallback and empty states',
       const streamedFocusCache = JSON.parse(localStorage.getItem(focusCacheKey) || '{}');
       outcomes.loadFocusCardStreamsAndCachesLocalAI = focusAiCalls.length === 1
         && focusAiCalls[0].stream === true
+        && focusAiCalls[0].max_tokens === 500
+        && focusAiCalls[0].reasoning_effort === 'none'
         && document.getElementById('focus-card-body')?.textContent.includes('Vitamin D is low. Recheck with ApoB') === true
         && streamedFocusCache.text === 'Vitamin D is low. Recheck with ApoB.';
+
+      localStorage.removeItem(focusCacheKey);
+      focusResponseMode = 'failure';
+      document.getElementById('focus-card-body').innerHTML = '';
+      await focus.loadFocusCard();
+      const failedFocusBody = document.getElementById('focus-card-body');
+      outcomes.loadFocusCardSafelySurfacesProviderFailure =
+        failedFocusBody?.textContent.includes('model rejected request') === true
+        && failedFocusBody.querySelector('img') === null;
       window.fetch = saved.fetch;
 
       localStorage.removeItem(focusCacheKey);

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -1164,6 +1164,8 @@ assert('buildFocusContext exists in focus-card.js', focusCardSrc.includes('funct
 assert('views.js imports focus card module', viewsSrc.includes("from './focus-card.js'"));
 assert('Focus card uses buildFocusContext', focusCardSrc.includes('buildFocusContext()'));
 assert('Focus card context-aware system prompt', focusCardSrc.includes("this person's goals/conditions"));
+assert('Focus card disables reasoning for its small token cap', /reasoningEffort:\s*'none'/.test(focusCardSrc));
+assert('Focus card surfaces the failure reason', focusCardSrc.includes('escapeHTML(reason)'));
 
 assert('askAIAboutMarker uses marker.refMin/refMax', chatMarkerPromptsSrc.includes('${marker.refMin}') && chatMarkerPromptsSrc.includes('${marker.refMax}'));
 assert('askAIAboutMarker has trend direction', chatMarkerPromptsSrc.includes("Trend: ${dir}"));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.15.0';
+self.APP_VERSION = '1.15.1';


### PR DESCRIPTION
## Summary

On a thinking model the insight (focus) card always fails with "Could not load insight", and the reason is invisible even though the transport already explains it.

Two independent problems, both in `js/focus-card.js`:

1. The card requests `maxTokens: 500`. A thinking model spends that entire budget on reasoning tokens, so the stream ends `finish_reason: "length"` with `delta.content` never non-empty and nothing to render.
2. `callOpenAICompatibleAPI` raises a precise, actionable error for exactly this case — *"Local AI returned reasoning but no final answer. Reasoning used the output budget; disable thinking for this task or increase the model context/output limit."* — but the card's `catch(e)` discards `e` and renders a generic string, so that guidance never reaches the user.

Because of (2), the visible symptom is unrelated to the cause. In Firefox the aborted request surfaces as `Cross-Origin Request Blocked … CORS request did not succeed. Status code: (null)`, which sends you debugging reverse-proxy and CORS config rather than token budgets.

## Changes

- **`js/focus-card.js`** — pass `reasoningEffort: 'none'`, consistent with the other small-cap callers (`pdf-import.js`, `pdf-import-preflight.js`). The providers already translate it (`think: false` on Ollama, `reasoning_effort: 'none'` on OpenAI-compatible and LM Studio). This also matches the card's own system prompt, which already asks the model for no thinking, no reasoning and no preamble.
- **`js/focus-card.js`** — `console.error` the failure and include the message in the card (HTML-escaped) instead of swallowing it.
- **`tests/test-audit.js`** — assertions covering both.
- **`version.js`** — bumped per CONTRIBUTING.

This deliberately leaves the Local AI output-cap policy alone: suppressing thinking for a 500-token card keeps the *"keeps the context-planned output cap for Local AI thinking models"* contract intact rather than bumping caps for local models.

## Evidence

Measured against Ollama 0.31.2 with `qwen3.6:27b` through `/v1/chat/completions`:

| | finish_reason | completion tokens | content |
|---|---|---|---|
| before | `length` | 500 (all reasoning) | empty |
| after | `stop` | 24 | complete insight |

## Open question

Some users may want reasoning here and accept the latency — with the cap raised so reasoning and the answer both fit, the same model produced a slightly sharper reading in my testing (it named a specific differential the fast path missed), at roughly 15× the latency. Happy to follow up with a PR making this configurable rather than hardcoded if you'd like it exposed as a setting; I kept this PR to the bug.
