### PR TITLE
Improve Context and Reports UX

### DIFF
--- a/css/dashboard-widgets.css
+++ b/css/dashboard-widgets.css
@@ -258,55 +258,49 @@
 .dashboard-picker-card[data-configured="true"] .dashboard-picker-action { color: var(--green); }
 .dashboard-picker-check { color: var(--green); font-weight: 700; }
 .context-hub-dialog {
-  width: min(1120px, calc(100vw - 32px));
-  max-width: 1120px;
-  max-height: min(90vh, 820px);
-  overflow: auto;
-  padding: 22px;
+  display: flex;
+  flex-direction: column;
+  width: min(980px, calc(100vw - 32px));
+  max-width: 980px;
+  max-height: min(92dvh, 860px);
+  overflow: hidden;
+  padding: 0;
 }
 .context-hub-header {
+  flex: 0 0 auto;
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   gap: 16px;
-  margin-bottom: 12px;
 }
 .context-hub-heading {
   min-width: 0;
   flex: 1;
 }
-.context-hub-dialog .confirm-message {
-  margin: 0 0 4px;
-}
 .context-hub-subtext {
-  margin: 0;
+  margin: 5px 0 0;
   color: var(--text-muted);
   font-size: 12px;
-  line-height: 1.35;
+  line-height: 1.4;
 }
 .context-hub-close {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex: 0 0 auto;
-  width: 34px;
-  height: 34px;
-  border: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
-  border-radius: var(--radius-sm);
-  background: var(--bg-secondary);
-  color: var(--text-muted);
-  cursor: pointer;
-  font-size: 22px;
-  line-height: 1;
+  width: 40px !important;
+  height: 40px !important;
 }
-.context-hub-close:hover {
-  border-color: color-mix(in srgb, var(--accent) 38%, var(--border));
-  color: var(--text-primary);
-  background: var(--bg-hover);
+.context-hub-body {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+  padding: 20px 22px 22px;
 }
-.context-hub-close:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--accent) 78%, transparent);
-  outline-offset: 2px;
+.context-hub-scroll {
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding-right: 2px;
+  -webkit-overflow-scrolling: touch;
 }
 .context-source-panel {
   margin: 14px 0 10px;
@@ -332,33 +326,58 @@
 .context-source-head-sub { font-size: 12px; line-height: 1.35; color: var(--text-muted); }
 .context-source-summary {
   display: grid;
-  gap: 5px;
-  margin: 0 0 10px;
-  padding: 8px 10px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  margin: 0 0 12px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+}
+.context-summary-metric {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-width: 0;
+  padding: 9px 10px;
   border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
   border-radius: var(--radius-sm);
   background: color-mix(in srgb, var(--bg-secondary) 42%, transparent);
 }
-.context-summary-line {
-  display: grid;
-  grid-template-columns: 78px minmax(0, 1fr);
-  gap: 8px;
-  align-items: start;
+.context-summary-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 30px;
+  width: 30px;
+  height: 30px;
+  border-radius: 9px;
+  background: var(--bg-card);
+  color: var(--text-primary);
+  font-size: 15px;
+  font-weight: 750;
+}
+.context-summary-included .context-summary-count {
+  background: color-mix(in srgb, var(--green) 14%, var(--bg-card));
+  color: var(--green);
+}
+.context-summary-copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 1px;
 }
 .context-summary-label {
-  font-size: 10px;
-  font-weight: 800;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 700;
+}
+.context-summary-detail {
+  overflow: hidden;
   color: var(--text-muted);
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
-.context-summary-values {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 5px;
-  min-width: 0;
-}
-.context-summary-chip,
 .context-affect-chip {
   display: inline-flex;
   align-items: center;
@@ -372,33 +391,40 @@
   line-height: 1.25;
   white-space: nowrap;
 }
-.context-summary-empty {
-  font-size: 12px;
-  color: var(--text-muted);
-  line-height: 1.55;
-}
 .context-source-sections {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 12px 14px;
-  align-items: start;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+  align-items: stretch;
 }
 .context-source-section {
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 9px;
   margin: 0;
+  padding: 12px;
+  border: 1px solid color-mix(in srgb, var(--border) 76%, transparent);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--bg-secondary) 34%, transparent);
 }
 .context-source-section-head {
   display: flex;
   flex-direction: column;
   gap: 2px;
-  padding: 0 2px;
 }
 .context-source-section-title { font-size: 12px; font-weight: 750; color: var(--text-primary); }
 .context-source-section-sub { font-size: 11px; line-height: 1.35; color: var(--text-muted); }
 .context-source-list { display: flex; flex-direction: column; gap: 6px; }
+.context-source-section-wide { grid-column: 1 / -1; }
+.context-source-section-wide .context-source-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+.context-source-section-wide .context-source-list:has(.context-source-row:only-child) {
+  grid-template-columns: 1fr;
+}
+.context-source-section-wide .context-source-row.child { margin-left: 0; }
 .context-source-row {
   display: flex;
   align-items: center;
@@ -421,13 +447,6 @@
   flex-direction: column;
   gap: 2px;
   min-width: 0;
-}
-.context-source-kicker {
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: color-mix(in srgb, var(--accent) 70%, var(--text-muted));
 }
 .context-source-title { font-size: 13px; font-weight: 650; color: var(--text-primary); }
 .context-source-desc, .context-source-status { font-size: 12px; line-height: 1.35; color: var(--text-muted); }
@@ -457,10 +476,17 @@
 .context-grounding-panel .ai-picker-card::before {
   inset: 12px auto 12px 0;
 }
