### PR TITLE
Polish marker category picker

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -9,8 +9,8 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 
 | Metric | Current |
 | --- | ---: |
-| Modules | 638 |
-| Internal import edges | 2698 |
+| Modules | 639 |
+| Internal import edges | 2700 |
 | Dynamic internal edges | 72 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -226,11 +226,12 @@ Native browser modules shipped with the static application.
 
 </details>
 
-<details><summary><code>category</code> family — 6 modules</summary>
+<details><summary><code>category</code> family — 7 modules</summary>
 
 - [`js/category-customization-runtime.js`](js/category-customization-runtime.js) → [`js/utils.js`](js/utils.js)
 - [`js/category-customization.js`](js/category-customization.js) → [`js/category-customization-runtime.js`](js/category-customization-runtime.js), [`js/data.js`](js/data.js), [`js/marker-detail-modal.js`](js/marker-detail-modal.js), [`js/marker-placement.js`](js/marker-placement.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/category-glyphs.js`](js/category-glyphs.js) → [`js/utils.js`](js/utils.js)
+- [`js/category-order.js`](js/category-order.js) → no in-scope imports
 - [`js/category-page-runtime.js`](js/category-page-runtime.js) → [`js/recommendations-runtime.js`](js/recommendations-runtime.js)
 - [`js/category-page-view.js`](js/category-page-view.js) → [`js/category-glyphs.js`](js/category-glyphs.js), [`js/category-page-runtime.js`](js/category-page-runtime.js), [`js/category-view-renderers.js`](js/category-view-renderers.js), [`js/chart-card-recs.js`](js/chart-card-recs.js), [`js/data.js`](js/data.js), [`js/health-data-loader.js`](js/health-data-loader.js), [`js/marker-analysis.js`](js/marker-analysis.js), [`js/marker-detail-actions.js`](js/marker-detail-actions.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/category-view-renderers.js`](js/category-view-renderers.js) → [`js/charts-runtime.js`](js/charts-runtime.js), [`js/health-data-loader.js`](js/health-data-loader.js), [`js/marker-analysis.js`](js/marker-analysis.js), [`js/marker-detail-actions.js`](js/marker-detail-actions.js), [`js/state.js`](js/state.js), [`js/theme.js`](js/theme.js), [`js/utils.js`](js/utils.js)
