### PR TITLE
Fix synced manual deletions and chat reopen state

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -11,7 +11,7 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | --- | ---: |
 | Modules | 651 |
 | Internal import edges | 2726 |
-| Dynamic internal edges | 72 |
+| Dynamic internal edges | 73 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
 | Largest cyclic component | 0 |
@@ -59,7 +59,7 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 | [`js/utils.js`](js/utils.js) | 264 | [`js/app-shell-hooks.js`](js/app-shell-hooks.js) | 74 |
 | [`js/state.js`](js/state.js) | 183 | [`js/app-light-sun-modules.js`](js/app-light-sun-modules.js) | 36 |
 | [`js/caught-error.js`](js/caught-error.js) | 83 | [`js/chat-send.js`](js/chat-send.js) | 28 |
-| [`js/data.js`](js/data.js) | 78 | [`js/sync-configure.js`](js/sync-configure.js) | 27 |
+| [`js/data.js`](js/data.js) | 77 | [`js/sync-configure.js`](js/sync-configure.js) | 27 |
 | [`js/modal-lifecycle.js`](js/modal-lifecycle.js) | 75 | [`js/pdf-import.js`](js/pdf-import.js) | 26 |
 | [`js/api.js`](js/api.js) | 66 | [`js/settings.js`](js/settings.js) | 26 |
 | [`js/profile.js`](js/profile.js) | 48 | [`js/wearables-connect.js`](js/wearables-connect.js) | 25 |
@@ -839,7 +839,7 @@ Native browser modules shipped with the static application.
 - [`js/profile-list-store.js`](js/profile-list-store.js) → [`js/crypto.js`](js/crypto.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/profile-marker-alias-migrations.js`](js/profile-marker-alias-migrations.js) → [`js/adapters.js`](js/adapters.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/schema.js`](js/schema.js)
 - [`js/profile-marker-migrations.js`](js/profile-marker-migrations.js) → [`js/adapters.js`](js/adapters.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/profile-fatty-acid-migrations.js`](js/profile-fatty-acid-migrations.js), [`js/profile-marker-alias-migrations.js`](js/profile-marker-alias-migrations.js), [`js/schema.js`](js/schema.js)
-- [`js/profile-runtime.js`](js/profile-runtime.js) → [`js/chat-loader.js`](js/chat-loader.js), [`js/state.js`](js/state.js), [`js/wearables-connect.js`](js/wearables-connect.js) *(dynamic)*
+- [`js/profile-runtime.js`](js/profile-runtime.js) → [`js/chat-loader.js`](js/chat-loader.js), [`js/state.js`](js/state.js), [`js/wearables-connect.js`](js/wearables-connect.js) *(dynamic)*, [`js/wearables-manual.js`](js/wearables-manual.js) *(dynamic)*
 - [`js/profile-share-loader.js`](js/profile-share-loader.js) → [`js/profile-share.js`](js/profile-share.js) *(dynamic)*, [`js/utils-runtime.js`](js/utils-runtime.js), [`js/utils.js`](js/utils.js)
 - [`js/profile-share.js`](js/profile-share.js) → [`js/caught-error.js`](js/caught-error.js), [`js/export.js`](js/export.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils-runtime.js`](js/utils-runtime.js), [`js/utils.js`](js/utils.js)
 - [`js/profile-storage-cleanup.js`](js/profile-storage-cleanup.js) → [`js/blob-storage.js`](js/blob-storage.js), [`js/crypto.js`](js/crypto.js), [`js/cycle-store.js`](js/cycle-store.js), [`js/profile-storage-key.js`](js/profile-storage-key.js), [`js/wearables-store.js`](js/wearables-store.js)
@@ -1247,7 +1247,7 @@ Native browser modules shipped with the static application.
 - [`js/wearables-polar.js`](js/wearables-polar.js) → [`js/caught-error.js`](js/caught-error.js), [`js/utils.js`](js/utils.js)
 - [`js/wearables-runtime.js`](js/wearables-runtime.js) → [`js/emf-runtime.js`](js/emf-runtime.js), [`js/settings-runtime-bridge.js`](js/settings-runtime-bridge.js), [`js/utils.js`](js/utils.js)
 - [`js/wearables-settings-groups.js`](js/wearables-settings-groups.js) → no in-scope imports
-- [`js/wearables-settings-panel.js`](js/wearables-settings-panel.js) → [`js/brand-assets.js`](js/brand-assets.js), [`js/caught-error.js`](js/caught-error.js), [`js/data.js`](js/data.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js), [`js/wearable-adapters.js`](js/wearable-adapters.js), [`js/wearables-apple-health.js`](js/wearables-apple-health.js) *(dynamic)*, [`js/wearables-connect.js`](js/wearables-connect.js), [`js/wearables-manual.js`](js/wearables-manual.js), [`js/wearables-settings-groups.js`](js/wearables-settings-groups.js), [`js/wearables-settings-runtime.js`](js/wearables-settings-runtime.js), [`js/wearables-store.js`](js/wearables-store.js), [`js/wearables-summary.js`](js/wearables-summary.js)
+- [`js/wearables-settings-panel.js`](js/wearables-settings-panel.js) → [`js/brand-assets.js`](js/brand-assets.js), [`js/caught-error.js`](js/caught-error.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js), [`js/wearable-adapters.js`](js/wearable-adapters.js), [`js/wearables-apple-health.js`](js/wearables-apple-health.js) *(dynamic)*, [`js/wearables-connect.js`](js/wearables-connect.js), [`js/wearables-manual.js`](js/wearables-manual.js), [`js/wearables-settings-groups.js`](js/wearables-settings-groups.js), [`js/wearables-settings-runtime.js`](js/wearables-settings-runtime.js), [`js/wearables-store.js`](js/wearables-store.js), [`js/wearables-summary.js`](js/wearables-summary.js)
 - [`js/wearables-settings-runtime.js`](js/wearables-settings-runtime.js) → [`js/settings-runtime-bridge.js`](js/settings-runtime-bridge.js), [`js/utils.js`](js/utils.js)
 - [`js/wearables-store.js`](js/wearables-store.js) → no in-scope imports
 - [`js/wearables-strip-actions.js`](js/wearables-strip-actions.js) → [`js/caught-error.js`](js/caught-error.js), [`js/data.js`](js/data.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js), [`js/wearable-adapters.js`](js/wearable-adapters.js), [`js/wearables-connect.js`](js/wearables-connect.js), [`js/wearables-detail-modal.js`](js/wearables-detail-modal.js), [`js/wearables-manual-form-ui.js`](js/wearables-manual-form-ui.js), [`js/wearables-manual.js`](js/wearables-manual.js), [`js/wearables-runtime.js`](js/wearables-runtime.js), [`js/wearables-summary.js`](js/wearables-summary.js)

--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -11,7 +11,7 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | --- | ---: |
 | Modules | 651 |
 | Internal import edges | 2726 |
-| Dynamic internal edges | 73 |
+| Dynamic internal edges | 72 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
 | Largest cyclic component | 0 |