-
-@media (max-width: 980px) {
-  .context-source-sections { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.context-hub-actions {
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 14px;
+  padding-top: 14px;
 }
+.context-hub-save-note {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
 @media (max-width: 1100px) {
   .dashboard-widget-half,
   .dashboard-widget-two-third { grid-column: span 12; }
@@ -471,12 +497,20 @@
 @media (max-width: 760px) {
   .context-hub-dialog {
     width: min(100%, calc(100vw - 20px));
-    padding: 18px;
+    max-height: calc(100dvh - 20px);
   }
   .context-hub-header { gap: 12px; }
+  .context-hub-body { padding: 15px; }
   .context-source-sections { grid-template-columns: 1fr; }
+  .context-source-section-wide { grid-column: auto; }
+  .context-source-section-wide .context-source-list { grid-template-columns: 1fr; }
   .context-source-row.child { margin-left: 0; }
-  .context-summary-line { grid-template-columns: 1fr; gap: 4px; }
+  .context-source-summary { grid-template-columns: 1fr; }
+  .context-summary-detail { white-space: normal; }
+  .context-hub-actions { align-items: stretch; flex-direction: column; }
+  .context-hub-save-note { text-align: center; }
+  .context-hub-actions .import-btn,
+  .context-hub-close { min-height: 44px; }
 }
 @media (max-width: 640px) {
   .ai-picker-grid { grid-template-columns: 1fr; }

--- a/css/modal-shared.css
+++ b/css/modal-shared.css
@@ -779,12 +779,53 @@ select.kb-field-control {
   gap: 16px;
   overflow-y: auto;
   overscroll-behavior: contain;
+  scrollbar-gutter: stable;
   padding-right: 2px;
   -webkit-overflow-scrolling: touch;
 }
 .report-builder-actions {
+  align-items: center;
+  justify-content: space-between;
   flex: 0 0 auto;
   margin-top: 0;
+}
+.report-builder-intro {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 13px 14px;
+  border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--border));
+  border-radius: 12px;
+  background:
+    radial-gradient(circle at 0% 0%, color-mix(in srgb, var(--accent) 13%, transparent), transparent 46%),
+    color-mix(in srgb, var(--bg-card) 82%, transparent);
+}
+.report-builder-intro-title,
+.report-builder-section-title {
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 750;
+}
+.report-builder-local-badge,
+.report-selection-count,
+.report-optional-label {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  border: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--bg-secondary) 78%, transparent);
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+.report-builder-local-badge {
+  flex: 0 0 auto;
+  min-height: 26px;
+  padding: 4px 9px;
+  color: var(--green);
 }
 .report-builder-section {
   display: flex;
@@ -793,8 +834,14 @@ select.kb-field-control {
   min-width: 0;
   padding: 14px;
   border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
+  border-radius: 12px;
   background: color-mix(in srgb, var(--bg-card) 72%, transparent);
+}
+.report-builder-section-head {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
 }
 .report-builder-two-col {
   display: grid;
@@ -814,6 +861,20 @@ select.kb-field-control {
   flex-direction: column;
   gap: 8px;
   min-width: 0;
+}
+.report-builder-field-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
+}
+.report-selection-count {
+  min-height: 22px;
+  padding: 2px 7px;
+  font-family: var(--font-sans);
+  letter-spacing: 0;
+  text-transform: none;
 }
 .report-builder-select {
   width: 100%;
@@ -842,7 +903,7 @@ select.kb-field-control {
 }
 .report-preset-btn {
   display: flex;
-  min-height: 64px;
+  min-height: 70px;
   flex-direction: column;
   align-items: flex-start;
   justify-content: center;
@@ -882,13 +943,18 @@ select.kb-field-control {
   align-items: center;
   gap: 9px;
   min-width: 0;
-  min-height: 38px;
+  min-height: 44px;
   padding: 8px 10px;
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   background: var(--bg-secondary);
   color: var(--text-primary);
   font-size: 13px;
+}
+.report-builder-check:has(input:checked),
+.report-category-row:has(input:checked) {
+  border-color: color-mix(in srgb, var(--accent) 34%, var(--border));
+  background: color-mix(in srgb, var(--accent) 7%, var(--bg-secondary));
 }
 .report-builder-check input,
 .report-category-row input {
@@ -907,17 +973,14 @@ select.kb-field-control {
   justify-content: flex-end;
 }
 .report-mini-btn {
-  min-height: 30px;
-  padding: 5px 9px;
+  min-height: 36px;
+  padding: 6px 10px;
   font-size: 12px;
 }
 .report-category-list {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 8px;
-  max-height: min(32vh, 280px);
-  overflow: auto;
-  padding-right: 2px;
 }
 .report-category-copy {
   display: flex;
@@ -932,6 +995,7 @@ select.kb-field-control {
   white-space: nowrap;
 }
 .report-builder-empty {
+  padding: 10px 2px 2px;
   color: var(--text-muted);
   font-size: 13px;
 }
@@ -952,6 +1016,12 @@ select.kb-field-control {
   font-size: 12px;
   line-height: 1.4;
   margin-top: 10px;
+}
+.report-optional-label {
+  min-height: 20px;
+  margin-left: 5px;
+  padding: 1px 6px;
+  vertical-align: 1px;
 }
 .report-ai-summary-text {
   width: 100%;
@@ -977,6 +1047,16 @@ select.kb-field-control {
   color: #07111f;
   box-shadow: 0 10px 28px color-mix(in srgb, var(--accent) 24%, transparent);
 }
+.report-builder-selection-summary {
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.4;
+}
+.report-builder-footer-buttons {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
 .report-builder-preview-btn:hover {
   box-shadow: var(--shadow-glow);
   transform: translateY(-1px);
@@ -992,9 +1072,6 @@ select.kb-field-control {
   .report-category-list {
     grid-template-columns: 1fr;
   }
-  .report-category-list {
-    max-height: min(36vh, 320px);
-  }
   .report-builder-row-head {
     align-items: flex-start;
     flex-direction: column;
@@ -1003,6 +1080,19 @@ select.kb-field-control {
   .report-ai-actions {
     justify-content: flex-start;
   }
+  .report-builder-intro {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+  .report-builder-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+  .report-builder-selection-summary { text-align: center; }
+  .report-builder-footer-buttons { width: 100%; }
+  .report-mini-btn,
+  .report-builder-footer-buttons .import-btn { min-height: 44px; }
+  .report-builder-footer-buttons .import-btn { flex: 1 1 0; }
 }
 
 .modal-nudge { animation: modal-nudge 0.3s ease; }

--- a/js/context-card-dashboard-ai-impl.js
+++ b/js/context-card-dashboard-ai-impl.js
@@ -265,7 +265,6 @@ function hasSupplementsMedsData() {
  * @param {{
  *   key: string,
  *   toggleKey?: string,
- *   kicker: string,
  *   title: string,
  *   description: string,
  *   status: string,
@@ -276,7 +275,7 @@ function hasSupplementsMedsData() {
  *   affects?: string[],
  * }} options
  */
-function renderContextSourceToggle({ key, toggleKey = key, kicker, title, description, status, checked, disabled = false, attrs = {}, child = false, affects = [] }) {
+function renderContextSourceToggle({ key, toggleKey = key, title, description, status, checked, disabled = false, attrs = {}, child = false, affects = [] }) {
   const id = `context-source-${key}`;
   const titleId = `${id}-title`;
   const descriptionId = `${id}-description`;
@@ -290,7 +289,6 @@ function renderContextSourceToggle({ key, toggleKey = key, kicker, title, descri
     : '';
   return `<div class="context-source-row${checked ? ' active' : ''}${disabled ? ' disabled' : ''}${child ? ' child' : ''}" data-context-source="${escapeAttr(key)}"${extraAttrs}>
     <div class="context-source-copy">
-      <span class="context-source-kicker">${escapeHTML(kicker)}</span>
       <span class="context-source-title" id="${escapeAttr(titleId)}">${escapeHTML(title)}</span>
       <span class="context-source-desc" id="${escapeAttr(descriptionId)}">${escapeHTML(description)}</span>
       ${affectsHtml}
@@ -303,8 +301,8 @@ function renderContextSourceToggle({ key, toggleKey = key, kicker, title, descri
   </div>`;
 }
 
-function renderContextSourceSection(title, subtitle, rows) {
-  return `<section class="context-source-section">
+function renderContextSourceSection(key, title, subtitle, rows, { wide = false } = {}) {
+  return `<section class="context-source-section${wide ? ' context-source-section-wide' : ''}" data-context-section="${escapeAttr(key)}">
     <div class="context-source-section-head">
       <span class="context-source-section-title">${escapeHTML(title)}</span>
       <span class="context-source-section-sub">${escapeHTML(subtitle)}</span>
@@ -313,11 +311,7 @@ function renderContextSourceSection(title, subtitle, rows) {
   </section>`;
 }
 
-function renderContextSummaryChip(label) {
-  return `<span class="context-summary-chip">${escapeHTML(label)}</span>`;
-}
-
-function renderContextSourceSummary({ insightOn, hasInsight, supplementsOn, hasSupplements, labStats, labOn, genomeSummaryOn, genomePriorityOn, genomeOn, hasGenomeSummary, hasGenome, lightOn, bodyOn }) {
+function renderContextSourceSummary({ insightOn, hasInsight, supplementsOn, hasSupplements, labStats, labOn, genomeSummaryOn, genomePriorityOn, genomeOn, hasGenomeSummary, hasGenome, lightOn, bodyOn, hasBody }) {
   /** @type {string[]} */
   const included = [];
   /** @type {string[]} */
@@ -331,14 +325,14 @@ function renderContextSourceSummary({ insightOn, hasInsight, supplementsOn, hasS
   if (hasSupplements) {
     if (supplementsOn) included.push('Supplements & Meds');
     else excluded.push('Supplements & Meds');
-  } else if (supplementsOn) inactive.push('Supplements & Meds');
-  else excluded.push('Supplements & Meds');
-  if (labOn && labStats.totalMarkers > 0) included.push('Blood markers');
-  else if (labOn) inactive.push('Blood markers');
-  else excluded.push('Blood markers');
+  } else inactive.push('Supplements & Meds');
+  if (labStats.totalMarkers > 0) {
+    if (labOn) included.push('Blood markers');
+    else excluded.push('Blood markers');
+  } else inactive.push('Blood markers');
   for (const group of labStats.groups) {
     const title = getLabGroupTitle(group);
-    if (!labOn) inactive.push(title);
+    if (!labOn) excluded.push(title);
     else if (isGroupInAIContext(group.name)) included.push(title);
     else excluded.push(title);
   }
@@ -357,16 +351,21 @@ function renderContextSourceSummary({ insightOn, hasInsight, supplementsOn, hasS
   }
   if (lightOn) included.push('Light & Sun');
   else excluded.push('Light & Sun');
-  if (bodyOn) included.push('Wearables');
-  else excluded.push('Wearables');
-  const renderList = (label, items, empty) => `<div class="context-summary-line">
-    <span class="context-summary-label">${escapeHTML(label)}</span>
-    <span class="context-summary-values">${items.length ? items.map(renderContextSummaryChip).join('') : `<span class="context-summary-empty">${escapeHTML(empty)}</span>`}</span>
+  if (hasBody) {
+    if (bodyOn) included.push('Wearables');
+    else excluded.push('Wearables');
+  } else inactive.push('Wearables');
+  const renderMetric = (tone, label, items, detail) => `<div class="context-summary-metric context-summary-${escapeAttr(tone)}" aria-label="${escapeAttr(`${label}: ${items.length ? items.join(', ') : 'none'}`)}">
+    <span class="context-summary-count">${items.length}</span>
+    <span class="context-summary-copy">
+      <span class="context-summary-label">${escapeHTML(label)}</span>
+      <span class="context-summary-detail">${escapeHTML(detail)}</span>
+    </span>
   </div>`;
   return `<div class="context-source-summary" aria-label="Current context source summary">
-    ${renderList('Included now', included, 'Nothing active yet')}
-    ${renderList('Off', excluded, 'Nothing intentionally excluded')}
-    ${renderList('Not imported', inactive, 'All fixed sources have data')}
+    ${renderMetric('included', 'Included', included, 'Can influence results')}
+    ${renderMetric('excluded', 'Off', excluded, 'Explicitly excluded')}
+    ${renderMetric('unavailable', 'No data', inactive, 'Waiting for profile data')}
   </div>`;
 }
 
@@ -389,7 +388,6 @@ function renderContextSourceControls() {
   const insightRows = [
     renderContextSourceToggle({
       key: 'insight-cards',
-      kicker: 'Profile',
       title: 'Insight Context Cards',
       description: 'Health goals, medical history, diet, exercise, sleep, stress, environment, notes, biometrics, and cycle context.',
       status: insightOn
@@ -400,7 +398,6 @@ function renderContextSourceControls() {
     }),
     renderContextSourceToggle({
       key: 'supplements-meds',
-      kicker: 'Profile',
       title: 'Supplements & Medications',
       description: 'Tracked supplements, medications, ingredients, timing, mitochondrial warnings, and supplement-impact context.',
       status: supplementsOn
@@ -414,7 +411,6 @@ function renderContextSourceControls() {
   const labRows = [
     renderContextSourceToggle({
       key: 'lab-markers',
-      kicker: 'Labs',
       title: 'Blood marker results',
       description: 'Imported lab values, ranges, trends, Biology Score context, marker notes, and flagged-result summaries.',
       status: labOn
@@ -426,7 +422,6 @@ function renderContextSourceControls() {
     ...labStats.groups.map((group, index) => renderContextSourceToggle({
       key: `lab-group-${index}-${group.name.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`,
       toggleKey: 'lab-group',
-      kicker: 'Specialty labs',
       title: getLabGroupTitle(group),
       description: getLabGroupDescription(group),
       status: !labOn
@@ -441,7 +436,6 @@ function renderContextSourceControls() {
   const genomeRows = [
     renderContextSourceToggle({
       key: 'genome-summary',
-      kicker: 'Genome',
       title: 'APOE & mtDNA summary',
       description: 'High-level inherited context such as APOE haplotype and mtDNA haplogroup.',
       status: hasGenomeSummary
@@ -453,7 +447,6 @@ function renderContextSourceControls() {
     }),
     renderContextSourceToggle({
       key: 'genome-priority',
-      kicker: 'Genome',
       title: 'Priority SNP findings',
       description: 'Effectful or protective SNPs relevant to interpretation; normal/neutral calls stay out.',
       status: hasGenome
@@ -465,7 +458,6 @@ function renderContextSourceControls() {
     }),
     renderContextSourceToggle({
       key: 'genome-lookup',
-      kicker: 'Genome',
       title: 'Other SNP lookup inventory',
       description: 'All imported SNP calls, including neutral/no-impact calls from the Genome Lens Other SNPs inventory.',
       status: hasGenome
@@ -480,7 +472,6 @@ function renderContextSourceControls() {
   const lightRows = [
     renderContextSourceToggle({
       key: 'light-sun',
-      kicker: 'Light lens',
       title: 'Light & Sun context',
       description: 'Logged sun, light devices, indoor light environment, and light-related score modifiers.',
       status: lightOn
@@ -493,7 +484,6 @@ function renderContextSourceControls() {
   const bodyRows = [
     renderContextSourceToggle({
       key: 'body-wearables',
-      kicker: 'Body lens',
       title: 'Wearable recovery context',
       description: 'HRV, sleep, resting pulse, recovery, body metrics, and wearable trend summaries.',
       status: bodyOn
@@ -508,13 +498,13 @@ function renderContextSourceControls() {
       <span class="context-source-head-title">Data sources</span>
       <span class="context-source-head-sub">Choose exactly which profile data can influence AI answers and score context.</span>
     </div>
-    ${renderContextSourceSummary({ insightOn, hasInsight, supplementsOn, hasSupplements, labStats, labOn, genomeSummaryOn, genomePriorityOn, genomeOn, hasGenomeSummary, hasGenome, lightOn, bodyOn })}
+    ${renderContextSourceSummary({ insightOn, hasInsight, supplementsOn, hasSupplements, labStats, labOn, genomeSummaryOn, genomePriorityOn, genomeOn, hasGenomeSummary, hasGenome, lightOn, bodyOn, hasBody })}
     <div class="context-source-sections">
-      ${renderContextSourceSection('Profile', 'Personal profile context, with meds and supplements controlled separately.', insightRows)}
-      ${renderContextSourceSection('Labs', 'Blood markers and imported specialty panels.', labRows)}
-      ${renderContextSourceSection('Genome', 'Inherited context split by sensitivity and token cost.', genomeRows)}
-      ${renderContextSourceSection('Light & Sun', 'Light exposure context, logged sessions, and score modifiers.', lightRows)}
-      ${renderContextSourceSection('Body', 'Wearables and recovery signals.', bodyRows)}
+      ${renderContextSourceSection('profile', 'Profile', 'Personal profile context, with meds and supplements controlled separately.', insightRows)}
+      ${renderContextSourceSection('genome', 'Genome', 'Inherited context split by sensitivity and token cost.', genomeRows)}
+      ${renderContextSourceSection('labs', 'Labs', 'Blood markers and imported specialty panels.', labRows, { wide: true })}
+      ${renderContextSourceSection('light-sun', 'Light & Sun', 'Light exposure context, logged sessions, and score modifiers.', lightRows)}
+      ${renderContextSourceSection('body', 'Body', 'Wearables and recovery signals.', bodyRows)}
     </div>
   </div>`;
 }
@@ -660,23 +650,30 @@ export function openContextModal() {
   const kbSet = !!kbSummary?.configured;
   const kbEnabled = !!kbSummary?.enabled;
   const check = '<span class="dashboard-picker-check" aria-hidden="true">&#10003;</span>';
-  overlay.innerHTML = `<div class="confirm-dialog context-hub-dialog" role="dialog" aria-modal="true" aria-labelledby="context-hub-title" aria-describedby="context-hub-description">
-    <div class="context-hub-header">
+  overlay.innerHTML = `<div class="confirm-dialog gb-form-modal context-hub-dialog" role="dialog" aria-modal="true" aria-labelledby="context-hub-title" aria-describedby="context-hub-description">
+    <div class="gb-modal-head context-hub-header">
       <div class="context-hub-heading">
-        <p class="confirm-message" id="context-hub-title">Context</p>
-        <p class="confirm-subtext context-hub-subtext" id="context-hub-description">Manage which profile data is allowed to influence AI answers, score context, and source-driven warnings.</p>
+        <div class="gb-modal-kicker">Manage</div>
+        <div class="gb-modal-title" id="context-hub-title">Context</div>
+        <p class="context-hub-subtext" id="context-hub-description">Control what can influence AI answers, Biology Scores, and source-driven warnings.</p>
       </div>
-      <button type="button" class="context-hub-close" id="context-hub-close" aria-label="Close Context">&times;</button>
+      <button type="button" class="modal-close context-hub-close" id="context-hub-close" aria-label="Close Context">&times;</button>
     </div>
-    ${renderAnswerGroundingPanel({ lensSet, kbSet, kbEnabled, kbSummary, check })}
-    ${renderContextSourceControls()}
-    <div class="confirm-actions" style="margin-top:6px">
-      <button class="confirm-btn confirm-btn-cancel" id="context-hub-cancel">Close</button>
+    <div class="gb-form-body context-hub-body">
+      <div class="context-hub-scroll">
+        ${renderAnswerGroundingPanel({ lensSet, kbSet, kbEnabled, kbSummary, check })}
+        ${renderContextSourceControls()}
+      </div>
+      <div class="gb-form-actions context-hub-actions">
+        <span class="context-hub-save-note">Changes save automatically.</span>
+        <button type="button" class="import-btn import-btn-primary" id="context-hub-cancel">Done</button>
+      </div>
     </div>
   </div>`;
   openModalOverlay(overlay, {
     initialFocus: '.ai-picker-card,[data-context-toggle],#context-hub-cancel',
     focusDelay: 50,
+    scrollLock: true,
   });
   document.addEventListener('keydown', onKey);
   overlay.onclick = (e) => { if (e.target === overlay) close(); };

--- a/js/export-report-builder.js
+++ b/js/export-report-builder.js
@@ -80,7 +80,10 @@ function renderReportCategoryChecks(categoryOptions, selectedCategoryKeys) {
   }
   return categoryOptions.map(option => {
     const checked = selected.has(option.key);
-    const flagText = option.flaggedCount > 0 ? `${option.flaggedCount} flagged` : `${option.markerCount} markers`;
+    const markerText = `${option.markerCount} marker${option.markerCount === 1 ? '' : 's'}`;
+    const flagText = option.flaggedCount > 0
+      ? `${markerText} · ${option.flaggedCount} flagged`
+      : markerText;
     return `<label class="report-category-row">
       <input type="checkbox" data-report-category="${escapeAttr(option.key)}" data-report-priority="${option.flaggedCount > 0 ? 'true' : 'false'}" ${checked ? 'checked' : ''}>
       <span class="report-category-copy">
@@ -89,6 +92,13 @@ function renderReportCategoryChecks(categoryOptions, selectedCategoryKeys) {
       </span>
     </label>`;
   }).join('');
+}
+
+function formatSelectionCount(selected, total, noun) {
+  const label = total === 1
+    ? noun
+    : (noun.endsWith('y') ? `${noun.slice(0, -1)}ies` : `${noun}s`);
+  return `${selected} of ${total} ${label}`;
 }
 
 function renderReportBuilder(presetId = DEFAULT_REPORT_PRESET) {
@@ -103,19 +113,40 @@ function renderReportBuilder(presetId = DEFAULT_REPORT_PRESET) {
     `<option value="${escapeAttr(option.value)}" ${preset.dateRange === option.value ? 'selected' : ''}>${escapeHTML(option.label)}</option>`
   ).join('');
 
+  const selectedSectionCount = preset.sections.length;
+  const selectedCategoryCount = selectedCategoryKeys.length;
+  const priorityAction = categoryOptions.some(option => option.flaggedCount > 0)
+    ? `<button type="button" class="report-mini-btn" aria-label="Select lab categories with flagged results" ${reportBuilderActionAttrs('select-priority-categories')}>Flagged</button>`
+    : '';
+  const categoryActions = categoryOptions.length ? `<div class="report-category-actions">
+    <button type="button" class="report-mini-btn" aria-label="Select all lab categories" ${reportBuilderActionAttrs('select-all-categories')}>All</button>
+    ${priorityAction}
+    <button type="button" class="report-mini-btn" aria-label="Clear selected lab categories" ${reportBuilderActionAttrs('clear-categories')}>Clear</button>
+  </div>` : '';
+
   return `<div class="modal-overlay" id="${REPORT_BUILDER_OVERLAY_ID}" data-report-builder-overlay data-report-preset="${escapeAttr(presetId)}">
     <div class="modal gb-form-modal report-builder-modal" role="dialog" aria-modal="true" aria-labelledby="report-builder-title">
       <div class="gb-modal-head">
         <div>
-          <div class="gb-modal-kicker">Export</div>
-          <div class="gb-modal-title" id="report-builder-title">Reports</div>
+          <div class="gb-modal-kicker">Reports</div>
+          <div class="gb-modal-title" id="report-builder-title">Create a report</div>
         </div>
         <button type="button" class="modal-close" aria-label="Close" ${reportBuilderActionAttrs('close')}>&times;</button>
       </div>
       <div class="gb-form-body report-builder-body">
         <div class="report-builder-scroll">
+        <div class="report-builder-intro">
+          <div>
+            <div class="report-builder-intro-title">Choose what you want to share</div>
+            <div class="report-builder-help">Build a print-ready view of this profile. The preview is created locally in your browser.</div>
+          </div>
+          <span class="report-builder-local-badge">Local preview</span>
+        </div>
         <div class="report-builder-section">
-          <div class="report-builder-label">Report type</div>
+          <div class="report-builder-section-head">
+            <div class="report-builder-section-title">Start with a template</div>
+            <div class="report-builder-help">Templates set the initial range and sections. You can adjust everything below.</div>
+          </div>
           <div class="report-preset-grid">${presetButtons}</div>
         </div>
         <div class="report-builder-section report-builder-two-col">
@@ -124,39 +155,47 @@ function renderReportBuilder(presetId = DEFAULT_REPORT_PRESET) {
             <select id="report-date-range" class="report-builder-select">${dateOptions}</select>
           </label>
           <div class="report-builder-field">
-            <span class="report-builder-label">Sections</span>
+            <div class="report-builder-field-head">
+              <span class="report-builder-label">Sections</span>
+              <span class="report-selection-count" data-report-section-count>${escapeHTML(formatSelectionCount(selectedSectionCount, REPORT_SECTION_DEFS.length, 'section'))}</span>
+            </div>
             <div class="report-section-grid">${renderReportSectionChecks(preset)}</div>
           </div>
         </div>
         <div class="report-builder-section">
           <div class="report-builder-row-head">
-            <div class="report-builder-label">Lab categories</div>
-            <div class="report-category-actions">
-              <button type="button" class="report-mini-btn" ${reportBuilderActionAttrs('select-all-categories')}>All</button>
-              <button type="button" class="report-mini-btn" ${reportBuilderActionAttrs('select-priority-categories')}>Priority</button>
-              <button type="button" class="report-mini-btn" ${reportBuilderActionAttrs('clear-categories')}>Clear</button>
+            <div class="report-builder-section-head">
+              <div class="report-builder-field-head">
+                <span class="report-builder-section-title">Lab categories</span>
+                <span class="report-selection-count" data-report-category-count>${categoryOptions.length ? escapeHTML(formatSelectionCount(selectedCategoryCount, categoryOptions.length, 'category')) : 'No lab data'}</span>
+              </div>
+              <div class="report-builder-help">Choose which imported lab groups appear in lab-based sections.</div>
             </div>
+            ${categoryActions}
           </div>
           <div class="report-category-list">${renderReportCategoryChecks(categoryOptions, selectedCategoryKeys)}</div>
         </div>
         <div class="report-builder-section report-ai-builder">
           <div class="report-builder-row-head">
             <div>
-              <div class="report-builder-label">Practitioner overview</div>
-              <div class="report-builder-help">Generate a one-minute clinical picture from the selected report data. Edit it before preview if needed.</div>
+              <div class="report-builder-section-title">Practitioner overview <span class="report-optional-label">Optional</span></div>
+              <div class="report-builder-help">Generating may share the report data selected above with your active AI provider. Preview works without it.</div>
             </div>
             <div class="report-ai-actions">
-              <button type="button" class="report-mini-btn report-ai-generate-btn" ${reportBuilderActionAttrs('generate-ai-summary')}>Generate</button>
+              <button type="button" class="report-mini-btn report-ai-generate-btn" ${reportBuilderActionAttrs('generate-ai-summary')}>Generate overview</button>
               <button type="button" class="report-mini-btn report-ai-clear-btn" hidden ${reportBuilderActionAttrs('clear-ai-summary')}>Clear</button>
             </div>
           </div>
-          <div class="report-ai-status" data-report-ai-status>Not generated.</div>
+          <div class="report-ai-status" data-report-ai-status aria-live="polite">Not generated.</div>
           <textarea id="report-ai-summary-text" class="report-ai-summary-text" aria-label="Editable practitioner overview" hidden></textarea>
         </div>
         </div>
         <div class="gb-form-actions report-builder-actions">
-          <button type="button" class="import-btn import-btn-secondary" ${reportBuilderActionAttrs('close')}>Cancel</button>
-          <button type="button" class="import-btn import-btn-primary report-builder-preview-btn" ${reportBuilderActionAttrs('export')}>Preview PDF</button>
+          <div class="report-builder-selection-summary" id="report-builder-selection-summary" data-report-selection-summary aria-live="polite">${escapeHTML(`${selectedSectionCount} sections${categoryOptions.length ? ` · ${selectedCategoryCount} lab categories` : ' · no lab data'}`)}</div>
+          <div class="report-builder-footer-buttons">
+            <button type="button" class="import-btn import-btn-secondary" ${reportBuilderActionAttrs('close')}>Cancel</button>
+            <button type="button" class="import-btn import-btn-primary report-builder-preview-btn" aria-describedby="report-builder-selection-summary" ${reportBuilderActionAttrs('export')}>Preview PDF</button>
+          </div>
         </div>
       </div>
     </div>
@@ -186,6 +225,16 @@ function collectReportBuilderOptions(overlay) {
   return options;
 }
 
+function getReportBuilderSelectionError(overlay, options) {
+  if (options.sections.length === 0) return 'Choose at least one report section';
+  const hasCategories = overlay.querySelectorAll('input[data-report-category]').length > 0;
+  const hasLabSection = options.sections.some(section => REPORT_LAB_SECTION_IDS.includes(section));
+  if (hasLabSection && hasCategories && options.categoryKeys.length === 0) {
+    return 'Choose at least one lab category or turn off lab sections';
+  }
+  return '';
+}
+
 function setReportCategoryChecks(overlay, mode) {
   const boxes = Array.from(overlay.querySelectorAll('input[data-report-category]'));
   if (mode === 'clear') {
@@ -198,6 +247,47 @@ function setReportCategoryChecks(overlay, mode) {
     return;
   }
   boxes.forEach(box => { box.checked = true; });
+}
+
+function updateReportBuilderSelectionState(overlay) {
+  const sectionBoxes = Array.from(overlay.querySelectorAll('input[data-report-section]'));
+  const categoryBoxes = Array.from(overlay.querySelectorAll('input[data-report-category]'));
+  const selectedSections = sectionBoxes.filter(box => box.checked).length;
+  const selectedCategories = categoryBoxes.filter(box => box.checked).length;
+  const sectionCount = overlay.querySelector('[data-report-section-count]');
+  const categoryCount = overlay.querySelector('[data-report-category-count]');
+  const summary = overlay.querySelector('[data-report-selection-summary]');
+  if (sectionCount) sectionCount.textContent = formatSelectionCount(selectedSections, sectionBoxes.length, 'section');
+  if (categoryCount) {
+    categoryCount.textContent = categoryBoxes.length
+      ? formatSelectionCount(selectedCategories, categoryBoxes.length, 'category')
+      : 'No lab data';
+  }
+  if (summary) {
+    summary.textContent = `${selectedSections} section${selectedSections === 1 ? '' : 's'}${categoryBoxes.length
+      ? ` · ${selectedCategories} lab categor${selectedCategories === 1 ? 'y' : 'ies'}`
+      : ' · no lab data'}`;
+  }
+}
+
+function applyReportPreset(overlay, presetId) {
+  const normalizedPresetId = REPORT_PRESETS[presetId] ? presetId : DEFAULT_REPORT_PRESET;
+  const preset = getReportPreset(normalizedPresetId);
+  overlay.dataset.reportPreset = normalizedPresetId;
+  overlay.querySelectorAll('[data-report-action="set-preset"]').forEach(button => {
+    const active = button.dataset.reportPreset === normalizedPresetId;
+    button.classList.toggle('active', active);
+    button.setAttribute('aria-pressed', String(active));
+  });
+  const range = overlay.querySelector('#report-date-range');
+  if (range) range.value = preset.dateRange;
+  const selectedSections = new Set(preset.sections);
+  overlay.querySelectorAll('input[data-report-section]').forEach(box => {
+    box.checked = selectedSections.has(box.dataset.reportSection);
+  });
+  setReportCategoryChecks(overlay, preset.categoryMode === 'priority' ? 'priority' : 'all');
+  clearReportBuilderAISummaryForOptionChange(overlay);
+  updateReportBuilderSelectionState(overlay);
 }
 
 function setReportBuilderAISummary(overlay, summary) {
@@ -242,6 +332,12 @@ async function generateReportBuilderAISummary(overlay, actionEl) {
   if (statusEl) statusEl.textContent = 'Generating practitioner overview...';
   try {
     const options = collectReportBuilderOptions(overlay);
+    const selectionError = getReportBuilderSelectionError(overlay, options);
+    if (selectionError) {
+      if (statusEl) statusEl.textContent = `${selectionError}.`;
+      showNotification(selectionError, 'error');
+      return;
+    }
     delete options.aiSummary;
     const summary = await generateReportAISummary(options);
     if (summary) {
@@ -270,28 +366,28 @@ async function handleReportBuilderClick(event) {
   if (action === 'close') {
     closeReportBuilder();
   } else if (action === 'set-preset') {
-    openReportBuilder(actionEl.dataset.reportPreset || DEFAULT_REPORT_PRESET);
+    applyReportPreset(overlay, actionEl.dataset.reportPreset || DEFAULT_REPORT_PRESET);
   } else if (action === 'select-all-categories') {
     setReportCategoryChecks(overlay, 'all');
     clearReportBuilderAISummaryForOptionChange(overlay);
+    updateReportBuilderSelectionState(overlay);
   } else if (action === 'select-priority-categories') {
     setReportCategoryChecks(overlay, 'priority');
     clearReportBuilderAISummaryForOptionChange(overlay);
+    updateReportBuilderSelectionState(overlay);
   } else if (action === 'clear-categories') {
     setReportCategoryChecks(overlay, 'clear');
     clearReportBuilderAISummaryForOptionChange(overlay);
+    updateReportBuilderSelectionState(overlay);
   } else if (action === 'generate-ai-summary') {
     await generateReportBuilderAISummary(overlay, actionEl);
   } else if (action === 'clear-ai-summary') {
     setReportBuilderAISummary(overlay, null);
   } else if (action === 'export') {
     const options = collectReportBuilderOptions(overlay);
-    const hasCategories = overlay.querySelectorAll('input[data-report-category]').length > 0;
-    const hasLabSection = options.sections.some(section => REPORT_LAB_SECTION_IDS.includes(section));
-    if (options.sections.length === 0) {
-      showNotification('Choose at least one report section', 'error');
-    } else if (hasLabSection && hasCategories && options.categoryKeys.length === 0) {
-      showNotification('Choose at least one lab category or turn off lab sections', 'error');
+    const selectionError = getReportBuilderSelectionError(overlay, options);
+    if (selectionError) {
+      showNotification(selectionError, 'error');
     } else if (exportPDFReport(options)) {
       closeReportBuilder();
     }
@@ -310,6 +406,7 @@ function handleReportBuilderChange(event) {
     target.matches('input[data-report-category]')
   ) {
     clearReportBuilderAISummaryForOptionChange(overlay);
+    updateReportBuilderSelectionState(overlay);
   }
 }
 
@@ -330,6 +427,7 @@ export function openReportBuilder(presetId = DEFAULT_REPORT_PRESET) {
   const overlay = template.content.firstElementChild;
   if (!(overlay instanceof HTMLElement)) return;
   openAppendedModalOverlay(overlay, closeReportBuilder, { initialFocus: '.report-preset-btn.active', focusDelay: 50 });
+  updateReportBuilderSelectionState(overlay);
 }
 
 export function closeReportBuilder() {

--- a/js/export-report-builder.js
+++ b/js/export-report-builder.js
@@ -44,7 +44,7 @@ function getReportCategoryOptions(data = getActiveData()) {
       markerCount,
       flaggedCount: flagCounts.get(key) || 0,
     };
-  }).filter(Boolean);
+  }).filter(option => option !== null);
 }
 
 function getDefaultReportCategoryKeys(presetId, categoryOptions) {

--- a/js/export-report.js
+++ b/js/export-report.js
@@ -98,7 +98,7 @@ export function normalizeReportOptions(options = {}) {
   const fallbackPreset = hasExplicitOptions ? DEFAULT_REPORT_PRESET : 'full';
   const presetId = REPORT_PRESETS[options.preset] ? options.preset : fallbackPreset;
   const preset = getReportPreset(presetId);
-  const sectionInput = Array.isArray(options.sections) && options.sections.length > 0
+  const sectionInput = Array.isArray(options.sections)
     ? options.sections
     : preset.sections;
   const sectionSet = new Set(sectionInput);
@@ -594,6 +594,8 @@ function buildReportAITrendLines(data, limit = REPORT_AI_CONTEXT_TREND_LIMIT) {
 
 function buildReportAISummaryContext(payload) {
   const { reportOptions, data, profile, profileName, sexLabel, flags, notes, supps, contextSections } = payload;
+  const sections = new Set(reportOptions.sections);
+  const includesLabData = reportOptions.sections.some(section => REPORT_LAB_SECTION_IDS.includes(section));
   const dateLabels = (data.dates || []).map(formatReportDateLabel).filter(Boolean);
   const dateRange = dateLabels.length
     ? `${dateLabels[0]} to ${dateLabels[dateLabels.length - 1]}`
@@ -628,28 +630,23 @@ function buildReportAISummaryContext(payload) {
     `Age: ${getReportAgeLabel(profile?.dob) || 'not specified'}`,
     `Profile status: ${profile?.status || 'not specified'}`,
     `Report type: ${reportOptions.presetLabel}`,
-    `Selected report window: ${dateRange}`,
-    `Range mode: ${state.rangeMode || 'optimal'}`,
-    `Lab dates in report: ${data.dates?.length || 0}`,
-    `Markers reviewed: ${totalWithData}`,
-    `Markers within selected range: ${totalInRange}`,
-    `Latest markers outside selected range: ${flags.length}`,
   ];
-  if (Array.isArray(profile?.tags) && profile.tags.length > 0) {
+  if (includesLabData) lines.push(`Selected report window: ${dateRange}`, `Range mode: ${state.rangeMode || 'optimal'}`, `Lab dates in report: ${data.dates?.length || 0}`, `Markers reviewed: ${totalWithData}`, `Markers within selected range: ${totalInRange}`, `Latest markers outside selected range: ${flags.length}`);
+  if (sections.has('context') && Array.isArray(profile?.tags) && profile.tags.length > 0) {
     lines.push(`Profile tags: ${profile.tags.slice(0, 8).join(', ')}`);
   }
-  if (profile?.notes) {
+  if (sections.has('context') && profile?.notes) {
     lines.push(`Profile notes: ${String(profile.notes).replace(/\s+/g, ' ').slice(0, 280)}`);
   }
 
-  if (flags.length > 0) {
+  if ((sections.has('flagged') || sections.has('summary')) && flags.length > 0) {
     lines.push('Latest out-of-range markers:');
     for (const flag of flags.slice(0, REPORT_AI_CONTEXT_FLAG_LIMIT)) {
       lines.push(`- ${flag.name}: ${flag.value} ${flag.unit || ''} ${flag.status} (range ${formatReportRange(flag.effectiveMin, flag.effectiveMax)})`);
     }
   }
 
-  if (markerLines.length > 0) {
+  if ((sections.has('categories') || sections.has('summary')) && markerLines.length > 0) {
     lines.push('Representative latest lab results:');
     for (const item of markerLines.slice(0, REPORT_AI_CONTEXT_MARKER_LIMIT)) {
       lines.push(`- ${item.text}`);
@@ -657,12 +654,12 @@ function buildReportAISummaryContext(payload) {
   }
 
   const trendLines = buildReportAITrendLines(data);
-  if (trendLines.length > 0) {
+  if (sections.has('trends') && trendLines.length > 0) {
     lines.push('Notable trends:');
     for (const item of trendLines) lines.push(`- ${item}`);
   }
 
-  if (Array.isArray(supps) && supps.length > 0) {
+  if (sections.has('supplements') && Array.isArray(supps) && supps.length > 0) {
     lines.push('Supplements and medications:');
     for (const supp of supps.slice(0, 12)) {
       const dosage = [supp.dosage, supp.dose, supp.amount, supp.frequency].filter(Boolean).join(', ');
@@ -670,14 +667,14 @@ function buildReportAISummaryContext(payload) {
     }
   }
 
-  if (notes.length > 0) {
+  if (sections.has('notes') && notes.length > 0) {
     lines.push('Recent report notes:');
     for (const note of notes.slice(-5)) {
       lines.push(`- ${note.date || 'undated'}: ${String(note.text || '').slice(0, 220)}`);
     }
   }
 
-  if (contextSections.length > 0) {
+  if (sections.has('context') && contextSections.length > 0) {
     lines.push('Profile context:');
     for (const section of contextSections.slice(0, REPORT_AI_CONTEXT_CONTEXT_LIMIT)) {
       lines.push(`- ${section.title}: ${String(section.text || '').replace(/\s+/g, ' ').slice(0, 280)}`);
@@ -685,12 +682,16 @@ function buildReportAISummaryContext(payload) {
   }
 
   const genetics = state.importedData.genetics;
-  if (genetics?.apoe) lines.push(`Genetics: APOE ${genetics.apoe}`);
+  if (sections.has('genetics') && genetics?.apoe) lines.push(`Genetics: APOE ${genetics.apoe}`);
 
   return lines.join('\n');
 }
 
 export async function generateReportAISummary(options = {}) {
+  if (Array.isArray(options.sections) && options.sections.length === 0) {
+    showNotification('Choose at least one report section', 'error');
+    return null;
+  }
   if (!hasAIProvider()) {
     showNotification('Connect an AI provider before generating a report summary', 'error');
     return null;

--- a/scripts/dom-sink-policy.json
+++ b/scripts/dom-sink-policy.json
@@ -181,7 +181,7 @@
     },
     "js/context-card-dashboard-ai-impl.js": {
       "count": 3,
-      "digest": "bc8f678cd7bf79bbb47b06c5e3f16c5a8c5395b36c56b6e59e615999fccef652",
+      "digest": "e799e10e329e293e28533c7f1ce861753690152d655e4ea400126f8260aaaa0f",
       "kinds": {
         "innerHTML": 2,
         "outerHTML": 1

--- a/tests/playwright/dashboard-knowledge-base.spec.js
+++ b/tests/playwright/dashboard-knowledge-base.spec.js
@@ -12,6 +12,7 @@ test('Context hub opens from Personalize AI alias and dismisses', async ({ page 
 
   const overlay = page.locator('#context-hub-overlay');
   await expect(overlay).toHaveClass(/show/);
+  await expect.poll(() => page.evaluate(() => document.body.style.overflow)).toBe('hidden');
   await expect(overlay.locator('.ai-picker-card')).toHaveCount(2);
   await expect(overlay.locator('.context-source-row')).toHaveCount(8);
   await expect(overlay.locator('.context-source-desc')).toHaveCount(8);
@@ -19,8 +20,16 @@ test('Context hub opens from Personalize AI alias and dismisses', async ({ page 
   await expect(overlay.locator('.context-grounding-panel + .context-source-panel')).toHaveCount(1);
   await expect(overlay).toContainText('Context');
   await expect(overlay).toContainText('Data sources');
-  await expect(overlay).toContainText('Included now');
-  await expect(overlay).toContainText('Not imported');
+  await expect(overlay).toContainText('Included');
+  await expect(overlay).toContainText('No data');
+  await expect(overlay.locator('.context-summary-metric')).toHaveCount(3);
+  await expect(overlay.locator('.context-hub-scroll')).toBeVisible();
+  await expect(overlay.locator('.context-hub-actions')).toContainText('Changes save automatically.');
+  await expect(overlay.locator('.context-source-section-wide[data-context-section="labs"]')).toHaveCount(1);
+  const sourceSectionOrder = await overlay.locator('[data-context-section]').evaluateAll(sections =>
+    sections.map(section => section.getAttribute('data-context-section'))
+  );
+  expect(sourceSectionOrder).toEqual(['profile', 'genome', 'labs', 'light-sun', 'body']);
   await expect(overlay).toContainText('Answer grounding');
   await expect(overlay).toContainText('Personalize how AI answers');
   await expect(overlay).toContainText('Interpretive Lens');
@@ -69,8 +78,10 @@ test('Context hub opens from Personalize AI alias and dismisses', async ({ page 
   await expect(overlay).toHaveClass(/show/);
 
   await expect(overlay.locator('#context-hub-cancel')).toBeVisible();
+  await expect(overlay.locator('#context-hub-cancel')).toHaveText('Done');
   await overlay.locator('#context-hub-cancel').click();
   await expect(overlay).not.toHaveClass(/show/);
+  await expect.poll(() => page.evaluate(() => document.body.style.overflow)).toBe('');
 });
 
 test('Context hub data source toggles control prompt and score context', async ({ page }) => {

--- a/tests/playwright/report-export-browser-coverage.spec.js
+++ b/tests/playwright/report-export-browser-coverage.spec.js
@@ -256,9 +256,16 @@ test('report builder modal delegates presets categories AI state and preview exp
 });
 
 test('report lab categories use the modal scroll surface for reliable wheel input', async ({ page }) => {
+  await page.addInitScript(() => {
+    const profileId = localStorage.getItem('labcharts-active-profile') || 'default';
+    localStorage.setItem(`labcharts-${profileId}-emptyTour`, 'completed');
+    localStorage.setItem(`labcharts-${profileId}-tour`, 'completed');
+  });
   await page.goto('/app', { waitUntil: 'load' });
 
   await page.evaluate(async () => {
+    const { endTour } = await import('/js/tour.js');
+    endTour({ openEmptyChat: false });
     const [demo, dataModule, exportModule] = await Promise.all([
       fetch('/data/demo-male.json').then(response => response.json()),
       import('/js/data.js'),
@@ -274,6 +281,7 @@ test('report lab categories use the modal scroll surface for reliable wheel inpu
   const overlay = page.locator('#report-builder-overlay');
   const modalScroll = overlay.locator('.report-builder-scroll');
   const categoryList = overlay.locator('.report-category-list');
+  await expect(page.locator('#tour-overlay')).toHaveCount(0);
   await expect(overlay).toHaveClass(/show/);
   await expect.poll(() => categoryList.locator('.report-category-row').count()).toBeGreaterThan(4);
   await expect.poll(() => categoryList.evaluate(element => getComputedStyle(element).overflowY)).toBe('visible');

--- a/tests/playwright/report-export-browser-coverage.spec.js
+++ b/tests/playwright/report-export-browser-coverage.spec.js
@@ -122,17 +122,25 @@ test('report builder modal delegates presets categories AI state and preview exp
       let overlay = getOverlay();
       outcomes.opensClinicianBuilder = !!overlay
         && overlay.dataset.reportPreset === 'clinician'
+        && overlay.querySelector('#report-builder-title')?.textContent === 'Create a report'
+        && overlay.querySelector('.report-builder-local-badge')?.textContent === 'Local preview'
         && overlay.querySelectorAll('.report-preset-btn').length === 3
         && overlay.querySelectorAll('input[data-report-section]').length >= 6
         && overlay.querySelectorAll('input[data-report-category]').length >= 2
-        && checkedCategories(overlay).includes('biochemistry');
+        && checkedCategories(overlay).includes('biochemistry')
+        && overlay.querySelector('[data-report-section-count]')?.textContent === '6 of 8 sections'
+        && overlay.querySelector('[data-report-category-count]')?.textContent === '1 of 2 categories';
 
+      const presetOverlay = overlay;
       click('[data-report-action="set-preset"][data-report-preset="full"]');
       await wait();
       overlay = getOverlay();
-      outcomes.presetClickRerendersFull = overlay?.dataset.reportPreset === 'full'
+      outcomes.presetClickUpdatesInPlace = overlay === presetOverlay
+        && overlay?.dataset.reportPreset === 'full'
         && overlay.querySelector('.report-preset-btn.active')?.textContent.includes('Full lab report') === true
-        && overlay.querySelector('#report-date-range')?.value === 'all';
+        && overlay.querySelector('#report-date-range')?.value === 'all'
+        && overlay.querySelector('[data-report-section-count]')?.textContent === '8 of 8 sections'
+        && overlay.querySelector('[data-report-category-count]')?.textContent === '2 of 2 categories';
 
       const textEl = overlay.querySelector('#report-ai-summary-text');
       const statusEl = overlay.querySelector('[data-report-ai-status]');
@@ -165,6 +173,9 @@ test('report builder modal delegates presets categories AI state and preview exp
 
       const sectionBoxes = Array.from(overlay.querySelectorAll('input[data-report-section]'));
       sectionBoxes.forEach(box => { box.checked = false; });
+      click('[data-report-action="generate-ai-summary"]');
+      await wait();
+      outcomes.generateRequiresSectionSelection = statusEl.textContent === 'Choose at least one report section.';
       click('[data-report-action="export"]');
       await wait();
       outcomes.exportRequiresSectionSelection = !!getOverlay()
@@ -174,6 +185,8 @@ test('report builder modal delegates presets categories AI state and preview exp
 
       click('[data-report-action="clear-categories"]');
       await wait();
+      outcomes.categoryCountUpdatesAfterClear = overlay.querySelector('[data-report-category-count]')?.textContent === '0 of 2 categories'
+        && overlay.querySelector('[data-report-selection-summary]')?.textContent.includes('0 lab categories');
       click('[data-report-action="export"]');
       await wait();
       outcomes.exportRequiresCategoryForLabSections = !!getOverlay()
@@ -240,6 +253,37 @@ test('report builder modal delegates presets categories AI state and preview exp
   for (const [name, passed] of Object.entries(results)) {
     expect(passed, name).toBe(true);
   }
+});
+
+test('report lab categories use the modal scroll surface for reliable wheel input', async ({ page }) => {
+  await page.goto('/app', { waitUntil: 'load' });
+
+  await page.evaluate(async () => {
+    const [demo, dataModule, exportModule] = await Promise.all([
+      fetch('/data/demo-male.json').then(response => response.json()),
+      import('/js/data.js'),
+      import('/js/export.js'),
+    ]);
+    const { state } = await import('/js/state.js');
+    state.importedData = demo;
+    state.profileSex = 'male';
+    dataModule.invalidateActiveDataCache?.();
+    await exportModule.openReportBuilder('full');
+  });
+
+  const overlay = page.locator('#report-builder-overlay');
+  const modalScroll = overlay.locator('.report-builder-scroll');
+  const categoryList = overlay.locator('.report-category-list');
+  await expect(overlay).toHaveClass(/show/);
+  await expect.poll(() => categoryList.locator('.report-category-row').count()).toBeGreaterThan(4);
+  await expect.poll(() => categoryList.evaluate(element => getComputedStyle(element).overflowY)).toBe('visible');
+
+  const firstCategory = categoryList.locator('.report-category-row').first();
+  await firstCategory.scrollIntoViewIfNeeded();
+  await firstCategory.hover();
+  const before = await modalScroll.evaluate(element => element.scrollTop);
+  await page.mouse.wheel(0, 640);
+  await expect.poll(() => modalScroll.evaluate(element => element.scrollTop)).toBeGreaterThan(before);
 });
 
 test('report payload and HTML cover filtered context genetics and supplement branches', async ({ page }) => {
@@ -788,6 +832,7 @@ Discussion focus:
         notes: [{ date: '2026-06-02', text: 'Training load increased' }],
         supplements: [{ name: 'Vitamin D', dosage: '2000 IU', type: 'supplement' }],
         contextNotes: 'Prefers concise practitioner reports.',
+        genetics: { apoe: 'ε3/ε4' },
         customMarkers: {},
       };
       dataModule.invalidateActiveDataCache?.();
@@ -804,6 +849,10 @@ Discussion focus:
       localStorage.setItem('labcharts-ai-provider', 'ollama');
       localStorage.setItem('labcharts-ollama-model', 'summary-test-model');
       localStorage.setItem('labcharts-ai-paused', 'true');
+      const emptySelection = await report.generateReportAISummary({ dateRange: 'all', sections: [] });
+      outcomes.emptySelectionDoesNotGenerate = emptySelection === null
+        && Array.from(document.querySelectorAll('.notification-toast.error'))
+          .some(toast => toast.textContent.includes('Choose at least one report section'));
       const unavailable = await report.generateReportAISummary({ dateRange: 'all' });
       outcomes.unavailableAIShowsErrorAndReturnsNull = unavailable === null
         && Array.from(document.querySelectorAll('.notification-toast.error'))
@@ -846,7 +895,24 @@ Discussion focus:
         && request.body.messages.some(message => message.role === 'system' && message.content.includes('You write practitioner-facing patient overviews'))
         && userContext.includes('Profile: Report AI Coverage')
         && userContext.includes('Notable trends:')
-        && userContext.includes('Recent report notes:');
+        && userContext.includes('Recent report notes:')
+        && userContext.includes('Vitamin D')
+        && userContext.includes('Prefers concise practitioner reports.')
+        && !userContext.includes('Genetics: APOE');
+
+      await report.generateReportAISummary({
+        preset: 'personal',
+        dateRange: 'all',
+        sections: ['notes'],
+        categoryKeys: ['biochemistry'],
+      });
+      const notesOnlyContext = requests[1].body.messages.find(message => message.role === 'user')?.content || '';
+      outcomes.summaryHonorsSelectedSections = notesOnlyContext.includes('Recent report notes:')
+        && !notesOnlyContext.includes('Representative latest lab results:')
+        && !notesOnlyContext.includes('Notable trends:')
+        && !notesOnlyContext.includes('Supplements and medications:')
+        && !notesOnlyContext.includes('Profile context:')
+        && !notesOnlyContext.includes('Genetics: APOE');
 
       returnEmpty = true;
       let emptyResponseThrows = false;
@@ -924,7 +990,8 @@ test('report export helpers cover option normalization AI markup and popup block
         && normalized.dateRange === 'current'
         && normalized.sections.join('|') === 'summary|notes'
         && normalized.categoryKeys.join('|') === 'vitamins'
-        && normalized.aiSummary.text.includes('Stable <script>alert(1)</script>');
+        && normalized.aiSummary.text.includes('Stable <script>alert(1)</script>')
+        && report.normalizeReportOptions({ sections: [] }).sections.length === 0;
 
       const aiMarkup = report.renderReportAISummarySection(normalized.aiSummary);
       outcomes.aiSummaryMarkupEscapesAndStructures = aiMarkup.includes('<h2>Practitioner Overview</h2>')


### PR DESCRIPTION
## What changed

- Align the Context manager with the current first-class modal design.
- Group Context sources intentionally on desktop and provide clearer included/off/no-data summaries.
- Refresh the Reports builder hierarchy, selection feedback, mobile layout, and local-preview messaging.
- Use one continuous Reports scroll surface so mouse-wheel input over Lab Categories remains reliable.
- Update report templates in place instead of remounting the modal.
- Ensure the optional AI practitioner overview honors selected sections and never sends unchecked notes, genetics, supplements, or profile context.

## Why

Context used an older confirmation-dialog shell and allowed source groups to auto-flow into a fragmented desktop layout. Reports nested a scrolling category list inside its scrolling modal, which could trap downward wheel input. Its AI overview also assembled more profile data than the selected report sections implied.

## Impact

Context and Reports now match the rest of the application more closely, remain usable on desktop and mobile, provide clearer selection state, and preserve the report builder's privacy expectations.

## Validation

- `PORT=8192 npx playwright test tests/playwright/dashboard-knowledge-base.spec.js tests/playwright/report-export-browser-coverage.spec.js --workers=1` — 14 passed
- `npm test -- tests/context-source-registry.test.js tests/report-export-html-runtime.test.js` — 4 passed
- `npm run typecheck:checkjs`
- `npm run quality` — 17 guardrails passed
- Populated desktop and mobile visual review