### PR TITLE
Add safe marker category placement UI

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -10,7 +10,7 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | Metric | Current |
 | --- | ---: |
 | Modules | 638 |
-| Internal import edges | 2697 |
+| Internal import edges | 2698 |
 | Dynamic internal edges | 72 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -69,8 +69,8 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 | [`js/constants.js`](js/constants.js) | 22 | [`js/export.js`](js/export.js) | 19 |
 | [`js/utils-runtime.js`](js/utils-runtime.js) | 20 | [`js/lab-context.js`](js/lab-context.js) | 19 |
 | [`js/marker-analysis.js`](js/marker-analysis.js) | 19 | [`js/marker-detail-modal-impl.js`](js/marker-detail-modal-impl.js) | 19 |
-| [`js/chat-runtime.js`](js/chat-runtime.js) | 18 | [`js/marker-schema/index.js`](js/marker-schema/index.js) | 19 |
-| [`js/marker-placement.js`](js/marker-placement.js) | 18 | [`js/app-chat-hooks.js`](js/app-chat-hooks.js) | 17 |
+| [`js/marker-placement.js`](js/marker-placement.js) | 19 | [`js/marker-schema/index.js`](js/marker-schema/index.js) | 19 |
+| [`js/chat-runtime.js`](js/chat-runtime.js) | 18 | [`js/app-chat-hooks.js`](js/app-chat-hooks.js) | 17 |
 
 ## Existing cyclic components
 
@@ -709,7 +709,7 @@ Native browser modules shipped with the static application.
 
 - [`js/marker-analysis.js`](js/marker-analysis.js) → [`js/marker-placement.js`](js/marker-placement.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/marker-detail-actions.js`](js/marker-detail-actions.js) → [`js/utils.js`](js/utils.js)
-- [`js/marker-detail-content.js`](js/marker-detail-content.js) → [`js/api.js`](js/api.js), [`js/schema.js`](js/schema.js)
+- [`js/marker-detail-content.js`](js/marker-detail-content.js) → [`js/api.js`](js/api.js), [`js/marker-placement.js`](js/marker-placement.js), [`js/schema.js`](js/schema.js)
 - [`js/marker-detail-custom-markers.js`](js/marker-detail-custom-markers.js) → [`js/custom-marker-identity.js`](js/custom-marker-identity.js), [`js/data.js`](js/data.js), [`js/lab-entry-mutations.js`](js/lab-entry-mutations.js), [`js/marker-detail-actions.js`](js/marker-detail-actions.js), [`js/marker-detail-runtime.js`](js/marker-detail-runtime.js), [`js/marker-placement.js`](js/marker-placement.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/marker-detail-editing.js`](js/marker-detail-editing.js) → [`js/data.js`](js/data.js), [`js/marker-detail-actions.js`](js/marker-detail-actions.js), [`js/marker-detail-runtime.js`](js/marker-detail-runtime.js), [`js/marker-detail-store.js`](js/marker-detail-store.js), [`js/marker-placement.js`](js/marker-placement.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/marker-detail-manual-entry.js`](js/marker-detail-manual-entry.js) → [`js/data.js`](js/data.js), [`js/marker-detail-actions.js`](js/marker-detail-actions.js), [`js/marker-detail-editing.js`](js/marker-detail-editing.js), [`js/marker-detail-runtime.js`](js/marker-detail-runtime.js), [`js/marker-placement.js`](js/marker-placement.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)

--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -9,8 +9,8 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 
 | Metric | Current |
 | --- | ---: |
-| Modules | 637 |
-| Internal import edges | 2689 |
+| Modules | 638 |
+| Internal import edges | 2697 |
 | Dynamic internal edges | 72 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -56,11 +56,11 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 
 | High fan-in | Dependants | High fan-out | Imports |
 | --- | ---: | --- | ---: |
-| [`js/utils.js`](js/utils.js) | 261 | [`js/app-shell-hooks.js`](js/app-shell-hooks.js) | 74 |
-| [`js/state.js`](js/state.js) | 181 | [`js/app-light-sun-modules.js`](js/app-light-sun-modules.js) | 36 |
+| [`js/utils.js`](js/utils.js) | 262 | [`js/app-shell-hooks.js`](js/app-shell-hooks.js) | 74 |
+| [`js/state.js`](js/state.js) | 182 | [`js/app-light-sun-modules.js`](js/app-light-sun-modules.js) | 36 |
 | [`js/caught-error.js`](js/caught-error.js) | 83 | [`js/chat-send.js`](js/chat-send.js) | 28 |
-| [`js/data.js`](js/data.js) | 77 | [`js/sync-configure.js`](js/sync-configure.js) | 27 |
-| [`js/modal-lifecycle.js`](js/modal-lifecycle.js) | 74 | [`js/pdf-import.js`](js/pdf-import.js) | 26 |
+| [`js/data.js`](js/data.js) | 78 | [`js/sync-configure.js`](js/sync-configure.js) | 27 |
+| [`js/modal-lifecycle.js`](js/modal-lifecycle.js) | 75 | [`js/pdf-import.js`](js/pdf-import.js) | 26 |
 | [`js/api.js`](js/api.js) | 66 | [`js/settings.js`](js/settings.js) | 26 |
 | [`js/profile.js`](js/profile.js) | 48 | [`js/wearables-connect.js`](js/wearables-connect.js) | 25 |
 | [`js/schema.js`](js/schema.js) | 34 | [`js/views.js`](js/views.js) | 22 |
@@ -68,9 +68,9 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 | [`js/data-merge.js`](js/data-merge.js) | 30 | [`js/biology-scores.js`](js/biology-scores.js) | 19 |
 | [`js/constants.js`](js/constants.js) | 22 | [`js/export.js`](js/export.js) | 19 |
 | [`js/utils-runtime.js`](js/utils-runtime.js) | 20 | [`js/lab-context.js`](js/lab-context.js) | 19 |
-| [`js/marker-analysis.js`](js/marker-analysis.js) | 19 | [`js/marker-schema/index.js`](js/marker-schema/index.js) | 19 |
-| [`js/chat-runtime.js`](js/chat-runtime.js) | 18 | [`js/marker-detail-modal-impl.js`](js/marker-detail-modal-impl.js) | 18 |
-| [`js/marker-placement.js`](js/marker-placement.js) | 17 | [`js/app-chat-hooks.js`](js/app-chat-hooks.js) | 17 |
+| [`js/marker-analysis.js`](js/marker-analysis.js) | 19 | [`js/marker-detail-modal-impl.js`](js/marker-detail-modal-impl.js) | 19 |
+| [`js/chat-runtime.js`](js/chat-runtime.js) | 18 | [`js/marker-schema/index.js`](js/marker-schema/index.js) | 19 |
+| [`js/marker-placement.js`](js/marker-placement.js) | 18 | [`js/app-chat-hooks.js`](js/app-chat-hooks.js) | 17 |
 
 ## Existing cyclic components
 
@@ -705,7 +705,7 @@ Native browser modules shipped with the static application.
 
 </details>
 
-<details><summary><code>marker</code> family — 13 modules</summary>
+<details><summary><code>marker</code> family — 14 modules</summary>
 
 - [`js/marker-analysis.js`](js/marker-analysis.js) → [`js/marker-placement.js`](js/marker-placement.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/marker-detail-actions.js`](js/marker-detail-actions.js) → [`js/utils.js`](js/utils.js)