@@ -839,7 +839,7 @@ Native browser modules shipped with the static application.
 - [`js/profile-list-store.js`](js/profile-list-store.js) → [`js/crypto.js`](js/crypto.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
 - [`js/profile-marker-alias-migrations.js`](js/profile-marker-alias-migrations.js) → [`js/adapters.js`](js/adapters.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/schema.js`](js/schema.js)
 - [`js/profile-marker-migrations.js`](js/profile-marker-migrations.js) → [`js/adapters.js`](js/adapters.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/profile-fatty-acid-migrations.js`](js/profile-fatty-acid-migrations.js), [`js/profile-marker-alias-migrations.js`](js/profile-marker-alias-migrations.js), [`js/schema.js`](js/schema.js)
-- [`js/profile-runtime.js`](js/profile-runtime.js) → [`js/chat-loader.js`](js/chat-loader.js), [`js/state.js`](js/state.js), [`js/wearables-connect.js`](js/wearables-connect.js) *(dynamic)*, [`js/wearables-manual.js`](js/wearables-manual.js) *(dynamic)*
+- [`js/profile-runtime.js`](js/profile-runtime.js) → [`js/chat-loader.js`](js/chat-loader.js), [`js/state.js`](js/state.js), [`js/wearables-connect.js`](js/wearables-connect.js) *(dynamic)*, [`js/wearables-manual.js`](js/wearables-manual.js)
 - [`js/profile-share-loader.js`](js/profile-share-loader.js) → [`js/profile-share.js`](js/profile-share.js) *(dynamic)*, [`js/utils-runtime.js`](js/utils-runtime.js), [`js/utils.js`](js/utils.js)
 - [`js/profile-share.js`](js/profile-share.js) → [`js/caught-error.js`](js/caught-error.js), [`js/export.js`](js/export.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils-runtime.js`](js/utils-runtime.js), [`js/utils.js`](js/utils.js)
 - [`js/profile-storage-cleanup.js`](js/profile-storage-cleanup.js) → [`js/blob-storage.js`](js/blob-storage.js), [`js/crypto.js`](js/crypto.js), [`js/cycle-store.js`](js/cycle-store.js), [`js/profile-storage-key.js`](js/profile-storage-key.js), [`js/wearables-store.js`](js/wearables-store.js)

--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -146,6 +146,7 @@ import {
   configureProfileRefreshDeps,
   dispatchProfileSwitched,
   invalidateProfileContextCache,
+  reconcilePulledManualWearables,
   refreshProfileButton,
   refreshProfileWearables,
   reloadProfileRuntimeShell,
@@ -353,7 +354,7 @@ configureStartupUIDeps({
 });
 configureOnboardingViewRuntimeDeps({ buildSidebar, createNewThread, navigate, openChatPanel, toggleChatPanel });
 configureTourRuntimeDeps({ openChatPanel });
-configureSyncPull({ renderProfileButton });
+configureSyncPull({ renderProfileButton, reconcilePulledManualWearables });
 configureSyncPullActiveRefreshDeps({
   buildSidebar,
   ensureActiveThread: ensureActiveThreadIfLoaded,

--- a/js/chat-panel.js
+++ b/js/chat-panel.js
@@ -49,12 +49,16 @@ let useChatPresentationStylesheetRetryUrl = false;
 
 /** @type {{
  *   restoreDiscussionContinuePrompt: (() => void) | null,
+ *   isChatStreaming: (() => boolean) | null,
  *   refreshMobileDashboardActiveTab: (() => void) | null,
+ *   restoreChatGenerationUI: (() => boolean) | null,
  *   stopVoiceActivity: (() => void) | null,
  * }} */
 const panelCallbacks = {
   restoreDiscussionContinuePrompt: null,
+  isChatStreaming: null,
   refreshMobileDashboardActiveTab: null,
+  restoreChatGenerationUI: null,
   stopVoiceActivity: null,
 };
 let chatThreadInputBlocked = false;
@@ -76,7 +80,7 @@ function updateChatPanelAccessibility(panel, open) {
   setChatBackgroundInert(open && mobile);
 }
 
-/** @param {{ restoreDiscussionContinuePrompt?: (() => void) | null, refreshMobileDashboardActiveTab?: (() => void) | null, stopVoiceActivity?: (() => void) | null }} [callbacks] */
+/** @param {{ restoreDiscussionContinuePrompt?: (() => void) | null, isChatStreaming?: (() => boolean) | null, refreshMobileDashboardActiveTab?: (() => void) | null, restoreChatGenerationUI?: (() => boolean) | null, stopVoiceActivity?: (() => void) | null }} [callbacks] */
 export function configureChatPanel(callbacks = {}) {
   const previous = { ...panelCallbacks };
   Object.assign(panelCallbacks, callbacks);
@@ -285,18 +289,28 @@ export async function openChatPanel(prefillMessage) {
   const wsCb = /** @type {HTMLInputElement | null} */ (panel.querySelector('#chat-websearch-checkbox'));
   if (wsCb) wsCb.checked = getChatWebSearchEnabled();
   updateWebSearchToggleVisibility();
+  // An in-flight answer exists only in the live request/typewriter state
+  // until it finishes. Reloading the persisted thread here would erase that
+  // partial response and typing indicator while the request kept running,
+  // making the latest user message look interrupted and retryable.
+  const generationInProgress = panelCallbacks.isChatStreaming?.() === true;
   // Load threads and ensure active thread
-  const threadsLoaded = await loadChatThreads();
-  chatThreadInputBlocked = threadsLoaded === false;
-  if (threadsLoaded !== false) ensureActiveThread();
+  let threadsLoaded = true;
+  if (!generationInProgress) {
+    threadsLoaded = await loadChatThreads();
+    chatThreadInputBlocked = threadsLoaded === false;
+    if (threadsLoaded !== false) ensureActiveThread();
+  }
   restoreRailState();
   renderThreadList();
   renderSavedSummaries();
-  if (threadsLoaded !== false) await loadChatHistory();
-  panelCallbacks.restoreDiscussionContinuePrompt?.();
+  if (!generationInProgress && threadsLoaded !== false) await loadChatHistory();
+  if (!generationInProgress) panelCallbacks.restoreDiscussionContinuePrompt?.();
   updateChatInputState();
   initChatComposer();
-  if (!chatThreadInputBlocked) {
+  if (generationInProgress) {
+    panelCallbacks.restoreChatGenerationUI?.();
+  } else if (!chatThreadInputBlocked) {
     if (prefillMessage) setChatInputValue(prefillMessage, { focus: true });
     else await restoreChatDraft(undefined, { focus: true });
   }

--- a/js/chat-send.js
+++ b/js/chat-send.js
@@ -66,6 +66,9 @@ import { setChatStreamStatus } from './chat-stream-status.js';
 /** @type {AbortController | null} */
 let _chatAbortController = null;
 
+/** @type {{ container: HTMLElement, typingEl: HTMLElement, aiMsgEl: HTMLElement | null, labelEl: HTMLElement | null, personalityName: string } | null} */
+let _activeChatGenerationUI = null;
+
 export function isChatStreaming() {
   return !!_chatAbortController;
 }
@@ -80,6 +83,30 @@ export function setChatAbortController(controller) {
 
 export function stopChatGeneration() {
   _chatAbortController?.abort();
+}
+
+// Closing the panel deliberately does not stop generation. If reopening (or
+// another transcript render) displaced the live placeholder, reconnect the
+// same DOM nodes and restore the Stop affordance without restarting or
+// duplicating the billable request.
+export function restoreChatGenerationUI() {
+  if (!_chatAbortController) return false;
+  const sendBtn = /** @type {HTMLButtonElement | null} */ (document.getElementById('chat-send-btn'));
+  setSendButtonMode(sendBtn, 'streaming');
+
+  const active = _activeChatGenerationUI;
+  if (!active) return true; // Discussion rounds own their live message UI.
+  const container = /** @type {HTMLElement | null} */ (document.getElementById('chat-messages')) || active.container;
+  active.container = container;
+  if (active.aiMsgEl?.textContent) {
+    if (active.labelEl && !active.labelEl.isConnected) container.appendChild(active.labelEl);
+    if (!active.aiMsgEl.isConnected) container.appendChild(active.aiMsgEl);
+  } else if (!active.typingEl.isConnected) {
+    container.appendChild(active.typingEl);
+  }
+  setChatStreamStatus(`${active.personalityName} is responding.`, { busy: true });
+  notifyChatContentAdded(container);
+  return true;
 }
 
 // ═══════════════════════════════════════════════
@@ -152,6 +179,14 @@ initChatScrollControls();
 // ═══════════════════════════════════════════════
 export function setSendButtonMode(btn, mode) {
   if (!btn) return;
+  // Editing the latest prompt would replace the response that is currently
+  // arriving. Keep the action out of sight until the active request settles,
+  // including after a close/reopen cycle.
+  document.querySelectorAll('.chat-edit-retry-action').forEach(action => {
+    const button = /** @type {HTMLButtonElement} */ (action);
+    button.hidden = mode === 'streaming';
+    button.disabled = mode === 'streaming';
+  });
   if (mode === 'streaming') {
     btn.disabled = false;
     setIconButtonContent(btn, 'stop');
@@ -244,6 +279,13 @@ export async function sendChatMessage() {
 
   // Switch to stop mode
   _chatAbortController = new AbortController();
+  _activeChatGenerationUI = {
+    container,
+    typingEl,
+    aiMsgEl: null,
+    labelEl: null,
+    personalityName: getActivePersonality().name,
+  };
   setSendButtonMode(sendBtn, 'streaming');
   setChatStreamStatus(`${getActivePersonality().name} is responding.`, { busy: true });
   let streamOutcome = 'complete';
@@ -304,6 +346,7 @@ export async function sendChatMessage() {
       labelEl.className = 'chat-persona-label';
       labelEl.textContent = `${personality.icon || ''} ${personality.name}`;
       container.appendChild(labelEl);
+      if (_activeChatGenerationUI) _activeChatGenerationUI.labelEl = labelEl;
     }
 
     // Create AI message placeholder
@@ -311,7 +354,9 @@ export async function sendChatMessage() {
     aiMsgEl.className = 'chat-msg chat-ai';
     aiMsgEl.setAttribute('role', 'article');
     aiMsgEl.setAttribute('aria-label', `${personality.name} response`);
+    aiMsgEl.dataset.chatStreaming = 'true';
     aiMsgEl.style.whiteSpace = 'pre-wrap';
+    if (_activeChatGenerationUI) _activeChatGenerationUI.aiMsgEl = aiMsgEl;
 
     // Typewriter: trickle buffered text at a steady rate for smooth appearance
     const typewriter = createTypewriter(aiMsgEl, typingEl, container);
@@ -332,6 +377,7 @@ export async function sendChatMessage() {
     // Final render with full markdown
     typewriter.stop();
     aiMsgEl.style.whiteSpace = '';
+    delete aiMsgEl.dataset.chatStreaming;
     if (typingEl.parentNode) typingEl.remove();
     if (!aiMsgEl.parentNode) container.appendChild(aiMsgEl);
 
@@ -509,6 +555,7 @@ export async function sendChatMessage() {
   }
 
   _chatAbortController = null;
+  _activeChatGenerationUI = null;
   setSendButtonMode(sendBtn, 'idle');
   updateDiscussButton();
   updateChatHeaderTitle();

--- a/js/chat-window-bindings.js
+++ b/js/chat-window-bindings.js
@@ -4,7 +4,8 @@
 import { configureChatThreadDeps } from './chat-threads.js';
 import { renderChatMessages } from './chat-render.js';
 import {
-  createTypewriter, getChatAbortController, sendChatMessage,
+  createTypewriter, getChatAbortController, isChatStreaming,
+  restoreChatGenerationUI, sendChatMessage,
   setChatAbortController, stopChatGeneration,
   setSendButtonMode,
 } from './chat-send.js';
@@ -38,7 +39,11 @@ configureChatOnboarding({
   setChatNudge,
   updateChatNudge,
 });
-configureChatPanel({ restoreDiscussionContinuePrompt });
+configureChatPanel({
+  isChatStreaming,
+  restoreChatGenerationUI,
+  restoreDiscussionContinuePrompt,
+});
 configureChatThreadDeps({
   cleanupDiscussionState,
   deleteAttachmentDraft,

--- a/js/chat.js
+++ b/js/chat.js
@@ -5,7 +5,10 @@ import './chat-window-bindings.js';
 
 export { renderChatMessages } from './chat-render.js';
 export { askAIAboutCorrelations, askAIAboutMarker } from './chat-marker-prompts.js';
-export { handleChatKeydown, isChatStreaming, sendChatMessage, stopChatGeneration } from './chat-send.js';
+export {
+  handleChatKeydown, isChatStreaming, restoreChatGenerationUI,
+  sendChatMessage, stopChatGeneration,
+} from './chat-send.js';
 export {
   autoResizePersonaTextarea, cancelCustomPersonalityEditor, deleteCustomPersonality, editCustomPersonality,
   generateCustomPersonality, getActivePersonality, getCustomPersonalities,

--- a/js/dashboard-page-view.js
+++ b/js/dashboard-page-view.js
@@ -297,6 +297,10 @@ export function createDashboardPageView(deps) {
         }
         setTimeout(() => {
           if (!isDesktopChatOnboardingViewport || getDashboardPageRuntimeValue('innerWidth') <= 768) return;
+          // Rendering real data or an explicit chat close removes this
+          // reservation. Treat that as cancellation so a stale onboarding
+          // timer cannot reopen chat after the user has dismissed it.
+          if (!document.body.classList.contains('chat-autostart-reserved')) return;
           const panel = document.getElementById('chat-panel');
           if (state.chatHistory.length > 0 || panel?.classList.contains('open')) {
             document.body.classList.remove('chat-autostart-reserved');

--- a/js/data-merge.js
+++ b/js/data-merge.js
@@ -105,6 +105,7 @@ const LOCAL_WINS_MAP_FIELDS = [
   'markerNotes',
   'markerValueNotes',
   'manualValues',
+  'manualMetricTombstones',
 ];
 
 const TOMBSTONE_META_KEY = '_deletedAt';

--- a/js/export-import.js
+++ b/js/export-import.js
@@ -334,6 +334,18 @@ export function importDataJSON(file) {
           if (!state.importedData.manualValues) state.importedData.manualValues = {};
           Object.assign(state.importedData.manualValues, json.manualValues);
         }
+        // Manual wearable deletions are privacy state. Merge by the newest
+        // deletion clock so importing an older backup cannot resurrect a
+        // reading that was deleted later on this or another device.
+        if (json.manualMetricTombstones && typeof json.manualMetricTombstones === 'object'
+            && !Array.isArray(json.manualMetricTombstones)) {
+          if (!state.importedData.manualMetricTombstones) state.importedData.manualMetricTombstones = {};
+          for (const [key, deletedAt] of Object.entries(json.manualMetricTombstones)) {
+            const incoming = Number(deletedAt) || 0;
+            const current = Number(state.importedData.manualMetricTombstones[key]) || 0;
+            if (incoming > current) state.importedData.manualMetricTombstones[key] = incoming;
+          }
+        }
         // Import Light & Sun stack (added v1.6.x; was missing from importDataJSON
         // entirely so demo + JSON imports silently dropped sun sessions, devices,
         // rooms, audits, measurements, sunDefaults, lightDailyVerdicts). Merge
@@ -663,6 +675,15 @@ async function _importDatabaseBundle(json) {
           for (const [k, v] of Object.entries(importData[field])) {
             if (!current[field][k]) current[field][k] = v;
           }
+        }
+      }
+      if (importData.manualMetricTombstones && typeof importData.manualMetricTombstones === 'object'
+          && !Array.isArray(importData.manualMetricTombstones)) {
+        if (!current.manualMetricTombstones) current.manualMetricTombstones = {};
+        for (const [key, deletedAt] of Object.entries(importData.manualMetricTombstones)) {
+          const incoming = Number(deletedAt) || 0;
+          const existing = Number(current.manualMetricTombstones[key]) || 0;
+          if (incoming > existing) current.manualMetricTombstones[key] = incoming;
         }
       }
       // Save

--- a/js/export-import.js
+++ b/js/export-import.js
@@ -520,7 +520,7 @@ export function importDataJSON(file) {
         }
 
         migrateProfileData(state.importedData);
-        saveImportedData(isDemoLoadingProfile(state.currentProfile)
+        await saveImportedData(isDemoLoadingProfile(state.currentProfile)
           ? { skipSync: true, reason: 'demo-import' }
           : {});
         if (json.chat) {

--- a/js/export.js
+++ b/js/export.js
@@ -261,6 +261,7 @@ async function _exportChatData(profileId) {
  * @property {Object.<string, unknown>} markerNotes
  * @property {Object.<string, unknown>} markerValueNotes
  * @property {Object.<string, unknown>} manualValues
+ * @property {Object.<string, number>} manualMetricTombstones
  * @property {Array<unknown>} changeHistory
  * @property {Array<unknown>} chatSummaries
  * @property {unknown} wearableSummary
@@ -327,6 +328,7 @@ export async function buildClientExportObject(profileId, includeChat = false) {
     markerNotes: data.markerNotes || {},
     markerValueNotes: data.markerValueNotes || {},
     manualValues: data.manualValues || {},
+    manualMetricTombstones: data.manualMetricTombstones || {},
     changeHistory: data.changeHistory || [],
     chatSummaries: data.chatSummaries || [],
     // Wearable layer (added v1.27.1). Only the synced surfaces — L2 summary

--- a/js/profile-data-migrations.js
+++ b/js/profile-data-migrations.js
@@ -240,6 +240,8 @@ export function migrateProfileData(data) {
   if (data.changeHistory === undefined) data.changeHistory = [];
   if (data.importSnapshots === undefined) data.importSnapshots = [];
   if (data.biometrics === undefined) data.biometrics = null;
+  if (!data.manualMetricTombstones || typeof data.manualMetricTombstones !== 'object'
+      || Array.isArray(data.manualMetricTombstones)) data.manualMetricTombstones = {};
   if (data.sunSessions === undefined) data.sunSessions = [];
   if (data.deviceSessions === undefined) data.deviceSessions = [];
   if (data.lightDevices === undefined) data.lightDevices = [];

--- a/js/profile-runtime.js
+++ b/js/profile-runtime.js
@@ -71,6 +71,20 @@ export async function refreshProfileWearables(profileId, biometrics) {
   connect.syncStaleWearablesNow?.().catch(() => {});
 }
 
+// Apply newly pulled manual-reading deletion markers before sync-pull renders
+// the active profile. `merged` is the object that pull will persist, so IDB,
+// legacy biometrics, and the derived wearable summary converge atomically
+// from the user's perspective.
+export async function reconcilePulledManualWearables(profileId, merged) {
+  if (!profileId || profileId !== state.currentProfile || !merged || typeof merged !== 'object') return false;
+  state.importedData = merged;
+  const manual = await import('./wearables-manual.js');
+  const result = await manual.reconcileManualMetricTombstones(profileId);
+  if (!result || ((result.prunedRows || 0) === 0 && (result.prunedLegacy || 0) === 0)) return false;
+  await manual.refreshManualSummary(profileId);
+  return true;
+}
+
 export function refreshProfileButton() {
   profileRefreshDeps.renderProfileButton();
 }

--- a/js/profile-runtime.js
+++ b/js/profile-runtime.js
@@ -3,6 +3,10 @@
 
 import { isChatModuleLoaded, loadChatModule } from './chat-loader.js';
 import { state } from './state.js';
+import {
+  reconcileManualMetricTombstones,
+  refreshManualSummary,
+} from './wearables-manual.js';
 
 /** @type {Record<string, (...args: any[]) => any>} */
 const profileRefreshDeps = {
@@ -78,10 +82,9 @@ export async function refreshProfileWearables(profileId, biometrics) {
 export async function reconcilePulledManualWearables(profileId, merged) {
   if (!profileId || profileId !== state.currentProfile || !merged || typeof merged !== 'object') return false;
   state.importedData = merged;
-  const manual = await import('./wearables-manual.js');
-  const result = await manual.reconcileManualMetricTombstones(profileId);
+  const result = await reconcileManualMetricTombstones(profileId);
   if (!result || ((result.prunedRows || 0) === 0 && (result.prunedLegacy || 0) === 0)) return false;
-  await manual.refreshManualSummary(profileId);
+  await refreshManualSummary(profileId);
   return true;
 }
 

--- a/js/profile.js
+++ b/js/profile.js
@@ -232,6 +232,7 @@ export function createDefaultProfileData() {
     importSnapshots: [],
     biometrics: null,
     manualValues: {},
+    manualMetricTombstones: {},
     sunSessions: [],
     deviceSessions: [],
     lightDevices: [],

--- a/js/profile.js
+++ b/js/profile.js
@@ -110,11 +110,29 @@ async function reloadProfileRuntimeShell(profileId) {
   await profileRuntimeDeps.reloadProfileRuntimeShell?.(profileId);
 }
 
+/** @type {Map<string, Promise<void>>} */
+const pendingProfileWearableRefreshes = new Map();
+
 function refreshProfileWearables(profileId, biometrics) {
+  /** @type {Promise<void>} */
+  let pending;
   try {
-    const pending = profileRuntimeDeps.refreshProfileWearables?.(profileId, biometrics);
-    Promise.resolve(pending).catch(() => {});
-  } catch {}
+    pending = Promise.resolve(
+      profileRuntimeDeps.refreshProfileWearables?.(profileId, biometrics),
+    ).then(() => undefined, () => undefined);
+  } catch {
+    pending = Promise.resolve();
+  }
+  pendingProfileWearableRefreshes.set(profileId, pending);
+  void pending.finally(() => {
+    if (pendingProfileWearableRefreshes.get(profileId) === pending) {
+      pendingProfileWearableRefreshes.delete(profileId);
+    }
+  });
+}
+
+async function waitForProfileWearables(profileId) {
+  await pendingProfileWearableRefreshes.get(profileId);
 }
 
 /**
@@ -471,6 +489,11 @@ export async function switchProfile(profileId) {
   // overwritten when the (delayed) loadProfile finally read the empty
   // localStorage row for the new profile.
   await loadProfile(profileId);
+  // loadProfile keeps the ordinary app-shell refresh non-blocking, but a
+  // caller explicitly awaiting a profile switch needs a stable imported-data
+  // snapshot. Otherwise the old background wearable refresh can finish after
+  // an immediate import and replace its wearable summary.
+  await waitForProfileWearables(profileId);
   const profiles = getProfiles();
   const p = profiles.find(p => p.id === profileId);
   profileDeps.showNotification(`Switched to ${p ? p.name : 'profile'}`, 'info');

--- a/js/sync-delta-map-planner.js
+++ b/js/sync-delta-map-planner.js
@@ -11,7 +11,13 @@ import {
 import { _readDeltaSnapshot } from './sync-delta-snapshot.js';
 import { getPlannerItemRows } from './sync-delta-planner-context.js';
 
-const CLEARED_VALUE_MAPS = new Set(['manualValues', 'markerValueNotes']);
+const CLEARED_VALUE_MAPS = new Set([
+  'manualValues',
+  'markerValueNotes',
+  // Zero is an explicit resurrection marker: a user intentionally re-added
+  // a manual metric/date that had previously been deleted on another device.
+  'manualMetricTombstones',
+]);
 
 // Keyed-map planner. Same shape as _planArrayDelta but iterates
 // Object.entries() and uses the map key (sanitized) as itemId. Payload

--- a/js/sync-delta-surfaces.js
+++ b/js/sync-delta-surfaces.js
@@ -44,6 +44,11 @@ export const DELTA_MAPS = [
   'customMarkers',
   'markerPlacements',
   'manualValues',
+  // Durable privacy deletions for device-local manual wearable rows. Raw
+  // wearable rows stay per-device, so these per-metric/date markers are what
+  // stop another device (or a legacy biometrics migration) resurrecting a
+  // reading after the user deletes it.
+  'manualMetricTombstones',
   'refOverrides',
   'categoryLabels',
   'categoryIcons',

--- a/js/sync-pull.js
+++ b/js/sync-pull.js
@@ -37,6 +37,8 @@ var _pushDirtyProfiles = _pushDirtyProfiles || (async () => ({ total: 0, succeed
 /** @type {(...args: any[]) => Promise<any>} */
 var _pushProfilesById = _pushProfilesById || (async () => ({ total: 0, succeeded: 0, failed: 0, skipped: 0 }));
 var _renderProfileButton = _renderProfileButton || (() => {});
+/** @type {(...args: any[]) => Promise<any>} */
+var _reconcilePulledManualWearables = _reconcilePulledManualWearables || (async () => false);
 /** @type {(...args: any[]) => any} */
 var _debug = _debug || (() => {});
 let _pulling = false;
@@ -105,6 +107,7 @@ export function combinePulledAISettings(selection) {
  *   pushDirtyProfiles?: (...args: any[]) => Promise<any>,
  *   pushProfilesById?: (...args: any[]) => Promise<any>,
  *   renderProfileButton?: () => void,
+ *   reconcilePulledManualWearables?: (...args: any[]) => Promise<any>,
  *   debug?: (...args: any[]) => any,
  * }} [deps]
  */
@@ -117,6 +120,7 @@ export function configureSyncPull({
   pushDirtyProfiles,
   pushProfilesById,
   renderProfileButton,
+  reconcilePulledManualWearables,
   debug,
 } = {}) {
   if (typeof getEvolu === 'function') _getEvolu = getEvolu;
@@ -127,6 +131,7 @@ export function configureSyncPull({
   if (typeof pushDirtyProfiles === 'function') _pushDirtyProfiles = pushDirtyProfiles;
   if (typeof pushProfilesById === 'function') _pushProfilesById = pushProfilesById;
   if (typeof renderProfileButton === 'function') _renderProfileButton = renderProfileButton;
+  if (typeof reconcilePulledManualWearables === 'function') _reconcilePulledManualWearables = reconcilePulledManualWearables;
   if (typeof debug === 'function') _debug = debug;
 }
 
@@ -295,6 +300,11 @@ export async function onSyncReceived() {
         dbg(mergeMsg);
         logSyncEvent('pull', mergeMsg);
 
+        // Raw manual wearable rows are intentionally device-local, while
+        // per-metric/date deletion markers sync. Apply those markers before
+        // persistence/render so an old local row cannot recreate a pulse the
+        // user deleted on another device.
+        await _reconcilePulledManualWearables(profileId, merged);
         await persistPulledImportedData(localKey, profileId, merged, remoteUpdated);
         if (restoreJoinApplied) clearRestoreJoinPending();
 

--- a/js/wearables-manual.js
+++ b/js/wearables-manual.js
@@ -10,7 +10,17 @@
 // migration. The dashboard strip, per-metric source picker, and AI context
 // layer all pick up 'manual' rows via the existing generic summary logic.
 
-import { upsertDaily, upsertDailyBatch, countSource, getDaily, deleteDaily, getMeta, setMeta } from './wearables-store.js';
+import {
+  upsertDaily,
+  upsertDailyBatch,
+  countSource,
+  getDaily,
+  getDailyRange,
+  deleteDaily,
+  clearSource,
+  getMeta,
+  setMeta,
+} from './wearables-store.js';
 import { state } from './state.js';
 import { saveImportedData } from './data.js';
 import { isoDay } from './wearable-adapters.js';
@@ -22,7 +32,15 @@ import { syncWearableSummary } from './wearables-summary.js';
 // loses the morning's BP when the weight upsert overwrites the row.
 async function _mergeManualRow(profileId, date, patch) {
   const existing = await getDaily(profileId, 'manual', date);
-  const merged = { ...(existing || {}), source: 'manual', date, ...patch };
+  const base = { ...(existing || {}) };
+  // A synced deletion can land while this tab is still open. Do not let a
+  // later same-day weight/BP write preserve an already-deleted pulse from the
+  // device-local row. Explicitly re-added fields have their marker cleared
+  // before this helper runs and therefore survive.
+  for (const metric of MANUAL_METRICS) {
+    if (isManualMetricTombstoned(metric, date)) delete base[metric];
+  }
+  const merged = { ...base, source: 'manual', date, ...patch };
   await upsertDaily(profileId, merged);
 }
 
@@ -42,6 +60,139 @@ export const MANUAL_TAGS = ['resting', 'morning-fasted', 'post-workout', 'stress
 
 // One-time migration flag key in the wearables meta store.
 const MIGRATION_FLAG = 'biometrics-migrated-v1';
+const MANUAL_TOMBSTONE_FIELD = 'manualMetricTombstones';
+const MANUAL_HISTORY_START = '1970-01-01';
+const MANUAL_HISTORY_END = '9999-12-31';
+const ISO_DAY_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export function manualMetricTombstoneKey(metric, date) {
+  if (!MANUAL_METRICS.includes(metric) || typeof date !== 'string'
+      || (date !== 'all' && !ISO_DAY_RE.test(date))) return null;
+  return `${metric}.${date}`;
+}
+
+function _manualMetricTombstones() {
+  const imported = state.importedData;
+  if (!imported || typeof imported !== 'object') return null;
+  const current = imported[MANUAL_TOMBSTONE_FIELD];
+  if (current && typeof current === 'object' && !Array.isArray(current)) return current;
+  imported[MANUAL_TOMBSTONE_FIELD] = {};
+  return imported[MANUAL_TOMBSTONE_FIELD];
+}
+
+export function isManualMetricTombstoned(metric, date) {
+  const key = manualMetricTombstoneKey(metric, date);
+  if (!key) return false;
+  const tombstones = state.importedData?.[MANUAL_TOMBSTONE_FIELD];
+  if (!tombstones || typeof tombstones !== 'object') return false;
+  // An exact zero is an intentional re-add and wins over an earlier
+  // delete-all marker. Otherwise the metric-wide marker protects dates this
+  // device never had locally and therefore could not enumerate at deletion.
+  if (Object.prototype.hasOwnProperty.call(tombstones, key)) {
+    return Number.isFinite(Number(tombstones[key])) && Number(tombstones[key]) > 0;
+  }
+  const allKey = manualMetricTombstoneKey(metric, 'all');
+  const allValue = allKey ? tombstones[allKey] : 0;
+  return Number.isFinite(Number(allValue)) && Number(allValue) > 0;
+}
+
+function _recordManualMetricTombstone(metric, date, deletedAt = Date.now()) {
+  const key = manualMetricTombstoneKey(metric, date);
+  const tombstones = _manualMetricTombstones();
+  if (!key || !tombstones) return false;
+  const timestamp = Number(deletedAt);
+  if (!Number.isFinite(timestamp) || timestamp <= 0) return false;
+  tombstones[key] = Math.max(Number(tombstones[key]) || 0, timestamp);
+  return true;
+}
+
+function _clearManualMetricTombstone(metric, date) {
+  const key = manualMetricTombstoneKey(metric, date);
+  const tombstones = state.importedData?.[MANUAL_TOMBSTONE_FIELD];
+  if (!key || !tombstones || typeof tombstones !== 'object') return false;
+  const allKey = manualMetricTombstoneKey(metric, 'all');
+  const hasMetricWideDelete = !!allKey && Number(tombstones[allKey]) > 0;
+  if (!Object.prototype.hasOwnProperty.call(tombstones, key) && !hasMetricWideDelete) return false;
+  // Keep an explicit zero rather than deleting the map key. A device that
+  // first learned about the deletion from pull may not have the key in its
+  // push-side delta snapshot; zero produces an unambiguous row update that
+  // wins over the older positive deletion clock everywhere.
+  tombstones[key] = 0;
+  return true;
+}
+
+function _legacyBiometricField(metric) {
+  if (metric === 'weight') return 'weight';
+  if (metric === 'rhr') return 'pulse';
+  if (metric === 'bp_systolic' || metric === 'bp_diastolic') return 'bp';
+  return null;
+}
+
+function _removeLegacyBiometric(metric, date) {
+  const field = _legacyBiometricField(metric);
+  const biometrics = state.importedData?.biometrics;
+  if (!field || !biometrics || !Array.isArray(biometrics[field])) return false;
+  const before = biometrics[field].length;
+  biometrics[field] = biometrics[field].filter(entry => entry?.date !== date);
+  return biometrics[field].length !== before;
+}
+
+/**
+ * Apply synced deletion markers to both device-local manual rows and the
+ * legacy synced biometrics arrays. This runs before the one-time migration
+ * check: every device must honor a deletion received after it had already
+ * migrated the old pulse locally.
+ */
+export async function reconcileManualMetricTombstones(profileId) {
+  if (!profileId || state.currentProfile !== profileId) return { skipped: 'inactive-profile' };
+  const tombstones = state.importedData?.[MANUAL_TOMBSTONE_FIELD];
+  if (!tombstones || typeof tombstones !== 'object' || Array.isArray(tombstones)
+      || Object.keys(tombstones).length === 0) {
+    return { prunedRows: 0, prunedLegacy: 0 };
+  }
+
+  let prunedRows = 0;
+  const rows = await getDailyRange(profileId, 'manual', MANUAL_HISTORY_START, MANUAL_HISTORY_END);
+  for (const row of rows) {
+    const next = { ...row };
+    let changed = false;
+    for (const metric of MANUAL_METRICS) {
+      if (isManualMetricTombstoned(metric, row.date) && next[metric] != null) {
+        delete next[metric];
+        changed = true;
+      }
+    }
+    if (!changed) continue;
+    prunedRows++;
+    if (MANUAL_METRICS.some(metric => next[metric] != null)) await upsertDaily(profileId, next);
+    else await deleteDaily(profileId, 'manual', row.date);
+  }
+
+  let prunedLegacy = 0;
+  const biometrics = state.importedData?.biometrics;
+  if (biometrics && typeof biometrics === 'object') {
+    const legacyPairs = [
+      ['weight', 'weight'],
+      ['pulse', 'rhr'],
+    ];
+    for (const [field, metric] of legacyPairs) {
+      if (!Array.isArray(biometrics[field])) continue;
+      const before = biometrics[field].length;
+      biometrics[field] = biometrics[field].filter(entry => !isManualMetricTombstoned(metric, entry?.date));
+      prunedLegacy += before - biometrics[field].length;
+    }
+    if (Array.isArray(biometrics.bp)) {
+      const before = biometrics.bp.length;
+      biometrics.bp = biometrics.bp.filter(entry => (
+        !isManualMetricTombstoned('bp_systolic', entry?.date)
+        && !isManualMetricTombstoned('bp_diastolic', entry?.date)
+      ));
+      prunedLegacy += before - biometrics.bp.length;
+    }
+  }
+  if (prunedLegacy > 0) await saveImportedData();
+  return { prunedRows, prunedLegacy };
+}
 
 /**
  * Ensure `wearableConnections.manual` exists so listConnectedSources() and
@@ -49,8 +200,8 @@ const MIGRATION_FLAG = 'biometrics-migrated-v1';
  * wearables-apple-health uses — no OAuth token, just a connectedAt stamp.
  * Refreshes lastSyncAt + coverageDays on every call.
  */
-export function ensureManualConnection({ coverageDays = 0 } = {}) {
-  if (!state.importedData) return;
+export async function ensureManualConnection({ coverageDays = 0 } = {}) {
+  if (!state.importedData) return false;
   if (!state.importedData.wearableConnections) state.importedData.wearableConnections = {};
   const prev = state.importedData.wearableConnections.manual;
   const nowISO = new Date().toISOString();
@@ -61,7 +212,7 @@ export function ensureManualConnection({ coverageDays = 0 } = {}) {
     coverageDays: Math.max(coverageDays, prev?.coverageDays || 0),
     needsReauth: false,
   };
-  saveImportedData();
+  return saveImportedData();
 }
 
 /**
@@ -81,12 +232,13 @@ export async function logManualMetric(profileId, metric, { date, value, tags, no
     throw new Error('logManualMetric: value must be a finite number');
   }
   const d = date || isoDay();
+  _clearManualMetricTombstone(metric, d);
   const patch = { [metric]: value };
   if (Array.isArray(tags) && tags.length) patch.tags = _sanitizeTags(tags);
   const noteClean = _sanitizeNote(note);
   if (noteClean) patch.note = noteClean;
   await _mergeManualRow(profileId, d, patch);
-  ensureManualConnection();
+  await ensureManualConnection();
 }
 
 /**
@@ -96,9 +248,18 @@ export async function logManualMetric(profileId, metric, { date, value, tags, no
 export async function logManualBP(profileId, { date, systolic, diastolic, pulse, tags, note }) {
   const d = date || isoDay();
   const row = { source: 'manual', date: d };
-  if (systolic != null && isFinite(systolic)) row.bp_systolic = systolic;
-  if (diastolic != null && isFinite(diastolic)) row.bp_diastolic = diastolic;
-  if (pulse != null && isFinite(pulse)) row.rhr = pulse;
+  if (systolic != null && isFinite(systolic)) {
+    _clearManualMetricTombstone('bp_systolic', d);
+    row.bp_systolic = systolic;
+  }
+  if (diastolic != null && isFinite(diastolic)) {
+    _clearManualMetricTombstone('bp_diastolic', d);
+    row.bp_diastolic = diastolic;
+  }
+  if (pulse != null && isFinite(pulse)) {
+    _clearManualMetricTombstone('rhr', d);
+    row.rhr = pulse;
+  }
   if (!row.bp_systolic && !row.bp_diastolic && !row.rhr) return;
   if (Array.isArray(tags) && tags.length) row.tags = _sanitizeTags(tags);
   const noteClean = _sanitizeNote(note);
@@ -106,7 +267,7 @@ export async function logManualBP(profileId, { date, systolic, diastolic, pulse,
   // Merge rather than replace — preserves same-day weight from a prior entry.
   const { source: _s, date: _d, ...patch } = row;
   await _mergeManualRow(profileId, d, patch);
-  ensureManualConnection();
+  await ensureManualConnection();
 }
 
 // Trim + cap so a runaway paste doesn't bloat the row. 500 chars covers
@@ -140,11 +301,12 @@ function _sanitizeTags(tags) {
  * run so re-opening the app doesn't re-insert. Returns a small summary for
  * telemetry / debug output.
  *
- * Does NOT delete the original biometrics data — the Edit Client modal keeps
- * writing there until Commit 4 of the Health Metrics unification.
+ * Legacy biometrics are retained for old backup compatibility, except rows
+ * covered by a durable manualMetricTombstones deletion marker.
  */
 export async function migrateBiometricsToManual(profileId, biometrics) {
   if (!profileId) return { skipped: 'no-profile' };
+  await reconcileManualMetricTombstones(profileId);
   const alreadyRan = await getMeta(profileId, MIGRATION_FLAG);
   if (alreadyRan) return { skipped: 'already-migrated' };
   if (!biometrics) {
@@ -190,7 +352,7 @@ export async function migrateBiometricsToManual(profileId, biometrics) {
     await upsertDailyBatch(profileId, rows);
     // Surface 'manual' as a connected source so the dashboard strip and
     // Settings → Integrations see it. Coverage = distinct dates migrated.
-    ensureManualConnection({ coverageDays: rows.length });
+    await ensureManualConnection({ coverageDays: rows.length });
   }
 
   const counts = { weight: weight.length, bp: bp.length, pulse: pulse.length, rows: rows.length };
@@ -208,8 +370,13 @@ export async function deleteManualMetric(profileId, metric, date) {
   if (!MANUAL_METRICS.includes(metric)) {
     throw new Error(`deleteManualMetric: unknown metric "${metric}"`);
   }
+  _recordManualMetricTombstone(metric, date);
+  _removeLegacyBiometric(metric, date);
   const existing = await getDaily(profileId, 'manual', date);
-  if (!existing) return;
+  if (!existing) {
+    await saveImportedData();
+    return;
+  }
   const { source, date: _d, importedAt, ...rest } = existing;
   delete rest[metric];
   // Any metric field left? If so, write updated row. If nothing measurable
@@ -222,6 +389,51 @@ export async function deleteManualMetric(profileId, metric, date) {
   } else {
     await deleteDaily(profileId, 'manual', date);
   }
+  // Persist the durable delete marker and the legacy biometrics cleanup in
+  // the same profile save that schedules cross-device sync.
+  await saveImportedData();
+}
+
+/**
+ * Remove every device-local manual reading and record per-field tombstones,
+ * including legacy biometrics dates that may not exist in this device's IDB.
+ */
+export async function deleteAllManualMetrics(profileId) {
+  if (!profileId || state.currentProfile !== profileId) return { skipped: 'inactive-profile' };
+  const deletedAt = Date.now();
+  const rows = await getDailyRange(profileId, 'manual', MANUAL_HISTORY_START, MANUAL_HISTORY_END);
+  let tombstonesRecorded = 0;
+  // Metric-wide markers cover readings that exist only on another device.
+  // Exact per-date markers below remain useful diagnostics and allow older
+  // clients that do not understand the `all` key to honor known deletions.
+  for (const metric of MANUAL_METRICS) {
+    if (_recordManualMetricTombstone(metric, 'all', deletedAt)) tombstonesRecorded++;
+  }
+  for (const row of rows) {
+    for (const metric of MANUAL_METRICS) {
+      if (row[metric] != null && _recordManualMetricTombstone(metric, row.date, deletedAt)) tombstonesRecorded++;
+    }
+  }
+  const biometrics = state.importedData?.biometrics;
+  for (const entry of (Array.isArray(biometrics?.weight) ? biometrics.weight : [])) {
+    if (_recordManualMetricTombstone('weight', entry?.date, deletedAt)) tombstonesRecorded++;
+  }
+  for (const entry of (Array.isArray(biometrics?.pulse) ? biometrics.pulse : [])) {
+    if (_recordManualMetricTombstone('rhr', entry?.date, deletedAt)) tombstonesRecorded++;
+  }
+  for (const entry of (Array.isArray(biometrics?.bp) ? biometrics.bp : [])) {
+    if (_recordManualMetricTombstone('bp_systolic', entry?.date, deletedAt)) tombstonesRecorded++;
+    if (_recordManualMetricTombstone('bp_diastolic', entry?.date, deletedAt)) tombstonesRecorded++;
+  }
+  if (biometrics && typeof biometrics === 'object') {
+    if (Array.isArray(biometrics.weight)) biometrics.weight = [];
+    if (Array.isArray(biometrics.pulse)) biometrics.pulse = [];
+    if (Array.isArray(biometrics.bp)) biometrics.bp = [];
+  }
+  await clearSource(profileId, 'manual');
+  if (state.importedData?.wearableConnections) delete state.importedData.wearableConnections.manual;
+  await saveImportedData();
+  return { deletedRows: rows.length, tombstonesRecorded };
 }
 
 /**
@@ -233,7 +445,7 @@ export async function deleteManualMetric(profileId, metric, date) {
 export async function refreshManualSummary(profileId) {
   try {
     const { listConnectedSources } = await import('./wearables-connect.js');
-    await syncWearableSummary(profileId, listConnectedSources());
+    await syncWearableSummary(profileId, listConnectedSources(), { force: true });
   } catch { /* non-fatal */ }
 }
 

--- a/js/wearables-manual.js
+++ b/js/wearables-manual.js
@@ -132,6 +132,24 @@ function _removeLegacyBiometric(metric, date) {
   const field = _legacyBiometricField(metric);
   const biometrics = state.importedData?.biometrics;
   if (!field || !biometrics || !Array.isArray(biometrics[field])) return false;
+  if (field === 'bp') {
+    const component = metric === 'bp_systolic' ? 'systolic' : 'diastolic';
+    let changed = false;
+    const remaining = [];
+    for (const entry of biometrics.bp) {
+      if (!entry || typeof entry !== 'object' || entry.date !== date
+          || !Object.prototype.hasOwnProperty.call(entry, component)) {
+        remaining.push(entry);
+        continue;
+      }
+      const next = { ...entry };
+      delete next[component];
+      changed = true;
+      if (next.systolic != null || next.diastolic != null) remaining.push(next);
+    }
+    biometrics.bp = remaining;
+    return changed;
+  }
   const before = biometrics[field].length;
   biometrics[field] = biometrics[field].filter(entry => entry?.date !== date);
   return biometrics[field].length !== before;
@@ -182,12 +200,31 @@ export async function reconcileManualMetricTombstones(profileId) {
       prunedLegacy += before - biometrics[field].length;
     }
     if (Array.isArray(biometrics.bp)) {
-      const before = biometrics.bp.length;
-      biometrics.bp = biometrics.bp.filter(entry => (
-        !isManualMetricTombstoned('bp_systolic', entry?.date)
-        && !isManualMetricTombstoned('bp_diastolic', entry?.date)
-      ));
-      prunedLegacy += before - biometrics.bp.length;
+      const remaining = [];
+      for (const entry of biometrics.bp) {
+        if (!entry || typeof entry !== 'object') {
+          remaining.push(entry);
+          continue;
+        }
+        const next = { ...entry };
+        let changed = false;
+        if (isManualMetricTombstoned('bp_systolic', entry.date)
+            && Object.prototype.hasOwnProperty.call(next, 'systolic')) {
+          delete next.systolic;
+          changed = true;
+          prunedLegacy++;
+        }
+        if (isManualMetricTombstoned('bp_diastolic', entry.date)
+            && Object.prototype.hasOwnProperty.call(next, 'diastolic')) {
+          delete next.diastolic;
+          changed = true;
+          prunedLegacy++;
+        }
+        if (!changed || next.systolic != null || next.diastolic != null) {
+          remaining.push(changed ? next : entry);
+        }
+      }
+      biometrics.bp = remaining;
     }
   }
   if (prunedLegacy > 0) await saveImportedData();

--- a/js/wearables-settings-panel.js
+++ b/js/wearables-settings-panel.js
@@ -25,9 +25,8 @@ import {
 } from './wearables-connect.js';
 import { syncWearableSummary } from './wearables-summary.js';
 import { getActiveProfileId } from './profile.js';
-import { saveImportedData } from './data.js';
-import { clearSource, getDailyRange } from './wearables-store.js';
-import { refreshManualSummary } from './wearables-manual.js';
+import { getDailyRange } from './wearables-store.js';
+import { deleteAllManualMetrics, refreshManualSummary } from './wearables-manual.js';
 import {
   closeWearableSettingsModal,
   confirmWearableSettingsAction,
@@ -545,13 +544,10 @@ async function handleManualDisconnect() {
   )) {
     try {
       const profileId = getActiveProfileId();
-      await clearSource(profileId, 'manual');
-      // Drop the connection record too — the row disappears from the strip
-      // source header and the Settings integrations list.
-      if (state.importedData.wearableConnections) {
-        delete state.importedData.wearableConnections.manual;
-        await saveImportedData();
-      }
+      // Records synced per-field/date deletion markers before clearing L1,
+      // including dates that only survive in the legacy biometrics payload.
+      // A peer can therefore no longer rebuild and republish these readings.
+      await deleteAllManualMetrics(profileId);
       await refreshManualSummary(profileId);
       showNotification?.('All manual entries deleted', 'success');
       refreshSettingsWearables();
@@ -738,7 +734,12 @@ async function handleWearableDisconnect(adapterId) {
 
 function refreshSettingsWearables() {
   const section = document.getElementById('wearables-section');
-  if (section) section.innerHTML = renderWearablesSettingsSection();
+  if (!section) return;
+  section.innerHTML = renderWearablesSettingsSection();
+  // Runtime OAuth configuration can arrive after the initial counts read and
+  // replace the whole section. Rehydrate the async manual counts on the new
+  // DOM instead of leaving the row stuck at "Counting readings…".
+  queueMicrotask(_updateManualCounts);
 }
 
 export const wearableSettingsActionHandlers = Object.freeze({

--- a/js/wearables-summary.js
+++ b/js/wearables-summary.js
@@ -321,6 +321,12 @@ export function shouldWriteL2(newSummary, oldSummary) {
       // purpose of this trigger for the users it most needs to help.
       trippedReason = trippedReason || `latest-advanced:${metricId}`;
     }
+    // A deletion can move the latest surviving reading backward. Treat that
+    // as equally significant: otherwise a small/no-value-change deletion can
+    // leave the synced summary pointing at the removed date indefinitely.
+    if (neu.latestDate && old.latestDate && neu.latestDate < old.latestDate) {
+      trippedReason = trippedReason || `latest-regressed:${metricId}`;
+    }
 
     // 1. d7 rolling-mean delta
     const oldD7 = old.rolling?.d7, newD7 = neu.rolling?.d7;
@@ -406,7 +412,23 @@ export function persistWearableSummary(newSummary, anomalyEvents) {
 export async function syncWearableSummary(profileId, connectedSources, { force = false } = {}) {
   if (!profileId || !connectedSources) return { wrote: false, reason: 'noop-inputs' };
   const sourceIds = Object.keys(connectedSources);
-  if (sourceIds.length === 0) return { wrote: false, reason: 'no-sources' };
+  if (sourceIds.length === 0) {
+    if (state.currentProfile !== profileId) return { wrote: false, reason: 'profile-changed' };
+    const old = state.importedData?.wearableSummary || null;
+    const hasStaleSummary = !!old && (
+      Object.keys(old.metrics || {}).length > 0
+      || Object.keys(old.sources || {}).length > 0
+    );
+    if (!force && !hasStaleSummary) return { wrote: false, reason: 'no-sources' };
+    const emptySummary = computeWearableSummary({}, {}, {});
+    persistWearableSummary(emptySummary, []);
+    return {
+      wrote: true,
+      reason: force ? 'force-no-sources' : 'no-sources-cleared',
+      summary: emptySummary,
+      anomalies: [],
+    };
+  }
 
   // Pull last 90 days for vendor sources. Manual entries are sparse, user-
   // authored rows, so read all history; otherwise a single older pulse/BP

--- a/scripts/cold-load-budget.json
+++ b/scripts/cold-load-budget.json
@@ -5,7 +5,7 @@
   "maximums": {
     "requests": 302,
     "transferBytes": 1193220,
-    "decodedBytes": 3035000
+    "decodedBytes": 3050000
   },
   "reference": {
     "requests": 276,

--- a/tests/chat-runtime.test.js
+++ b/tests/chat-runtime.test.js
@@ -237,7 +237,9 @@ describe('chat presentation stylesheet runtime behavior', () => {
       const chatPanel = await import('../js/chat-panel.js');
       expect(chatPanel.configureChatPanel({})).toEqual({
         restoreDiscussionContinuePrompt: null,
+        isChatStreaming: null,
         refreshMobileDashboardActiveTab: null,
+        restoreChatGenerationUI: null,
         stopVoiceActivity: null,
       });
       expect(chatPanel.isChatThreadInputBlocked()).toBe(false);

--- a/tests/export-import-runtime.test.js
+++ b/tests/export-import-runtime.test.js
@@ -98,6 +98,7 @@ describe('JSON restore runtime', () => {
         pulse: [],
         bp: [],
       },
+      manualMetricTombstones: { 'rhr.2026-01-01': 200 },
       sunSessions: [{ id: 'sun-existing' }],
       deviceSessions: [],
       lightDevices: [],
@@ -217,6 +218,10 @@ describe('JSON restore runtime', () => {
       markerNotes: { glucose: 'fasted' },
       markerValueNotes: { 'glucose:2026-01-10': 'morning' },
       manualValues: { 'glucose:2026-01-10': true },
+      manualMetricTombstones: {
+        'rhr.2026-01-01': 100,
+        'rhr.2026-01-10': 300,
+      },
       sunSessions: [
         { id: 'sun-existing' },
         { id: 'sun-new' },
@@ -331,6 +336,10 @@ describe('JSON restore runtime', () => {
     expect(imported.menstrualCycle.periods).toHaveLength(2);
     expect(imported.emfAssessment.assessments).toHaveLength(2);
     expect(imported.biometrics.weight).toHaveLength(2);
+    expect(imported.manualMetricTombstones).toEqual({
+      'rhr.2026-01-01': 200,
+      'rhr.2026-01-10': 300,
+    });
     expect(imported.sunSessions).toEqual([
       { id: 'sun-existing' },
       { id: 'sun-new' },

--- a/tests/manual-heart-rate-deletion.test.js
+++ b/tests/manual-heart-rate-deletion.test.js
@@ -1,0 +1,204 @@
+// @vitest-environment jsdom
+
+import { IDBFactory } from 'fake-indexeddb';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { state } from '../js/state.js';
+import {
+  deleteAllManualMetrics,
+  deleteManualMetric,
+  isManualMetricTombstoned,
+  logManualMetric,
+  reconcileManualMetricTombstones,
+  refreshManualSummary,
+} from '../js/wearables-manual.js';
+import {
+  deleteWearablesDB,
+  getDaily,
+  upsertDaily,
+} from '../js/wearables-store.js';
+import {
+  configureWearableSummary,
+  shouldWriteL2,
+  syncWearableSummary,
+} from '../js/wearables-summary.js';
+import { reconcilePulledManualWearables } from '../js/profile-runtime.js';
+import { DELTA_MAPS, _planKeyedMapDelta } from '../js/sync-delta.js';
+
+const PROFILE_ID = 'manual-heart-rate-delete';
+let previousProfile;
+let previousImportedData;
+let previousSummaryDeps;
+
+function oldRhrSummary(date = '2026-08-12') {
+  return {
+    summaryUpdatedAt: new Date().toISOString(),
+    sources: { manual: { connectedSince: date, coverageDays: 1 } },
+    metrics: {
+      rhr: {
+        latest: 61,
+        latestDate: date,
+        primarySource: 'manual',
+        baseline: 61,
+        rolling: { d7: 61, d30: 61, d90: 61 },
+        trend30d: 'flat',
+        weekly: [61],
+      },
+    },
+  };
+}
+
+beforeEach(() => {
+  globalThis.indexedDB = new IDBFactory();
+  localStorage.clear();
+  previousProfile = state.currentProfile;
+  previousImportedData = state.importedData;
+  state.currentProfile = PROFILE_ID;
+  localStorage.setItem('labcharts-active-profile', PROFILE_ID);
+  state.importedData = {
+    entries: [],
+    biometrics: {
+      weight: [],
+      bp: [],
+      pulse: [{ date: '2026-08-12', value: 61, source: 'manual' }],
+    },
+    manualMetricTombstones: {},
+    wearableConnections: {
+      manual: { connectedAt: '2026-08-12T00:00:00.000Z', lastSyncAt: Date.now() },
+    },
+    wearableSummary: oldRhrSummary(),
+  };
+  previousSummaryDeps = configureWearableSummary({ saveImportedData: vi.fn(async () => true) });
+});
+
+afterEach(async () => {
+  configureWearableSummary(previousSummaryDeps);
+  await deleteWearablesDB(PROFILE_ID).catch(() => {});
+  state.currentProfile = previousProfile;
+  state.importedData = previousImportedData;
+  localStorage.clear();
+});
+
+describe('durable manual heart-rate deletion', () => {
+  it('removes local and legacy copies, then rejects a stale-device resurrection', async () => {
+    await upsertDaily(PROFILE_ID, {
+      source: 'manual',
+      date: '2026-08-12',
+      weight: 72,
+      rhr: 61,
+    });
+
+    await deleteManualMetric(PROFILE_ID, 'rhr', '2026-08-12');
+
+    expect(await getDaily(PROFILE_ID, 'manual', '2026-08-12')).toMatchObject({ weight: 72 });
+    expect((await getDaily(PROFILE_ID, 'manual', '2026-08-12')).rhr).toBeUndefined();
+    expect(state.importedData.biometrics.pulse).toEqual([]);
+    expect(isManualMetricTombstoned('rhr', '2026-08-12')).toBe(true);
+
+    // Simulate an old peer/local restore putting both historical copies back.
+    await upsertDaily(PROFILE_ID, {
+      source: 'manual',
+      date: '2026-08-12',
+      weight: 72,
+      rhr: 61,
+    });
+    state.importedData.biometrics.pulse.push({ date: '2026-08-12', value: 61 });
+
+    const reconciled = await reconcileManualMetricTombstones(PROFILE_ID);
+
+    expect(reconciled).toEqual({ prunedRows: 1, prunedLegacy: 1 });
+    expect(await getDaily(PROFILE_ID, 'manual', '2026-08-12')).toMatchObject({ weight: 72 });
+    expect((await getDaily(PROFILE_ID, 'manual', '2026-08-12')).rhr).toBeUndefined();
+    expect(state.importedData.biometrics.pulse).toEqual([]);
+  });
+
+  it('allows an intentional re-add to clear the synced deletion marker', async () => {
+    await upsertDaily(PROFILE_ID, { source: 'manual', date: '2026-08-12', rhr: 61 });
+    await deleteManualMetric(PROFILE_ID, 'rhr', '2026-08-12');
+    state.importedData.manualMetricTombstones['rhr.all'] = Date.now();
+
+    await logManualMetric(PROFILE_ID, 'rhr', { date: '2026-08-12', value: 64 });
+
+    expect(isManualMetricTombstoned('rhr', '2026-08-12')).toBe(false);
+    expect(state.importedData.manualMetricTombstones['rhr.2026-08-12']).toBe(0);
+    expect(await getDaily(PROFILE_ID, 'manual', '2026-08-12')).toMatchObject({ rhr: 64 });
+  });
+
+  it('applies a pulled deletion before rebuilding the receiving device summary', async () => {
+    await upsertDaily(PROFILE_ID, { source: 'manual', date: '2026-08-12', rhr: 61 });
+    const merged = {
+      ...state.importedData,
+      biometrics: { weight: [], bp: [], pulse: [{ date: '2026-08-12', value: 61 }] },
+      manualMetricTombstones: { 'rhr.2026-08-12': Date.now() },
+      wearableSummary: oldRhrSummary(),
+    };
+
+    expect(await reconcilePulledManualWearables(PROFILE_ID, merged)).toBe(true);
+
+    expect(await getDaily(PROFILE_ID, 'manual', '2026-08-12')).toBeNull();
+    expect(merged.biometrics.pulse).toEqual([]);
+    expect(merged.wearableSummary.metrics.rhr).toBeUndefined();
+  });
+
+  it('delete-all clears the final source and its stale synced summary', async () => {
+    await upsertDaily(PROFILE_ID, { source: 'manual', date: '2026-08-12', rhr: 61 });
+
+    await deleteAllManualMetrics(PROFILE_ID);
+    // Simulate an unknown older reading arriving from a peer after this
+    // device performed delete-all. The metric-wide marker must cover it too.
+    await upsertDaily(PROFILE_ID, { source: 'manual', date: '2025-01-01', rhr: 59 });
+    await reconcileManualMetricTombstones(PROFILE_ID);
+    await refreshManualSummary(PROFILE_ID);
+
+    expect(await getDaily(PROFILE_ID, 'manual', '2026-08-12')).toBeNull();
+    expect(await getDaily(PROFILE_ID, 'manual', '2025-01-01')).toBeNull();
+    expect(state.importedData.manualMetricTombstones['rhr.all']).toBeGreaterThan(0);
+    expect(state.importedData.wearableConnections.manual).toBeUndefined();
+    expect(state.importedData.wearableSummary.metrics).toEqual({});
+    expect(state.importedData.wearableSummary.sources).toEqual({});
+  });
+
+  it('ships deletion clocks through the per-map CRDT surface', async () => {
+    expect(DELTA_MAPS).toContain('manualMetricTombstones');
+
+    const plan = await _planKeyedMapDelta(PROFILE_ID, 'manualMetricTombstones', {
+      'rhr.2026-08-12': 123456,
+      'rhr.all': 123456,
+    });
+
+    expect(plan.ops).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        kind: 'insert',
+        args: expect.objectContaining({ arrayName: 'manualMetricTombstones', itemId: 'rhr.2026-08-12' }),
+      }),
+      expect.objectContaining({
+        kind: 'insert',
+        args: expect.objectContaining({ arrayName: 'manualMetricTombstones', itemId: 'rhr.all' }),
+      }),
+    ]));
+  });
+});
+
+describe('wearable summary deletion gates', () => {
+  it('persists a latest-date regression caused by deleting the newest reading', () => {
+    const oldSummary = oldRhrSummary('2026-08-12');
+    const newSummary = oldRhrSummary('2026-08-11');
+
+    expect(shouldWriteL2(newSummary, oldSummary)).toMatchObject({
+      write: true,
+      reason: 'latest-regressed:rhr',
+    });
+  });
+
+  it('force-clears a stale summary when no sources remain', async () => {
+    const saveImportedData = vi.fn(async () => true);
+    configureWearableSummary({ saveImportedData });
+    state.importedData.wearableSummary = oldRhrSummary();
+
+    const result = await syncWearableSummary(PROFILE_ID, {}, { force: true });
+
+    expect(result).toMatchObject({ wrote: true, reason: 'force-no-sources' });
+    expect(state.importedData.wearableSummary.metrics).toEqual({});
+    expect(saveImportedData).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/manual-heart-rate-deletion.test.js
+++ b/tests/manual-heart-rate-deletion.test.js
@@ -9,6 +9,7 @@ import {
   deleteManualMetric,
   isManualMetricTombstoned,
   logManualMetric,
+  migrateBiometricsToManual,
   reconcileManualMetricTombstones,
   refreshManualSummary,
 } from '../js/wearables-manual.js';
@@ -122,6 +123,49 @@ describe('durable manual heart-rate deletion', () => {
     expect(isManualMetricTombstoned('rhr', '2026-08-12')).toBe(false);
     expect(state.importedData.manualMetricTombstones['rhr.2026-08-12']).toBe(0);
     expect(await getDaily(PROFILE_ID, 'manual', '2026-08-12')).toMatchObject({ rhr: 64 });
+  });
+
+  it('preserves the undeleted legacy BP component for migration', async () => {
+    state.importedData.biometrics.bp = [
+      { date: '2026-08-10', systolic: 120, diastolic: 76 },
+      { date: '2026-08-11', systolic: 118, diastolic: 74 },
+    ];
+    state.importedData.manualMetricTombstones = {
+      'bp_systolic.2026-08-10': Date.now(),
+      'bp_diastolic.2026-08-11': Date.now(),
+    };
+
+    expect(await reconcileManualMetricTombstones(PROFILE_ID)).toEqual({
+      prunedRows: 0,
+      prunedLegacy: 2,
+    });
+    expect(state.importedData.biometrics.bp).toEqual([
+      { date: '2026-08-10', diastolic: 76 },
+      { date: '2026-08-11', systolic: 118 },
+    ]);
+
+    await migrateBiometricsToManual(PROFILE_ID, state.importedData.biometrics);
+
+    expect(await getDaily(PROFILE_ID, 'manual', '2026-08-10')).toMatchObject({
+      bp_diastolic: 76,
+    });
+    expect((await getDaily(PROFILE_ID, 'manual', '2026-08-10')).bp_systolic).toBeUndefined();
+    expect(await getDaily(PROFILE_ID, 'manual', '2026-08-11')).toMatchObject({
+      bp_systolic: 118,
+    });
+    expect((await getDaily(PROFILE_ID, 'manual', '2026-08-11')).bp_diastolic).toBeUndefined();
+  });
+
+  it('deleting one BP metric leaves its legacy counterpart intact', async () => {
+    state.importedData.biometrics.bp = [
+      { date: '2026-08-12', systolic: 121, diastolic: 77 },
+    ];
+
+    await deleteManualMetric(PROFILE_ID, 'bp_systolic', '2026-08-12');
+
+    expect(state.importedData.biometrics.bp).toEqual([
+      { date: '2026-08-12', diastolic: 77 },
+    ]);
   });
 
   it('applies a pulled deletion before rebuilding the receiving device summary', async () => {

--- a/tests/playwright/chat-reopen-streaming.spec.js
+++ b/tests/playwright/chat-reopen-streaming.spec.js
@@ -9,10 +9,11 @@ test('closing and reopening chat preserves an in-flight response', async ({ page
     // point at the same live chat module used by the test.
     const chatLoader = await import('/js/chat-loader.js');
     await chatLoader.loadChatModule();
-    const [{ state }, chatPanel, chatSend] = await Promise.all([
+    const [{ state }, chatPanel, chatSend, tour] = await Promise.all([
       import('/js/state.js'),
       import('/js/chat-panel.js'),
       import('/js/chat-send.js'),
+      import('/js/tour.js'),
     ]);
     const panel = document.getElementById('chat-panel');
     const backdrop = document.getElementById('chat-backdrop');
@@ -41,6 +42,11 @@ test('closing and reopening chat preserves an in-flight response', async ({ page
     });
 
     try {
+      // Escape dismisses the highest-priority overlay first. Remove the
+      // empty-profile tour so this fixture exercises the chat Escape route
+      // deterministically, even when CI reaches the test before onboarding
+      // has settled.
+      tour.endTour({ openEmptyChat: false });
       const liveHistory = [
         { role: 'user', content: 'Explain this result' },
       ];

--- a/tests/playwright/chat-reopen-streaming.spec.js
+++ b/tests/playwright/chat-reopen-streaming.spec.js
@@ -1,0 +1,137 @@
+import { expect, test } from './coverage-fixture.js';
+
+test('closing and reopening chat preserves an in-flight response', async ({ page }) => {
+  await page.goto('/app', { waitUntil: 'load' });
+  await page.waitForSelector('#chat-panel');
+
+  const outcomes = await page.evaluate(async () => {
+    // Load through the production lazy boundary so the shell X/Escape routes
+    // point at the same live chat module used by the test.
+    const chatLoader = await import('/js/chat-loader.js');
+    await chatLoader.loadChatModule();
+    const [{ state }, chatPanel, chatSend] = await Promise.all([
+      import('/js/state.js'),
+      import('/js/chat-panel.js'),
+      import('/js/chat-send.js'),
+    ]);
+    const panel = document.getElementById('chat-panel');
+    const backdrop = document.getElementById('chat-backdrop');
+    const messages = document.getElementById('chat-messages');
+    const sendButton = document.getElementById('chat-send-btn');
+    const storage = new Map(Array.from({ length: localStorage.length }, (_, index) => {
+      const key = localStorage.key(index);
+      return [key, key == null ? null : localStorage.getItem(key)];
+    }));
+    const original = {
+      history: state.chatHistory,
+      panelClass: panel?.className || '',
+      panelAriaHidden: panel?.getAttribute('aria-hidden'),
+      backdropClass: backdrop?.className || '',
+      messagesHTML: messages?.innerHTML || '',
+      sendHTML: sendButton?.innerHTML || '',
+      sendClass: sendButton?.className || '',
+      sendDisabled: sendButton?.disabled,
+      sendLabel: sendButton?.getAttribute('aria-label'),
+      sendTitle: sendButton?.getAttribute('title'),
+    };
+    const controller = new AbortController();
+    let discussionRestoreCalls = 0;
+    const previousCallbacks = chatPanel.configureChatPanel({
+      restoreDiscussionContinuePrompt: () => { discussionRestoreCalls += 1; },
+    });
+
+    try {
+      const liveHistory = [
+        { role: 'user', content: 'Explain this result' },
+      ];
+      state.chatHistory = liveHistory;
+      if (messages) {
+        messages.innerHTML = `
+          <div class="chat-msg chat-user">Explain this result
+            <button class="chat-action-btn chat-edit-retry-action" data-chat-message-action="edit-user-message">Edit &amp; retry</button>
+          </div>
+          <div class="chat-persona-label">AI Lab Analyst</div>
+          <div class="chat-msg chat-ai" data-chat-streaming="true">Partial answer still arriving…</div>
+        `;
+        messages.setAttribute('aria-busy', 'true');
+      }
+      panel?.classList.add('open');
+      backdrop?.classList.add('open');
+      chatSend.setChatAbortController(controller);
+
+      // The X and Escape routes both call closeChatPanel; exercise both entry
+      // points while keeping the same request controller alive.
+      document.querySelector('.chat-close-btn')?.dispatchEvent(
+        new MouseEvent('click', { bubbles: true, cancelable: true }),
+      );
+      await new Promise(resolve => setTimeout(resolve, 0));
+      const xClosedWithoutAbort = !panel?.classList.contains('open')
+        && chatSend.getChatAbortController() === controller
+        && !controller.signal.aborted;
+
+      await chatPanel.openChatPanel();
+      const xReopenPreservedLiveResponse = messages?.textContent.includes('Partial answer still arriving')
+        && messages?.querySelector('[data-chat-streaming="true"]') != null
+        && state.chatHistory === liveHistory
+        && sendButton?.getAttribute('aria-label') === 'Stop generating';
+
+      document.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        cancelable: true,
+      }));
+      await new Promise(resolve => setTimeout(resolve, 0));
+      const escapeClosedWithoutAbort = !panel?.classList.contains('open')
+        && chatSend.getChatAbortController() === controller
+        && !controller.signal.aborted;
+
+      await chatPanel.openChatPanel();
+      return {
+        xClosedWithoutAbort,
+        xReopenPreservedLiveResponse,
+        escapeClosedWithoutAbort,
+        escapeReopenPreservedLiveResponse:
+          messages?.textContent.includes('Partial answer still arriving')
+          && messages?.querySelector('[data-chat-streaming="true"]') != null
+          && state.chatHistory === liveHistory,
+        doesNotRestoreIdleDiscussionPrompt: discussionRestoreCalls === 0,
+        stopButtonRemainsAvailable: sendButton?.classList.contains('streaming')
+          && sendButton?.getAttribute('aria-label') === 'Stop generating'
+          && sendButton.disabled === false,
+        retryActionSuppressedWhileResponseActive: (() => {
+          const retry = messages?.querySelector('.chat-edit-retry-action');
+          return retry?.hidden === true && retry?.disabled === true;
+        })(),
+        transcriptRemainsBusy: messages?.getAttribute('aria-busy') === 'true',
+      };
+    } finally {
+      chatSend.setChatAbortController(null);
+      chatPanel.configureChatPanel(previousCallbacks);
+      state.chatHistory = original.history;
+      if (messages) messages.innerHTML = original.messagesHTML;
+      if (panel) {
+        panel.className = original.panelClass;
+        if (original.panelAriaHidden == null) panel.removeAttribute('aria-hidden');
+        else panel.setAttribute('aria-hidden', original.panelAriaHidden);
+      }
+      if (backdrop) backdrop.className = original.backdropClass;
+      if (sendButton) {
+        sendButton.innerHTML = original.sendHTML;
+        sendButton.className = original.sendClass;
+        sendButton.disabled = Boolean(original.sendDisabled);
+        if (original.sendLabel == null) sendButton.removeAttribute('aria-label');
+        else sendButton.setAttribute('aria-label', original.sendLabel);
+        if (original.sendTitle == null) sendButton.removeAttribute('title');
+        else sendButton.setAttribute('title', original.sendTitle);
+      }
+      localStorage.clear();
+      for (const [key, value] of storage) {
+        if (key != null && value != null) localStorage.setItem(key, value);
+      }
+    }
+  });
+
+  for (const [name, passed] of Object.entries(outcomes)) {
+    expect(passed, name).toBe(true);
+  }
+});

--- a/tests/profile-wearable-refresh.test.js
+++ b/tests/profile-wearable-refresh.test.js
@@ -2,7 +2,7 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { configureProfileRuntimeDeps, loadProfile } from '../js/profile.js';
+import { configureProfileRuntimeDeps, loadProfile, switchProfile } from '../js/profile.js';
 import { state } from '../js/state.js';
 
 const PROFILE_ID = 'injected-wearable-refresh';
@@ -34,6 +34,39 @@ describe('profile wearable refresh dependency', () => {
         PROFILE_ID,
         expect.objectContaining({ weight: 72 })
       );
+    } finally {
+      configureProfileRuntimeDeps(previousDeps);
+      state.currentProfile = previousProfile;
+      state.importedData = previousImportedData;
+      if (previousActiveProfile == null) localStorage.removeItem('labcharts-active-profile');
+      else localStorage.setItem('labcharts-active-profile', previousActiveProfile);
+    }
+  });
+
+  it('waits for the loaded profile wearable refresh before resolving a switch', async () => {
+    const previousProfile = state.currentProfile;
+    const previousImportedData = state.importedData;
+    const previousActiveProfile = localStorage.getItem('labcharts-active-profile');
+    let finishRefresh;
+    const refreshProfileWearables = vi.fn(() => new Promise(resolve => {
+      finishRefresh = resolve;
+    }));
+    const previousDeps = configureProfileRuntimeDeps({
+      reloadProfileRuntimeShell: async () => {},
+      refreshProfileWearables,
+    });
+    state.currentProfile = `${PROFILE_ID}-previous`;
+
+    try {
+      let switched = false;
+      const switching = switchProfile(PROFILE_ID).then(() => { switched = true; });
+      await vi.waitFor(() => expect(refreshProfileWearables).toHaveBeenCalled());
+      await Promise.resolve();
+      expect(switched).toBe(false);
+
+      finishRefresh();
+      await switching;
+      expect(switched).toBe(true);
     } finally {
       configureProfileRuntimeDeps(previousDeps);
       state.currentProfile = previousProfile;

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -316,7 +316,8 @@ assert('App shell injects sync pull profile refresh without bridge lookups',
     && syncPullSrc.includes("if (typeof renderProfileButton === 'function') _renderProfileButton = renderProfileButton;")
     && syncPullSrc.includes('_renderProfileButton();')
     && appShellHooksSrc.includes("import { configureSyncPull } from './sync-pull.js';")
-    && appShellHooksSrc.includes('configureSyncPull({ renderProfileButton });'));
+    && appShellHooksSrc.includes('reconcilePulledManualWearables,')
+    && appShellHooksSrc.includes('configureSyncPull({ renderProfileButton, reconcilePulledManualWearables });'));
 
 assert('App shell injects PDF import review callbacks without a runtime back-import',
   appShellHooksSrc.includes("const confirmPdfImport = () => import('./pdf-import-commit.js')")

--- a/tests/test-sun-ui-flow.js
+++ b/tests/test-sun-ui-flow.js
@@ -23,6 +23,8 @@ return (async function() {
   const { state: S } = await import('/js/state.js');
   const dataModule = await import('/js/data.js');
   const viewsModule = await import('/js/views.js');
+  const { loadLightSunModules } = await import('/js/light-sun-loader.js');
+  await loadLightSunModules();
   const lightDevices = await import('/js/light-devices.js');
   const sun = await import('/js/sun.js');
   const sunSessionUI = await import('/js/sun-session-ui.js');

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -2100,8 +2100,8 @@ await import('../js/settings.js');
     /_planKeyedMapDelta[\s\S]{0,3500}DELTA_MAP_CONFIG\[mapName\][\s\S]{0,3500}keyIdFn\(rawKey\)/.test(deltaSearchSrc));
   assert('_planKeyedMapDelta payload preserves the ORIGINAL raw key (not the synth)',
     /payloadObj\s*=\s*\{\s*k:\s*rawKey,\s*v:\s*value\s*\}/.test(deltaSearchSrc));
-  assert('_planKeyedMapDelta keeps manual value clears as live null rows',
-    /CLEARED_VALUE_MAPS\s*=\s*new Set\(\['manualValues', 'markerValueNotes'\]\)/.test(syncDeltaMapPlannerSrc)
+  assert('_planKeyedMapDelta keeps manual value and tombstone clears as live rows',
+    /CLEARED_VALUE_MAPS\s*=\s*new Set\([\s\S]{0,200}'manualValues'[\s\S]{0,200}'markerValueNotes'[\s\S]{0,200}'manualMetricTombstones'[\s\S]{0,100}\)/.test(syncDeltaMapPlannerSrc)
       && /value === null && !CLEARED_VALUE_MAPS\.has\(mapName\)/.test(syncDeltaMapPlannerSrc));
   assert('Map-shape pull verifies via keyIdFn(parsed.k) === row.itemId',
     /keyIdFn\(parsed\.k\)\s*!==\s*row\.itemId/.test(deltaSearchSrc));
@@ -3021,7 +3021,7 @@ await import('../js/settings.js');
     'entries', 'notes', 'supplements', 'healthGoals', 'changeHistory',
     'chatSummaries',
     // Maps
-    'markerNotes', 'customMarkers', 'manualValues', 'refOverrides',
+    'markerNotes', 'customMarkers', 'manualValues', 'manualMetricTombstones', 'refOverrides',
     'categoryLabels', 'categoryIcons', 'markerLabels',
     'wearablePrimaryOverride', 'genetics.snps', 'lightDailyVerdicts',
     'contextSourceSettings',

--- a/tests/test-tour.js
+++ b/tests/test-tour.js
@@ -204,6 +204,8 @@ assert('Empty first visit starts empty tour before chat onboarding',
   dashboardPageViewSrc.includes("const shouldAutoStartEmptyTour = !localStorage.getItem(profileStorageKey(state.currentProfile, 'emptyTour'))") &&
   dashboardPageViewSrc.includes('setTimeout(() => startEmptyTour(true), 100)') &&
   dashboardPageViewSrc.includes('if (!shouldAutoStartEmptyTour && state.chatHistory.length === 0)'));
+assert('Cancelled chat onboarding timer cannot reopen a dismissed panel',
+  dashboardPageViewSrc.includes("if (!document.body.classList.contains('chat-autostart-reserved')) return;"));
 const setupIdx = dashboardPageViewSrc.indexOf('setupDropZone()');
 const emptyTourIdx = dashboardPageViewSrc.indexOf('setTimeout(() => startEmptyTour(true), 100)');
 const tourIdx = dashboardPageViewSrc.indexOf('startTour(true)');

--- a/types/app-state.d.ts
+++ b/types/app-state.d.ts
@@ -42,6 +42,7 @@ export interface ProfileData {
   changeHistory: any[];
   importSnapshots: any[];
   biometrics?: Record<string, any> | null;
+  manualMetricTombstones?: Record<string, number>;
   manualValues?: Record<string, any>;
   sunSessions?: any[];
   deviceSessions?: any[];


### PR DESCRIPTION
## Summary

- make manual wearable metric deletions durable across devices with synced per-metric/date and delete-all tombstones
- reconcile pulled deletion markers against device-local IndexedDB rows and legacy biometrics before rebuilding wearable summaries
- preserve active chat generation state when the panel is closed and reopened, including partial output, busy state, Stop control, and retry-action suppression

## Root causes

Manual wearable history lives in device-local IndexedDB while legacy `biometrics` and derived summaries sync. Deleting only the local row left old synced pulse data and peer-local rows able to recreate the reading.

Chat reopening always reloaded persisted thread history. In-flight assistant output is intentionally not persisted until completion, so that reload erased the live typewriter DOM while the request continued.

## User impact

Deleted manual heart-rate, weight, and blood-pressure readings stay deleted across synced devices and backups, while deliberate re-entry remains supported. Closing chat with X or Escape no longer makes an active response appear interrupted; reopening shows the same response still generating without restarting the request.

## Validation

- `node tests/test-wearables-manual.js` (101 passed)
- `node tests/test-wearables.js` (603 passed)
- `node tests/test-sync.js` (850 passed)
- focused Vitest suites for manual deletion, sync/runtime/export, chat runtime/composer/event listeners
- focused Playwright coverage for manual data flows, chat X/Escape reopen, chat action bars, and desktop/mobile panel behavior
- `npx tsc -p tsconfig.checkjs.json --pretty false`
- `npm run quality -- --changed`
- `npm run architecture:check`
- `git diff --check`