@@ -715,7 +716,7 @@ Native browser modules shipped with the static application.
 - [`js/marker-detail-manual-entry.js`](js/marker-detail-manual-entry.js) → [`js/data.js`](js/data.js), [`js/marker-detail-actions.js`](js/marker-detail-actions.js), [`js/marker-detail-editing.js`](js/marker-detail-editing.js), [`js/marker-detail-runtime.js`](js/marker-detail-runtime.js), [`js/marker-placement.js`](js/marker-placement.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/marker-detail-modal-impl.js`](js/marker-detail-modal-impl.js) → [`js/api.js`](js/api.js), [`js/charts.js`](js/charts.js), [`js/context-cards.js`](js/context-cards.js), [`js/data.js`](js/data.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/marker-analysis.js`](js/marker-analysis.js), [`js/marker-detail-actions.js`](js/marker-detail-actions.js), [`js/marker-detail-content.js`](js/marker-detail-content.js), [`js/marker-detail-custom-markers.js`](js/marker-detail-custom-markers.js), [`js/marker-detail-editing.js`](js/marker-detail-editing.js), [`js/marker-detail-manual-entry.js`](js/marker-detail-manual-entry.js), [`js/marker-detail-placement.js`](js/marker-detail-placement.js), [`js/marker-detail-runtime.js`](js/marker-detail-runtime.js), [`js/marker-placement.js`](js/marker-placement.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/modal-trigger-memory.js`](js/modal-trigger-memory.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/marker-detail-modal.js`](js/marker-detail-modal.js) → [`js/health-data-loader.js`](js/health-data-loader.js), [`js/marker-detail-actions.js`](js/marker-detail-actions.js), [`js/marker-detail-modal-impl.js`](js/marker-detail-modal-impl.js) *(dynamic)*, [`js/marker-detail-runtime.js`](js/marker-detail-runtime.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/modal-trigger-memory.js`](js/modal-trigger-memory.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
-- [`js/marker-detail-placement.js`](js/marker-detail-placement.js) → [`js/data.js`](js/data.js), [`js/marker-detail-actions.js`](js/marker-detail-actions.js), [`js/marker-detail-runtime.js`](js/marker-detail-runtime.js), [`js/marker-placement.js`](js/marker-placement.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
+- [`js/marker-detail-placement.js`](js/marker-detail-placement.js) → [`js/category-order.js`](js/category-order.js), [`js/data.js`](js/data.js), [`js/marker-detail-actions.js`](js/marker-detail-actions.js), [`js/marker-detail-runtime.js`](js/marker-detail-runtime.js), [`js/marker-placement.js`](js/marker-placement.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/marker-detail-runtime.js`](js/marker-detail-runtime.js) → [`js/dna-runtime-bridge.js`](js/dna-runtime-bridge.js), [`js/emf-runtime.js`](js/emf-runtime.js), [`js/recommendations-runtime.js`](js/recommendations-runtime.js), [`js/utils.js`](js/utils.js), [`js/wearables-runtime.js`](js/wearables-runtime.js)
 - [`js/marker-detail-store.js`](js/marker-detail-store.js) → [`js/data.js`](js/data.js), [`js/lab-entry-mutations.js`](js/lab-entry-mutations.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/state.js`](js/state.js)
 - [`js/marker-placement.js`](js/marker-placement.js) → [`js/custom-marker-identity.js`](js/custom-marker-identity.js), [`js/marker-schema.js`](js/marker-schema.js)
@@ -741,7 +742,7 @@ Native browser modules shipped with the static application.
 <details><summary><code>nav</code> family — 2 modules</summary>
 
 - [`js/nav-runtime.js`](js/nav-runtime.js) → [`js/context-cards-runtime.js`](js/context-cards-runtime.js), [`js/emf-runtime.js`](js/emf-runtime.js), [`js/export-loader.js`](js/export-loader.js)
-- [`js/nav.js`](js/nav.js) → [`js/data.js`](js/data.js), [`js/lens.js`](js/lens.js), [`js/marker-analysis.js`](js/marker-analysis.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/nav-runtime.js`](js/nav-runtime.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
+- [`js/nav.js`](js/nav.js) → [`js/category-order.js`](js/category-order.js), [`js/data.js`](js/data.js), [`js/lens.js`](js/lens.js), [`js/marker-analysis.js`](js/marker-analysis.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/nav-runtime.js`](js/nav-runtime.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 
 </details>
 

--- a/docs/marker-identity.md
+++ b/docs/marker-identity.md
@@ -68,11 +68,12 @@ Every projected marker carries `markerId`, `storageDotKey`,
 Placements travel through profile exports, database backups, encrypted shares,
 imports, and per-row sync. Missing or invalid assignments fall back to the
 native category and are preserved for forward-compatible sync ordering.
-Calculated categories cannot participate, regular and single-point category
-modes cannot be mixed, and marker-key collisions are rejected. Moving a marker
-back to its native category removes the redundant assignment. Profiles without
-`markerPlacements` migrate to an empty map and require no value migration or
-re-import.
+Calculated destinations are rejected, but calculated markers may be displayed
+in compatible regular categories after computation. Regular and single-point
+category modes cannot be mixed, and marker-key collisions are rejected. Moving
+a marker back to its native category removes the redundant assignment. Profiles
+without `markerPlacements` migrate to an empty map and require no value migration
+or re-import.
 
 ### User-facing placement
 

--- a/js/category-order.js
+++ b/js/category-order.js
@@ -1,0 +1,24 @@
+// @ts-check
+// category-order.js — Shared ordering for lab-category navigation and controls.
+
+/**
+ * Keep regular lab categories first, followed by specialty groups in their
+ * schema order. This mirrors the sidebar without depending on rendered DOM.
+ *
+ * @param {Record<string, any>} categories
+ * @returns {Array<[string, any]>}
+ */
+export function getLabCategoryEntriesInSidebarOrder(categories) {
+  const regular = [];
+  const specialtyGroups = new Map();
+  for (const entry of Object.entries(categories || {})) {
+    const group = entry[1]?.group;
+    if (!group) {
+      regular.push(entry);
+      continue;
+    }
+    if (!specialtyGroups.has(group)) specialtyGroups.set(group, []);
+    specialtyGroups.get(group).push(entry);
+  }
+  return regular.concat(...specialtyGroups.values());
+}

--- a/js/marker-detail-placement.js
+++ b/js/marker-detail-placement.js
@@ -2,6 +2,7 @@
 // marker-detail-placement.js — Marker category placement form and persistence.
 
 import { getActiveData, invalidateActiveDataCache, saveImportedDataForProfile } from './data.js';
+import { getLabCategoryEntriesInSidebarOrder } from './category-order.js';
 import { markerDetailActionAttrs } from './marker-detail-actions.js';
 import {
   clearMarkerPlacement,
@@ -79,8 +80,8 @@ function categoryHasData(category) {
 
 /**
  * Return only destinations accepted by the placement engine. Categories that
- * cannot preserve marker semantics (calculated, mode-mismatched, or colliding)
- * stay out of the control instead of failing after the user chooses them.
+ * cannot preserve marker semantics (calculated destinations, mode-mismatched,
+ * or colliding) stay out of the control instead of failing after selection.
  *
  * @param {string} id
  */
@@ -89,7 +90,7 @@ export function getMarkerPlacementChoices(id) {
   if (!context) return null;
   const choices = [];
   let unavailableCount = 0;
-  for (const [categoryKey, category] of Object.entries(context.data.categories || {})) {
+  for (const [categoryKey, category] of getLabCategoryEntriesInSidebarOrder(context.data.categories || {})) {
     const candidatePlacements = clonePlacements(state.importedData?.markerPlacements) || {};
     const candidateProfile = { ...state.importedData, markerPlacements: candidatePlacements };
     const result = setMarkerPlacement(candidateProfile, context.markerReference, categoryKey);
@@ -100,17 +101,12 @@ export function getMarkerPlacementChoices(id) {
     choices.push({
       categoryKey,
       label: category.label || categoryKey,
-      icon: category.icon || '',
       inProfile: categoryHasData(category)
         || categoryKey === context.displayCategoryKey
         || categoryKey === context.nativeCategoryKey,
       selected: categoryKey === context.displayCategoryKey,
     });
   }
-  choices.sort((left, right) => {
-    if (left.inProfile !== right.inProfile) return left.inProfile ? -1 : 1;
-    return String(left.label).localeCompare(String(right.label));
-  });
   return { ...context, choices, unavailableCount };
 }
 
@@ -146,10 +142,7 @@ function renderPlacementOptions(choices) {
   return groups
     .filter(group => group.options.length > 0)
     .map(({ label, options }) => `<optgroup label="${escapeAttr(label)}">
-      ${options.map(choice => {
-        const visibleLabel = `${choice.icon ? `${choice.icon} ` : ''}${choice.label}`;
-        return `<option value="${escapeAttr(choice.categoryKey)}"${choice.selected ? ' selected' : ''}>${escapeHTML(visibleLabel)}</option>`;
-      }).join('')}
+      ${options.map(choice => `<option value="${escapeAttr(choice.categoryKey)}"${choice.selected ? ' selected' : ''}>${escapeHTML(choice.label)}</option>`).join('')}
     </optgroup>`)
     .join('');
 }

--- a/js/nav.js
+++ b/js/nav.js
@@ -2,6 +2,7 @@
 // nav.js — Sidebar, compact profile button
 
 import { state } from './state.js';
+import { getLabCategoryEntriesInSidebarOrder } from './category-order.js';
 import { escapeHTML, escapeAttr, hashString } from './utils.js';
 import { getActiveData, filterDatesByRange } from './data.js';
 import { countFlagged } from './marker-analysis.js';
@@ -285,7 +286,7 @@ export function buildSidebar(data) {
   // Separate categories into blood work (no group) and specialty groups
   const bloodWork = [];
   const specialtyGroups = {};
-  for (const [key, cat] of Object.entries(data.categories)) {
+  for (const [key, cat] of getLabCategoryEntriesInSidebarOrder(data.categories)) {
     const item = _buildNavItem(key, cat);
     if (!item) continue;
     if (cat.group) {

--- a/scripts/cold-load-budget.json
+++ b/scripts/cold-load-budget.json
@@ -3,7 +3,7 @@
   "route": "/app",
   "scenario": "Fresh mobile returning-user load with browser cache and service workers disabled",
   "maximums": {
-    "requests": 296,
+    "requests": 297,
     "transferBytes": 1193220,
     "decodedBytes": 2955000
   },

--- a/scripts/dom-sink-policy.json
+++ b/scripts/dom-sink-policy.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "scope": "Every non-generated JavaScript module under js/",
   "reviewRule": "Any added or modified HTML-writing sink requires security review and a policy refresh.",
-  "scannedFiles": 619,
+  "scannedFiles": 620,
   "sinkCount": 497,
   "files": {
     "js/backup.js": {

--- a/service-worker.js
+++ b/service-worker.js
@@ -374,6 +374,7 @@ const APP_SHELL = [
   '/js/chart-card-recs.js',
   '/js/category-customization-runtime.js',
   '/js/category-glyphs.js',
+  '/js/category-order.js',
   '/js/category-page-runtime.js',
   '/js/category-page-view.js',
   '/js/category-view-renderers.js',
@@ -769,7 +770,6 @@ const NETWORK_ONLY_HOSTS = new Set([
   'sync.getbased.health',
   'free.evoluhq.com',
 ]);
-
 function isLocalOrPrivateHost(hostname) {
   return hostname === 'localhost' ||
     hostname === '127.0.0.1' ||

--- a/tests/category-order.test.js
+++ b/tests/category-order.test.js
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { getLabCategoryEntriesInSidebarOrder } from '../js/category-order.js';
+
+describe('lab category order', () => {
+  it('keeps regular categories first and preserves sidebar specialty groups', () => {
+    const categories = {
+      biochemistry: { label: 'Biochemistry' },
+      bodyComposition: { label: 'Body Composition', group: 'DEXA' },
+      customPanel: { label: 'Custom Panel' },
+      boneDensity: { label: 'Bone Density', group: 'DEXA' },
+      oatEnergy: { label: 'Energy', group: 'OAT' },
+    };
+
+    expect(getLabCategoryEntriesInSidebarOrder(categories).map(([key]) => key)).toEqual([
+      'biochemistry',
+      'customPanel',
+      'bodyComposition',
+      'boneDensity',
+      'oatEnergy',
+    ]);
+  });
+});

--- a/tests/marker-placement-ui.test.js
+++ b/tests/marker-placement-ui.test.js
@@ -36,7 +36,11 @@ function activeData() {
       icon: '❤️',
       markers: { cholesterol: { name: 'Cholesterol', values: [4.4] } },
     },
-    hormones: { label: 'Hormones', icon: '⚗️', markers: {} },
+    hormones: {
+      label: 'Hormones',
+      icon: '⚗️',
+      markers: { testosterone: { name: 'Testosterone', values: [18] } },
+    },
     calculatedRatios: {
       label: 'Calculated Ratios',
       icon: '📐',
@@ -131,6 +135,8 @@ describe('marker placement UI', () => {
     expect(modal.textContent).toContain('Only where this marker appears will change.');
     expect(modal.textContent).toContain('Values, history, units, notes, reference ranges, backups, shares, imports, and sync');
     expect(select.value).toBe('biochemistry');
+    expect([...select.options].map(option => option.value)).toEqual(['biochemistry', 'lipids', 'hormones']);
+    expect([...select.options].map(option => option.textContent)).toEqual(['Biochemistry', 'Lipids', 'Hormones']);
     expect([...select.options].map(option => option.value)).not.toContain('calculatedRatios');
   });
 

--- a/tests/playwright/marker-placement-ui.spec.js
+++ b/tests/playwright/marker-placement-ui.spec.js
@@ -59,6 +59,15 @@ test('marker detail moves and restores a marker without re-keying profile data',
   const category = form.getByLabel('Category');
   await expect(category).toHaveValue('biochemistry');
   await expect(category.locator('option[value="calculatedRatios"]')).toHaveCount(0);
+  expect((await category.locator('option').evaluateAll(options => options.map(option => ({
+    value: option.value,
+    label: option.textContent,
+  })))).slice(0, 4)).toEqual([
+    { value: 'biochemistry', label: 'Biochemistry' },
+    { value: 'lipids', label: 'Lipid Panel' },
+    { value: 'hormones', label: 'Hormones' },
+    { value: 'electrolytes', label: 'Electrolytes & Minerals' },
+  ]);
   await category.selectOption('lipids');
   await form.getByRole('button', { name: 'Move marker' }).click();
 

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -489,6 +489,7 @@
     "js/category-customization-runtime.js",
     "js/category-customization.js",
     "js/category-glyphs.js",
+    "js/category-order.js",
     "js/category-page-runtime.js",
     "js/category-page-view.js",
     "js/category-view-renderers.js",


### PR DESCRIPTION
## Summary

- remove category emoji from the marker-placement dropdown and use restrained plain-text labels
- share one category-order helper between the sidebar and placement picker so their order cannot drift
- preserve the useful “In this profile” grouping while keeping sidebar order within both option groups
- correct the marker identity documentation: calculated markers may move to compatible regular categories, while calculated destinations remain blocked
- add focused unit and browser regression coverage for ordering and labels

## Why

The placement dropdown still exposed legacy schema emoji after the rest of the application moved to a more restrained visual language. It also alphabetized categories independently of the sidebar, making the same categories appear in different sequences.

## User impact

The picker now matches the sidebar’s category hierarchy and uses clean text labels. Placement storage, calculation, backup, import, sharing, and synchronization behavior are unchanged.

## Validation

- `npm test -- tests/category-order.test.js tests/marker-placement-ui.test.js tests/marker-placement.test.js` — 16 passed
- `npx playwright test tests/playwright/marker-placement-ui.spec.js tests/playwright/nav-delegated-actions.spec.js --workers=1` — 6 passed
- `npm run typecheck:checkjs`
- `npm run typecheck:strict-null`
- `npm run quality`
- `npm run marker-schema:check`
- `npm run production:check`
- `npm run architecture:check`
- `git diff --check`