@@ -713,8 +713,9 @@ Native browser modules shipped with the static application.
 - [`js/marker-detail-custom-markers.js`](js/marker-detail-custom-markers.js) → [`js/custom-marker-identity.js`](js/custom-marker-identity.js), [`js/data.js`](js/data.js), [`js/lab-entry-mutations.js`](js/lab-entry-mutations.js), [`js/marker-detail-actions.js`](js/marker-detail-actions.js), [`js/marker-detail-runtime.js`](js/marker-detail-runtime.js), [`js/marker-placement.js`](js/marker-placement.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/marker-detail-editing.js`](js/marker-detail-editing.js) → [`js/data.js`](js/data.js), [`js/marker-detail-actions.js`](js/marker-detail-actions.js), [`js/marker-detail-runtime.js`](js/marker-detail-runtime.js), [`js/marker-detail-store.js`](js/marker-detail-store.js), [`js/marker-placement.js`](js/marker-placement.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/marker-detail-manual-entry.js`](js/marker-detail-manual-entry.js) → [`js/data.js`](js/data.js), [`js/marker-detail-actions.js`](js/marker-detail-actions.js), [`js/marker-detail-editing.js`](js/marker-detail-editing.js), [`js/marker-detail-runtime.js`](js/marker-detail-runtime.js), [`js/marker-placement.js`](js/marker-placement.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
-- [`js/marker-detail-modal-impl.js`](js/marker-detail-modal-impl.js) → [`js/api.js`](js/api.js), [`js/charts.js`](js/charts.js), [`js/context-cards.js`](js/context-cards.js), [`js/data.js`](js/data.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/marker-analysis.js`](js/marker-analysis.js), [`js/marker-detail-actions.js`](js/marker-detail-actions.js), [`js/marker-detail-content.js`](js/marker-detail-content.js), [`js/marker-detail-custom-markers.js`](js/marker-detail-custom-markers.js), [`js/marker-detail-editing.js`](js/marker-detail-editing.js), [`js/marker-detail-manual-entry.js`](js/marker-detail-manual-entry.js), [`js/marker-detail-runtime.js`](js/marker-detail-runtime.js), [`js/marker-placement.js`](js/marker-placement.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/modal-trigger-memory.js`](js/modal-trigger-memory.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
+- [`js/marker-detail-modal-impl.js`](js/marker-detail-modal-impl.js) → [`js/api.js`](js/api.js), [`js/charts.js`](js/charts.js), [`js/context-cards.js`](js/context-cards.js), [`js/data.js`](js/data.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/marker-analysis.js`](js/marker-analysis.js), [`js/marker-detail-actions.js`](js/marker-detail-actions.js), [`js/marker-detail-content.js`](js/marker-detail-content.js), [`js/marker-detail-custom-markers.js`](js/marker-detail-custom-markers.js), [`js/marker-detail-editing.js`](js/marker-detail-editing.js), [`js/marker-detail-manual-entry.js`](js/marker-detail-manual-entry.js), [`js/marker-detail-placement.js`](js/marker-detail-placement.js), [`js/marker-detail-runtime.js`](js/marker-detail-runtime.js), [`js/marker-placement.js`](js/marker-placement.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/modal-trigger-memory.js`](js/modal-trigger-memory.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/marker-detail-modal.js`](js/marker-detail-modal.js) → [`js/health-data-loader.js`](js/health-data-loader.js), [`js/marker-detail-actions.js`](js/marker-detail-actions.js), [`js/marker-detail-modal-impl.js`](js/marker-detail-modal-impl.js) *(dynamic)*, [`js/marker-detail-runtime.js`](js/marker-detail-runtime.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/modal-trigger-memory.js`](js/modal-trigger-memory.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
+- [`js/marker-detail-placement.js`](js/marker-detail-placement.js) → [`js/data.js`](js/data.js), [`js/marker-detail-actions.js`](js/marker-detail-actions.js), [`js/marker-detail-runtime.js`](js/marker-detail-runtime.js), [`js/marker-placement.js`](js/marker-placement.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/marker-detail-runtime.js`](js/marker-detail-runtime.js) → [`js/dna-runtime-bridge.js`](js/dna-runtime-bridge.js), [`js/emf-runtime.js`](js/emf-runtime.js), [`js/recommendations-runtime.js`](js/recommendations-runtime.js), [`js/utils.js`](js/utils.js), [`js/wearables-runtime.js`](js/wearables-runtime.js)
 - [`js/marker-detail-store.js`](js/marker-detail-store.js) → [`js/data.js`](js/data.js), [`js/lab-entry-mutations.js`](js/lab-entry-mutations.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/state.js`](js/state.js)
 - [`js/marker-placement.js`](js/marker-placement.js) → [`js/custom-marker-identity.js`](js/custom-marker-identity.js), [`js/marker-schema.js`](js/marker-schema.js)

--- a/css/marker-detail-modal.css
+++ b/css/marker-detail-modal.css
@@ -78,6 +78,41 @@
   letter-spacing: 0.1em;
   text-transform: uppercase;
 }
+.gb-detail-category-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px 9px;
+}
+.gb-detail-category-change,
+.gb-detail-category-restore {
+  appearance: none;
+  border: 0;
+  padding: 1px 0;
+  background: transparent;
+  color: var(--accent);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  cursor: pointer;
+}
+.gb-detail-category-change:hover,
+.gb-detail-category-restore:hover {
+  text-decoration: underline;
+}
+.gb-detail-category-change:focus-visible,
+.gb-detail-category-restore:focus-visible {
+  border-radius: 3px;
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.gb-detail-category-origin {
+  border-left: 1px solid var(--border);
+  padding-left: 9px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
 .marker-detail-modal h3 {
   margin: 4px 48px 4px 0;
   font-size: 23px;
@@ -733,6 +768,40 @@
 .marker-detail-modal .gb-detail-actions [id^="rec-modal-"]:empty {
   display: none;
 }
+.marker-placement-form {
+  max-width: 580px;
+}
+.marker-placement-safety {
+  display: grid;
+  gap: 4px;
+  padding: 14px 16px;
+  border: 1px solid color-mix(in srgb, var(--accent) 32%, var(--border));
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--accent) 7%, var(--bg-card));
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.45;
+}
+.marker-placement-safety strong {
+  color: var(--text-primary);
+  font-size: 14px;
+}
+.marker-placement-form #marker-placement-category {
+  width: 100%;
+}
+.marker-placement-current,
+.marker-placement-help {
+  margin-top: 7px;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+.marker-placement-current strong {
+  color: var(--text-secondary);
+}
+.marker-placement-restore {
+  margin-right: auto;
+}
 @media (max-width: 640px) {
   .marker-detail-modal .gb-detail-head {
     background: var(--bg-secondary);
@@ -767,6 +836,12 @@
   }
   .marker-detail-modal .gb-detail-action-row {
     gap: 8px;
+  }
+  .gb-detail-category-origin {
+    flex-basis: auto;
+  }
+  .marker-placement-restore {
+    margin-right: 0;
   }
 }
 @media (max-width: 380px) {

--- a/docs/marker-identity.md
+++ b/docs/marker-identity.md
@@ -74,6 +74,19 @@ back to its native category removes the redundant assignment. Profiles without
 `markerPlacements` migrate to an empty map and require no value migration or
 re-import.
 
+### User-facing placement
+
+Marker details expose a **Change category** action. The picker lists categories
+that the placement engine can accept, puts categories already used by the
+profile first, and hides calculated, mode-incompatible, and marker-key
+collisions. A moved marker shows its original category and offers a one-click
+restore path.
+
+The picker deliberately changes only the marker's primary display category. It
+does not create aliases or duplicate a marker across multiple categories, and
+it never rewrites historical values. Dashboard pins and other saved marker
+references continue to resolve through the immutable storage identity.
+
 ## Terminology metadata
 
 LOINC, NPU, NCLP, and other terminology mappings should be stored in a separate

--- a/docs/marker-identity.md
+++ b/docs/marker-identity.md
@@ -78,9 +78,11 @@ re-import.
 
 Marker details expose a **Change category** action. The picker lists categories
 that the placement engine can accept, puts categories already used by the
-profile first, and hides calculated, mode-incompatible, and marker-key
-collisions. A moved marker shows its original category and offers a one-click
-restore path.
+profile first, and hides calculated destinations, mode-incompatible categories,
+and marker-key collisions. A calculated marker may be displayed in a compatible
+regular category after its value is computed, but regular markers cannot be
+moved into a calculated category. A moved marker shows its original category
+and offers a one-click restore path.
 
 The picker deliberately changes only the marker's primary display category. It
 does not create aliases or duplicate a marker across multiple categories, and

--- a/js/dashboard-lab-widget-renderers.js
+++ b/js/dashboard-lab-widget-renderers.js
@@ -6,19 +6,17 @@ import { dashboardWidgetActionAttrs } from './dashboard-widget-controls.js';
 import { openDashboardMarkerDetail } from './dashboard-widget-runtime.js';
 import { profileStorageKey } from './profile.js';
 import { escapeAttr, escapeHTML, formatValue, getStatus, getTrend, safeMarkerId, showNotification } from './utils.js';
-import { filterDatesByRange, renderDateRangeFilter } from './data.js';
+import { filterDatesByRange, getActiveData, renderDateRangeFilter } from './data.js';
 import { detectTrendAlerts, getAllFlaggedMarkers, getEffectiveRange, getEffectiveRangeForDate, getKeyTrendMarkers, getLatestValueIndex } from './marker-analysis.js';
 import { getBiologyProfileContext } from './profile-context.js';
-import { resolveActiveMarkerPath } from './marker-placement.js';
+import { getMarkerStorageViewId, resolveActiveMarkerPath, resolveMarkerStorageViewId } from './marker-placement.js';
 
 function dashboardNavigateAttrs(route) {
   return dashboardWidgetActionAttrs('navigate', { route });
 }
-
 function dashboardMarkerDetailAttrs(id) {
   return dashboardWidgetActionAttrs('open-marker-detail', { id });
 }
-
 export function createDashboardLabWidgetRenderers(deps) {
   const {
     markerHasData,
@@ -54,7 +52,7 @@ export function createDashboardLabWidgetRenderers(deps) {
     const status = getStatus(value, range.min, range.max);
     const trend = getTrend(marker.values || [], range.min, range.max);
     state.markerRegistry[id] = marker;
-    return { id, category, marker, latestIdx, range, value, status, trend };
+    return { id, storageId: getMarkerStorageViewId(marker, id) || id, category, marker, latestIdx, range, value, status, trend };
   }
   function getDashboardMarkerById(data, id) {
     if (!safeMarkerId(id)) return null;
@@ -218,11 +216,12 @@ export function createDashboardLabWidgetRenderers(deps) {
   }
 
   function isDashboardQuickMarkerPinned(id) {
-    return getDashboardQuickMarkerPins().includes(id);
+    return getDashboardQuickMarkerPins().includes(resolveMarkerStorageViewId(getActiveData().categories, id) || id);
   }
 
   function toggleDashboardQuickMarkerPin(id) {
     if (!safeMarkerId(id)) return;
+    id = resolveMarkerStorageViewId(getActiveData().categories, id) || id;
     const pins = getDashboardQuickMarkerPins();
     const existing = pins.indexOf(id);
     let pinned = false;
@@ -283,8 +282,9 @@ export function createDashboardLabWidgetRenderers(deps) {
     const base = scoreDashboardSpotlightHit(hit, priority);
     let score = base.priorityScore;
     let reason = base.priorityReason;
+    const storageId = hit.storageId || hit.id;
 
-    const goalMatch = priority.goalMatches.get(hit.id);
+    const goalMatch = priority.goalMatches.get(storageId);
     if (goalMatch) {
       score += goalMatch.score;
       if (base.priorityScore < 25 || reason === 'core dashboard marker' || reason === 'latest tracked marker') {
@@ -292,13 +292,13 @@ export function createDashboardLabWidgetRenderers(deps) {
       }
     }
 
-    const coreRank = priority.coreRanks.get(hit.id);
+    const coreRank = priority.coreRanks.get(storageId);
     if (coreRank != null) {
       score += Math.max(4, 18 - coreRank * 2);
       if (reason === 'latest tracked marker') reason = 'core quick marker';
     }
 
-    const pinned = priority.pinnedIds.has(hit.id);
+    const pinned = priority.pinnedIds.has(storageId);
     if (pinned) {
       score += 140;
       reason = 'manual pick';
@@ -350,7 +350,7 @@ export function createDashboardLabWidgetRenderers(deps) {
         || priority.coreRanks.has(hit.id)
         || priority.goalMatches.has(hit.id));
 
-    const byId = new Map(scored.map(hit => [hit.id, hit]));
+    const byId = new Map(scored.map(hit => [hit.storageId || hit.id, hit]));
     const pinned = priority.pins.map(id => byId.get(id)).filter(Boolean);
     const pinnedIds = new Set(pinned.map(hit => hit.id));
     const dynamic = scored

--- a/js/data.js
+++ b/js/data.js
@@ -213,13 +213,13 @@ export async function saveImportedData(options = {}) {
 }
 
 // Persist a specific profile snapshot without consulting or replacing the
-// active global profile. Long-running privacy operations (for example,
-// wearable disconnect) can finish after the user switches profiles; routing
-// through saveImportedData() at that point would write profile A's deletion
-// into profile B. Active-profile calls retain the usual save hooks.
+// active global profile. Long-running operations can finish after the user
+// switches profiles; routing through saveImportedData() at that point would
+// write profile A's change into profile B. Active-profile calls retain the
+// usual save hooks unless the caller explicitly requires profile scoping.
 export async function saveImportedDataForProfile(profileId, importedData, options = {}) {
   if (!profileId || !importedData || typeof importedData !== 'object') return false;
-  if (profileId === state.currentProfile && importedData === state.importedData) {
+  if (!options?.forceProfileScope && profileId === state.currentProfile && importedData === state.importedData) {
     return saveImportedData(options);
   }
   try {

--- a/js/marker-detail-actions.js
+++ b/js/marker-detail-actions.js
@@ -68,6 +68,12 @@ function handleMarkerDetailAction(actionEl, event, actions) {
     void actions.renameMarker?.(id);
   } else if (action === 'revert-marker-name') {
     void actions.revertMarkerName?.(id);
+  } else if (action === 'open-marker-placement') {
+    void actions.openMarkerPlacementModal?.(id);
+  } else if (action === 'save-marker-placement') {
+    void actions.saveMarkerPlacement?.(id);
+  } else if (action === 'restore-marker-placement') {
+    void actions.restoreMarkerPlacement?.(id);
   } else if (action === 'toggle-history-note') {
     actionEl.closest('.marker-history-row')?.querySelector('.mv-note-text')?.classList.toggle('show');
   } else if (action === 'edit-marker-value') {

--- a/js/marker-detail-content.js
+++ b/js/marker-detail-content.js
@@ -2,6 +2,7 @@
 // marker-detail-content.js — Biological-age and custom-description content helpers
 
 import { callClaudeAPI, getActiveModelId, getAIProvider, hasAIProvider } from './api.js';
+import { resolveActiveMarkerPath } from './marker-placement.js';
 import { trackUsage } from './schema.js';
 
 // Keep these inputs aligned with the PhenoAge and Bortz Age calculations in
@@ -69,7 +70,7 @@ export function bioAgeReferenceIndex(data, marker, latestPoint) {
 export function bioAgeInputStatusAtIndex(data, idx, inputs, profileRequirement = null) {
   const status = inputs.map(([category, key, label]) => ({
     label,
-    present: idx >= 0 && data.categories?.[category]?.markers?.[key]?.values?.[idx] != null,
+    present: idx >= 0 && resolveActiveMarkerPath(data.categories, category, key)?.marker?.values?.[idx] != null,
     kind: 'marker',
   }));
   if (profileRequirement) status.unshift(profileRequirement);

--- a/js/marker-detail-modal-impl.js
+++ b/js/marker-detail-modal-impl.js
@@ -10,7 +10,7 @@ import { createLineChart, getMarkerDescription } from './charts.js';
 import { closeSuggestionsOnClickOutside } from './context-cards.js';
 import { hasAIProvider } from './api.js';
 import { getInsulinMirrorMarkerKey } from './lab-entry.js';
-import { getMarkerStorageDotKey } from './marker-placement.js';
+import { getMarkerStorageDotKey, resolveActiveMarkerPath } from './marker-placement.js';
 import { installMarkerDetailActionDelegates, markerDetailActionAttrs } from './marker-detail-actions.js';
 import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 import { rememberModalTrigger, restoreModalTrigger } from './modal-trigger-memory.js';
@@ -520,7 +520,6 @@ function renderDetailModal(id, opts = {}) {
     const dir = ch > 0 ? "increased" : ch < 0 ? "decreased" : "unchanged";
     html += `<div class="modal-ref-info"><strong>Trend:</strong> ${dir} by ${Math.abs(ch).toFixed(2)} ${escapeHTML(marker.unit)} (${ch>0?"+":""}${pct}%) from ${dates[f.i]} to ${dates[l.i]}</div>`;
   }
-  // Calculated marker input diagnostic — show missing inputs
   const calcInputs = {
     'calculatedRatios_phenoAge': BIO_AGE_PHENO_INPUTS,
     'calculatedRatios_bortzAge': BIO_AGE_BORTZ_INPUTS,
@@ -539,34 +538,35 @@ function renderDetailModal(id, opts = {}) {
     'calculatedRatios_apoBapoAIRatio': [['lipids', 'apoB', 'ApoB'], ['lipids', 'apoAI', 'ApoA-I']],
     'calculatedRatios_crpHdlRatio': [['proteins', 'hsCRP', 'hs-CRP'], ['lipids', 'hdl', 'HDL']],
   };
-  const inputs = calcInputs[id];
+  const inputs = calcInputs[dotKey.replace('.', '_')];
   if (inputs) {
     const issues = [];
+    const activeMarker = (cat, key) => resolveActiveMarkerPath(data.categories, cat, key)?.marker;
     // Check for completely missing markers
     const missing = inputs.filter(([cat, key]) => {
-      const vals = data.categories[cat]?.markers[key]?.values;
+      const vals = activeMarker(cat, key)?.values;
       return !vals || vals.every(v => v == null);
     });
-    if ((id === 'calculatedRatios_phenoAge' || id === 'calculatedRatios_bortzAge' || id === 'calculatedRatios_biologicalAge') && !state.profileDob) {
+    if ((dotKey === 'calculatedRatios.phenoAge' || dotKey === 'calculatedRatios.bortzAge' || dotKey === 'calculatedRatios.biologicalAge') && !state.profileDob) {
       issues.push('Date of birth not set (required for age at blood draw)');
     }
     if (missing.length > 0) {
       issues.push(`Missing: ${missing.map(m => m[2]).join(', ')}`);
     }
     // Biological age clocks: per-date gap check, CRP fallback, unit sanity
-    const _isBioAgeClock = id === 'calculatedRatios_phenoAge' || id === 'calculatedRatios_bortzAge';
+    const _isBioAgeClock = dotKey === 'calculatedRatios.phenoAge' || dotKey === 'calculatedRatios.bortzAge';
     if (_isBioAgeClock && state.profileDob) {
       // For CRP check: accept either hs-CRP or standard CRP
       const _hasCRPonDate = (idx) => {
-        const hs = data.categories.proteins?.markers.hsCRP?.values?.[idx];
-        const std = data.categories.proteins?.markers.crp?.values?.[idx];
+        const hs = activeMarker('proteins', 'hsCRP')?.values?.[idx];
+        const std = activeMarker('proteins', 'crp')?.values?.[idx];
         return hs != null || std != null;
       };
       // Override the missing check for CRP — it's satisfied by either marker
       const crpInInputs = inputs.some(([, key]) => key === 'hsCRP');
       if (crpInInputs && missing.some(([, key]) => key === 'hsCRP')) {
-        const hasAnyCRP = data.categories.proteins?.markers.hsCRP?.values?.some(v => v != null)
-          || data.categories.proteins?.markers.crp?.values?.some(v => v != null);
+        const hasAnyCRP = activeMarker('proteins', 'hsCRP')?.values?.some(v => v != null)
+          || activeMarker('proteins', 'crp')?.values?.some(v => v != null);
         if (hasAnyCRP) {
           // Remove CRP from missing list — it's covered by the fallback
           const idx = missing.findIndex(([, key]) => key === 'hsCRP');
@@ -586,28 +586,28 @@ function renderDetailModal(id, opts = {}) {
         if (latestIdx >= 0) {
           const nullAt = inputs.filter(([cat, key]) => {
             if (key === 'hsCRP') return !_hasCRPonDate(latestIdx);
-            const v = data.categories[cat]?.markers[key]?.values?.[latestIdx];
+            const v = activeMarker(cat, key)?.values?.[latestIdx];
             return v == null;
           });
           if (nullAt.length > 0) {
             issues.push(`Missing on latest date (${data.dateLabels[latestIdx]}): ${nullAt.map(m => m[2]).join(', ')}`);
           }
           // CRP value sanity
-          const crpVal = data.categories.proteins?.markers.hsCRP?.values?.[latestIdx]
-            ?? data.categories.proteins?.markers.crp?.values?.[latestIdx];
+          const crpVal = activeMarker('proteins', 'hsCRP')?.values?.[latestIdx]
+            ?? activeMarker('proteins', 'crp')?.values?.[latestIdx];
           if (crpVal != null && crpVal <= 0) {
             issues.push('CRP is zero or negative — cannot calculate (log undefined)');
           }
           // Unit sanity warnings
-          const albVal = data.categories.proteins?.markers.albumin?.values?.[latestIdx];
+          const albVal = activeMarker('proteins', 'albumin')?.values?.[latestIdx];
           if (albVal != null && albVal > 10) {
             issues.push(`Albumin value ${albVal} looks like g/dL — expected g/L (typically 35–55)`);
           }
-          const lymphVal = data.categories.differential?.markers.lymphocytesPct?.values?.[latestIdx];
+          const lymphVal = activeMarker('differential', 'lymphocytesPct')?.values?.[latestIdx];
           if (lymphVal != null && lymphVal > 1) {
             issues.push(`Lymphocytes % value ${lymphVal} looks like a percentage — expected fraction 0–1 (e.g. 0.28)`);
           }
-          const alpVal = data.categories.biochemistry?.markers.alp?.values?.[latestIdx];
+          const alpVal = activeMarker('biochemistry', 'alp')?.values?.[latestIdx];
           if (alpVal != null && alpVal > 10) {
             issues.push(`ALP value ${alpVal} looks like U/L — expected µkat/L (typically 0.5–2.0)`);
           }
@@ -617,12 +617,12 @@ function renderDetailModal(id, opts = {}) {
     // Biological Age: show component breakdown. The dashboard can show a
     // value from whichever component is non-null, so the modal should not
     // describe that as a generic "Not calculated" error.
-    if (id === 'calculatedRatios_biologicalAge') {
+    if (dotKey === 'calculatedRatios.biologicalAge') {
       const refIdx = bioAgeReferenceIndex(data, marker, latestPoint);
       const refDate = refIdx >= 0 ? data.dates?.[refIdx] : null;
       const refDateLabel = refIdx >= 0 ? (data.dateLabels?.[refIdx] || refDate || '') : '';
-      const pheno = refIdx >= 0 ? data.categories.calculatedRatios?.markers?.phenoAge?.values?.[refIdx] : null;
-      const bortz = refIdx >= 0 ? data.categories.calculatedRatios?.markers?.bortzAge?.values?.[refIdx] : null;
+      const pheno = refIdx >= 0 ? activeMarker('calculatedRatios', 'phenoAge')?.values?.[refIdx] : null;
+      const bortz = refIdx >= 0 ? activeMarker('calculatedRatios', 'bortzAge')?.values?.[refIdx] : null;
       const age = state.profileDob && refDate
         ? ((new Date(refDate + 'T00:00:00').getTime() - new Date(state.profileDob + 'T00:00:00').getTime()) / (365.25*24*60*60*1000))
         : null;

--- a/js/marker-detail-modal-impl.js
+++ b/js/marker-detail-modal-impl.js
@@ -32,6 +32,7 @@ import {
   pickNewCatIcon,
   saveCustomMarker,
 } from './marker-detail-custom-markers.js';
+import { configureMarkerDetailPlacement, openMarkerPlacementModal, renderMarkerPlacementSummary, restoreMarkerPlacement, saveMarkerPlacement } from './marker-detail-placement.js';
 import {
   askAIAboutMarkerRuntime,
   buildMarkerDetailSidebarRuntime,
@@ -87,8 +88,7 @@ export {
   saveMarkerNote,
   deleteMarkerNote,
 };
-export { loadMarkerDetailStylesheet };
-export { rememberModalTrigger };
+export { loadMarkerDetailStylesheet, rememberModalTrigger };
 
 const markerDetailDeps = /** @type {{
   navigate: (category?: string, data?: any) => any,
@@ -122,16 +122,14 @@ configureMarkerDetailEditing({
   openManualEntryForm: (id, prefillDate) => id ? openManualEntryForm(id, prefillDate) : false,
   closeModal: () => closeModal(),
 });
-configureMarkerDetailManualEntry({
-  showDetailModal,
-});
+configureMarkerDetailManualEntry({ showDetailModal });
 configureMarkerDetailCustomMarkers({
   closeModal,
   navigate: (...args) => markerDetailDeps.navigate(...args),
   openManualEntryForm,
   showEmojiPicker: (...args) => markerDetailDeps.showEmojiPicker(...args),
 });
-
+configureMarkerDetailPlacement({ showDetailModal });
 if (typeof document !== 'undefined') {
   installMarkerDetailActionDelegates({
     closeModal,
@@ -140,6 +138,7 @@ if (typeof document !== 'undefined') {
     revertRefRange,
     renameMarker: (...args) => markerDetailDeps.renameMarker(...args),
     revertMarkerName: (...args) => markerDetailDeps.revertMarkerName(...args),
+    openMarkerPlacementModal, saveMarkerPlacement, restoreMarkerPlacement,
     editMarkerValue,
     deleteMarkerValue,
     revertMarkerValue,
@@ -412,7 +411,7 @@ function renderDetailModal(id, opts = {}) {
   const quickMarkerPinTitle = quickMarkerPinned ? 'Remove from Quick Markers' : 'Pin to Quick Markers';
   let html = `<div class="gb-detail-head">
       <div>
-        <div class="gb-detail-kicker">${escapeHTML(data.categories[catKey]?.label || catKey)}</div>
+        ${renderMarkerPlacementSummary(id, marker, data.categories)}
         <h3>${escapeHTML(marker.name)}${renameLink}</h3>
         <div class="modal-unit">${escapeHTML(marker.unit)}</div>
         ${altUnitInfo}
@@ -722,7 +721,7 @@ function renderDetailModal(id, opts = {}) {
   // Async-fill recommendation section (unified: genetics + actionable tips)
   if (shouldRenderRecommendations) {
     const _markerStatus = latestStatus === 'unrated' ? 'missing' : latestStatus;
-    renderRecommendationSectionRuntime(id.replace('_','.'), { label: 'What can help', maxProducts: 3, inlineSNPs: _inlineSNPs, markerStatus: _markerStatus })
+    renderRecommendationSectionRuntime(dotKey, { label: 'What can help', maxProducts: 3, inlineSNPs: _inlineSNPs, markerStatus: _markerStatus })
       .then(h => {
         const el = document.getElementById('rec-modal-' + id);
         if (h && el) {
@@ -740,13 +739,14 @@ function renderDetailModal(id, opts = {}) {
   // Display marker description (sync for schema markers, async fetch for custom)
   const descEl = document.getElementById('marker-desc');
   if (descEl) {
-    const desc = getMarkerDescription(id);
+    const descriptionKey = dotKey.replace('.', '_');
+    const desc = getMarkerDescription(id) || getMarkerDescription(descriptionKey);
     if (desc) {
       descEl.textContent = desc;
       descEl.classList.add('loaded');
     } else if (!marker.desc && hasAIProvider()) {
       descEl.classList.add('loading');
-      fetchCustomMarkerDescription(id, marker.name, marker.unit).then(text => {
+      fetchCustomMarkerDescription(descriptionKey, marker.name, marker.unit).then(text => {
         const el = document.getElementById('marker-desc');
         if (text && el) {
           el.textContent = text;

--- a/js/marker-detail-placement.js
+++ b/js/marker-detail-placement.js
@@ -22,7 +22,7 @@ import { escapeAttr, escapeHTML, safeMarkerId, showNotification } from './utils.
 const placementRuntime = {
   showDetailModal: () => false,
 };
-let placementMutationInFlight = false;
+const placementMutationProfiles = new Set();
 
 /** @param {{ showDetailModal?: (id: string) => any }} [runtime] */
 export function configureMarkerDetailPlacement(runtime = {}) {
@@ -217,16 +217,16 @@ function setPlacementControlsBusy(busy) {
   });
 }
 
-/** @param {() => Promise<boolean>} mutation */
-async function runPlacementMutation(mutation) {
-  if (placementMutationInFlight) return false;
-  placementMutationInFlight = true;
+/** @param {string} profileId @param {() => Promise<boolean>} mutation */
+async function runPlacementMutation(profileId, mutation) {
+  if (placementMutationProfiles.has(profileId)) return false;
+  placementMutationProfiles.add(profileId);
   setPlacementControlsBusy(true);
   try {
     return await mutation();
   } finally {
-    placementMutationInFlight = false;
-    setPlacementControlsBusy(false);
+    placementMutationProfiles.delete(profileId);
+    if (state.currentProfile === profileId) setPlacementControlsBusy(false);
   }
 }
 
@@ -293,7 +293,7 @@ export async function saveMarkerPlacement(id) {
   const select = /** @type {HTMLSelectElement | null} */ (document.getElementById('marker-placement-category'));
   if (!select?.value) return false;
   const categoryKey = select.value;
-  return runPlacementMutation(() => persistMarkerPlacement(id, categoryKey, 'move'));
+  return runPlacementMutation(state.currentProfile, () => persistMarkerPlacement(id, categoryKey, 'move'));
 }
 
 /** @param {string} id */
@@ -301,5 +301,5 @@ export async function restoreMarkerPlacement(id) {
   if (!safeMarkerId(id)) return false;
   const context = getMarkerPlacementContext(id);
   if (!context) return false;
-  return runPlacementMutation(() => persistMarkerPlacement(id, context.nativeCategoryKey, 'restore'));
+  return runPlacementMutation(state.currentProfile, () => persistMarkerPlacement(id, context.nativeCategoryKey, 'restore'));
 }

--- a/js/marker-detail-placement.js
+++ b/js/marker-detail-placement.js
@@ -1,7 +1,7 @@
 // @ts-check
 // marker-detail-placement.js — Marker category placement form and persistence.
 
-import { getActiveData, invalidateActiveDataCache, saveImportedData } from './data.js';
+import { getActiveData, invalidateActiveDataCache, saveImportedDataForProfile } from './data.js';
 import { markerDetailActionAttrs } from './marker-detail-actions.js';
 import {
   clearMarkerPlacement,
@@ -238,11 +238,16 @@ async function runPlacementMutation(mutation) {
 async function persistMarkerPlacement(id, categoryKey, action) {
   const context = getMarkerPlacementContext(id);
   if (!context) return false;
-  const hadPlacements = isRecord(state.importedData?.markerPlacements);
-  const previousPlacements = clonePlacements(state.importedData?.markerPlacements);
+  const profileId = state.currentProfile;
+  const profileData = state.importedData;
+  const modal = document.getElementById('detail-modal');
+  const modalContent = modal?.firstElementChild;
+  const overlay = document.getElementById('modal-overlay');
+  const hadPlacements = isRecord(profileData?.markerPlacements);
+  const previousPlacements = clonePlacements(profileData?.markerPlacements);
   const result = action === 'restore'
-    ? clearMarkerPlacement(state.importedData, context.markerReference)
-    : setMarkerPlacement(state.importedData, context.markerReference, categoryKey);
+    ? clearMarkerPlacement(profileData, context.markerReference)
+    : setMarkerPlacement(profileData, context.markerReference, categoryKey);
   if (!result.ok) {
     showNotification('That marker cannot be placed in the selected category.', 'error');
     return false;
@@ -251,13 +256,22 @@ async function persistMarkerPlacement(id, categoryKey, action) {
     placementRuntime.showDetailModal(id);
     return true;
   }
-  const saved = await saveImportedData();
+  invalidateActiveDataCache();
+  const saved = await saveImportedDataForProfile(profileId, profileData, {
+    forceProfileScope: true,
+    reason: 'marker-placement',
+  });
   if (!saved) {
-    if (hadPlacements) state.importedData.markerPlacements = previousPlacements || {};
-    else Reflect.deleteProperty(state.importedData, 'markerPlacements');
+    if (hadPlacements) profileData.markerPlacements = previousPlacements || {};
+    else Reflect.deleteProperty(profileData, 'markerPlacements');
     invalidateActiveDataCache();
     return false;
   }
+  const stillOwnsView = state.currentProfile === profileId
+    && state.importedData === profileData
+    && modal?.firstElementChild === modalContent
+    && overlay?.classList.contains('show');
+  if (!stillOwnsView) return true;
   const destinationCategoryKey = result.categoryKey;
   const destinationLabel = getActiveData().categories?.[destinationCategoryKey]?.label || destinationCategoryKey;
   const nextId = `${destinationCategoryKey}_${context.markerKey}`;

--- a/js/marker-detail-placement.js
+++ b/js/marker-detail-placement.js
@@ -1,0 +1,278 @@
+// @ts-check
+// marker-detail-placement.js — Marker category placement form and persistence.
+
+import { getActiveData, invalidateActiveDataCache, saveImportedData } from './data.js';
+import { markerDetailActionAttrs } from './marker-detail-actions.js';
+import {
+  clearMarkerPlacement,
+  getMarkerStorageDotKey,
+  setMarkerPlacement,
+} from './marker-placement.js';
+import {
+  buildMarkerDetailSidebarRuntime,
+  navigateMarkerDetailRuntime,
+  openWithMarkerDetailStylesheet,
+  setDetailModalShell,
+} from './marker-detail-runtime.js';
+import { openModalOverlay } from './modal-lifecycle.js';
+import { state } from './state.js';
+import { escapeAttr, escapeHTML, safeMarkerId, showNotification } from './utils.js';
+
+/** @type {{ showDetailModal: (id: string) => any }} */
+const placementRuntime = {
+  showDetailModal: () => false,
+};
+
+/** @param {{ showDetailModal?: (id: string) => any }} [runtime] */
+export function configureMarkerDetailPlacement(runtime = {}) {
+  const previous = { ...placementRuntime };
+  if (typeof runtime.showDetailModal === 'function') placementRuntime.showDetailModal = runtime.showDetailModal;
+  return previous;
+}
+
+/** @param {unknown} value */
+function isRecord(value) {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+/** @param {Record<string, any> | undefined} placements */
+function clonePlacements(placements) {
+  if (!isRecord(placements)) return undefined;
+  return Object.fromEntries(Object.entries(placements).map(([key, value]) => [
+    key,
+    isRecord(value) ? { ...value } : value,
+  ]));
+}
+
+/** @param {string} id */
+function getMarkerPlacementContext(id) {
+  if (!safeMarkerId(id)) return null;
+  const separator = id.indexOf('_');
+  if (separator < 1 || separator === id.length - 1) return null;
+  const data = getActiveData();
+  const displayCategoryKey = id.slice(0, separator);
+  const markerKey = id.slice(separator + 1);
+  const marker = data.categories?.[displayCategoryKey]?.markers?.[markerKey];
+  if (!marker) return null;
+  const storageDotKey = getMarkerStorageDotKey(marker, id);
+  if (!storageDotKey) return null;
+  const nativeCategoryKey = marker.nativeCategoryKey || storageDotKey.slice(0, storageDotKey.indexOf('.'));
+  const markerReference = marker.markerId || storageDotKey;
+  return {
+    data,
+    marker,
+    markerKey,
+    markerReference,
+    storageDotKey,
+    displayCategoryKey: marker.displayCategoryKey || displayCategoryKey,
+    nativeCategoryKey,
+  };
+}
+
+/** @param {Record<string, any>} category */
+function categoryHasData(category) {
+  return Object.values(category?.markers || {}).some(marker =>
+    Array.isArray(marker?.values) && marker.values.some(value => value != null));
+}
+
+/**
+ * Return only destinations accepted by the placement engine. Categories that
+ * cannot preserve marker semantics (calculated, mode-mismatched, or colliding)
+ * stay out of the control instead of failing after the user chooses them.
+ *
+ * @param {string} id
+ */
+export function getMarkerPlacementChoices(id) {
+  const context = getMarkerPlacementContext(id);
+  if (!context) return null;
+  const choices = [];
+  let unavailableCount = 0;
+  for (const [categoryKey, category] of Object.entries(context.data.categories || {})) {
+    const candidatePlacements = clonePlacements(state.importedData?.markerPlacements) || {};
+    const candidateProfile = { ...state.importedData, markerPlacements: candidatePlacements };
+    const result = setMarkerPlacement(candidateProfile, context.markerReference, categoryKey);
+    if (!result.ok) {
+      unavailableCount++;
+      continue;
+    }
+    choices.push({
+      categoryKey,
+      label: category.label || categoryKey,
+      icon: category.icon || '',
+      inProfile: categoryHasData(category)
+        || categoryKey === context.displayCategoryKey
+        || categoryKey === context.nativeCategoryKey,
+      selected: categoryKey === context.displayCategoryKey,
+    });
+  }
+  choices.sort((left, right) => {
+    if (left.inProfile !== right.inProfile) return left.inProfile ? -1 : 1;
+    return String(left.label).localeCompare(String(right.label));
+  });
+  return { ...context, choices, unavailableCount };
+}
+
+/**
+ * @param {string} id
+ * @param {Record<string, any>} marker
+ * @param {Record<string, any>} categories
+ */
+export function renderMarkerPlacementSummary(id, marker, categories) {
+  const storageDotKey = getMarkerStorageDotKey(marker, id);
+  const nativeCategoryKey = marker.nativeCategoryKey
+    || (storageDotKey ? storageDotKey.slice(0, storageDotKey.indexOf('.')) : '');
+  const displayCategoryKey = marker.displayCategoryKey || id.slice(0, id.indexOf('_'));
+  const currentCategory = categories?.[displayCategoryKey];
+  const nativeCategory = categories?.[nativeCategoryKey];
+  const currentLabel = currentCategory?.label || displayCategoryKey;
+  const nativeLabel = nativeCategory?.label || nativeCategoryKey;
+  const moved = !!nativeCategoryKey && nativeCategoryKey !== displayCategoryKey;
+  return `<div class="gb-detail-category-row">
+    <span class="gb-detail-kicker">${escapeHTML(currentLabel)}</span>
+    <button type="button" class="gb-detail-category-change" aria-label="Change category for ${escapeAttr(marker.name || 'marker')}" ${markerDetailActionAttrs('open-marker-placement', { id })}>Change category</button>
+    ${moved ? `<span class="gb-detail-category-origin">Originally ${escapeHTML(nativeLabel)}</span>
+      <button type="button" class="gb-detail-category-restore" ${markerDetailActionAttrs('restore-marker-placement', { id })}>Restore</button>` : ''}
+  </div>`;
+}
+
+/** @param {Array<Record<string, any>>} choices */
+function renderPlacementOptions(choices) {
+  const groups = [
+    { label: 'In this profile', options: choices.filter(choice => choice.inProfile) },
+    { label: 'Other compatible categories', options: choices.filter(choice => !choice.inProfile) },
+  ];
+  return groups
+    .filter(group => group.options.length > 0)
+    .map(({ label, options }) => `<optgroup label="${escapeAttr(label)}">
+      ${options.map(choice => {
+        const visibleLabel = `${choice.icon ? `${choice.icon} ` : ''}${choice.label}`;
+        return `<option value="${escapeAttr(choice.categoryKey)}"${choice.selected ? ' selected' : ''}>${escapeHTML(visibleLabel)}</option>`;
+      }).join('')}
+    </optgroup>`)
+    .join('');
+}
+
+/** @param {string} id */
+export function openMarkerPlacementModal(id) {
+  if (!safeMarkerId(id)) return false;
+  return openWithMarkerDetailStylesheet(() => renderMarkerPlacementModal(id));
+}
+
+/** @param {string} id */
+function renderMarkerPlacementModal(id) {
+  const context = getMarkerPlacementChoices(id);
+  if (!context) return false;
+  const modal = setDetailModalShell('gb-form-modal', 'marker-placement-form');
+  const overlay = document.getElementById('modal-overlay');
+  if (!modal || !overlay) return false;
+  const currentLabel = context.data.categories[context.displayCategoryKey]?.label || context.displayCategoryKey;
+  const nativeLabel = context.data.categories[context.nativeCategoryKey]?.label || context.nativeCategoryKey;
+  const moved = context.displayCategoryKey !== context.nativeCategoryKey;
+  modal.innerHTML = `<div class="gb-modal-head">
+      <button type="button" class="context-back-btn" aria-label="Back to marker details" ${markerDetailActionAttrs('show-detail-modal', { id })}>
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m15 18-6-6 6-6"></path></svg>
+      </button>
+      <div>
+        <div class="gb-modal-kicker">Category placement</div>
+        <div class="gb-modal-title">Move ${escapeHTML(context.marker.name)}</div>
+      </div>
+      <button type="button" class="modal-close" aria-label="Close" ${markerDetailActionAttrs('close-modal')}>&times;</button>
+    </div>
+    <div class="gb-form-body">
+      <div class="marker-placement-safety" role="note">
+        <strong>Only where this marker appears will change.</strong>
+        <span>Values, history, units, notes, reference ranges, backups, shares, imports, and sync stay linked to the same marker.</span>
+      </div>
+      <div class="manual-entry-form">
+        <div class="me-field">
+          <label for="marker-placement-category">Category</label>
+          <select id="marker-placement-category" aria-describedby="marker-placement-help">
+            ${renderPlacementOptions(context.choices)}
+          </select>
+          <div class="marker-placement-current">Current: <strong>${escapeHTML(currentLabel)}</strong> &middot; Original: <strong>${escapeHTML(nativeLabel)}</strong></div>
+          <div class="marker-placement-help" id="marker-placement-help">Choose an existing compatible category. ${context.unavailableCount ? `${context.unavailableCount} calculated, incompatible, or conflicting ${context.unavailableCount === 1 ? 'category is' : 'categories are'} hidden.` : ''}</div>
+        </div>
+        <div class="gb-form-actions">
+          ${moved ? `<button type="button" class="import-btn import-btn-secondary marker-placement-restore" ${markerDetailActionAttrs('restore-marker-placement', { id })}>Restore original</button>` : ''}
+          <button type="button" class="import-btn import-btn-secondary" ${markerDetailActionAttrs('show-detail-modal', { id })}>Cancel</button>
+          <button type="button" class="import-btn import-btn-primary marker-placement-save" ${markerDetailActionAttrs('save-marker-placement', { id })}>Move marker</button>
+        </div>
+      </div>
+    </div>`;
+  openModalOverlay(overlay, { initialFocus: '#marker-placement-category', focusDelay: 20 });
+  return true;
+}
+
+function setPlacementControlsBusy(busy) {
+  const select = /** @type {HTMLSelectElement | null} */ (document.getElementById('marker-placement-category'));
+  const button = /** @type {HTMLButtonElement | null} */ (document.querySelector('.marker-placement-save'));
+  if (select) select.disabled = busy;
+  if (button) {
+    button.disabled = busy;
+    button.textContent = busy ? 'Moving…' : 'Move marker';
+  }
+}
+
+/**
+ * @param {string} id
+ * @param {string} categoryKey
+ * @param {'move' | 'restore'} action
+ */
+async function persistMarkerPlacement(id, categoryKey, action) {
+  const context = getMarkerPlacementContext(id);
+  if (!context) return false;
+  const hadPlacements = isRecord(state.importedData?.markerPlacements);
+  const previousPlacements = clonePlacements(state.importedData?.markerPlacements);
+  const result = action === 'restore'
+    ? clearMarkerPlacement(state.importedData, context.markerReference)
+    : setMarkerPlacement(state.importedData, context.markerReference, categoryKey);
+  if (!result.ok) {
+    showNotification('That marker cannot be placed in the selected category.', 'error');
+    return false;
+  }
+  if (!result.changed) {
+    placementRuntime.showDetailModal(id);
+    return true;
+  }
+  const saved = await saveImportedData();
+  if (!saved) {
+    if (hadPlacements) state.importedData.markerPlacements = previousPlacements || {};
+    else delete state.importedData.markerPlacements;
+    invalidateActiveDataCache();
+    return false;
+  }
+  const destinationCategoryKey = result.categoryKey;
+  const destinationLabel = getActiveData().categories?.[destinationCategoryKey]?.label || destinationCategoryKey;
+  const nextId = `${destinationCategoryKey}_${context.markerKey}`;
+  buildMarkerDetailSidebarRuntime();
+  navigateMarkerDetailRuntime(destinationCategoryKey, getActiveData());
+  placementRuntime.showDetailModal(nextId);
+  showNotification(
+    action === 'restore'
+      ? `Restored “${context.marker.name}” to ${destinationLabel}`
+      : `Moved “${context.marker.name}” to ${destinationLabel}. Values and history stayed linked.`,
+    'success',
+  );
+  return true;
+}
+
+/** @param {string} id */
+export async function saveMarkerPlacement(id) {
+  if (!safeMarkerId(id)) return false;
+  const select = /** @type {HTMLSelectElement | null} */ (document.getElementById('marker-placement-category'));
+  if (!select?.value) return false;
+  setPlacementControlsBusy(true);
+  try {
+    return await persistMarkerPlacement(id, select.value, 'move');
+  } finally {
+    setPlacementControlsBusy(false);
+  }
+}
+
+/** @param {string} id */
+export async function restoreMarkerPlacement(id) {
+  if (!safeMarkerId(id)) return false;
+  const context = getMarkerPlacementContext(id);
+  if (!context) return false;
+  return persistMarkerPlacement(id, context.nativeCategoryKey, 'restore');
+}

--- a/js/marker-detail-placement.js
+++ b/js/marker-detail-placement.js
@@ -30,7 +30,7 @@ export function configureMarkerDetailPlacement(runtime = {}) {
   return previous;
 }
 
-/** @param {unknown} value */
+/** @param {unknown} value @returns {value is Record<string, any>} */
 function isRecord(value) {
   return !!value && typeof value === 'object' && !Array.isArray(value);
 }
@@ -237,7 +237,7 @@ async function persistMarkerPlacement(id, categoryKey, action) {
   const saved = await saveImportedData();
   if (!saved) {
     if (hadPlacements) state.importedData.markerPlacements = previousPlacements || {};
-    else delete state.importedData.markerPlacements;
+    else Reflect.deleteProperty(state.importedData, 'markerPlacements');
     invalidateActiveDataCache();
     return false;
   }

--- a/js/marker-detail-placement.js
+++ b/js/marker-detail-placement.js
@@ -22,6 +22,7 @@ import { escapeAttr, escapeHTML, safeMarkerId, showNotification } from './utils.
 const placementRuntime = {
   showDetailModal: () => false,
 };
+let placementMutationInFlight = false;
 
 /** @param {{ showDetailModal?: (id: string) => any }} [runtime] */
 export function configureMarkerDetailPlacement(runtime = {}) {
@@ -211,6 +212,22 @@ function setPlacementControlsBusy(busy) {
     button.disabled = busy;
     button.textContent = busy ? 'Moving…' : 'Move marker';
   }
+  document.querySelectorAll('[data-marker-detail-action="restore-marker-placement"]').forEach(control => {
+    if (control instanceof HTMLButtonElement) control.disabled = busy;
+  });
+}
+
+/** @param {() => Promise<boolean>} mutation */
+async function runPlacementMutation(mutation) {
+  if (placementMutationInFlight) return false;
+  placementMutationInFlight = true;
+  setPlacementControlsBusy(true);
+  try {
+    return await mutation();
+  } finally {
+    placementMutationInFlight = false;
+    setPlacementControlsBusy(false);
+  }
 }
 
 /**
@@ -261,12 +278,8 @@ export async function saveMarkerPlacement(id) {
   if (!safeMarkerId(id)) return false;
   const select = /** @type {HTMLSelectElement | null} */ (document.getElementById('marker-placement-category'));
   if (!select?.value) return false;
-  setPlacementControlsBusy(true);
-  try {
-    return await persistMarkerPlacement(id, select.value, 'move');
-  } finally {
-    setPlacementControlsBusy(false);
-  }
+  const categoryKey = select.value;
+  return runPlacementMutation(() => persistMarkerPlacement(id, categoryKey, 'move'));
 }
 
 /** @param {string} id */
@@ -274,5 +287,5 @@ export async function restoreMarkerPlacement(id) {
   if (!safeMarkerId(id)) return false;
   const context = getMarkerPlacementContext(id);
   if (!context) return false;
-  return persistMarkerPlacement(id, context.nativeCategoryKey, 'restore');
+  return runPlacementMutation(() => persistMarkerPlacement(id, context.nativeCategoryKey, 'restore'));
 }

--- a/js/marker-detail-placement.js
+++ b/js/marker-detail-placement.js
@@ -22,7 +22,8 @@ import { escapeAttr, escapeHTML, safeMarkerId, showNotification } from './utils.
 const placementRuntime = {
   showDetailModal: () => false,
 };
-const placementMutationProfiles = new Set();
+/** @type {Map<string, Promise<boolean>>} */
+const placementMutationProfiles = new Map();
 
 /** @param {{ showDetailModal?: (id: string) => any }} [runtime] */
 export function configureMarkerDetailPlacement(runtime = {}) {
@@ -219,27 +220,31 @@ function setPlacementControlsBusy(busy) {
 
 /** @param {string} profileId @param {() => Promise<boolean>} mutation */
 async function runPlacementMutation(profileId, mutation) {
-  if (placementMutationProfiles.has(profileId)) return false;
-  placementMutationProfiles.add(profileId);
+  const previous = placementMutationProfiles.get(profileId) || Promise.resolve(true);
+  const pending = previous.catch(() => false).then(() => {
+    if (state.currentProfile === profileId) setPlacementControlsBusy(true);
+    return mutation();
+  });
+  placementMutationProfiles.set(profileId, pending);
   setPlacementControlsBusy(true);
   try {
-    return await mutation();
+    return await pending;
   } finally {
-    placementMutationProfiles.delete(profileId);
-    if (state.currentProfile === profileId) setPlacementControlsBusy(false);
+    if (placementMutationProfiles.get(profileId) === pending) {
+      placementMutationProfiles.delete(profileId);
+      if (state.currentProfile === profileId) setPlacementControlsBusy(false);
+    }
   }
 }
 
 /**
- * @param {string} id
+ * @param {NonNullable<ReturnType<typeof getMarkerPlacementContext>>} context
+ * @param {string} profileId
+ * @param {Record<string, any>} profileData
  * @param {string} categoryKey
  * @param {'move' | 'restore'} action
  */
-async function persistMarkerPlacement(id, categoryKey, action) {
-  const context = getMarkerPlacementContext(id);
-  if (!context) return false;
-  const profileId = state.currentProfile;
-  const profileData = state.importedData;
+async function persistMarkerPlacement(context, profileId, profileData, categoryKey, action) {
   const modal = document.getElementById('detail-modal');
   const modalContent = modal?.firstElementChild;
   const overlay = document.getElementById('modal-overlay');
@@ -252,8 +257,12 @@ async function persistMarkerPlacement(id, categoryKey, action) {
     showNotification('That marker cannot be placed in the selected category.', 'error');
     return false;
   }
+  const destinationCategoryKey = result.categoryKey;
+  const nextId = `${destinationCategoryKey}_${context.markerKey}`;
   if (!result.changed) {
-    placementRuntime.showDetailModal(id);
+    if (state.currentProfile === profileId && state.importedData === profileData) {
+      placementRuntime.showDetailModal(nextId);
+    }
     return true;
   }
   invalidateActiveDataCache();
@@ -272,9 +281,7 @@ async function persistMarkerPlacement(id, categoryKey, action) {
     && modal?.firstElementChild === modalContent
     && overlay?.classList.contains('show');
   if (!stillOwnsView) return true;
-  const destinationCategoryKey = result.categoryKey;
   const destinationLabel = getActiveData().categories?.[destinationCategoryKey]?.label || destinationCategoryKey;
-  const nextId = `${destinationCategoryKey}_${context.markerKey}`;
   buildMarkerDetailSidebarRuntime();
   navigateMarkerDetailRuntime(destinationCategoryKey, getActiveData());
   placementRuntime.showDetailModal(nextId);
@@ -292,8 +299,12 @@ export async function saveMarkerPlacement(id) {
   if (!safeMarkerId(id)) return false;
   const select = /** @type {HTMLSelectElement | null} */ (document.getElementById('marker-placement-category'));
   if (!select?.value) return false;
+  const context = getMarkerPlacementContext(id);
+  if (!context) return false;
   const categoryKey = select.value;
-  return runPlacementMutation(state.currentProfile, () => persistMarkerPlacement(id, categoryKey, 'move'));
+  const profileId = state.currentProfile;
+  const profileData = state.importedData;
+  return runPlacementMutation(profileId, () => persistMarkerPlacement(context, profileId, profileData, categoryKey, 'move'));
 }
 
 /** @param {string} id */
@@ -301,5 +312,7 @@ export async function restoreMarkerPlacement(id) {
   if (!safeMarkerId(id)) return false;
   const context = getMarkerPlacementContext(id);
   if (!context) return false;
-  return runPlacementMutation(state.currentProfile, () => persistMarkerPlacement(id, context.nativeCategoryKey, 'restore'));
+  const profileId = state.currentProfile;
+  const profileData = state.importedData;
+  return runPlacementMutation(profileId, () => persistMarkerPlacement(context, profileId, profileData, context.nativeCategoryKey, 'restore'));
 }

--- a/js/marker-placement.js
+++ b/js/marker-placement.js
@@ -274,6 +274,17 @@ export function getMarkerStorageDotKey(marker, viewId) {
 }
 
 /**
+ * Return the immutable storage path in the underscore form used by UI state.
+ *
+ * @param {Record<string, any> | null | undefined} marker
+ * @param {unknown} viewId
+ */
+export function getMarkerStorageViewId(marker, viewId) {
+  const parts = splitDotKey(getMarkerStorageDotKey(marker, viewId));
+  return parts ? `${parts.categoryKey}_${parts.markerKey}` : null;
+}
+
+/**
  * Resolve a rendered path first, then its immutable native storage path. The
  * fallback lets saved dashboard references follow a marker after placement.
  *
@@ -293,4 +304,13 @@ export function resolveActiveMarkerPath(categories, categoryKey, markerKey) {
     }
   }
   return null;
+}
+
+/** @param {Record<string, any>} categories @param {unknown} viewId */
+export function resolveMarkerStorageViewId(categories, viewId) {
+  if (typeof viewId !== 'string') return null;
+  const separator = viewId.indexOf('_');
+  if (separator < 1 || separator === viewId.length - 1) return null;
+  const resolved = resolveActiveMarkerPath(categories, viewId.slice(0, separator), viewId.slice(separator + 1));
+  return getMarkerStorageViewId(resolved?.marker, viewId);
 }

--- a/js/marker-placement.js
+++ b/js/marker-placement.js
@@ -147,7 +147,7 @@ export function getMarkerPlacementPlan(profileData) {
       const destinationSlot = `${requestedCategoryKey}.${marker.markerKey}`;
       if (!destinationMode) {
         reason = 'unknown-category';
-      } else if (sourceMode?.calculated || destinationMode.calculated) {
+      } else if (destinationMode.calculated) {
         reason = 'calculated-category';
       } else if (!!sourceMode?.singlePoint !== !!destinationMode.singlePoint) {
         reason = 'category-mode-mismatch';

--- a/scripts/dom-sink-policy.json
+++ b/scripts/dom-sink-policy.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "scope": "Every non-generated JavaScript module under js/",
   "reviewRule": "Any added or modified HTML-writing sink requires security review and a policy refresh.",
-  "scannedFiles": 618,
-  "sinkCount": 496,
+  "scannedFiles": 619,
+  "sinkCount": 497,
   "files": {
     "js/backup.js": {
       "count": 1,
@@ -537,6 +537,13 @@
       "digest": "0050e72c749706f23cc5307ad5b3ccfc5b854849bea494c551b90f67e5ad4248",
       "kinds": {
         "innerHTML": 2
+      }
+    },
+    "js/marker-detail-placement.js": {
+      "count": 1,
+      "digest": "ddb46b5fad395b08b92ed8c75eace88d47b64ea8b8143dce358e291f48951aa1",
+      "kinds": {
+        "innerHTML": 1
       }
     },
     "js/mobile-dashboard.js": {

--- a/service-worker.js
+++ b/service-worker.js
@@ -384,6 +384,7 @@ const APP_SHELL = [
   '/js/marker-detail-content.js',
   '/js/marker-detail-manual-entry.js',
   '/js/marker-detail-custom-markers.js',
+  '/js/marker-detail-placement.js',
   '/js/modal-trigger-memory.js',
   '/js/marker-detail-runtime.js',
   '/js/marker-detail-actions.js',
@@ -789,7 +790,6 @@ function shouldUseNetworkOnly(url, sameOrigin) {
  *   }
  * }} */
 const serviceWorkerScope = /** @type {any} */ (self);
-
 serviceWorkerScope.GetBasedServiceWorkerRuntime.install({
   scope: serviceWorkerScope,
   appShell: APP_SHELL,

--- a/tests/dashboard-lab-widget-renderers.test.js
+++ b/tests/dashboard-lab-widget-renderers.test.js
@@ -3,6 +3,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createDashboardLabWidgetRenderers } from '../js/dashboard-lab-widget-renderers.js';
+import { invalidateActiveDataCache } from '../js/data.js';
+import { getBuiltinMarkerId } from '../js/marker-schema.js';
 import { profileStorageKey } from '../js/profile.js';
 import { state } from '../js/state.js';
 
@@ -58,6 +60,7 @@ describe('dashboard lab widget renderers', () => {
     state.profileDob = savedState.profileDob;
     localStorage.clear();
     document.body.innerHTML = '';
+    invalidateActiveDataCache();
     vi.restoreAllMocks();
   });
 
@@ -84,6 +87,27 @@ describe('dashboard lab widget renderers', () => {
     expect(renderers.isDashboardQuickMarkerPinned('lipids_apoB')).toBe(true);
 
     renderers.toggleDashboardQuickMarkerPin('lipids_apoB');
+    expect(JSON.parse(localStorage.getItem(storageKey))).toEqual([]);
+  });
+
+  it('keeps quick pins attached to storage identity after a marker moves', () => {
+    const glucoseId = getBuiltinMarkerId('biochemistry.glucose');
+    state.importedData = {
+      entries: [{ date: '2026-08-01', markers: { 'biochemistry.glucose': 5.2 } }],
+      customMarkers: {},
+      markerPlacements: { [glucoseId]: { categoryKey: 'lipids' } },
+    };
+    invalidateActiveDataCache();
+    const renderers = createRenderers();
+    const storageKey = profileStorageKey(state.currentProfile, 'dashboardQuickMarkerPinsV1');
+
+    renderers.toggleDashboardQuickMarkerPin('lipids_glucose');
+
+    expect(JSON.parse(localStorage.getItem(storageKey))).toEqual(['biochemistry_glucose']);
+    expect(renderers.isDashboardQuickMarkerPinned('lipids_glucose')).toBe(true);
+    expect(renderers.isDashboardQuickMarkerPinned('biochemistry_glucose')).toBe(true);
+
+    renderers.toggleDashboardQuickMarkerPin('biochemistry_glucose');
     expect(JSON.parse(localStorage.getItem(storageKey))).toEqual([]);
   });
 });

--- a/tests/marker-placement-ui.test.js
+++ b/tests/marker-placement-ui.test.js
@@ -9,7 +9,7 @@ const runtime = vi.hoisted(() => ({
     currentView: 'biochemistry',
     markerRegistry: {},
   },
-  saveImportedData: vi.fn(async () => true),
+  saveImportedDataForProfile: vi.fn(async () => true),
   invalidateActiveDataCache: vi.fn(),
   buildSidebar: vi.fn(),
   navigate: vi.fn(),
@@ -58,7 +58,7 @@ vi.mock('../js/state.js', () => ({ state: runtime.state }));
 vi.mock('../js/data.js', () => ({
   getActiveData: () => activeData(),
   invalidateActiveDataCache: runtime.invalidateActiveDataCache,
-  saveImportedData: runtime.saveImportedData,
+  saveImportedDataForProfile: runtime.saveImportedDataForProfile,
 }));
 vi.mock('../js/marker-detail-runtime.js', () => ({
   buildMarkerDetailSidebarRuntime: runtime.buildSidebar,
@@ -95,7 +95,8 @@ const {
 describe('marker placement UI', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    runtime.saveImportedData.mockResolvedValue(true);
+    runtime.saveImportedDataForProfile.mockResolvedValue(true);
+    runtime.state.currentProfile = 'marker-placement-ui-test';
     runtime.state.importedData = {
       entries: [{ date: '2026-08-01', markers: { 'biochemistry.glucose': 5.2 } }],
       customMarkers: {
@@ -146,7 +147,11 @@ describe('marker placement UI', () => {
     });
     expect(runtime.state.importedData.entries).toEqual(originalEntries);
     expect(runtime.state.importedData.markerNotes).toEqual(originalNotes);
-    expect(runtime.saveImportedData).toHaveBeenCalledTimes(1);
+    expect(runtime.saveImportedDataForProfile).toHaveBeenCalledWith(
+      'marker-placement-ui-test',
+      runtime.state.importedData,
+      { forceProfileScope: true, reason: 'marker-placement' },
+    );
     expect(runtime.navigate).toHaveBeenCalledWith('lipids', expect.any(Object));
     expect(runtime.showDetailModal).toHaveBeenCalledWith('lipids_glucose');
 
@@ -166,7 +171,7 @@ describe('marker placement UI', () => {
 
   it('rolls placement metadata back when persistence fails', async () => {
     delete runtime.state.importedData.markerPlacements;
-    runtime.saveImportedData.mockResolvedValueOnce(false);
+    runtime.saveImportedDataForProfile.mockResolvedValueOnce(false);
     await openMarkerPlacementModal('biochemistry_glucose');
     document.getElementById('marker-placement-category').value = 'lipids';
 
@@ -183,7 +188,7 @@ describe('marker placement UI', () => {
       'gb:marker:glucose': { categoryKey: 'lipids' },
     };
     let finishSave;
-    runtime.saveImportedData.mockImplementationOnce(() => new Promise(resolve => { finishSave = resolve; }));
+    runtime.saveImportedDataForProfile.mockImplementationOnce(() => new Promise(resolve => { finishSave = resolve; }));
     await openMarkerPlacementModal('lipids_glucose');
     const restoreControl = document.querySelector('[data-marker-detail-action="restore-marker-placement"]');
     document.getElementById('marker-placement-category').value = 'hormones';
@@ -194,7 +199,7 @@ describe('marker placement UI', () => {
     expect(document.getElementById('marker-placement-category').disabled).toBe(true);
     expect(restoreControl.disabled).toBe(true);
     await expect(restoring).resolves.toBe(false);
-    expect(runtime.saveImportedData).toHaveBeenCalledTimes(1);
+    expect(runtime.saveImportedDataForProfile).toHaveBeenCalledTimes(1);
     finishSave(true);
     await expect(moving).resolves.toBe(true);
 
@@ -203,5 +208,44 @@ describe('marker placement UI', () => {
     });
     expect(runtime.navigate).toHaveBeenCalledTimes(1);
     expect(runtime.showDetailModal).toHaveBeenLastCalledWith('hormones_glucose');
+  });
+
+  it('rolls a failed save back on its initiating profile after a profile switch', async () => {
+    let finishSave;
+    runtime.saveImportedDataForProfile.mockImplementationOnce(() => new Promise(resolve => { finishSave = resolve; }));
+    await openMarkerPlacementModal('biochemistry_glucose');
+    document.getElementById('marker-placement-category').value = 'lipids';
+    const initiatingData = runtime.state.importedData;
+
+    const moving = saveMarkerPlacement('biochemistry_glucose');
+    runtime.state.currentProfile = 'other-profile';
+    runtime.state.importedData = { markerPlacements: { 'custom:other': { categoryKey: 'hormones' } } };
+    finishSave(false);
+    await expect(moving).resolves.toBe(false);
+
+    expect(initiatingData.markerPlacements).toEqual({});
+    expect(runtime.state.importedData.markerPlacements).toEqual({
+      'custom:other': { categoryKey: 'hormones' },
+    });
+    expect(runtime.navigate).not.toHaveBeenCalled();
+    expect(runtime.showDetailModal).not.toHaveBeenCalled();
+  });
+
+  it('does not reopen stale marker UI after the placement flow is dismissed', async () => {
+    let finishSave;
+    runtime.saveImportedDataForProfile.mockImplementationOnce(() => new Promise(resolve => { finishSave = resolve; }));
+    await openMarkerPlacementModal('biochemistry_glucose');
+    document.getElementById('marker-placement-category').value = 'lipids';
+
+    const moving = saveMarkerPlacement('biochemistry_glucose');
+    document.getElementById('modal-overlay').classList.remove('show');
+    finishSave(true);
+    await expect(moving).resolves.toBe(true);
+
+    expect(runtime.state.importedData.markerPlacements).toEqual({
+      'gb:marker:glucose': { categoryKey: 'lipids' },
+    });
+    expect(runtime.navigate).not.toHaveBeenCalled();
+    expect(runtime.showDetailModal).not.toHaveBeenCalled();
   });
 });

--- a/tests/marker-placement-ui.test.js
+++ b/tests/marker-placement-ui.test.js
@@ -36,6 +36,7 @@ function activeData() {
       icon: '❤️',
       markers: { cholesterol: { name: 'Cholesterol', values: [4.4] } },
     },
+    hormones: { label: 'Hormones', icon: '⚗️', markers: {} },
     calculatedRatios: {
       label: 'Calculated Ratios',
       icon: '📐',
@@ -175,5 +176,32 @@ describe('marker placement UI', () => {
     expect(runtime.invalidateActiveDataCache).toHaveBeenCalled();
     expect(runtime.navigate).not.toHaveBeenCalled();
     expect(runtime.showDetailModal).not.toHaveBeenCalled();
+  });
+
+  it('single-flights move and restore so persistence and navigation cannot race', async () => {
+    runtime.state.importedData.markerPlacements = {
+      'gb:marker:glucose': { categoryKey: 'lipids' },
+    };
+    let finishSave;
+    runtime.saveImportedData.mockImplementationOnce(() => new Promise(resolve => { finishSave = resolve; }));
+    await openMarkerPlacementModal('lipids_glucose');
+    const restoreControl = document.querySelector('[data-marker-detail-action="restore-marker-placement"]');
+    document.getElementById('marker-placement-category').value = 'hormones';
+
+    const moving = saveMarkerPlacement('lipids_glucose');
+    const restoring = restoreMarkerPlacement('hormones_glucose');
+
+    expect(document.getElementById('marker-placement-category').disabled).toBe(true);
+    expect(restoreControl.disabled).toBe(true);
+    await expect(restoring).resolves.toBe(false);
+    expect(runtime.saveImportedData).toHaveBeenCalledTimes(1);
+    finishSave(true);
+    await expect(moving).resolves.toBe(true);
+
+    expect(runtime.state.importedData.markerPlacements).toEqual({
+      'gb:marker:glucose': { categoryKey: 'hormones' },
+    });
+    expect(runtime.navigate).toHaveBeenCalledTimes(1);
+    expect(runtime.showDetailModal).toHaveBeenLastCalledWith('hormones_glucose');
   });
 });

--- a/tests/marker-placement-ui.test.js
+++ b/tests/marker-placement-ui.test.js
@@ -1,0 +1,179 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const runtime = vi.hoisted(() => ({
+  state: {
+    importedData: {},
+    currentProfile: 'marker-placement-ui-test',
+    currentView: 'biochemistry',
+    markerRegistry: {},
+  },
+  saveImportedData: vi.fn(async () => true),
+  invalidateActiveDataCache: vi.fn(),
+  buildSidebar: vi.fn(),
+  navigate: vi.fn(),
+  showDetailModal: vi.fn(),
+  showNotification: vi.fn(),
+}));
+
+function activeData() {
+  const markerId = 'gb:marker:glucose';
+  const destination = runtime.state.importedData.markerPlacements?.[markerId]?.categoryKey || 'biochemistry';
+  const glucose = {
+    markerId,
+    storageDotKey: 'biochemistry.glucose',
+    nativeCategoryKey: 'biochemistry',
+    displayCategoryKey: destination,
+    name: 'Glucose',
+    unit: 'mmol/l',
+    values: [5.2],
+  };
+  const categories = {
+    biochemistry: { label: 'Biochemistry', icon: '🧪', markers: {} },
+    lipids: {
+      label: 'Lipids',
+      icon: '❤️',
+      markers: { cholesterol: { name: 'Cholesterol', values: [4.4] } },
+    },
+    calculatedRatios: {
+      label: 'Calculated Ratios',
+      icon: '📐',
+      calculated: true,
+      markers: { ratio: { name: 'Ratio', values: [1] } },
+    },
+    singlePanel: {
+      label: 'Single Panel',
+      icon: '📍',
+      singlePoint: true,
+      markers: { sample: { name: 'Sample', values: [1] } },
+    },
+  };
+  categories[destination].markers.glucose = glucose;
+  return { dates: ['2026-08-01'], dateLabels: ['1 Aug 2026'], categories };
+}
+
+vi.mock('../js/state.js', () => ({ state: runtime.state }));
+vi.mock('../js/data.js', () => ({
+  getActiveData: () => activeData(),
+  invalidateActiveDataCache: runtime.invalidateActiveDataCache,
+  saveImportedData: runtime.saveImportedData,
+}));
+vi.mock('../js/marker-detail-runtime.js', () => ({
+  buildMarkerDetailSidebarRuntime: runtime.buildSidebar,
+  navigateMarkerDetailRuntime: runtime.navigate,
+  openWithMarkerDetailStylesheet: open => Promise.resolve(open()),
+  setDetailModalShell: (...classes) => {
+    const modal = document.getElementById('detail-modal');
+    modal.className = ['modal', ...classes].join(' ');
+    return modal;
+  },
+}));
+vi.mock('../js/modal-lifecycle.js', () => ({
+  openModalOverlay: overlay => {
+    overlay.classList.add('show');
+    return overlay;
+  },
+}));
+vi.mock('../js/utils.js', () => ({
+  escapeAttr: value => String(value).replaceAll('&', '&amp;').replaceAll('"', '&quot;'),
+  escapeHTML: value => String(value).replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;'),
+  safeMarkerId: value => typeof value === 'string' && /^[A-Za-z][A-Za-z0-9]*_[A-Za-z0-9_]+$/.test(value),
+  showNotification: runtime.showNotification,
+}));
+
+const {
+  configureMarkerDetailPlacement,
+  getMarkerPlacementChoices,
+  openMarkerPlacementModal,
+  renderMarkerPlacementSummary,
+  restoreMarkerPlacement,
+  saveMarkerPlacement,
+} = await import('../js/marker-detail-placement.js');
+
+describe('marker placement UI', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    runtime.saveImportedData.mockResolvedValue(true);
+    runtime.state.importedData = {
+      entries: [{ date: '2026-08-01', markers: { 'biochemistry.glucose': 5.2 } }],
+      customMarkers: {
+        'singlePanel.sample': {
+          markerId: 'custom:single',
+          name: 'Sample',
+          singlePoint: true,
+        },
+      },
+      markerPlacements: {},
+      markerNotes: { 'biochemistry.glucose': 'Keep the immutable key' },
+    };
+    document.body.innerHTML = `
+      <div id="modal-overlay">
+        <div class="modal" id="detail-modal"></div>
+      </div>
+    `;
+    configureMarkerDetailPlacement({ showDetailModal: runtime.showDetailModal });
+  });
+
+  it('offers only compatible categories and explains the storage-safe change', async () => {
+    const context = getMarkerPlacementChoices('biochemistry_glucose');
+
+    expect(context.choices.map(choice => choice.categoryKey)).toContain('lipids');
+    expect(context.choices.map(choice => choice.categoryKey)).not.toContain('calculatedRatios');
+    expect(context.choices.map(choice => choice.categoryKey)).not.toContain('singlePanel');
+
+    await openMarkerPlacementModal('biochemistry_glucose');
+
+    const modal = document.getElementById('detail-modal');
+    const select = document.getElementById('marker-placement-category');
+    expect(modal.textContent).toContain('Only where this marker appears will change.');
+    expect(modal.textContent).toContain('Values, history, units, notes, reference ranges, backups, shares, imports, and sync');
+    expect(select.value).toBe('biochemistry');
+    expect([...select.options].map(option => option.value)).not.toContain('calculatedRatios');
+  });
+
+  it('moves and restores a marker without rewriting user data', async () => {
+    const originalEntries = structuredClone(runtime.state.importedData.entries);
+    const originalNotes = structuredClone(runtime.state.importedData.markerNotes);
+    await openMarkerPlacementModal('biochemistry_glucose');
+    document.getElementById('marker-placement-category').value = 'lipids';
+
+    await saveMarkerPlacement('biochemistry_glucose');
+
+    expect(runtime.state.importedData.markerPlacements).toEqual({
+      'gb:marker:glucose': { categoryKey: 'lipids' },
+    });
+    expect(runtime.state.importedData.entries).toEqual(originalEntries);
+    expect(runtime.state.importedData.markerNotes).toEqual(originalNotes);
+    expect(runtime.saveImportedData).toHaveBeenCalledTimes(1);
+    expect(runtime.navigate).toHaveBeenCalledWith('lipids', expect.any(Object));
+    expect(runtime.showDetailModal).toHaveBeenCalledWith('lipids_glucose');
+
+    const moved = activeData().categories.lipids.markers.glucose;
+    const summary = renderMarkerPlacementSummary('lipids_glucose', moved, activeData().categories);
+    expect(summary).toContain('Originally Biochemistry');
+    expect(summary).toContain('restore-marker-placement');
+
+    await restoreMarkerPlacement('lipids_glucose');
+
+    expect(runtime.state.importedData.markerPlacements).toEqual({});
+    expect(runtime.state.importedData.entries).toEqual(originalEntries);
+    expect(runtime.state.importedData.markerNotes).toEqual(originalNotes);
+    expect(runtime.navigate).toHaveBeenLastCalledWith('biochemistry', expect.any(Object));
+    expect(runtime.showDetailModal).toHaveBeenLastCalledWith('biochemistry_glucose');
+  });
+
+  it('rolls placement metadata back when persistence fails', async () => {
+    delete runtime.state.importedData.markerPlacements;
+    runtime.saveImportedData.mockResolvedValueOnce(false);
+    await openMarkerPlacementModal('biochemistry_glucose');
+    document.getElementById('marker-placement-category').value = 'lipids';
+
+    await expect(saveMarkerPlacement('biochemistry_glucose')).resolves.toBe(false);
+
+    expect(runtime.state.importedData.markerPlacements).toBeUndefined();
+    expect(runtime.invalidateActiveDataCache).toHaveBeenCalled();
+    expect(runtime.navigate).not.toHaveBeenCalled();
+    expect(runtime.showDetailModal).not.toHaveBeenCalled();
+  });
+});

--- a/tests/marker-placement-ui.test.js
+++ b/tests/marker-placement-ui.test.js
@@ -183,7 +183,7 @@ describe('marker placement UI', () => {
     expect(runtime.showDetailModal).not.toHaveBeenCalled();
   });
 
-  it('single-flights move and restore so persistence and navigation cannot race', async () => {
+  it('serializes move and restore so the latest user action is preserved', async () => {
     runtime.state.importedData.markerPlacements = {
       'gb:marker:glucose': { categoryKey: 'lipids' },
     };
@@ -194,20 +194,20 @@ describe('marker placement UI', () => {
     document.getElementById('marker-placement-category').value = 'hormones';
 
     const moving = saveMarkerPlacement('lipids_glucose');
-    const restoring = restoreMarkerPlacement('hormones_glucose');
+    const restoring = restoreMarkerPlacement('lipids_glucose');
 
     expect(document.getElementById('marker-placement-category').disabled).toBe(true);
     expect(restoreControl.disabled).toBe(true);
-    await expect(restoring).resolves.toBe(false);
+    await vi.waitFor(() => expect(runtime.saveImportedDataForProfile).toHaveBeenCalledTimes(1));
     expect(runtime.saveImportedDataForProfile).toHaveBeenCalledTimes(1);
     finishSave(true);
     await expect(moving).resolves.toBe(true);
+    await expect(restoring).resolves.toBe(true);
 
-    expect(runtime.state.importedData.markerPlacements).toEqual({
-      'gb:marker:glucose': { categoryKey: 'hormones' },
-    });
-    expect(runtime.navigate).toHaveBeenCalledTimes(1);
-    expect(runtime.showDetailModal).toHaveBeenLastCalledWith('hormones_glucose');
+    expect(runtime.state.importedData.markerPlacements).toEqual({});
+    expect(runtime.saveImportedDataForProfile).toHaveBeenCalledTimes(2);
+    expect(runtime.navigate).toHaveBeenCalledTimes(2);
+    expect(runtime.showDetailModal).toHaveBeenLastCalledWith('biochemistry_glucose');
   });
 
   it('rolls a failed save back on its initiating profile after a profile switch', async () => {
@@ -218,6 +218,7 @@ describe('marker placement UI', () => {
     const initiatingData = runtime.state.importedData;
 
     const moving = saveMarkerPlacement('biochemistry_glucose');
+    await vi.waitFor(() => expect(runtime.saveImportedDataForProfile).toHaveBeenCalledTimes(1));
     runtime.state.currentProfile = 'other-profile';
     runtime.state.importedData = { markerPlacements: { 'custom:other': { categoryKey: 'hormones' } } };
     finishSave(false);
@@ -239,6 +240,7 @@ describe('marker placement UI', () => {
     await openMarkerPlacementModal('biochemistry_glucose');
     document.getElementById('marker-placement-category').value = 'lipids';
     const firstMove = saveMarkerPlacement('biochemistry_glucose');
+    await vi.waitFor(() => expect(runtime.saveImportedDataForProfile).toHaveBeenCalledTimes(1));
 
     runtime.state.currentProfile = 'second-profile';
     runtime.state.importedData = secondProfileData;
@@ -271,6 +273,7 @@ describe('marker placement UI', () => {
     document.getElementById('marker-placement-category').value = 'lipids';
 
     const moving = saveMarkerPlacement('biochemistry_glucose');
+    await vi.waitFor(() => expect(runtime.saveImportedDataForProfile).toHaveBeenCalledTimes(1));
     document.getElementById('modal-overlay').classList.remove('show');
     finishSave(true);
     await expect(moving).resolves.toBe(true);

--- a/tests/marker-placement-ui.test.js
+++ b/tests/marker-placement-ui.test.js
@@ -231,6 +231,39 @@ describe('marker placement UI', () => {
     expect(runtime.showDetailModal).not.toHaveBeenCalled();
   });
 
+  it('allows an independent profile placement while another profile is saving', async () => {
+    let finishFirstSave;
+    runtime.saveImportedDataForProfile.mockImplementationOnce(() => new Promise(resolve => { finishFirstSave = resolve; }));
+    const firstProfileData = runtime.state.importedData;
+    const secondProfileData = structuredClone(firstProfileData);
+    await openMarkerPlacementModal('biochemistry_glucose');
+    document.getElementById('marker-placement-category').value = 'lipids';
+    const firstMove = saveMarkerPlacement('biochemistry_glucose');
+
+    runtime.state.currentProfile = 'second-profile';
+    runtime.state.importedData = secondProfileData;
+    await openMarkerPlacementModal('biochemistry_glucose');
+    document.getElementById('marker-placement-category').value = 'hormones';
+    await expect(saveMarkerPlacement('biochemistry_glucose')).resolves.toBe(true);
+
+    expect(secondProfileData.markerPlacements).toEqual({
+      'gb:marker:glucose': { categoryKey: 'hormones' },
+    });
+    expect(runtime.saveImportedDataForProfile).toHaveBeenCalledWith(
+      'second-profile',
+      secondProfileData,
+      { forceProfileScope: true, reason: 'marker-placement' },
+    );
+    expect(runtime.showDetailModal).toHaveBeenLastCalledWith('hormones_glucose');
+
+    finishFirstSave(true);
+    await expect(firstMove).resolves.toBe(true);
+    expect(firstProfileData.markerPlacements).toEqual({
+      'gb:marker:glucose': { categoryKey: 'lipids' },
+    });
+    expect(runtime.navigate).toHaveBeenCalledTimes(1);
+  });
+
   it('does not reopen stale marker UI after the placement flow is dismissed', async () => {
     let finishSave;
     runtime.saveImportedDataForProfile.mockImplementationOnce(() => new Promise(resolve => { finishSave = resolve; }));

--- a/tests/marker-placement.test.js
+++ b/tests/marker-placement.test.js
@@ -108,6 +108,20 @@ describe('marker category placement engine', () => {
     expect(profile.markerPlacements).toEqual({});
   });
 
+  it('places calculated markers in regular categories after calculation', () => {
+    const profile = { customMarkers: {}, markerPlacements: {} };
+
+    expect(setMarkerPlacement(profile, 'calculatedRatios.tgHdlRatio', 'lipids')).toMatchObject({
+      ok: true,
+      storageDotKey: 'calculatedRatios.tgHdlRatio',
+      categoryKey: 'lipids',
+    });
+    expect(getMarkerPlacementPlan(profile)[getBuiltinMarkerId('calculatedRatios.tgHdlRatio')])
+      .toMatchObject({ effectiveCategoryKey: 'lipids', reason: 'placed' });
+    expect(setMarkerPlacement(profile, 'biochemistry.glucose', 'calculatedRatios'))
+      .toMatchObject({ ok: false, reason: 'calculated-category' });
+  });
+
   it('preserves forward metadata and ignores unresolved imported assignments', () => {
     const unknownId = 'custom:arrives_later';
     const profile = {

--- a/tests/marker-placement.test.js
+++ b/tests/marker-placement.test.js
@@ -8,9 +8,11 @@ import {
   clearMarkerPlacement,
   getMarkerPlacementPlan,
   getMarkerStorageDotKey,
+  getMarkerStorageViewId,
   migrateMarkerPlacements,
   resolveMarkerIdentity,
   resolveActiveMarkerPath,
+  resolveMarkerStorageViewId,
   setMarkerPlacement,
 } from '../js/marker-placement.js';
 
@@ -151,6 +153,12 @@ describe('marker category placement engine', () => {
     });
     expect(getMarkerStorageDotKey(categories.lipids.markers.glucose, 'lipids_glucose'))
       .toBe('biochemistry.glucose');
+    expect(getMarkerStorageViewId(categories.lipids.markers.glucose, 'lipids_glucose'))
+      .toBe('biochemistry_glucose');
+    expect(resolveMarkerStorageViewId(categories, 'lipids_glucose'))
+      .toBe('biochemistry_glucose');
+    expect(resolveMarkerStorageViewId(categories, 'biochemistry_glucose'))
+      .toBe('biochemistry_glucose');
     expect(resolveActiveMarkerPath(categories, 'biochemistry', 'glucose')).toMatchObject({
       categoryKey: 'lipids',
       marker: { storageDotKey: 'biochemistry.glucose' },

--- a/tests/playwright/marker-detail-browser-coverage.spec.js
+++ b/tests/playwright/marker-detail-browser-coverage.spec.js
@@ -922,6 +922,9 @@ test('marker detail delegated actions cover click key and data attribute contrac
       revertRefRange: (id, type) => calls.push(['revert-ref', id, type]),
       renameMarker: id => calls.push(['rename', id]),
       revertMarkerName: id => calls.push(['revert-name', id]),
+      openMarkerPlacementModal: id => calls.push(['open-placement', id]),
+      saveMarkerPlacement: id => calls.push(['save-placement', id]),
+      restoreMarkerPlacement: id => calls.push(['restore-placement', id]),
       editMarkerValue: (id, date, value) => calls.push(['edit-value', id, date, value]),
       deleteMarkerValue: (id, date) => calls.push(['delete-value', id, date]),
       revertMarkerValue: (id, date) => calls.push(['revert-value', id, date]),
@@ -957,6 +960,9 @@ test('marker detail delegated actions cover click key and data attribute contrac
       clickAction('revert-ref-range', { id: 'proteins_albumin', type: 'optimal' });
       clickAction('rename-marker', { id: 'proteins_albumin' });
       clickAction('revert-marker-name', { id: 'proteins_albumin' });
+      clickAction('open-marker-placement', { id: 'proteins_albumin' });
+      clickAction('save-marker-placement', { id: 'proteins_albumin' });
+      clickAction('restore-marker-placement', { id: 'proteins_albumin' });
       clickAction('edit-marker-value', { id: 'proteins_albumin', date: '2026-06-01', value: 42.2 });
       clickAction('edit-marker-value', { id: 'proteins_albumin', date: '2026-06-01', value: 'not-number' });
       clickAction('delete-marker-value', { id: 'proteins_albumin', date: '2026-06-01' });
@@ -1024,6 +1030,9 @@ test('marker detail delegated actions cover click key and data attribute contrac
         && calls.some(call => call[0] === 'revert-ref' && call[2] === 'optimal')
         && calls.some(call => call[0] === 'rename')
         && calls.some(call => call[0] === 'revert-name')
+        && calls.some(call => call[0] === 'open-placement')
+        && calls.some(call => call[0] === 'save-placement')
+        && calls.some(call => call[0] === 'restore-placement')
         && calls.filter(call => call[0] === 'edit-value').length === 1
         && calls.some(call => call[0] === 'delete-value')
         && calls.some(call => call[0] === 'revert-value')

--- a/tests/playwright/marker-placement-ui.spec.js
+++ b/tests/playwright/marker-placement-ui.spec.js
@@ -1,0 +1,124 @@
+import { expect, test } from '@playwright/test';
+
+async function seedMarkerPlacementProfile(page) {
+  await page.addInitScript(() => {
+    localStorage.setItem('labcharts-default-tour', 'completed');
+    localStorage.setItem('labcharts-default-emptyTour', 'completed');
+  });
+  await page.goto('/app', { waitUntil: 'load' });
+  const legalOverlay = page.locator('#legal-consent-overlay');
+  if (await legalOverlay.count()) {
+    await page.locator('#legal-consent-checkbox').check();
+    await page.locator('[data-legal-consent-action="accept"]').click();
+    await expect(legalOverlay).toHaveCount(0);
+  }
+  await page.evaluate(async () => {
+    const { state } = await import('/js/state.js');
+    const data = await import('/js/data.js');
+    state.currentProfile = 'marker-placement-browser-coverage';
+    state.currentView = 'biochemistry';
+    state.profileSex = null;
+    state.profileDob = null;
+    state.unitSystem = 'EU';
+    state.markerRegistry = {};
+    state.importedData = {
+      entries: [{
+        date: '2026-08-01',
+        markers: {
+          'biochemistry.glucose': 5.2,
+          'lipids.cholesterol': 4.4,
+        },
+      }],
+      notes: [],
+      supplements: [],
+      healthGoals: [],
+      customMarkers: {},
+      markerPlacements: {},
+      markerNotes: { 'biochemistry.glucose': 'Fasting sample' },
+      markerValueNotes: { 'biochemistry.glucose:2026-08-01': 'Morning draw' },
+      refOverrides: { 'biochemistry.glucose': { refMin: 4, refMax: 6 } },
+      manualValues: { 'biochemistry.glucose:2026-08-01': true },
+    };
+    data.invalidateActiveDataCache();
+    const modal = await import('/js/marker-detail-modal.js');
+    await modal.showDetailModal('biochemistry_glucose');
+  });
+}
+
+test('marker detail moves and restores a marker without re-keying profile data', async ({ page }) => {
+  await seedMarkerPlacementProfile(page);
+
+  const detail = page.locator('#detail-modal');
+  await expect(detail).toHaveAttribute('data-sync-refresh-item-id', 'biochemistry_glucose');
+  await expect(detail.getByRole('button', { name: 'Change category for Glucose' })).toBeVisible();
+  await detail.getByRole('button', { name: 'Change category for Glucose' }).click();
+
+  const form = page.locator('#detail-modal.marker-placement-form');
+  await expect(form).toBeVisible();
+  await expect(form.getByRole('note')).toContainText('Only where this marker appears will change.');
+  const category = form.getByLabel('Category');
+  await expect(category).toHaveValue('biochemistry');
+  await expect(category.locator('option[value="calculatedRatios"]')).toHaveCount(0);
+  await category.selectOption('lipids');
+  await form.getByRole('button', { name: 'Move marker' }).click();
+
+  await expect(detail).toHaveAttribute('data-sync-refresh-item-id', 'lipids_glucose');
+  await expect(detail).toContainText('Originally Biochemistry');
+  const movedState = await page.evaluate(async () => {
+    const { state } = await import('/js/state.js');
+    return {
+      placements: state.importedData.markerPlacements,
+      entries: state.importedData.entries,
+      markerNotes: state.importedData.markerNotes,
+      markerValueNotes: state.importedData.markerValueNotes,
+      refOverrides: state.importedData.refOverrides,
+      manualValues: state.importedData.manualValues,
+    };
+  });
+  expect(movedState.placements).toEqual({
+    'gb:marker:glucose': { categoryKey: 'lipids' },
+  });
+  expect(movedState.entries[0].markers).toEqual({
+    'biochemistry.glucose': 5.2,
+    'lipids.cholesterol': 4.4,
+  });
+  expect(movedState.markerNotes).toEqual({ 'biochemistry.glucose': 'Fasting sample' });
+  expect(movedState.markerValueNotes).toEqual({ 'biochemistry.glucose:2026-08-01': 'Morning draw' });
+  expect(movedState.refOverrides).toEqual({ 'biochemistry.glucose': expect.objectContaining({ refMin: 4, refMax: 6 }) });
+  expect(movedState.manualValues).toEqual({ 'biochemistry.glucose:2026-08-01': true });
+
+  await detail.getByRole('button', { name: 'Restore' }).click();
+  await expect(detail).toHaveAttribute('data-sync-refresh-item-id', 'biochemistry_glucose');
+  await expect(detail).not.toContainText('Originally Biochemistry');
+  expect(await page.evaluate(async () => {
+    const { state } = await import('/js/state.js');
+    return state.importedData.markerPlacements;
+  })).toEqual({});
+});
+
+test('marker placement form remains focused and usable on a narrow mobile viewport', async ({ page }) => {
+  await page.setViewportSize({ width: 360, height: 780 });
+  await seedMarkerPlacementProfile(page);
+  await page.getByRole('button', { name: 'Change category for Glucose' }).click();
+
+  const form = page.locator('#detail-modal.marker-placement-form');
+  const category = form.getByLabel('Category');
+  await expect(form).toBeVisible();
+  await expect(category).toBeFocused();
+  await expect(form.getByRole('button', { name: 'Back to marker details' })).toBeVisible();
+  await expect(form.getByRole('button', { name: 'Cancel' })).toBeVisible();
+  await expect(form.getByRole('button', { name: 'Move marker' })).toBeVisible();
+
+  const layout = await form.evaluate(element => {
+    const rect = element.getBoundingClientRect();
+    return {
+      left: rect.left,
+      right: rect.right,
+      viewportWidth: window.innerWidth,
+      documentWidth: document.documentElement.scrollWidth,
+    };
+  });
+  expect(layout.left).toBeGreaterThanOrEqual(0);
+  expect(layout.right).toBeLessThanOrEqual(layout.viewportWidth + 1);
+  expect(layout.documentWidth).toBeLessThanOrEqual(layout.viewportWidth + 1);
+});

--- a/tests/playwright/marker-placement-ui.spec.js
+++ b/tests/playwright/marker-placement-ui.spec.js
@@ -96,6 +96,58 @@ test('marker detail moves and restores a marker without re-keying profile data',
   })).toEqual({});
 });
 
+test('calculated ratio can move to a regular category and keeps its diagnostics', async ({ page }) => {
+  await seedMarkerPlacementProfile(page);
+  await page.evaluate(async () => {
+    const { state } = await import('/js/state.js');
+    const data = await import('/js/data.js');
+    state.importedData.entries[0].markers['lipids.triglycerides'] = 1.5;
+    state.importedData.entries[0].markers['lipids.hdl'] = 1.2;
+    data.invalidateActiveDataCache();
+    const modal = await import('/js/marker-detail-modal.js');
+    await modal.showDetailModal('calculatedRatios_tgHdlRatio');
+  });
+
+  const detail = page.locator('#detail-modal');
+  await detail.getByRole('button', { name: 'Change category for TG/HDL Ratio' }).click();
+  const category = detail.getByLabel('Category');
+  await expect(category.locator('option[value="lipids"]')).toHaveCount(1);
+  await category.selectOption('lipids');
+  await detail.getByRole('button', { name: 'Move marker' }).click();
+
+  await expect(detail).toHaveAttribute('data-sync-refresh-item-id', 'lipids_tgHdlRatio');
+  await expect(detail).toContainText('Originally Calculated Ratios');
+  await expect(detail).not.toContainText('Not calculated');
+  const movedState = await page.evaluate(async () => {
+    const { state } = await import('/js/state.js');
+    const { getActiveData } = await import('/js/data.js');
+    const active = getActiveData();
+    return {
+      placements: state.importedData.markerPlacements,
+      storedMarkers: state.importedData.entries[0].markers,
+      ratio: active.categories.lipids.markers.tgHdlRatio,
+    };
+  });
+  expect(movedState.placements).toEqual({
+    'gb:marker:tgHdlRatio': { categoryKey: 'lipids' },
+  });
+  expect(movedState.storedMarkers).not.toHaveProperty('lipids.tgHdlRatio');
+  expect(movedState.ratio).toMatchObject({
+    storageDotKey: 'calculatedRatios.tgHdlRatio',
+    values: [1.25],
+  });
+
+  await page.evaluate(async () => {
+    const { state } = await import('/js/state.js');
+    const data = await import('/js/data.js');
+    delete state.importedData.entries[0].markers['lipids.hdl'];
+    data.invalidateActiveDataCache();
+    const modal = await import('/js/marker-detail-modal.js');
+    await modal.showDetailModal('lipids_tgHdlRatio');
+  });
+  await expect(detail).toContainText('Not calculated — Missing: HDL');
+});
+
 test('marker placement form remains focused and usable on a narrow mobile viewport', async ({ page }) => {
   await page.setViewportSize({ width: 360, height: 780 });
   await seedMarkerPlacementProfile(page);

--- a/tests/test-marker-detail-delegated-actions.js
+++ b/tests/test-marker-detail-delegated-actions.js
@@ -11,7 +11,8 @@ const modalFacadeSrc = fs.readFileSync(path.join(root, 'js/marker-detail-modal.j
 const modalImplSrc = fs.readFileSync(path.join(root, 'js/marker-detail-modal-impl.js'), 'utf8');
 const manualEntrySrc = fs.readFileSync(path.join(root, 'js/marker-detail-manual-entry.js'), 'utf8');
 const customMarkersSrc = fs.readFileSync(path.join(root, 'js/marker-detail-custom-markers.js'), 'utf8');
-const modalSrc = `${modalImplSrc}\n${manualEntrySrc}\n${customMarkersSrc}`;
+const placementSrc = fs.readFileSync(path.join(root, 'js/marker-detail-placement.js'), 'utf8');
+const modalSrc = `${modalImplSrc}\n${manualEntrySrc}\n${customMarkersSrc}\n${placementSrc}`;
 const editingSrc = fs.readFileSync(path.join(root, 'js/marker-detail-editing.js'), 'utf8');
 const actionSrc = fs.readFileSync(path.join(root, 'js/marker-detail-actions.js'), 'utf8');
 const runtimeSrc = fs.readFileSync(path.join(root, 'js/marker-detail-runtime.js'), 'utf8');
@@ -82,6 +83,8 @@ assert('service worker precaches marker-detail-actions.js',
   swSrc.includes("'/js/marker-detail-actions.js'"));
 assert('service worker precaches marker-detail-runtime.js',
   swSrc.includes("'/js/marker-detail-runtime.js'"));
+assert('service worker precaches marker-detail-placement.js',
+  swSrc.includes("'/js/marker-detail-placement.js'"));
 assert('marker-detail-modal delegates browser globals through runtime adapter',
   modalSrc.includes("from './marker-detail-runtime.js'") &&
     !/\bwindow(?:\.|\s*\[)/.test(modalSrc) &&
@@ -108,6 +111,9 @@ assert('marker-detail-modal only creates recommendation placeholders when render
   'revert-ref-range',
   'rename-marker',
   'revert-marker-name',
+  'open-marker-placement',
+  'save-marker-placement',
+  'restore-marker-placement',
   'toggle-history-note',
   'edit-marker-value',
   'delete-marker-value',
@@ -139,6 +145,9 @@ assert('marker-detail-modal only creates recommendation placeholders when render
   "markerDetailActionAttrs('save-ref-range', { id, type })",
   "markerDetailActionAttrs('revert-marker-name', { id })",
   "markerDetailActionAttrs('rename-marker', { id })",
+  "markerDetailActionAttrs('open-marker-placement', { id })",
+  "markerDetailActionAttrs('save-marker-placement', { id })",
+  "markerDetailActionAttrs('restore-marker-placement', { id })",
   "markerDetailActionAttrs('quick-pin', { id })",
   "markerDetailActionAttrs('close-modal')",
   "markerDetailActionAttrs('toggle-history-note')",

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -243,6 +243,7 @@
     "js/marker-detail-content.js",
     "js/marker-detail-custom-markers.js",
     "js/marker-detail-manual-entry.js",
+    "js/marker-detail-placement.js",
     "js/marker-detail-runtime.js",
     "js/modal-trigger-memory.js",
     "js/mobile-dashboard.js",


### PR DESCRIPTION
## Summary

- add a user-facing **Change category** flow to marker details, with compatible destinations, existing-profile categories first, and one-click restore
- keep the marker's immutable storage identity unchanged so values, history, notes, ranges, backups, shares, imports, and sync continue to resolve normally
- keep Quick Marker pins and dashboard priority references attached to that immutable identity after a move
- document the placement behavior and add focused unit and browser coverage, including a 360 px mobile interaction

## Design

This changes only a marker's primary display category. It does not duplicate markers or rewrite historical keys. Calculated, mode-incompatible, and colliding destinations are hidden by the same placement engine that validates persistence.

This implements the marker-move workflow discussed in #57; multi-category tagging remains separate.

## Validation

- `npm run quality`
- `npm run typecheck:checkjs`
- `npm run typecheck:service-worker`
- `npm run architecture:check`
- `npm run production:check`
- focused Vitest placement, dashboard, lazy-boundary, and production-build tests (61 passed)
- focused Playwright marker-detail and placement specs (16 passed)
- DOM sink audit and delegated-action guard (88 passed)