### PR TITLE
Restore CAMS sun timeline and air quality context

### DIFF
--- a/js/sun-uvdata.js
+++ b/js/sun-uvdata.js
@@ -43,10 +43,11 @@ export {
 // privacy posture.
 
 let _warnedAboutRejectedSelfhostUrl = false;
-// v4 invalidates reconstructed CAMS peaks and the old whole-response source
-// label. Current conditions use a five-minute TTL; historical requests can
-// remain cached longer because their underlying forecast snapshot is stable.
-const CACHE_PREFIX = 'meteo:v4:';
+// v5 invalidates CAMS-only rows that could contain direct UV while omitting
+// sunrise/sunset/peak and provider-computed AQI context. Current conditions
+// use a five-minute TTL; historical requests can remain cached longer because
+// their underlying forecast snapshot is stable.
+const CACHE_PREFIX = 'meteo:v5:';
 const NETWORK_TIMEOUT_MS = 8000;
 
 // ─── Public API ────────────────────────────────────────────────────────
@@ -94,29 +95,21 @@ export async function fetchAtmosphere({ lat, lon, isoTime, noCache } = {}) {
     try {
       const result = await provider.fetch({ lat: rLat, lon: rLon, isoTime: time, cfg });
       if (result) {
-        // CAMS sometimes returns a structurally valid response with
-        // sparse hourly fields (uvIndex/cloudCover/temperatureC all null
-        // — only DU and AQI populated). The "Conditions now" widget then
-        // renders a dash for UV even though Open-Meteo would have served
-        // a real number. When that happens AND we have a downstream
-        // provider, fetch it too and merge the missing primary fields,
-        // keeping CAMS's superior DU/AOD overlay.
-        const sparseUv = result.uvIndex == null && result.cloudCover == null;
+        // The CAMS relay can legitimately return a direct UV value while its
+        // companion context is unavailable (sunrise/sunset/peak, clouds,
+        // temperature, or provider-computed European AQI). Accepting that
+        // response as complete left Conditions Now with only the geometry-
+        // derived UV-A transitions and an empty air-quality card. When any of
+        // that context is missing, supplement it from the next provider while
+        // retaining CAMS UV, ozone-column, aerosol, and provenance fields.
+        const needsContextFallback = atmosphereNeedsContextFallback(result);
         const hasFallback = i + 1 < order.length;
-        if (sparseUv && hasFallback) {
+        if (needsContextFallback && hasFallback) {
           for (let j = i + 1; j < order.length; j++) {
             try {
               const fallback = await order[j].fetch({ lat: rLat, lon: rLon, isoTime: time, cfg });
-              if (fallback && fallback.uvIndex != null) {
-                const merged = Object.assign({}, fallback, {
-                  // Preserve CAMS strengths over Open-Meteo where present.
-                  ozoneDU: result.ozoneDU ?? fallback.ozoneDU,
-                  airQuality: result.airQuality || fallback.airQuality,
-                  // Annotate the merge for the inspector.
-                  source: `${result.source}+${fallback.source}`,
-                  confidence: Math.min(result.confidence ?? 1, fallback.confidence ?? 1),
-                  fetchedAt: Date.now(),
-                });
+              if (fallback) {
+                const merged = mergeAtmosphereContext(result, fallback);
                 const annotated = withRequestMeta(merged);
                 writeCache(cacheKey, annotated);
                 return annotated;
@@ -362,6 +355,95 @@ function availableProviders(candidates, ctx) {
   return candidates.filter(provider => providerIsAvailable(provider, ctx));
 }
 
+function hasUsefulProviderValue(value) {
+  if (value == null) return false;
+  if (typeof value === 'number') return Number.isFinite(value);
+  if (typeof value === 'string') return value.trim().length > 0;
+  if (Array.isArray(value)) return value.some(hasUsefulProviderValue);
+  return true;
+}
+
+function mergeUsefulFields(fallback, primary) {
+  const merged = { ...(fallback || {}) };
+  for (const [key, value] of Object.entries(primary || {})) {
+    if (hasUsefulProviderValue(value)) merged[key] = value;
+  }
+  return Object.keys(merged).length ? merged : null;
+}
+
+// Use the fallback's complete hourly clock as the output grid, then overlay
+// every meaningful primary sample at its matching instant. The live CAMS
+// relay commonly returns one UTC hour while Open-Meteo returns a multi-day
+// location-local grid; copying arrays wholesale would mismatch timestamps.
+function mergeHourlyContext(primary, fallback) {
+  if (!Array.isArray(fallback?.time) || fallback.time.length === 0) return primary || fallback || null;
+  if (!Array.isArray(primary?.time) || primary.time.length === 0) return fallback;
+
+  const fallbackOffset = Number(fallback.utcOffsetSeconds) || 0;
+  const primaryOffset = Number(primary.utcOffsetSeconds) || 0;
+  const merged = {};
+  for (const [key, value] of Object.entries(fallback)) {
+    merged[key] = Array.isArray(value) ? value.slice() : value;
+  }
+
+  for (const [key, values] of Object.entries(primary)) {
+    if (key === 'time' || key === 'utcOffsetSeconds' || !Array.isArray(values)) continue;
+    for (let i = 0; i < values.length; i++) {
+      const value = values[i];
+      if (!hasUsefulProviderValue(value)) continue;
+      const primaryMs = parseProviderTimeMs(primary.time[i], primaryOffset);
+      if (!Number.isFinite(primaryMs)) continue;
+      const fallbackIndex = nearestHourIndex(
+        fallback.time,
+        new Date(primaryMs).toISOString(),
+        fallbackOffset
+      );
+      if (fallbackIndex < 0) continue;
+      const fallbackMs = parseProviderTimeMs(fallback.time[fallbackIndex], fallbackOffset);
+      if (!Number.isFinite(fallbackMs) || Math.abs(fallbackMs - primaryMs) > 90 * 60 * 1000) continue;
+      if (!Array.isArray(merged[key])) merged[key] = Array(fallback.time.length).fill(null);
+      merged[key][fallbackIndex] = value;
+    }
+  }
+  merged.time = fallback.time.slice();
+  merged.utcOffsetSeconds = fallbackOffset;
+  return merged;
+}
+
+function atmosphereNeedsContextFallback(result) {
+  if (!String(result?.source || '').includes('cams')) return false;
+  const daily = result?.daily || {};
+  return result?.uvIndex == null
+    || result?.cloudCover == null
+    || result?.temperatureC == null
+    || !hasUsefulProviderValue(daily.sunrise)
+    || !hasUsefulProviderValue(daily.sunset)
+    || !hasUsefulProviderValue(daily.peakAt)
+    || !Number.isFinite(result?.airQuality?.european_aqi);
+}
+
+function mergeAtmosphereContext(primary, fallback) {
+  const sources = [];
+  for (const source of [primary?.source, fallback?.source]) {
+    for (const part of String(source || '').split('+')) {
+      if (part && !sources.includes(part)) sources.push(part);
+    }
+  }
+  return Object.assign({}, fallback, primary, {
+    uvIndex: primary?.uvIndex ?? fallback?.uvIndex ?? null,
+    uvClearSky: primary?.uvClearSky ?? fallback?.uvClearSky ?? null,
+    ozoneDU: primary?.ozoneDU ?? fallback?.ozoneDU ?? null,
+    cloudCover: primary?.cloudCover ?? fallback?.cloudCover ?? null,
+    temperatureC: primary?.temperatureC ?? fallback?.temperatureC ?? null,
+    airQuality: mergeUsefulFields(fallback?.airQuality, primary?.airQuality),
+    daily: mergeUsefulFields(fallback?.daily, primary?.daily),
+    hourly: mergeHourlyContext(primary?.hourly, fallback?.hourly),
+    source: sources.join('+'),
+    confidence: Math.min(primary?.confidence ?? 1, fallback?.confidence ?? 1),
+    fetchedAt: Date.now(),
+  });
+}
+
 function providerOrder(cfg, coords = {}) {
   const ctx = Object.assign({}, cfg, coords);
   // NOAA NWS doesn't allow browser CORS, so it's explicit-only and only useful
@@ -461,21 +543,21 @@ function readStaleCache(rLat, rLon) {
   }
 }
 
-// One-time sweep of pre-v4 cache entries on first import. Idempotent —
+// One-time sweep of pre-v5 cache entries on first import. Idempotent —
 // the marker key is only written once, so subsequent loads are no-ops.
 try {
-  if (typeof localStorage !== 'undefined' && !localStorage.getItem('meteo-cache-v4-purged')) {
+  if (typeof localStorage !== 'undefined' && !localStorage.getItem('meteo-cache-v5-purged')) {
     const stale = [];
     for (let i = 0; i < localStorage.length; i++) {
       const k = localStorage.key(i);
-      if (k && k.startsWith('meteo:') && !k.startsWith('meteo:v4:')) stale.push(k);
+      if (k && k.startsWith('meteo:') && !k.startsWith('meteo:v5:')) stale.push(k);
     }
     for (const k of stale) localStorage.removeItem(k);
-    localStorage.setItem('meteo-cache-v4-purged', '1');
+    localStorage.setItem('meteo-cache-v5-purged', '1');
   }
 } catch (e) {
   if (isSunDebugRuntime()) {
-    console.warn('[sun-uvdata] pre-v4 cache sweep failed', getErrorName(e) || e);
+    console.warn('[sun-uvdata] pre-v5 cache sweep failed', getErrorName(e) || e);
   }
 }
 

--- a/js/sun-uvdata.js
+++ b/js/sun-uvdata.js
@@ -43,10 +43,8 @@ export {
 // privacy posture.
 
 let _warnedAboutRejectedSelfhostUrl = false;
-// v5 invalidates CAMS-only rows that could contain direct UV while omitting
-// sunrise/sunset/peak and provider-computed AQI context. Current conditions
-// use a five-minute TTL; historical requests can remain cached longer because
-// their underlying forecast snapshot is stable.
+// v5 invalidates CAMS rows missing daily or AQI context. Live conditions use
+// a five-minute TTL; historical forecasts remain cached longer.
 const CACHE_PREFIX = 'meteo:v5:';
 const NETWORK_TIMEOUT_MS = 8000;
 
@@ -95,13 +93,8 @@ export async function fetchAtmosphere({ lat, lon, isoTime, noCache } = {}) {
     try {
       const result = await provider.fetch({ lat: rLat, lon: rLon, isoTime: time, cfg });
       if (result) {
-        // The CAMS relay can legitimately return a direct UV value while its
-        // companion context is unavailable (sunrise/sunset/peak, clouds,
-        // temperature, or provider-computed European AQI). Accepting that
-        // response as complete left Conditions Now with only the geometry-
-        // derived UV-A transitions and an empty air-quality card. When any of
-        // that context is missing, supplement it from the next provider while
-        // retaining CAMS UV, ozone-column, aerosol, and provenance fields.
+        // Direct CAMS UV can arrive without daily, weather, or AQI context.
+        // Fill those gaps from the next provider while retaining CAMS data.
         const needsContextFallback = atmosphereNeedsContextFallback(result);
         const hasFallback = i + 1 < order.length;
         if (needsContextFallback && hasFallback) {
@@ -356,11 +349,10 @@ function availableProviders(candidates, ctx) {
 }
 
 function hasUsefulProviderValue(value) {
-  if (value == null) return false;
-  if (typeof value === 'number') return Number.isFinite(value);
-  if (typeof value === 'string') return value.trim().length > 0;
   if (Array.isArray(value)) return value.some(hasUsefulProviderValue);
-  return true;
+  return value != null
+    && (typeof value !== 'number' || Number.isFinite(value))
+    && (typeof value !== 'string' || value.trim().length > 0);
 }
 
 function mergeUsefulFields(fallback, primary) {
@@ -371,74 +363,52 @@ function mergeUsefulFields(fallback, primary) {
   return Object.keys(merged).length ? merged : null;
 }
 
-// Use the fallback's complete hourly clock as the output grid, then overlay
-// every meaningful primary sample at its matching instant. The live CAMS
-// relay commonly returns one UTC hour while Open-Meteo returns a multi-day
-// location-local grid; copying arrays wholesale would mismatch timestamps.
+// Overlay CAMS samples on the fallback's complete, location-local time grid.
 function mergeHourlyContext(primary, fallback) {
-  if (!Array.isArray(fallback?.time) || fallback.time.length === 0) return primary || fallback || null;
-  if (!Array.isArray(primary?.time) || primary.time.length === 0) return fallback;
-
+  const fallbackTimes = fallback?.time;
+  const primaryTimes = primary?.time;
+  if (!Array.isArray(fallbackTimes) || !fallbackTimes.length) return primary || fallback || null;
+  if (!Array.isArray(primaryTimes) || !primaryTimes.length) return fallback;
   const fallbackOffset = Number(fallback.utcOffsetSeconds) || 0;
   const primaryOffset = Number(primary.utcOffsetSeconds) || 0;
-  const merged = {};
-  for (const [key, value] of Object.entries(fallback)) {
-    merged[key] = Array.isArray(value) ? value.slice() : value;
-  }
-
+  const merged = { ...fallback };
   for (const [key, values] of Object.entries(primary)) {
     if (key === 'time' || key === 'utcOffsetSeconds' || !Array.isArray(values)) continue;
+    const output = Array.isArray(merged[key])
+      ? merged[key].slice() : Array(fallbackTimes.length).fill(null);
     for (let i = 0; i < values.length; i++) {
       const value = values[i];
       if (!hasUsefulProviderValue(value)) continue;
-      const primaryMs = parseProviderTimeMs(primary.time[i], primaryOffset);
+      const primaryMs = parseProviderTimeMs(primaryTimes[i], primaryOffset);
       if (!Number.isFinite(primaryMs)) continue;
-      const fallbackIndex = nearestHourIndex(
-        fallback.time,
-        new Date(primaryMs).toISOString(),
-        fallbackOffset
-      );
+      const fallbackIndex = nearestHourIndex(fallbackTimes, new Date(primaryMs).toISOString(), fallbackOffset);
       if (fallbackIndex < 0) continue;
-      const fallbackMs = parseProviderTimeMs(fallback.time[fallbackIndex], fallbackOffset);
+      const fallbackMs = parseProviderTimeMs(fallbackTimes[fallbackIndex], fallbackOffset);
       if (!Number.isFinite(fallbackMs) || Math.abs(fallbackMs - primaryMs) > 90 * 60 * 1000) continue;
-      if (!Array.isArray(merged[key])) merged[key] = Array(fallback.time.length).fill(null);
-      merged[key][fallbackIndex] = value;
+      output[fallbackIndex] = value;
     }
+    merged[key] = output;
   }
-  merged.time = fallback.time.slice();
-  merged.utcOffsetSeconds = fallbackOffset;
-  return merged;
+  return { ...merged, time: fallbackTimes.slice(), utcOffsetSeconds: fallbackOffset };
 }
 
 function atmosphereNeedsContextFallback(result) {
-  if (!String(result?.source || '').includes('cams')) return false;
   const daily = result?.daily || {};
-  return result?.uvIndex == null
-    || result?.cloudCover == null
-    || result?.temperatureC == null
-    || !hasUsefulProviderValue(daily.sunrise)
-    || !hasUsefulProviderValue(daily.sunset)
-    || !hasUsefulProviderValue(daily.peakAt)
-    || !Number.isFinite(result?.airQuality?.european_aqi);
+  return String(result?.source || '').includes('cams')
+    && [result?.uvIndex, result?.cloudCover, result?.temperatureC,
+      daily.sunrise, daily.sunset, daily.peakAt,
+      result?.airQuality?.european_aqi].some(value => !hasUsefulProviderValue(value));
 }
 
 function mergeAtmosphereContext(primary, fallback) {
-  const sources = [];
-  for (const source of [primary?.source, fallback?.source]) {
-    for (const part of String(source || '').split('+')) {
-      if (part && !sources.includes(part)) sources.push(part);
-    }
-  }
-  return Object.assign({}, fallback, primary, {
-    uvIndex: primary?.uvIndex ?? fallback?.uvIndex ?? null,
-    uvClearSky: primary?.uvClearSky ?? fallback?.uvClearSky ?? null,
-    ozoneDU: primary?.ozoneDU ?? fallback?.ozoneDU ?? null,
-    cloudCover: primary?.cloudCover ?? fallback?.cloudCover ?? null,
-    temperatureC: primary?.temperatureC ?? fallback?.temperatureC ?? null,
+  const merged = mergeUsefulFields(fallback, primary) || {};
+  const source = [...new Set(`${primary?.source || ''}+${fallback?.source || ''}`
+    .split('+').filter(Boolean))].join('+');
+  return Object.assign(merged, {
     airQuality: mergeUsefulFields(fallback?.airQuality, primary?.airQuality),
     daily: mergeUsefulFields(fallback?.daily, primary?.daily),
     hourly: mergeHourlyContext(primary?.hourly, fallback?.hourly),
-    source: sources.join('+'),
+    source,
     confidence: Math.min(primary?.confidence ?? 1, fallback?.confidence ?? 1),
     fetchedAt: Date.now(),
   });

--- a/tests/playwright/sun-uvdata-browser-coverage.spec.js
+++ b/tests/playwright/sun-uvdata-browser-coverage.spec.js
@@ -24,12 +24,13 @@ test('sun uvdata browser coverage handles config cache module API and purging', 
       for (let i = 0; i < localStorage.length; i += 1) {
         const key = localStorage.key(i);
         if (
-          key === 'meteo-cache-v4-purged' ||
+          key === 'meteo-cache-v5-purged' ||
           key === 'meteo:legacy-a' ||
           key === 'meteo:v1:keep-a' ||
           key?.startsWith('meteo:v2:') ||
           key?.startsWith('meteo:v3:') ||
-          key?.startsWith('meteo:v4:')
+          key?.startsWith('meteo:v4:') ||
+          key?.startsWith('meteo:v5:')
         ) {
           keys.push(key);
         }
@@ -39,10 +40,11 @@ test('sun uvdata browser coverage handles config cache module API and purging', 
 
     try {
       cleanup();
-      localStorage.removeItem('meteo-cache-v4-purged');
+      localStorage.removeItem('meteo-cache-v5-purged');
       localStorage.setItem('meteo:legacy-a', 'old-cache');
       localStorage.setItem('meteo:v2:old-a', 'old-version-cache');
-      localStorage.setItem('meteo:v4:keep-a', 'fresh-cache');
+      localStorage.setItem('meteo:v4:old-a', 'old-version-cache');
+      localStorage.setItem('meteo:v5:keep-a', 'fresh-cache');
 
       const mod = await import(sunUrl);
 
@@ -50,8 +52,9 @@ test('sun uvdata browser coverage handles config cache module API and purging', 
         localStorage.getItem('meteo:legacy-a') === null
         && localStorage.getItem('meteo:v2:old-a') === null
         && localStorage.getItem('meteo:v3:keep-a') === null
-        && localStorage.getItem('meteo:v4:keep-a') === 'fresh-cache'
-        && localStorage.getItem('meteo-cache-v4-purged') === '1';
+        && localStorage.getItem('meteo:v4:old-a') === null
+        && localStorage.getItem('meteo:v5:keep-a') === 'fresh-cache'
+        && localStorage.getItem('meteo-cache-v5-purged') === '1';
 
       outcomes.uvdataExportsStayModuleOnly = [
         'fetchAtmosphere',
@@ -124,14 +127,14 @@ test('sun uvdata browser coverage handles config cache module API and purging', 
         && encryptedFallback.privacyRounding === 0.25;
 
       localStorage.setItem('meteo:v1:keep-a', '{}');
-      localStorage.setItem('meteo:v4:purge-a', '{}');
-      localStorage.setItem('meteo:v4:purge-b', '{}');
+      localStorage.setItem('meteo:v5:purge-a', '{}');
+      localStorage.setItem('meteo:v5:purge-b', '{}');
       const beforePurge = Array.from({ length: localStorage.length }, (_, i) => localStorage.key(i))
-        .filter(key => key?.startsWith('meteo:v4:')).length;
+        .filter(key => key?.startsWith('meteo:v5:')).length;
       const removed = mod.purgeMeteoCache();
       const afterPurge = Array.from({ length: localStorage.length }, (_, i) => localStorage.key(i))
-        .filter(key => key?.startsWith('meteo:v4:')).length;
-      outcomes.purgeMeteoCacheCountsAndRemovesOnlyV3Entries =
+        .filter(key => key?.startsWith('meteo:v5:')).length;
+      outcomes.purgeMeteoCacheCountsAndRemovesOnlyCurrentEntries =
         beforePurge === 3
         && removed === beforePurge
         && afterPurge === 0
@@ -209,6 +212,11 @@ test('sun uvdata browser coverage drives provider chain cache stale and offline 
         nitrogen_dioxide: [14],
         aerosol_optical_depth: [0.08],
         ozone: [70],
+        european_aqi: [18],
+        european_aqi_pm2_5: [10],
+        european_aqi_pm10: [12],
+        european_aqi_nitrogen_dioxide: [8],
+        european_aqi_ozone: [16],
       },
       current: { pm2_5: 6, pm10: 11, european_aqi: 18 },
     };
@@ -222,7 +230,7 @@ test('sun uvdata browser coverage drives provider chain cache stale and offline 
       const keys = [];
       for (let i = 0; i < localStorage.length; i += 1) {
         const key = localStorage.key(i);
-        if (key?.startsWith('meteo:v4:')) keys.push(key);
+        if (key?.startsWith('meteo:v5:')) keys.push(key);
       }
       keys.forEach(key => localStorage.removeItem(key));
     };
@@ -390,7 +398,7 @@ test('sun uvdata browser coverage drives provider chain cache stale and offline 
         const href = String(url);
         legacyNoaaCalls.push(href);
         if (href.includes('air-quality')) return jsonResponse(airQuality);
-        return jsonResponse(forecast(2.8));
+        return jsonResponse(forecast(2.8, { root: { airQuality } }));
       };
       const legacyNoaa = await mod.fetchAtmosphere({
         lat: 40,
@@ -435,7 +443,7 @@ test('sun uvdata browser coverage drives provider chain cache stale and offline 
         && cacheFetches === 4;
 
       cleanupCache();
-      localStorage.setItem('meteo:v4:50.00_14.00_2026-06-01T08', JSON.stringify({
+      localStorage.setItem('meteo:v5:50.00_14.00_2026-06-01T08', JSON.stringify({
         uvIndex: 2.2,
         uvClearSky: 3.0,
         ozoneDU: 300,
@@ -498,7 +506,7 @@ test('sun uvdata browser coverage handles response caps shapers and interpolatio
       const keys = [];
       for (let i = 0; i < localStorage.length; i += 1) {
         const key = localStorage.key(i);
-        if (key?.startsWith('meteo:v4:')) keys.push(key);
+        if (key?.startsWith('meteo:v5:')) keys.push(key);
       }
       keys.forEach(key => localStorage.removeItem(key));
     };

--- a/tests/test-sun-uvdata-flow.js
+++ b/tests/test-sun-uvdata-flow.js
@@ -124,6 +124,11 @@ const {
       nitrogen_dioxide: [14],
       aerosol_optical_depth: [0.08],
       ozone: [70],
+      european_aqi: [18],
+      european_aqi_pm2_5: [10],
+      european_aqi_pm10: [12],
+      european_aqi_nitrogen_dioxide: [8],
+      european_aqi_ozone: [16],
     },
     current: { pm2_5: 6, pm10: 11, european_aqi: 18 },
   };
@@ -170,6 +175,73 @@ const {
     JSON.stringify(autoAtm));
   assert('Auto mode did not need Open-Meteo fallback when CAMS succeeded',
     !openMeteoAfterAuto);
+
+  // Production CAMS can return a valid direct UV sample while its companion
+  // weather/daylight fields are null and its AQ block contains concentrations
+  // but no provider-computed European AQI. That response used to short-circuit
+  // the provider chain, leaving Conditions Now with only UV-A on/off events
+  // and an empty air-quality card. Supplement the missing context without
+  // replacing CAMS UV, ozone column, aerosol, or raw particle readings.
+  const contextCalls = [];
+  window.fetch = async (u) => {
+    const url = String(u);
+    contextCalls.push(url);
+    if (url === '/api/proxy') {
+      return responseJson({
+        latitude: 51.2,
+        longitude: 14.6,
+        timezone: 'GMT',
+        utc_offset_seconds: 0,
+        hourly: {
+          time: ['2026-05-12T12:00'],
+          uv_index: [5.2],
+          uv_index_clear_sky: [5.8],
+          uv_index_cams_total_sky: [5.2],
+          uv_index_cams_clear_sky: [5.8],
+          uv_index_source: ['cams_uvbed'],
+          cloud_cover: [null],
+          temperature_2m: [null],
+          ozone_du: [306],
+          aod: [0.12],
+          pm2_5: [2.4],
+          pm10: [3.1],
+        },
+        daily: {
+          time: ['2026-05-12'],
+          sunrise: [null],
+          sunset: [null],
+          uv_index_max: [null],
+        },
+        _camsMeta: { ageSec: 600, directUv: true },
+        _fieldSources: { uvIndex: 'cams_uvbed', ozoneDU: 'cams_global_forecast' },
+      });
+    }
+    if (url.includes('air-quality')) return responseJson(omAirQuality);
+    return responseJson(omForecast);
+  };
+  const contextMerged = await fetchAtmosphere({
+    lat: 51.23,
+    lon: 14.56,
+    isoTime: cacheIso,
+    noCache: true,
+  });
+  assert('CAMS direct UV supplements missing sunrise, sunset, peak, and AQ context',
+    contextMerged?.source === 'cams+open_meteo'
+      && contextMerged.uvIndex === 5.2
+      && contextMerged.ozoneDU === 306
+      && contextMerged.cloudCover === 18
+      && contextMerged.temperatureC === 20
+      && contextMerged.daily?.sunrise === '2026-05-12T05:10'
+      && contextMerged.daily?.sunset === '2026-05-12T20:35'
+      && contextMerged.daily?.peakAt === '2026-05-12T12:00'
+      && contextMerged.airQuality?.european_aqi === 18
+      && contextMerged.airQuality?.pm25 === 2.4
+      && contextMerged.airQuality?.aod === 0.12
+      && contextMerged.hourly?.uv_index?.[0] === 5.2
+      && contextMerged.hourly?.cloud_cover?.[0] === 18
+      && contextCalls.some(url => url.includes('api.open-meteo.com'))
+      && contextCalls.some(url => url.includes('air-quality-api.open-meteo.com')),
+    JSON.stringify(contextMerged));
 
   // ── 6. Local dev CAMS never falls through to getbased infrastructure ──
   purgeMeteoCache();


### PR DESCRIPTION
## Summary

- supplement direct CAMS UV responses when sunrise, sunset, peak, weather, or European AQI context is missing
- preserve CAMS UV, ozone, aerosols, particulate readings, and provenance while aligning fallback hourly data by timestamp
- migrate the atmosphere cache to v5 and add a production-shaped regression fixture

## Verification

- `npm test -- tests/_vitest-legacy.test.js -t test-sun-uvdata-flow.js`
- `npx playwright test tests/playwright/sun-uvdata-browser-coverage.spec.js tests/playwright/light-conditions-now-browser-coverage.spec.js`
- `npm run typecheck:checkjs`
- `git diff --check`