### PR TITLE
Add stable custom marker identities

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -9,8 +9,8 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 
 | Metric | Current |
 | --- | ---: |
-| Modules | 635 |
-| Internal import edges | 2663 |
+| Modules | 636 |
+| Internal import edges | 2669 |
 | Dynamic internal edges | 72 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -67,10 +67,10 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 | [`js/crypto.js`](js/crypto.js) | 33 | [`js/dashboard-view-composition.js`](js/dashboard-view-composition.js) | 20 |
 | [`js/data-merge.js`](js/data-merge.js) | 30 | [`js/biology-scores.js`](js/biology-scores.js) | 19 |
 | [`js/constants.js`](js/constants.js) | 22 | [`js/marker-schema/index.js`](js/marker-schema/index.js) | 19 |
-| [`js/utils-runtime.js`](js/utils-runtime.js) | 20 | [`js/lab-context.js`](js/lab-context.js) | 18 |
-| [`js/marker-analysis.js`](js/marker-analysis.js) | 19 | [`js/app-chat-hooks.js`](js/app-chat-hooks.js) | 17 |
-| [`js/chat-runtime.js`](js/chat-runtime.js) | 18 | [`js/chat-render.js`](js/chat-render.js) | 17 |
-| [`js/settings-runtime-bridge.js`](js/settings-runtime-bridge.js) | 17 | [`js/export.js`](js/export.js) | 17 |
+| [`js/utils-runtime.js`](js/utils-runtime.js) | 20 | [`js/export.js`](js/export.js) | 18 |
+| [`js/marker-analysis.js`](js/marker-analysis.js) | 19 | [`js/lab-context.js`](js/lab-context.js) | 18 |
+| [`js/chat-runtime.js`](js/chat-runtime.js) | 18 | [`js/app-chat-hooks.js`](js/app-chat-hooks.js) | 17 |
+| [`js/settings-runtime-bridge.js`](js/settings-runtime-bridge.js) | 17 | [`js/chat-render.js`](js/chat-render.js) | 17 |
 
 ## Existing cyclic components
 
@@ -381,6 +381,12 @@ Native browser modules shipped with the static application.
 
 </details>
 
+<details><summary><code>custom</code> family — 1 module</summary>
+
+- [`js/custom-marker-identity.js`](js/custom-marker-identity.js) → [`js/marker-schema.js`](js/marker-schema.js), [`js/unique-id.js`](js/unique-id.js)
+
+</details>
+
 <details><summary><code>cycle</code> family — 8 modules</summary>
 
 - [`js/cycle-import-adapters.js`](js/cycle-import-adapters.js) → [`js/cycle-summary.js`](js/cycle-summary.js)
