### PR TITLE
Auto-discover PPQ private TEE models

### DIFF
--- a/js/api-models.js
+++ b/js/api-models.js
@@ -74,7 +74,7 @@ const ROUTSTR_PRIVATE_RECOMMENDED = ['tinfoil-gemma4-31b', 'tinfoil-kimi-k2-6', 
 
 // PPQ uses bare model IDs for regular routing and private/ IDs for Tinfoil TEE models.
 const PPQ_RECOMMENDED = ['claude-sonnet-5', 'claude-sonnet-4.6', 'claude-opus-5', 'claude-opus-4.7', 'gpt-5.5', 'gpt-5.4', 'gemini-3.5-flash', 'gemini-3-flash-preview', 'z-ai/glm-5.2', 'glm-5.2', 'moonshotai/kimi-k3', 'kimi-k3', 'x-ai/grok-4.3', 'grok-4'];
-const PPQ_PRIVATE_RECOMMENDED = ['private/kimi-k2-6', 'private/glm-5-2', 'private/gpt-oss-120b'];
+const PPQ_PRIVATE_RECOMMENDED = ['private/kimi-k3', 'private/kimi-k2-6', 'private/glm-5-2'];
 
 function normalizedModelId(modelId) {
   return String(modelId || '').toLowerCase().replace(/[_.]/g, '-');

--- a/js/api-ppq.js
+++ b/js/api-ppq.js
@@ -27,15 +27,19 @@ const apiWindow = /** @type {PpqApiWindow} */ (typeof window !== 'undefined' ? w
 const PPQ_CURATED = ['claude-', 'gpt-5', 'gpt-4', 'gpt-oss', 'gemini-3', 'gemini-2', 'google/gemini-3', 'google/gemini-2', 'glm-5', 'z-ai/glm-5', 'moonshotai/kimi-', 'grok-', 'x-ai/grok-4', 'llama-', 'qwen', 'deepseek-', 'mistral-', 'kimi', 'perplexity'];
 const PPQ_DEFAULT_CANDIDATES = ['gpt-5.5', 'openai/gpt-5.5', 'claude-sonnet-5', 'claude-sonnet-4.6'];
 const PPQ_EXCLUDE = ['codex', 'audio', 'image', 'embed', 'tts', 'whisper', 'video', 'nano-banana'];
-const PPQ_PRIVATE_MODELS = [
-  { id: 'private/kimi-k2-6', name: 'Kimi K2.6 (Private TEE)', input: ['text', 'image'], pricing: { input_per_1M_tokens: '1.58', output_per_1M_tokens: '5.51' } },
-  { id: 'private/gpt-oss-120b', name: 'GPT-OSS 120B (Private TEE)', input: ['text'], pricing: { input_per_1M_tokens: '0.79', output_per_1M_tokens: '1.31' } },
-  { id: 'private/llama3-3-70b', name: 'Llama 3.3 70B (Private TEE)', input: ['text'], pricing: { input_per_1M_tokens: '1.84', output_per_1M_tokens: '2.89' } },
-  { id: 'private/qwen3-vl-30b', name: 'Qwen3-VL 30B (Private TEE)', input: ['text', 'image'], pricing: { input_per_1M_tokens: '1.31', output_per_1M_tokens: '4.20' } },
-  { id: 'private/glm-5-2', name: 'GLM-5.2 (Private TEE)', input: ['text'], pricing: { input_per_1M_tokens: '1.58', output_per_1M_tokens: '5.51' } },
-  { id: 'private/gemma4-31b', name: 'Gemma 4 31B (Private TEE)', input: ['text', 'image'], pricing: { input_per_1M_tokens: '0.47', output_per_1M_tokens: '1.05' } },
-];
-const PPQ_PRIVATE_MODEL_MAP = Object.fromEntries(PPQ_PRIVATE_MODELS.map(m => [m.id, m.id.replace(/^private\//, '')]));
+// The PPQ API is authoritative for private-model availability, names, and
+// pricing. This map only fills capability metadata that the current private
+// catalogue rows omit; it must never act as an availability allowlist.
+/** @type {Record<string, { input: string[] }>} */
+const PPQ_PRIVATE_MODEL_CAPABILITIES = {
+  'private/kimi-k2-6': { input: ['text', 'image'] },
+  'private/gpt-oss-120b': { input: ['text'] },
+  'private/llama3-3-70b': { input: ['text'] },
+  'private/qwen3-vl-30b': { input: ['text', 'image'] },
+  'private/glm-5-2': { input: ['text'] },
+  'private/gemma4-31b': { input: ['text', 'image'] },
+  'private/kimi-k3': { input: ['text', 'image'] },
+};
 
 export async function createPpqAccount() {
   const res = await fetch('https://api.ppq.ai/accounts/create', { method: 'POST' });
@@ -98,11 +102,9 @@ export async function fetchPpqModels(key) {
     if (!res.ok) return [];
     const json = await res.json();
     const rawModels = json.data || [];
-    const privateIds = new Set(PPQ_PRIVATE_MODELS.map(m => m.id));
     const privateFromApi = rawModels.filter(function(m) { return m?.id && m.id.startsWith('private/'); });
     const privateModels = privateFromApi
-      .filter(function(m) { return privateIds.has(m.id); })
-      .map(function(m) { return { ...PPQ_PRIVATE_MODELS.find(p => p.id === m.id), ...m }; })
+      .map(function(m) { return { ...PPQ_PRIVATE_MODEL_CAPABILITIES[m.id], ...m }; })
       .sort(function(a, b) { return (a.name || a.id).localeCompare(b.name || b.id); });
     const all = rawModels.filter(function(m) {
       if (!m.id || m.id.startsWith('private/')) return false;
@@ -175,7 +177,7 @@ export async function callPpqPrivateAPI(opts) {
   if (!key) throw new Error('No PPQ API key configured. Create an account or add your key in Settings.');
   if (!crypto?.subtle) throw new Error('PPQ Private TEE mode requires a secure context (HTTPS). Cannot encrypt on this page.');
   const modelId = getPpqModel();
-  const enclaveModelId = PPQ_PRIVATE_MODEL_MAP[modelId] || modelId.replace(/^private\//, '');
+  const enclaveModelId = modelId.replace(/^private\//, '');
   const { createPpqPrivateFetch } = await import('../vendor/ppq-private-tee.js');
   let secure;
   try {

--- a/tests/api-provider-runtime.test.js
+++ b/tests/api-provider-runtime.test.js
@@ -295,6 +295,49 @@ describe('API provider runtime behavior', () => {
     expect(getPpqModel()).toBe('private/glm-5-2');
   });
 
+  it('accepts newly API-listed PPQ private models without a local allowlist', async () => {
+    setAIProvider('ppq');
+    setPpqPrivateMode(true);
+    setPpqModel('private/kimi-k3');
+    fetch.mockResolvedValueOnce(jsonResponse({
+      data: [
+        { id: 'claude-sonnet-5', name: 'Claude Sonnet 5' },
+        {
+          id: 'private/kimi-k3',
+          name: 'Kimi K3 (Private via TEE)',
+          pricing: { input_per_1M_tokens: 4.22, output_per_1M_tokens: 21.1 },
+        },
+        {
+          id: 'private/future-tee-model',
+          name: 'Future TEE Model',
+          pricing: { input_per_1M_tokens: 1.25, output_per_1M_tokens: 2.5 },
+        },
+      ],
+    }));
+
+    const models = await fetchPpqModels('sk-ppq');
+
+    expect(models.map(model => model.id)).toEqual([
+      'private/future-tee-model',
+      'private/kimi-k3',
+    ]);
+    expect(JSON.parse(localStorage.getItem('labcharts-ppq-private-models'))
+      .map(model => model.id)).toEqual([
+      'private/future-tee-model',
+      'private/kimi-k3',
+    ]);
+    expect(JSON.parse(localStorage.getItem('labcharts-ppq-pricing'))).toMatchObject({
+      'private/future-tee-model': { input: 1.25, output: 2.5 },
+      'private/kimi-k3': { input: 4.22, output: 21.1 },
+    });
+    expect(JSON.parse(localStorage.getItem('labcharts-ppq-private-vision-models')))
+      .toContain('private/kimi-k3');
+    expect(getPpqModel()).toBe('private/kimi-k3');
+    expect(isRecommendedModel('ppq', 'private/kimi-k3')).toBe(true);
+    expect(isRecommendedModel('ppq', 'private/gpt-oss-120b')).toBe(false);
+    expect(supportsVision()).toBe(true);
+  });
+
   it('proxies Custom API validation for the explicit unsaved remote URL', async () => {
     setAIProvider('openrouter');
     setCustomApiUrl('http://localhost:11434/v1');

--- a/tests/playwright/ppq-private-tee-provider.spec.js
+++ b/tests/playwright/ppq-private-tee-provider.spec.js
@@ -42,6 +42,7 @@ test('PPQ Private TEE toggle appears after cold-cache model fetch without provid
             data: [
               { id: 'claude-sonnet-4.6', name: 'Claude Sonnet 4.6', pricing: { input_per_1M_tokens: '3', output_per_1M_tokens: '15' } },
               { id: 'private/glm-5-2', name: 'GLM 5.2 Private', pricing: { input_per_1M_tokens: '1', output_per_1M_tokens: '8' } },
+              { id: 'private/kimi-k3', name: 'Kimi K3 Private', pricing: { input_per_1M_tokens: '4.22', output_per_1M_tokens: '21.1' } },
               { id: 'codex-not-used', name: 'Codex' },
             ],
           }), { status: 200, headers: { 'Content-Type': 'application/json' } });
@@ -78,9 +79,11 @@ test('PPQ Private TEE toggle appears after cold-cache model fetch without provid
         after: {
           hasToggle: !!document.getElementById('ppq-private-toggle'),
           privateCount: JSON.parse(localStorage.getItem('labcharts-ppq-private-models') || '[]').length,
+          privateModels: JSON.parse(localStorage.getItem('labcharts-ppq-private-models') || '[]').map(model => model.id),
           regularCount: JSON.parse(localStorage.getItem('labcharts-ppq-models') || '[]').length,
           privateMode: localStorage.getItem('labcharts-ppq-private-mode'),
           modelSelectValue: document.getElementById('ppq-model-select')?.value || '',
+          modelOptions: Array.from(document.querySelectorAll('#ppq-model-select option')).map(option => option.value),
           indicatorText: document.getElementById('ppq-private-indicator')?.textContent || '',
           balanceText: document.getElementById('ppq-balance')?.textContent || '',
           balanceCalls,
@@ -105,10 +108,12 @@ test('PPQ Private TEE toggle appears after cold-cache model fetch without provid
   expect(result.before.hasToggle).toBe(false);
   expect(result.before.privateCount).toBe(0);
   expect(result.after.hasToggle).toBe(true);
-  expect(result.after.privateCount).toBeGreaterThan(0);
+  expect(result.after.privateCount).toBe(2);
+  expect(result.after.privateModels).toContain('private/kimi-k3');
   expect(result.after.regularCount).toBe(1);
   expect(result.after.privateMode).toBe('on');
   expect(result.after.modelSelectValue).toMatch(/^private\//);
+  expect(result.after.modelOptions).toContain('private/kimi-k3');
   expect(result.after.indicatorText).toContain('Prompts are encrypted in your browser');
   expect(result.after.balanceText).toContain('$1.23');
   expect(result.after.balanceCalls).toBeGreaterThanOrEqual(2);


### PR DESCRIPTION
## What changed

- Treat PPQ's live `private/*` API catalogue as authoritative instead of filtering it through a local allowlist.
- Keep a small local capability overlay only for metadata PPQ currently omits, including Kimi K3 vision support.
- Recommend private Kimi K3 while keeping GPT-OSS 120B available only in the full TEE model list.
- Preserve live pricing, entitlement gating, selection state, and encrypted TEE transport.

## Why

PPQ added `private/kimi-k3` to its models API, but Get Based discarded it because the private catalogue was intersected with a hard-coded list. The same behavior would hide every future private model until a code release.

## Impact

Kimi K3 now appears automatically in PPQ Private TEE Mode, and future API-listed private models will be selectable without app changes. GPT-OSS remains selectable but is no longer shown as recommended.

## Verification

- `npx vitest run tests/api-provider-runtime.test.js`
- `node tests/test-ppq-provider.js`
- `npx playwright test tests/playwright/ppq-private-tee-provider.spec.js`
- `npm run typecheck:checkjs`
- `npm run production:check`
- `npm run quality -- --changed`
- `npm run architecture:check`
- `git diff --check`