@@ -468,7 +474,7 @@ Native browser modules shipped with the static application.
 - [`js/export-report-html.js`](js/export-report-html.js) → [`js/export-report.js`](js/export-report.js), [`js/marker-analysis.js`](js/marker-analysis.js), [`js/state.js`](js/state.js), [`js/supplement-impact.js`](js/supplement-impact.js), [`js/supplement-medication-domain.js`](js/supplement-medication-domain.js), [`js/utils.js`](js/utils.js)
 - [`js/export-report.js`](js/export-report.js) → [`js/api.js`](js/api.js), [`js/cycle.js`](js/cycle.js), [`js/data.js`](js/data.js), [`js/marker-analysis.js`](js/marker-analysis.js), [`js/profile.js`](js/profile.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/export-runtime.js`](js/export-runtime.js) → [`js/cashu-wallet.js`](js/cashu-wallet.js) *(dynamic)*, [`js/crypto.js`](js/crypto.js), [`js/state.js`](js/state.js)
-- [`js/export.js`](js/export.js) → [`js/biology-score-context-ai.js`](js/biology-score-context-ai.js) *(dynamic)*, [`js/caught-error.js`](js/caught-error.js), [`js/context-cards.js`](js/context-cards.js) *(dynamic)*, [`js/crypto.js`](js/crypto.js), [`js/data.js`](js/data.js), [`js/export-import.js`](js/export-import.js) *(dynamic)*, [`js/export-report-builder.js`](js/export-report-builder.js) *(dynamic)*, [`js/export-report-html.js`](js/export-report-html.js), [`js/export-report.js`](js/export-report.js), [`js/export-runtime.js`](js/export-runtime.js), [`js/lab-entry-mutations.js`](js/lab-entry-mutations.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/nostr-discovery.js`](js/nostr-discovery.js), [`js/profile-storage-cleanup.js`](js/profile-storage-cleanup.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
+- [`js/export.js`](js/export.js) → [`js/biology-score-context-ai.js`](js/biology-score-context-ai.js) *(dynamic)*, [`js/caught-error.js`](js/caught-error.js), [`js/context-cards.js`](js/context-cards.js) *(dynamic)*, [`js/crypto.js`](js/crypto.js), [`js/custom-marker-identity.js`](js/custom-marker-identity.js), [`js/data.js`](js/data.js), [`js/export-import.js`](js/export-import.js) *(dynamic)*, [`js/export-report-builder.js`](js/export-report-builder.js) *(dynamic)*, [`js/export-report-html.js`](js/export-report-html.js), [`js/export-report.js`](js/export-report.js), [`js/export-runtime.js`](js/export-runtime.js), [`js/lab-entry-mutations.js`](js/lab-entry-mutations.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/nostr-discovery.js`](js/nostr-discovery.js), [`js/profile-storage-cleanup.js`](js/profile-storage-cleanup.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 
 </details>
 
@@ -704,7 +710,7 @@ Native browser modules shipped with the static application.
 - [`js/marker-analysis.js`](js/marker-analysis.js) → [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/marker-detail-actions.js`](js/marker-detail-actions.js) → [`js/utils.js`](js/utils.js)
 - [`js/marker-detail-content.js`](js/marker-detail-content.js) → [`js/api.js`](js/api.js), [`js/schema.js`](js/schema.js)
-- [`js/marker-detail-custom-markers.js`](js/marker-detail-custom-markers.js) → [`js/data.js`](js/data.js), [`js/lab-entry-mutations.js`](js/lab-entry-mutations.js), [`js/marker-detail-actions.js`](js/marker-detail-actions.js), [`js/marker-detail-runtime.js`](js/marker-detail-runtime.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
+- [`js/marker-detail-custom-markers.js`](js/marker-detail-custom-markers.js) → [`js/custom-marker-identity.js`](js/custom-marker-identity.js), [`js/data.js`](js/data.js), [`js/lab-entry-mutations.js`](js/lab-entry-mutations.js), [`js/marker-detail-actions.js`](js/marker-detail-actions.js), [`js/marker-detail-runtime.js`](js/marker-detail-runtime.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/marker-detail-editing.js`](js/marker-detail-editing.js) → [`js/data.js`](js/data.js), [`js/marker-detail-actions.js`](js/marker-detail-actions.js), [`js/marker-detail-runtime.js`](js/marker-detail-runtime.js), [`js/marker-detail-store.js`](js/marker-detail-store.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/marker-detail-manual-entry.js`](js/marker-detail-manual-entry.js) → [`js/data.js`](js/data.js), [`js/marker-detail-actions.js`](js/marker-detail-actions.js), [`js/marker-detail-editing.js`](js/marker-detail-editing.js), [`js/marker-detail-runtime.js`](js/marker-detail-runtime.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/marker-detail-modal-impl.js`](js/marker-detail-modal-impl.js) → [`js/api.js`](js/api.js), [`js/charts.js`](js/charts.js), [`js/context-cards.js`](js/context-cards.js), [`js/data.js`](js/data.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/marker-analysis.js`](js/marker-analysis.js), [`js/marker-detail-actions.js`](js/marker-detail-actions.js), [`js/marker-detail-content.js`](js/marker-detail-content.js), [`js/marker-detail-custom-markers.js`](js/marker-detail-custom-markers.js), [`js/marker-detail-editing.js`](js/marker-detail-editing.js), [`js/marker-detail-manual-entry.js`](js/marker-detail-manual-entry.js), [`js/marker-detail-runtime.js`](js/marker-detail-runtime.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/modal-trigger-memory.js`](js/modal-trigger-memory.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
@@ -772,7 +778,7 @@ Native browser modules shipped with the static application.
 <details><summary><code>pdf</code> family — 13 modules</summary>
 
 - [`js/pdf-import-ai-utils.js`](js/pdf-import-ai-utils.js) → [`js/api-provider-storage.js`](js/api-provider-storage.js), [`js/api.js`](js/api.js), [`js/utils.js`](js/utils.js)
-- [`js/pdf-import-commit.js`](js/pdf-import-commit.js) → [`js/adapters.js`](js/adapters.js), [`js/crypto.js`](js/crypto.js), [`js/data-merge.js`](js/data-merge.js), [`js/data.js`](js/data.js), [`js/import-benchmarks.js`](js/import-benchmarks.js), [`js/lab-entry-mutations.js`](js/lab-entry-mutations.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/pdf-import-marker-mapping.js`](js/pdf-import-marker-mapping.js), [`js/pdf-import-persistence.js`](js/pdf-import-persistence.js), [`js/pdf-import-review.js`](js/pdf-import-review.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/unique-id.js`](js/unique-id.js), [`js/utils.js`](js/utils.js)
+- [`js/pdf-import-commit.js`](js/pdf-import-commit.js) → [`js/adapters.js`](js/adapters.js), [`js/crypto.js`](js/crypto.js), [`js/custom-marker-identity.js`](js/custom-marker-identity.js), [`js/data-merge.js`](js/data-merge.js), [`js/data.js`](js/data.js), [`js/import-benchmarks.js`](js/import-benchmarks.js), [`js/lab-entry-mutations.js`](js/lab-entry-mutations.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/pdf-import-marker-mapping.js`](js/pdf-import-marker-mapping.js), [`js/pdf-import-persistence.js`](js/pdf-import-persistence.js), [`js/pdf-import-review.js`](js/pdf-import-review.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/unique-id.js`](js/unique-id.js), [`js/utils.js`](js/utils.js)
 - [`js/pdf-import-file-handlers.js`](js/pdf-import-file-handlers.js) → [`js/api.js`](js/api.js), [`js/caught-error.js`](js/caught-error.js), [`js/import-benchmarks.js`](js/import-benchmarks.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/pdf-import-ai-utils.js`](js/pdf-import-ai-utils.js), [`js/pdf-import-file-utils.js`](js/pdf-import-file-utils.js), [`js/pdf-import-preflight.js`](js/pdf-import-preflight.js), [`js/pdf-import-progress.js`](js/pdf-import-progress.js), [`js/pdf-import-review.js`](js/pdf-import-review.js), [`js/pdf-import-spreadsheet.js`](js/pdf-import-spreadsheet.js), [`js/pii.js`](js/pii.js), [`js/privacy-safe-diagnostics.js`](js/privacy-safe-diagnostics.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/pdf-import-file-utils.js`](js/pdf-import-file-utils.js) → [`js/pdf-import-spreadsheet.js`](js/pdf-import-spreadsheet.js), [`js/pdfjs-loader.js`](js/pdfjs-loader.js)
 - [`js/pdf-import-marker-mapping.js`](js/pdf-import-marker-mapping.js) → [`js/adapters.js`](js/adapters.js), [`js/schema.js`](js/schema.js), [`js/secondary-unit-conversions.js`](js/secondary-unit-conversions.js), [`js/state.js`](js/state.js)
@@ -809,7 +815,7 @@ Native browser modules shipped with the static application.
 <details><summary><code>profile</code> family — 11 modules</summary>
 
 - [`js/profile-context.js`](js/profile-context.js) → [`js/context-source-registry.js`](js/context-source-registry.js), [`js/health-goals-utils.js`](js/health-goals-utils.js), [`js/state.js`](js/state.js), [`js/supplement-medication-domain.js`](js/supplement-medication-domain.js)
-- [`js/profile-data-migrations.js`](js/profile-data-migrations.js) → [`js/adapters.js`](js/adapters.js), [`js/context-source-registry.js`](js/context-source-registry.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/light-env-evening.js`](js/light-env-evening.js), [`js/profile-marker-migrations.js`](js/profile-marker-migrations.js), [`js/schema.js`](js/schema.js), [`js/supplement-medication-domain.js`](js/supplement-medication-domain.js)
+- [`js/profile-data-migrations.js`](js/profile-data-migrations.js) → [`js/adapters.js`](js/adapters.js), [`js/context-source-registry.js`](js/context-source-registry.js), [`js/custom-marker-identity.js`](js/custom-marker-identity.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/light-env-evening.js`](js/light-env-evening.js), [`js/profile-marker-migrations.js`](js/profile-marker-migrations.js), [`js/schema.js`](js/schema.js), [`js/supplement-medication-domain.js`](js/supplement-medication-domain.js)
 - [`js/profile-fatty-acid-migrations.js`](js/profile-fatty-acid-migrations.js) → [`js/adapters.js`](js/adapters.js)
 - [`js/profile-list-store.js`](js/profile-list-store.js) → [`js/crypto.js`](js/crypto.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/profile-marker-migrations.js`](js/profile-marker-migrations.js) → [`js/adapters.js`](js/adapters.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/profile-fatty-acid-migrations.js`](js/profile-fatty-acid-migrations.js), [`js/schema.js`](js/schema.js)

--- a/docs/marker-identity.md
+++ b/docs/marker-identity.md
@@ -33,9 +33,19 @@ require no migration. Consumers can resolve current and historical locations
 through `getBuiltinMarkerId`, `getBuiltinMarkerDotKey`, and
 `resolveBuiltinMarkerDotKey` without changing the wire format.
 
-Custom markers likewise keep their current dotKeys. The `custom:<opaque-id>`
-namespace is reserved for a future dual-read migration; custom ids must be
-generated independently of category and display name before they are persisted.
+Custom markers likewise keep their current dotKeys for values and companion
+maps. Each custom marker definition now carries a `markerId` in the
+`custom:<opaque-id>` namespace. New ids are generated independently of category
+and display name. Legacy definitions receive deterministic opaque ids so two
+offline devices upgrading the same profile converge without coordination.
+
+The migration is additive and idempotent: it does not re-key entries,
+reference overrides, notes, labels, manual-value provenance, imports, exports,
+backups, shares, or sync payloads. Unique existing ids are preserved. Invalid
+or duplicated ids are repaired deterministically, and the current dotKey still
+wins all existing conflict behavior. Moving a custom marker in a later slice
+must preserve its `markerId` while category assignment becomes separate
+metadata.
 
 ## Terminology metadata
 

--- a/js/custom-marker-identity.js
+++ b/js/custom-marker-identity.js
@@ -1,0 +1,146 @@
+// @ts-check
+// custom-marker-identity.js — Stable identities for profile-owned markers.
+
+import { CUSTOM_MARKER_ID_PREFIX, isCustomMarkerId } from './marker-schema.js';
+import { createUniqueId } from './unique-id.js';
+
+const LEGACY_CUSTOM_MARKER_ID_PREFIX = `${CUSTOM_MARKER_ID_PREFIX}legacy_`;
+const LEGACY_HASH_SEEDS = [0x811c9dc5, 0x9e3779b9, 0x85ebca6b, 0xc2b2ae35];
+
+/** @param {unknown} value */
+function isDefinition(value) {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+/**
+ * A small deterministic 128-bit fingerprint for legacy migration. This is not
+ * a security primitive: it only lets separate offline devices derive the same
+ * opaque identity from the only stable legacy input they share.
+ *
+ * @param {string} value
+ */
+function legacyFingerprint(value) {
+  return LEGACY_HASH_SEEDS.map(seed => {
+    let hash = seed >>> 0;
+    for (let index = 0; index < value.length; index++) {
+      const code = value.charCodeAt(index);
+      hash ^= code & 0xff;
+      hash = Math.imul(hash, 0x01000193) >>> 0;
+      hash ^= code >>> 8;
+      hash = Math.imul(hash, 0x01000193) >>> 0;
+    }
+    return hash.toString(16).padStart(8, '0');
+  }).join('');
+}
+
+/**
+ * Derive a convergent identity for a marker that predates stable custom IDs.
+ * New markers must use createCustomMarkerId instead.
+ *
+ * @param {unknown} dotKey
+ * @returns {string | null}
+ */
+export function deriveLegacyCustomMarkerId(dotKey) {
+  if (typeof dotKey !== 'string' || dotKey.length === 0) return null;
+  return `${LEGACY_CUSTOM_MARKER_ID_PREFIX}${legacyFingerprint(dotKey)}`;
+}
+
+/**
+ * Create a category- and name-independent identity for a new custom marker.
+ *
+ * @param {Record<string, any> | null | undefined} [customMarkers]
+ * @returns {string}
+ */
+export function createCustomMarkerId(customMarkers = null) {
+  const usedIds = new Set(
+    Object.values(customMarkers || {})
+      .filter(isDefinition)
+      .map(definition => definition.markerId)
+      .filter(isCustomMarkerId),
+  );
+  for (let attempt = 0; attempt < 16; attempt++) {
+    const markerId = createUniqueId(CUSTOM_MARKER_ID_PREFIX);
+    if (!usedIds.has(markerId)) return markerId;
+  }
+  throw new Error('Could not allocate a unique custom marker identity.');
+}
+
+/**
+ * Ensure a newly authored definition has an opaque identity without replacing
+ * an identity received through import or sync.
+ *
+ * @param {any} definition
+ * @param {Record<string, any> | null | undefined} [customMarkers]
+ * @returns {string | null}
+ */
+export function ensureCustomMarkerIdentity(definition, customMarkers = null) {
+  if (!isDefinition(definition)) return null;
+  if (isCustomMarkerId(definition.markerId)) return definition.markerId;
+  definition.markerId = createCustomMarkerId(customMarkers);
+  return definition.markerId;
+}
+
+/**
+ * Add identities to legacy definitions and repair duplicate or malformed IDs.
+ * The lexicographically first definition owns a duplicated valid ID; later
+ * definitions receive deterministic legacy identities. Existing unique IDs
+ * are always preserved.
+ *
+ * @param {Record<string, any> | null | undefined} customMarkers
+ * @returns {Record<string, any> | null | undefined}
+ */
+export function migrateCustomMarkerIdentities(customMarkers) {
+  if (!customMarkers || typeof customMarkers !== 'object' || Array.isArray(customMarkers)) {
+    return customMarkers;
+  }
+
+  const entries = Object.entries(customMarkers)
+    .filter(([, definition]) => isDefinition(definition))
+    .sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0);
+  const ownerById = new Map();
+  for (const [dotKey, definition] of entries) {
+    if (isCustomMarkerId(definition.markerId) && !ownerById.has(definition.markerId)) {
+      ownerById.set(definition.markerId, dotKey);
+    }
+  }
+
+  const assignedIds = new Set(ownerById.keys());
+  for (const [dotKey, definition] of entries) {
+    if (isCustomMarkerId(definition.markerId) && ownerById.get(definition.markerId) === dotKey) {
+      continue;
+    }
+    const baseId = deriveLegacyCustomMarkerId(dotKey);
+    if (!baseId) continue;
+    let markerId = baseId;
+    let suffix = 2;
+    while (assignedIds.has(markerId)) markerId = `${baseId}_${suffix++}`;
+    definition.markerId = markerId;
+    assignedIds.add(markerId);
+  }
+  return customMarkers;
+}
+
+/** @param {Record<string, any> | null | undefined} customMarkers @param {unknown} dotKey */
+export function getCustomMarkerId(customMarkers, dotKey) {
+  if (typeof dotKey !== 'string') return null;
+  const definition = customMarkers?.[dotKey];
+  return isDefinition(definition) && isCustomMarkerId(definition.markerId)
+    ? definition.markerId
+    : null;
+}
+
+/** @param {Record<string, any> | null | undefined} customMarkers @param {unknown} markerId */
+export function getCustomMarkerDotKey(customMarkers, markerId) {
+  if (!isCustomMarkerId(markerId)) return null;
+  for (const [dotKey, definition] of Object.entries(customMarkers || {})) {
+    if (isDefinition(definition) && definition.markerId === markerId) return dotKey;
+  }
+  return null;
+}
+
+/** @param {Record<string, any> | null | undefined} customMarkers @param {unknown} value */
+export function resolveCustomMarkerDotKey(customMarkers, value) {
+  if (typeof value !== 'string') return null;
+  if (isDefinition(customMarkers?.[value])) return value;
+  return getCustomMarkerDotKey(customMarkers, value);
+}

--- a/js/export.js
+++ b/js/export.js
@@ -2,6 +2,7 @@
 // export.js — JSON export/import, report facade, clear all data
 
 import { getErrorMessage } from './caught-error.js';
+import { migrateCustomMarkerIdentities } from './custom-marker-identity.js';
 import { state } from './state.js';
 import { showNotification, showConfirmDialog } from './utils.js';
 import {
@@ -300,6 +301,7 @@ export async function buildClientExportObject(profileId, includeChat = false) {
   const raw = await encryptedGetItem(profileStorageKey(profileId, 'imported'));
   let data;
   try { data = raw ? JSON.parse(raw) : null; } catch { data = null; }
+  migrateCustomMarkerIdentities(data?.customMarkers);
   if (!data || !data.entries || data.entries.length === 0) throw new Error('No data to export for this client');
   const exportObj = {
     version: 2, exportedAt: new Date().toISOString(),
@@ -399,6 +401,7 @@ export async function buildAllDataBundle() {
     const raw = await encryptedGetItem(profileStorageKey(p.id, 'imported'));
     let data;
     try { data = raw ? JSON.parse(raw) : {}; } catch { data = {}; }
+    migrateCustomMarkerIdentities(data?.customMarkers);
     const chat = await _exportChatData(p.id);
     const entry = {
       id: p.id, name: p.name, sex: p.sex || null, dob: p.dob || null,

--- a/js/marker-detail-custom-markers.js
+++ b/js/marker-detail-custom-markers.js
@@ -2,6 +2,7 @@
 // marker-detail-custom-markers.js — Custom biomarker create/delete flow owner
 
 import { state } from './state.js';
+import { createCustomMarkerId } from './custom-marker-identity.js';
 import { escapeHTML, showConfirmDialog, showNotification } from './utils.js';
 import { getActiveData, saveImportedData, updateHeaderDates } from './data.js';
 import { deleteEmptyLabEntries, deleteLabEntryMarkerValues } from './lab-entry-mutations.js';
@@ -178,6 +179,7 @@ export function saveCustomMarker() {
 
   if (!state.importedData.customMarkers) state.importedData.customMarkers = {};
   state.importedData.customMarkers[fullKey] = {
+    markerId: createCustomMarkerId(state.importedData.customMarkers),
     name,
     unit: (unitInput?.value || '').trim(),
     refMin: validRefMin,

--- a/js/pdf-import-commit.js
+++ b/js/pdf-import-commit.js
@@ -2,6 +2,7 @@
 // pdf-import-commit.js - Import commit, snapshot deletion, and re-review actions.
 
 import { state } from './state.js';
+import { ensureCustomMarkerIdentity } from './custom-marker-identity.js';
 import { maybeShowEncryptionNudge } from './crypto.js';
 import { MARKER_SCHEMA } from './schema.js';
 import { SPECIALTY_MARKER_DEFS } from './adapters.js';
@@ -158,6 +159,7 @@ export async function confirmImport() {
       || cmDef.categoryLabel
       || (catKey === 'spadiaFA' ? 'Spadia' : catKey.charAt(0).toUpperCase() + catKey.slice(1));
     cmDef.group = m.suggestedGroup || importGroup || def.group || cmDef.group || null;
+    ensureCustomMarkerIdentity(cmDef, state.importedData.customMarkers);
     state.importedData.customMarkers[m.mappedKey] = cmDef;
   }
   // Save new (custom) marker values and definitions
@@ -179,6 +181,7 @@ export async function confirmImport() {
     cmDef.categoryLabel = categoryLabel;
     // FA-normalized markers carry their own group — don't override with testType-based importGroup
     cmDef.group = m.suggestedGroup || importGroup || m.group || cmDef.group || null;
+    ensureCustomMarkerIdentity(cmDef, state.importedData.customMarkers);
     state.importedData.customMarkers[m.suggestedKey] = cmDef;
   }
   // Mirror insulin between hormones and diabetes categories (AI may map to either)

--- a/js/profile-data-migrations.js
+++ b/js/profile-data-migrations.js
@@ -3,6 +3,7 @@
 
 import { SPECIALTY_MARKER_DEFS } from './adapters.js';
 import { normalizeContextSourceSettings } from './context-source-registry.js';
+import { migrateCustomMarkerIdentities } from './custom-marker-identity.js';
 import { normalizeLightEnvironmentEveningFields } from './light-env-evening.js';
 import {
   deleteLabEntryMarker,
@@ -262,5 +263,6 @@ export function migrateProfileData(data) {
     delete data.sunDefaults.location;
   }
   migrateSupplementMedicationRecords(data);
+  migrateCustomMarkerIdentities(data.customMarkers);
   return data;
 }

--- a/scripts/cold-load-budget.json
+++ b/scripts/cold-load-budget.json
@@ -3,7 +3,7 @@
   "route": "/app",
   "scenario": "Fresh mobile returning-user load with browser cache and service workers disabled",
   "maximums": {
-    "requests": 294,
+    "requests": 295,
     "transferBytes": 1193220,
     "decodedBytes": 2940000
   },

--- a/scripts/dom-sink-policy.json
+++ b/scripts/dom-sink-policy.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "scope": "Every non-generated JavaScript module under js/",
   "reviewRule": "Any added or modified HTML-writing sink requires security review and a policy refresh.",
-  "scannedFiles": 616,
+  "scannedFiles": 617,
   "sinkCount": 496,
   "files": {
     "js/backup.js": {

--- a/service-worker.js
+++ b/service-worker.js
@@ -95,6 +95,7 @@ const APP_SHELL = [
   '/js/legal-consent.js',
   '/js/schema.js',
   '/js/marker-schema.js',
+  '/js/custom-marker-identity.js',
   '/js/schema-environment.js',
   '/js/constants.js',
   '/js/state.js',

--- a/service-worker.js
+++ b/service-worker.js
@@ -19,7 +19,6 @@ async function resolveCacheName() {
   }
   return _cacheNamePromise;
 }
-
 // Local app shell — pre-cached on install
 const APP_SHELL = [
   '/version.js',

--- a/tests/custom-marker-export-boundaries.test.js
+++ b/tests/custom-marker-export-boundaries.test.js
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { deriveLegacyCustomMarkerId } from '../js/custom-marker-identity.js';
+
+const runtime = vi.hoisted(() => ({
+  encryptedGetItem: vi.fn(),
+  profiles: [{
+    id: 'profile-1',
+    name: 'Primary',
+    location: { country: 'CZ', zip: '' },
+    tags: [],
+    notes: '',
+    status: 'active',
+  }],
+}));
+
+vi.mock('../js/state.js', () => ({ state: { currentProfile: 'profile-1', importedData: {} } }));
+vi.mock('../js/utils.js', () => ({
+  showConfirmDialog: vi.fn(),
+  showNotification: vi.fn(),
+}));
+vi.mock('../js/data.js', () => ({
+  filterDatesByRange: vi.fn(),
+  getActiveData: vi.fn(),
+  invalidateActiveDataCache: vi.fn(),
+  saveImportedData: vi.fn(),
+  updateHeaderDates: vi.fn(),
+}));
+vi.mock('../js/profile.js', () => ({
+  createDefaultProfileData: vi.fn(),
+  createProfile: vi.fn(),
+  getProfiles: () => runtime.profiles,
+  migrateProfileData: vi.fn(),
+  profileStorageKey: (profileId, suffix) => `labcharts-${profileId}-${suffix}`,
+  saveProfiles: vi.fn(),
+  switchProfile: vi.fn(),
+}));
+vi.mock('../js/crypto.js', () => ({
+  encryptedGetItem: runtime.encryptedGetItem,
+  encryptedRemoveItem: vi.fn(),
+}));
+vi.mock('../js/profile-storage-cleanup.js', () => ({
+  clearProfileStorage: vi.fn(),
+  listStoredProfileIds: vi.fn(),
+}));
+vi.mock('../js/lab-entry-mutations.js', () => ({ findOrCreateLabEntry: vi.fn() }));
+vi.mock('../js/lab-entry.js', () => ({ setLabEntryMarker: vi.fn() }));
+vi.mock('../js/nostr-discovery.js', () => ({ getSelectedNodeUrl: () => null }));
+vi.mock('../js/export-report.js', () => ({ generateReportAISummary: vi.fn() }));
+vi.mock('../js/export-report-html.js', () => ({
+  buildReportHTML: vi.fn(),
+  exportPDFReport: vi.fn(),
+}));
+vi.mock('../js/export-runtime.js', () => ({
+  clearDemoLoadingProfile: vi.fn(),
+  destroyWalletRuntimeDB: vi.fn(),
+  markDemoLoadingProfile: vi.fn(),
+  refreshImportRuntimeShell: vi.fn(),
+}));
+
+const { buildAllDataBundle, buildClientExportObject } = await import('../js/export.js');
+
+describe('custom marker export boundaries', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+    runtime.encryptedGetItem.mockImplementation(async key => {
+      if (key === 'labcharts-profile-1-imported') {
+        return JSON.stringify({
+          entries: [{
+            date: '2026-07-01',
+            markers: { 'oatEnergy.acetoaceticAcid': 12.5 },
+          }],
+          customMarkers: {
+            'oatEnergy.acetoaceticAcid': {
+              name: 'Acetoacetic Acid',
+              futureField: { preserve: true },
+            },
+          },
+        });
+      }
+      return null;
+    });
+  });
+
+  it('includes migrated ids in client exports used by sharing', async () => {
+    const exported = await buildClientExportObject('profile-1');
+
+    expect(exported.customMarkers['oatEnergy.acetoaceticAcid']).toMatchObject({
+      markerId: deriveLegacyCustomMarkerId('oatEnergy.acetoaceticAcid'),
+      name: 'Acetoacetic Acid',
+      futureField: { preserve: true },
+    });
+    expect(exported.entries[0].markers).toEqual({ 'oatEnergy.acetoaceticAcid': 12.5 });
+  });
+
+  it('includes the same ids in full database backups', async () => {
+    const bundle = JSON.parse(await buildAllDataBundle());
+    const definition = bundle.profiles[0].data.customMarkers['oatEnergy.acetoaceticAcid'];
+
+    expect(definition.markerId)
+      .toBe(deriveLegacyCustomMarkerId('oatEnergy.acetoaceticAcid'));
+    expect(bundle.profiles[0].data.entries[0].markers)
+      .toEqual({ 'oatEnergy.acetoaceticAcid': 12.5 });
+  });
+});

--- a/tests/custom-marker-identity.test.js
+++ b/tests/custom-marker-identity.test.js
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createCustomMarkerId,
+  deriveLegacyCustomMarkerId,
+  getCustomMarkerDotKey,
+  getCustomMarkerId,
+  migrateCustomMarkerIdentities,
+  resolveCustomMarkerDotKey,
+} from '../js/custom-marker-identity.js';
+import { mergeImportedData } from '../js/data-merge.js';
+import { migrateProfileData } from '../js/profile-data-migrations.js';
+import { isCustomMarkerId } from '../js/marker-schema.js';
+
+describe('stable custom marker identity contract', () => {
+  it('creates opaque category-independent ids for newly authored markers', () => {
+    const first = createCustomMarkerId();
+    const second = createCustomMarkerId({ existing: { markerId: first } });
+
+    expect(isCustomMarkerId(first)).toBe(true);
+    expect(isCustomMarkerId(second)).toBe(true);
+    expect(second).not.toBe(first);
+    expect(first).not.toContain('category');
+    expect(first).not.toContain('marker');
+  });
+
+  it('backfills legacy definitions deterministically and idempotently', () => {
+    const original = {
+      'urineAminoAcids.acetoaceticAcid': {
+        name: 'Acetoacetic Acid',
+        unit: 'mmol/mol creatinine',
+        futureField: { preserve: true },
+      },
+      'antioxidants.glutathione': { name: 'Glutathione' },
+    };
+    const firstDevice = structuredClone(original);
+    const secondDevice = structuredClone(original);
+
+    migrateCustomMarkerIdentities(firstDevice);
+    migrateCustomMarkerIdentities(secondDevice);
+    const firstPass = structuredClone(firstDevice);
+    migrateCustomMarkerIdentities(firstDevice);
+
+    expect(firstDevice).toEqual(firstPass);
+    expect(secondDevice).toEqual(firstDevice);
+    expect(firstDevice['urineAminoAcids.acetoaceticAcid']).toMatchObject({
+      markerId: deriveLegacyCustomMarkerId('urineAminoAcids.acetoaceticAcid'),
+      futureField: { preserve: true },
+    });
+  });
+
+  it('preserves valid ids and deterministically repairs duplicates and collisions', () => {
+    const collidingLegacyId = deriveLegacyCustomMarkerId('a.first');
+    const customMarkers = {
+      'a.first': { name: 'First' },
+      'b.owner': { markerId: 'custom:shared', name: 'Owner' },
+      'c.duplicate': { markerId: 'custom:shared', name: 'Duplicate' },
+      'd.invalid': { markerId: 'not a custom id', name: 'Invalid' },
+      'z.reserved': { markerId: collidingLegacyId, name: 'Reserved' },
+    };
+
+    migrateCustomMarkerIdentities(customMarkers);
+
+    expect(customMarkers['z.reserved'].markerId).toBe(collidingLegacyId);
+    expect(customMarkers['a.first'].markerId).toBe(`${collidingLegacyId}_2`);
+    expect(customMarkers['b.owner'].markerId).toBe('custom:shared');
+    expect(customMarkers['c.duplicate'].markerId)
+      .toBe(deriveLegacyCustomMarkerId('c.duplicate'));
+    expect(customMarkers['d.invalid'].markerId)
+      .toBe(deriveLegacyCustomMarkerId('d.invalid'));
+    expect(new Set(Object.values(customMarkers).map(definition => definition.markerId)).size)
+      .toBe(Object.keys(customMarkers).length);
+  });
+
+  it('resolves both ids and dot keys while preserving identity across a future move', () => {
+    const markerId = 'custom:fixed_identity';
+    const definition = { markerId, name: 'Acetoacetic Acid' };
+    let customMarkers = { 'urineAminoAcids.acetoaceticAcid': definition };
+
+    expect(getCustomMarkerId(customMarkers, 'urineAminoAcids.acetoaceticAcid')).toBe(markerId);
+    expect(getCustomMarkerDotKey(customMarkers, markerId))
+      .toBe('urineAminoAcids.acetoaceticAcid');
+    expect(resolveCustomMarkerDotKey(customMarkers, 'urineAminoAcids.acetoaceticAcid'))
+      .toBe('urineAminoAcids.acetoaceticAcid');
+
+    customMarkers = { 'energyMetabolism.acetoaceticAcid': definition };
+    migrateCustomMarkerIdentities(customMarkers);
+
+    expect(definition.markerId).toBe(markerId);
+    expect(resolveCustomMarkerDotKey(customMarkers, markerId))
+      .toBe('energyMetabolism.acetoaceticAcid');
+  });
+
+  it('adds ids without re-keying any user data and survives JSON exchange', () => {
+    const dotKey = 'oatEnergy.acetoaceticAcid';
+    const profile = {
+      entries: [{ date: '2026-07-01', markers: { [dotKey]: 12.5 } }],
+      customMarkers: {
+        [dotKey]: { name: 'Acetoacetic Acid', unit: 'mmol/mol creatinine' },
+      },
+      refOverrides: { [dotKey]: { refMax: 10 } },
+      markerNotes: { [dotKey]: 'Retest fasting' },
+      markerLabels: { [dotKey]: 'Acetoacetate' },
+      manualValues: { [`${dotKey}:2026-07-01`]: true },
+      markerValueNotes: { [`${dotKey}:2026-07-01`]: 'Imported from OAT' },
+    };
+    const markerDataBefore = structuredClone({
+      entries: profile.entries,
+      refOverrides: profile.refOverrides,
+      markerNotes: profile.markerNotes,
+      markerLabels: profile.markerLabels,
+      manualValues: profile.manualValues,
+      markerValueNotes: profile.markerValueNotes,
+    });
+
+    migrateProfileData(profile);
+    const markerId = profile.customMarkers[dotKey].markerId;
+    const exchanged = JSON.parse(JSON.stringify(profile));
+    migrateProfileData(exchanged);
+
+    expect(markerId).toBe(deriveLegacyCustomMarkerId(dotKey));
+    expect({
+      entries: profile.entries,
+      refOverrides: profile.refOverrides,
+      markerNotes: profile.markerNotes,
+      markerLabels: profile.markerLabels,
+      manualValues: profile.manualValues,
+      markerValueNotes: profile.markerValueNotes,
+    }).toEqual(markerDataBefore);
+    expect(exchanged.customMarkers[dotKey].markerId).toBe(markerId);
+  });
+
+  it('keeps identities intact when sync merges independent custom marker maps', () => {
+    const local = {
+      customMarkers: {
+        'localPanel.one': { markerId: 'custom:local_one', name: 'Local' },
+      },
+    };
+    const remote = {
+      customMarkers: {
+        'remotePanel.two': { markerId: 'custom:remote_two', name: 'Remote' },
+      },
+    };
+
+    const merged = mergeImportedData(local, remote);
+
+    expect(merged.customMarkers).toEqual({
+      'remotePanel.two': { markerId: 'custom:remote_two', name: 'Remote' },
+      'localPanel.one': { markerId: 'custom:local_one', name: 'Local' },
+    });
+    expect(local.customMarkers['localPanel.one'].markerId).toBe('custom:local_one');
+    expect(remote.customMarkers['remotePanel.two'].markerId).toBe('custom:remote_two');
+  });
+});

--- a/tests/playwright/modal-session-coverage-batch.spec.js
+++ b/tests/playwright/modal-session-coverage-batch.spec.js
@@ -102,6 +102,7 @@ test('marker detail modal covers custom marker create delete and focus restore p
       const createdKey = 'custom7ToxicMetals.leadBurden';
       const created = state.importedData.customMarkers?.[createdKey];
       outcomes.createStoresCustomMarkerDefinition = created?.name === 'Lead Burden'
+        && /^custom:[A-Za-z0-9_-]+$/.test(created?.markerId || '')
         && created?.unit === 'ug/L'
         && created?.refMax === 5
         && created?.categoryLabel === '7 Toxic Metals!'

--- a/tests/playwright/pdf-import-browser-coverage.spec.js
+++ b/tests/playwright/pdf-import-browser-coverage.spec.js
@@ -832,7 +832,8 @@ test('PDF import confirm flow covers preview persistence', async ({ page }) => {
         && restoredSpadia?.markerSources?.['spadiaFA.omega3Index']?.snapshotId === 'snap-spadia-re-review'
         && restoredSpadiaDef?.name === 'Omega-3 Index'
         && restoredSpadiaDef?.categoryLabel === 'Spadia'
-        && restoredSpadiaDef?.group === 'Fatty Acids';
+        && restoredSpadiaDef?.group === 'Fatty Acids'
+        && /^custom:[A-Za-z0-9_-]+$/.test(restoredSpadiaDef?.markerId || '');
     } finally {
       state.importedData = original.importedData;
       state.currentProfile = original.currentProfile;

--- a/tests/sync-runtime.test.js
+++ b/tests/sync-runtime.test.js
@@ -80,6 +80,7 @@ import {
 import { setSyncRelay } from '../js/sync-environment.js';
 import { buildAgentAccessSetupCommand } from '../js/settings-agent-access-panel.js';
 import { configureChatRuntimeCallbacks } from '../js/chat-runtime.js';
+import { deriveLegacyCustomMarkerId } from '../js/custom-marker-identity.js';
 
 const PROFILE_ID = 'profile-runtime';
 const PROFILE_QUERY = Symbol('profile-query');
@@ -747,8 +748,14 @@ describe('sync push runtime behavior', () => {
     configureRuntimeDeps(fake);
 
     await expect(pushProfile(PROFILE_ID, {
-      entries: [{ date: '2026-01-01', markers: { 'hormones.cPeptide': 1 } }],
-      customMarkers: { 'hormones.cPeptide': { name: 'C-peptide' } },
+      entries: [{
+        date: '2026-01-01',
+        markers: { 'hormones.cPeptide': 1, 'customPanel.acetoacetate': 2 },
+      }],
+      customMarkers: {
+        'hormones.cPeptide': { name: 'C-peptide' },
+        'customPanel.acetoacetate': { name: 'Acetoacetate' },
+      },
     })).resolves.toEqual({ ok: true });
 
     const profileWrite = fake.calls.insert.find(call => call.table === 'profileData')?.args;
@@ -756,6 +763,8 @@ describe('sync push runtime behavior', () => {
     expect(parsed.importedData.entries[0].markers['diabetes.cPeptide']).toBe(1);
     expect(parsed.importedData.entries[0].markers['hormones.cPeptide']).toBeUndefined();
     expect(parsed.importedData.customMarkers['hormones.cPeptide']).toBeUndefined();
+    expect(parsed.importedData.customMarkers['customPanel.acetoacetate'].markerId)
+      .toBe(deriveLegacyCustomMarkerId('customPanel.acetoacetate'));
   });
 
   it('does not append another Evolu message when the complete outbound state is unchanged', async () => {

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -542,6 +542,7 @@
     "js/provider-wallet-panel-renderers.js",
     "js/recommendation-actions.js",
     "js/recommendations-region.js",
+    "js/custom-marker-identity.js",
     "js/marker-schema.js",
     "js/marker-schema/index.js",
     "js/marker-schema/biochemistry.js",

--- a/types/app-state.d.ts
+++ b/types/app-state.d.ts
@@ -1,3 +1,15 @@
+export interface CustomMarkerDefinition {
+  markerId?: string;
+  name?: string;
+  unit?: string;
+  refMin?: number | null;
+  refMax?: number | null;
+  categoryLabel?: string;
+  icon?: string;
+  group?: string | null;
+  [key: string]: any;
+}
+
 export interface ProfileData {
   entries: Array<Record<string, any>>;
   notes: any[];
@@ -16,7 +28,7 @@ export interface ProfileData {
   menstrualCycle: any;
   emfAssessment: any;
   genetics: any;
-  customMarkers: Record<string, any>;
+  customMarkers: Record<string, CustomMarkerDefinition>;
   markerNotes: Record<string, any>;
   markerValueNotes: Record<string, any>;
   biologyScoreAI: Record<string, any>;


### PR DESCRIPTION
## What changed

- add opaque, category-independent `custom:*` identities to newly created custom markers
- deterministically backfill legacy custom markers so offline devices converge
- preserve valid imported and synchronized identities while repairing malformed or duplicate IDs
- include migrated identities in client shares, exports, full backups, PDF imports, and sync payloads
- document the compatibility contract and add focused unit and browser coverage

## Why

Custom marker dot keys currently combine storage identity with category placement. A stable identity layer is needed before category assignment and marker movement can be separated safely.

This is an additive compatibility slice: existing dot-key-indexed values, notes, overrides, provenance, imports, backups, shares, and synchronization formats remain unchanged. It prepares the later marker-moving UI without introducing it yet.

Part of #57.

## Validation

- 73 focused Vitest tests
- 15 focused Chromium tests
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
- 44/44 quality guardrail tests
- `npm run architecture:check`
- `npm run marker-schema:check`
- `npm run marker-terminology:check`
- `npm run production:check`
- `git diff --check`