### PR TITLE
Fix CodeQL credential storage and randomness findings

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -10,8 +10,8 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | Metric | Current |
 | --- | ---: |
 | Modules | 660 |
-| Internal import edges | 2789 |
-| Dynamic internal edges | 74 |
+| Internal import edges | 2790 |
+| Dynamic internal edges | 75 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
 | Largest cyclic component | 0 |
@@ -392,7 +392,7 @@ Native browser modules shipped with the static application.
 
 - [`js/crypto-key-cache.js`](js/crypto-key-cache.js) → no in-scope imports
 - [`js/crypto-ui.js`](js/crypto-ui.js) → [`js/backup.js`](js/backup.js), [`js/caught-error.js`](js/caught-error.js), [`js/data-wipe.js`](js/data-wipe.js) *(dynamic)*, [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/utils.js`](js/utils.js)
-- [`js/crypto.js`](js/crypto.js) → [`js/app-extension-runtime.js`](js/app-extension-runtime.js), [`js/backup.js`](js/backup.js), [`js/blob-storage.js`](js/blob-storage.js), [`js/cashu-wallet-store.js`](js/cashu-wallet-store.js) *(dynamic)*, [`js/caught-error.js`](js/caught-error.js), [`js/crypto-key-cache.js`](js/crypto-key-cache.js), [`js/crypto-ui.js`](js/crypto-ui.js), [`js/cycle-store.js`](js/cycle-store.js), [`js/data-merge.js`](js/data-merge.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/profile-storage-key.js`](js/profile-storage-key.js), [`js/state.js`](js/state.js), [`js/wearables-store.js`](js/wearables-store.js)
+- [`js/crypto.js`](js/crypto.js) → [`js/app-extension-runtime.js`](js/app-extension-runtime.js), [`js/backup.js`](js/backup.js), [`js/blob-storage.js`](js/blob-storage.js), [`js/cashu-wallet-store.js`](js/cashu-wallet-store.js) *(dynamic)*, [`js/caught-error.js`](js/caught-error.js), [`js/crypto-key-cache.js`](js/crypto-key-cache.js), [`js/crypto-ui.js`](js/crypto-ui.js), [`js/cycle-store.js`](js/cycle-store.js), [`js/data-merge.js`](js/data-merge.js), [`js/modal-lifecycle.js`](js/modal-lifecycle.js), [`js/profile-storage-key.js`](js/profile-storage-key.js), [`js/state.js`](js/state.js), [`js/wearables-credential-vault.js`](js/wearables-credential-vault.js) *(dynamic)*, [`js/wearables-store.js`](js/wearables-store.js)
 
 </details>
 

--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -60,7 +60,7 @@ import {
 } from './context-cards-runtime.js';
 import {
   configureCryptoProfileDeps,
-  encryptedSetItem,
+  encryptedSetCredentialItem,
 } from './crypto.js';
 import { parseAppleHealthCycleBlob, showCycleImportPreview } from './cycle-import-loader.js';
 import { configureCycleRuntimeDeps } from './cycle-runtime.js';
@@ -189,7 +189,7 @@ function showInsufficientBalanceDialog() {
 }
 
 configureApiRuntimeCallbacks({ showInsufficientBalanceDialog });
-configureApiProviderStorageRuntimeDeps({ encryptedSetItem });
+configureApiProviderStorageRuntimeDeps({ encryptedSetItem: encryptedSetCredentialItem });
 configureStartupOAuthCallbackDeps({ showInsufficientBalanceDialog });
 configureChatRuntimeCallbacks({
   onChatSaved,

--- a/js/backup.js
+++ b/js/backup.js
@@ -27,11 +27,9 @@ function loadBackupCycleModule() {
 
 // Crypto imports this module for backup UI helpers, so inject the two crypto
 // operations backup needs instead of coupling the modules through globals.
-const appWindow = /** @type {Window & typeof globalThis & {
-  showDirectoryPicker?: (options?: { mode?: 'read' | 'readwrite' }) => Promise<any>,
-}} */ (typeof window !== 'undefined' ? window : {});
+const appWindow = /** @type {Window & typeof globalThis & { showDirectoryPicker?: (options?: { mode?: 'read' | 'readwrite' }) => Promise<any> }} */ (typeof window !== 'undefined' ? window : {});
 
-/** @typedef {{ encryptedGetItem: (key: string) => Promise<string | null>, getEncryptionEnabled: () => boolean }} BackupRuntimeDeps */
+/** @typedef {{ encryptedGetItem: (key: string) => Promise<string | null>, encryptedSetItem: (key: string, value: string) => Promise<void>, getEncryptionEnabled: () => boolean, isCredentialKey: (key: string) => boolean }} BackupRuntimeDeps */
 // `var` is intentional: the profile → crypto cycle can configure backup
 // while this module is still initializing, before lexical bindings are ready.
 /** @type {BackupRuntimeDeps | undefined} */
@@ -39,10 +37,8 @@ var backupRuntimeDeps;
 
 function getBackupRuntimeDeps() {
   if (!backupRuntimeDeps) {
-    backupRuntimeDeps = {
-      encryptedGetItem: async () => null,
-      getEncryptionEnabled: () => false,
-    };
+    backupRuntimeDeps = { encryptedGetItem: async () => null, getEncryptionEnabled: () => false, isCredentialKey: () => false,
+      encryptedSetItem: async () => { throw new Error('Credential storage is not configured.'); } };
   }
   return backupRuntimeDeps;
 }
@@ -51,10 +47,11 @@ export function configureBackupRuntimeDeps(deps = {}) {
   const runtimeDeps = getBackupRuntimeDeps();
   const previous = { ...runtimeDeps };
   if (typeof deps.encryptedGetItem === 'function') runtimeDeps.encryptedGetItem = deps.encryptedGetItem;
+  if (typeof deps.encryptedSetItem === 'function') runtimeDeps.encryptedSetItem = deps.encryptedSetItem;
   if (typeof deps.getEncryptionEnabled === 'function') runtimeDeps.getEncryptionEnabled = deps.getEncryptionEnabled;
+  if (typeof deps.isCredentialKey === 'function') runtimeDeps.isCredentialKey = deps.isCredentialKey;
   return previous;
 }
-
 const getEncryptionEnabled = () => Boolean(getBackupRuntimeDeps().getEncryptionEnabled());
 const isEncryptedValue = (v) => typeof v === 'string' && v.startsWith('v1:');
 const backupActionDelegateRoots = new WeakSet();
@@ -141,6 +138,16 @@ const PER_PROFILE_PREF_SUFFIXES = [
   'units', 'rangeMode', 'suppOverlay', 'noteOverlay', 'phaseOverlay',
   'chatPersonality', 'chatPersonalityCustom', 'chatPersonalityDeleted', 'chatRailOpen'
 ];
+
+async function restoreBackupSettings(backup) {
+  if (!backup.settings || typeof backup.settings !== 'object') return;
+  const deps = getBackupRuntimeDeps();
+  for (const [key, value] of Object.entries(backup.settings)) {
+    // Re-wrap credentials from legacy unencrypted backups before local storage.
+    if (!backup.encrypted && deps.isCredentialKey(key)) await deps.encryptedSetItem(key, String(value));
+    else localStorage.setItem(key, String(value));
+  }
+}
 
 // Wearable L1 IndexedDB lives outside localStorage (per-profile DB
 // `labcharts-wearables-${profileId}`) — read raw daily rows for every
@@ -262,6 +269,8 @@ export function buildBackupSnapshot() {
 
   const settings = {};
   for (const k of GLOBAL_SETTINGS_KEYS) {
+    // Device-key envelopes are not portable; only passphrase-encrypted backups include credentials.
+    if (!getEncryptionEnabled() && getBackupRuntimeDeps().isCredentialKey(k)) continue;
     const v = localStorage.getItem(k);
     if (v !== null) settings[k] = v;
   }
@@ -399,11 +408,7 @@ export function importEncryptedBackup(file) {
           localStorage.removeItem('labcharts-encryption-salt');
         }
 
-        if (backup.settings && typeof backup.settings === 'object') {
-          for (const [k, v] of Object.entries(backup.settings)) {
-            localStorage.setItem(k, v);
-          }
-        }
+        await restoreBackupSettings(backup);
 
         localStorage.setItem('labcharts-profiles', backup.profileList);
 
@@ -555,11 +560,7 @@ export async function restoreAutoBackup(id) {
       localStorage.removeItem('labcharts-encryption-enabled');
       localStorage.removeItem('labcharts-encryption-salt');
     }
-    if (backup.settings && typeof backup.settings === 'object') {
-      for (const [k, v] of Object.entries(backup.settings)) {
-        localStorage.setItem(k, v);
-      }
-    }
+    await restoreBackupSettings(backup);
     localStorage.setItem('labcharts-profiles', backup.profileList);
     if (backup.profiles) {
       for (const p of backup.profiles) {

--- a/js/changelog-impl.js
+++ b/js/changelog-impl.js
@@ -11,6 +11,12 @@ const changelogDelegateRoots = new WeakSet();
 
 const CHANGELOG = [
   {
+    version: '1.17.2', date: '2026-08-21', title: 'Credentials stay protected on this device',
+    items: [
+      '<b>Saved provider credentials are now encrypted even when profile encryption is off.</b> Existing keys migrate automatically, unencrypted backups omit credentials, and generated privacy replacements now use secure browser randomness.',
+    ]
+  },
+  {
     version: '1.17.1', date: '2026-08-21', title: 'Weight units stay accurate',
     items: [
       '<b>US weight entries now stay in pounds everywhere.</b> Manual entries, dashboards, charts, reports, and BMI calculations consistently convert between pounds and kilograms.',

--- a/js/crypto-key-cache.js
+++ b/js/crypto-key-cache.js
@@ -9,9 +9,10 @@ export function clearKeyCache() {
 
 export function getCachedKey(storageKey) {
   if (keyCache.has(storageKey)) return keyCache.get(storageKey);
-  // Fallback: raw localStorage when encryption is off or the cache has not
-  // been populated yet.
-  return localStorage.getItem(storageKey);
+  // Legacy plaintext values remain readable until startup migrates them.
+  // Never expose an at-rest envelope as though it were a usable credential.
+  const raw = localStorage.getItem(storageKey);
+  return raw?.startsWith('v1:') || raw?.startsWith('d1:') ? null : raw;
 }
 
 export function updateKeyCache(storageKey, value) {

--- a/js/crypto-ui.js
+++ b/js/crypto-ui.js
@@ -594,7 +594,7 @@ export function renderEncryptionSection() {
     <div class="encryption-status-icon">&#128275;</div>
     <div class="encryption-status-body">
       <div class="encryption-status-title">Encryption is OFF</div>
-      <div class="encryption-status-detail">Your data is stored as plaintext in localStorage. Browser extensions and anyone with filesystem access can read it.</div>
+      <div class="encryption-status-detail">Profile and health data is stored as plaintext. Saved provider credentials remain encrypted with a device-local key.</div>
     </div>
   </div>
   <button class="import-btn import-btn-primary" style="margin-top:12px" ${cryptoActionAttrs('enable-encryption')}>Enable Encryption</button>`;
@@ -605,7 +605,7 @@ export function renderBackupSection() {
   const autoStatus = lastAuto
     ? `Last auto-backup: ${new Date(lastAuto).toLocaleString()}`
     : 'No auto-backups yet';
-  return `<div class="ai-provider-desc" style="margin-bottom:10px">Create a full backup of all profiles, data, and chat history. ${cryptoUiDeps.getEncryptionEnabled() ? 'Backups inherit encryption \u2014 same passphrase required to restore.' : 'Backups are unencrypted unless encryption is enabled.'}</div>
+  return `<div class="ai-provider-desc" style="margin-bottom:10px">Create a full backup of all profiles, data, and chat history. ${cryptoUiDeps.getEncryptionEnabled() ? 'Backups inherit encryption \u2014 same passphrase required to restore.' : 'Backups are unencrypted and omit provider credentials unless encryption is enabled.'}</div>
   <div style="display:flex;gap:8px;flex-wrap:wrap">
     <button class="import-btn import-btn-primary" ${cryptoActionAttrs('export-backup')}>Download Backup</button>
     <label class="import-btn import-btn-secondary" style="cursor:pointer;display:inline-flex;align-items:center">

--- a/js/crypto.js
+++ b/js/crypto.js
@@ -181,8 +181,12 @@ export async function decryptKeyCache() {
     const raw = localStorage.getItem(lsKey);
     if (raw === null) continue;
     if (isDeviceCredentialValue(raw)) {
-      const plaintext = await decryptDeviceCredential(lsKey, raw);
-      if (plaintext !== null) updateKeyCache(lsKey, plaintext);
+      try {
+        const plaintext = await decryptDeviceCredential(lsKey, raw);
+        if (plaintext !== null) updateKeyCache(lsKey, plaintext);
+      } catch (error) {
+        console.warn(`[crypto] device credential ${lsKey} could not be loaded`, error);
+      }
     } else if (isEncryptedValue(raw) && _sessionKey) {
       const parsed = parseEncryptedValue(raw);
       if (!parsed) continue;
@@ -461,8 +465,9 @@ export async function encryptedRemoveItem(key, options = {}) {
 // ═══════════════════════════════════════════════
 export async function initEncryption() {
   if (!getEncryptionEnabled()) {
-    await migrateDeviceProtectedKeys();
+    const volatileCredentials = await migrateDeviceProtectedKeys();
     await decryptKeyCache();
+    for (const [key, value] of volatileCredentials) updateKeyCache(key, value);
     return;
   }
   if (needsDataProtectionStylesheet()) await loadDataProtectionStylesheetForAction();
@@ -558,14 +563,25 @@ async function decryptAllSensitiveKeys() {
 }
 
 async function migrateDeviceProtectedKeys() {
-  for (let index = 0; index < localStorage.length; index++) {
-    const key = localStorage.key(index);
+  const volatileCredentials = new Map();
+  const storageKeys = Array.from({ length: localStorage.length }, (_, index) => localStorage.key(index));
+  for (const key of storageKeys) {
     if (!key || !isCredentialKey(key)) continue;
     const raw = localStorage.getItem(key);
     if (raw === null || isDeviceCredentialValue(raw) || isEncryptedValue(raw)) continue;
-    localStorage.setItem(key, await encryptDeviceCredential(key, raw));
-    updateKeyCache(key, raw);
+    try {
+      localStorage.setItem(key, await encryptDeviceCredential(key, raw));
+      updateKeyCache(key, raw);
+    } catch (error) {
+      // A blocked/evicted IndexedDB vault must not abort the rest of startup
+      // or leave a legacy credential in clear text. Keep it usable in memory
+      // for this session; the provider will ask for it again after reload.
+      volatileCredentials.set(key, raw);
+      try { localStorage.removeItem(key); } catch {}
+      console.warn(`[crypto] device protection unavailable for ${key}; keeping it in memory only`, error);
+    }
   }
+  return volatileCredentials;
 }
 
 async function transformPayloadRows(rows, keyFields, mode) {

--- a/js/crypto.js
+++ b/js/crypto.js
@@ -133,6 +133,22 @@ export function isSensitiveKey(key) {
 // ═══════════════════════════════════════════════
 let _sessionKey = null;
 
+/** @type {Promise<typeof import('./wearables-credential-vault.js')> | null} */
+let deviceCredentialCryptoLoad = null;
+function loadDeviceCredentialCrypto() {
+  if (!deviceCredentialCryptoLoad) deviceCredentialCryptoLoad = import('./wearables-credential-vault.js');
+  return deviceCredentialCryptoLoad;
+}
+function isDeviceCredentialValue(value) {
+  return typeof value === 'string' && value.startsWith('d1:');
+}
+async function encryptDeviceCredential(storageKey, plaintext) {
+  return (await loadDeviceCredentialCrypto()).encryptDeviceCredential(storageKey, plaintext);
+}
+async function decryptDeviceCredential(storageKey, envelope) {
+  return (await loadDeviceCredentialCrypto()).decryptDeviceCredential(storageKey, envelope);
+}
+
 // ═══════════════════════════════════════════════
 // API KEY CACHE — sync access to decrypted API keys
 // ═══════════════════════════════════════════════
@@ -150,24 +166,32 @@ const API_KEY_LS_KEYS = [
   'labcharts-elevenlabs-voice-key',
   'labcharts-voice-local-server-key',
   'labcharts-cashu-wallet-mnemonic',
+  'labcharts-meteo-config',
 ];
+
+export function isCredentialKey(key) {
+  return API_KEY_LS_KEYS.includes(key) || isAppExtensionSyncEncryptedStorageKey(key);
+}
 
 export async function decryptKeyCache() {
   clearKeyCache();
-  for (const lsKey of Object.keys(localStorage)) {
-    if (API_KEY_LS_KEYS.includes(lsKey) || isAppExtensionSyncEncryptedStorageKey(lsKey)) {
-      const raw = localStorage[lsKey];
-      if (!raw) continue;
-      if (isEncryptedValue(raw) && _sessionKey) {
-        const parsed = parseEncryptedValue(raw);
-        if (!parsed) continue;
-        try {
-          const plaintext = await decrypt(_sessionKey, parsed.iv, parsed.ciphertext);
-          updateKeyCache(lsKey, plaintext);
-        } catch { /* skip if can't decrypt */ }
-      } else if (!isEncryptedValue(raw)) {
-        updateKeyCache(lsKey, raw);
-      }
+  for (let index = 0; index < localStorage.length; index++) {
+    const lsKey = localStorage.key(index);
+    if (!lsKey || !isCredentialKey(lsKey)) continue;
+    const raw = localStorage.getItem(lsKey);
+    if (raw === null) continue;
+    if (isDeviceCredentialValue(raw)) {
+      const plaintext = await decryptDeviceCredential(lsKey, raw);
+      if (plaintext !== null) updateKeyCache(lsKey, plaintext);
+    } else if (isEncryptedValue(raw) && _sessionKey) {
+      const parsed = parseEncryptedValue(raw);
+      if (!parsed) continue;
+      try {
+        const plaintext = await decrypt(_sessionKey, parsed.iv, parsed.ciphertext);
+        updateKeyCache(lsKey, plaintext);
+      } catch { /* skip if can't decrypt */ }
+    } else if (!isEncryptedValue(raw)) {
+      updateKeyCache(lsKey, raw);
     }
   }
 }
@@ -293,7 +317,7 @@ const indexedDBCryptoDeps = {
 export const getCashuWalletStoreCryptoDeps = () => ({
   ...indexedDBCryptoDeps,
   encryptedGetItem,
-  encryptedSetItem,
+  encryptedSetItem: encryptedSetCredentialItem,
 });
 configureCycleStoreCrypto(indexedDBCryptoDeps);
 configureWearablesStoreCrypto(indexedDBCryptoDeps);
@@ -330,7 +354,22 @@ export async function _migrateAllStorageForTest(mode) {
 // ═══════════════════════════════════════════════
 // STORAGE WRAPPERS
 // ═══════════════════════════════════════════════
+export async function encryptedSetCredentialItem(key, value) {
+  if (!isCredentialKey(key)) throw new Error(`Credential key is not allowlisted: ${key}`);
+  let stored;
+  if (getEncryptionEnabled()) {
+    if (!_sessionKey) throw new Error('Credential storage is locked; unlock encryption before saving.');
+    const { iv, ciphertext } = await encrypt(_sessionKey, value);
+    stored = formatEncryptedValue(iv, ciphertext);
+  } else {
+    stored = await encryptDeviceCredential(key, value);
+  }
+  localStorage.setItem(key, stored);
+  updateKeyCache(key, value);
+}
+
 export async function encryptedSetItem(key, value) {
+  if (isCredentialKey(key)) return encryptedSetCredentialItem(key, value);
   let stored;
   if (isSensitiveKey(key) && getEncryptionEnabled() && _sessionKey) {
     const { iv, ciphertext } = await encrypt(_sessionKey, value);
@@ -352,7 +391,6 @@ export async function encryptedSetItem(key, value) {
   } else {
     localStorage.setItem(key, stored);
   }
-  if (isAppExtensionSyncEncryptedStorageKey(key)) updateKeyCache(key, value);
 }
 
 export async function encryptedGetItem(key) {
@@ -379,11 +417,18 @@ export async function encryptedGetItem(key) {
     raw = localStorage.getItem(key);
   }
   if (raw == null) return null;
+  if (isDeviceCredentialValue(raw)) {
+    const plaintext = await decryptDeviceCredential(key, raw);
+    if (plaintext !== null && isCredentialKey(key)) updateKeyCache(key, plaintext);
+    return plaintext;
+  }
   if (isEncryptedValue(raw) && _sessionKey) {
     const parsed = parseEncryptedValue(raw);
     if (!parsed) return raw;
     try {
-      return await decrypt(_sessionKey, parsed.iv, parsed.ciphertext);
+      const plaintext = await decrypt(_sessionKey, parsed.iv, parsed.ciphertext);
+      if (isCredentialKey(key)) updateKeyCache(key, plaintext);
+      return plaintext;
     } catch {
       return null; // wrong key or corrupt
     }
@@ -415,7 +460,11 @@ export async function encryptedRemoveItem(key, options = {}) {
 // INITIALIZATION
 // ═══════════════════════════════════════════════
 export async function initEncryption() {
-  if (!getEncryptionEnabled()) return;
+  if (!getEncryptionEnabled()) {
+    await migrateDeviceProtectedKeys();
+    await decryptKeyCache();
+    return;
+  }
   if (needsDataProtectionStylesheet()) await loadDataProtectionStylesheetForAction();
   await new Promise((resolve) => {
     showPassphraseModal(resolve);
@@ -465,8 +514,12 @@ async function migrateSensitiveKeys() {
     const key = localStorage.key(i);
     if (!key || !isSensitiveKey(key)) continue;
     const raw = localStorage.getItem(key);
-    if (!raw || isEncryptedValue(raw)) continue; // already encrypted
-    const { iv, ciphertext } = await encrypt(_sessionKey, raw);
+    if (raw === null || isEncryptedValue(raw)) continue; // already encrypted
+    const plaintext = isDeviceCredentialValue(raw)
+      ? await decryptDeviceCredential(key, raw)
+      : raw;
+    if (plaintext === null) throw new Error(`Device credential ${key} could not be decrypted.`);
+    const { iv, ciphertext } = await encrypt(_sessionKey, plaintext);
     localStorage.setItem(key, formatEncryptedValue(iv, ciphertext));
   }
   for (const key of blobKeys) {
@@ -484,11 +537,16 @@ async function decryptAllSensitiveKeys() {
     const key = localStorage.key(i);
     if (!key || !isSensitiveKey(key)) continue;
     const raw = localStorage.getItem(key);
-    if (!raw || !isEncryptedValue(raw)) continue;
+    if (raw === null || !isEncryptedValue(raw)) continue;
     const parsed = parseEncryptedValue(raw);
     if (!parsed) throw new Error(`Encrypted value ${key} is malformed.`);
     const plaintext = await decrypt(_sessionKey, parsed.iv, parsed.ciphertext);
-    localStorage.setItem(key, plaintext);
+    if (isCredentialKey(key)) {
+      localStorage.setItem(key, await encryptDeviceCredential(key, plaintext));
+      updateKeyCache(key, plaintext);
+    } else {
+      localStorage.setItem(key, plaintext);
+    }
   }
   for (const key of blobKeys) {
     const raw = await getBlob(key);
@@ -496,6 +554,17 @@ async function decryptAllSensitiveKeys() {
     const parsed = parseEncryptedValue(raw);
     if (!parsed) throw new Error(`Encrypted value ${key} is malformed.`);
     await setBlob(key, await decrypt(_sessionKey, parsed.iv, parsed.ciphertext));
+  }
+}
+
+async function migrateDeviceProtectedKeys() {
+  for (let index = 0; index < localStorage.length; index++) {
+    const key = localStorage.key(index);
+    if (!key || !isCredentialKey(key)) continue;
+    const raw = localStorage.getItem(key);
+    if (raw === null || isDeviceCredentialValue(raw) || isEncryptedValue(raw)) continue;
+    localStorage.setItem(key, await encryptDeviceCredential(key, raw));
+    updateKeyCache(key, raw);
   }
 }
 
@@ -576,6 +645,7 @@ async function disableEncryptionStorage() {
   localStorage.removeItem('labcharts-encryption-salt');
   _sessionKey = null;
   clearKeyCache();
+  await decryptKeyCache();
 }
 
 async function changeEncryptionPassphrase(oldPassphrase, newPassphrase) {
@@ -609,7 +679,12 @@ async function changeEncryptionPassphrase(oldPassphrase, newPassphrase) {
 import { buildBackupSnapshot, configureBackupRuntimeDeps, scheduleAutoBackup, openBackupDB, initFolderBackup } from './backup.js';
 export { buildBackupSnapshot, scheduleAutoBackup, openBackupDB, initFolderBackup };
 
-configureBackupRuntimeDeps({ encryptedGetItem, getEncryptionEnabled });
+configureBackupRuntimeDeps({
+  encryptedGetItem,
+  encryptedSetItem: encryptedSetCredentialItem,
+  getEncryptionEnabled,
+  isCredentialKey,
+});
 configureCryptoUi({
   changeEncryptionPassphrase,
   clearEncryptionSession: () => { _sessionKey = null; },

--- a/js/data-wipe.js
+++ b/js/data-wipe.js
@@ -142,6 +142,7 @@ export async function eraseAllLocalAppData() {
       ...profileIds.flatMap(id => [`labcharts-wearables-${id}`, `labcharts-cycle-${id}`]),
       'labcharts-backups',
       'labcharts-blobs',
+      'labcharts-wearables-credential-vault',
     ],
     errors,
   );

--- a/js/lens.js
+++ b/js/lens.js
@@ -3,7 +3,7 @@
 // User-configured RAG endpoint that backs the Interpretive Lens with retrieved chunks.
 import { getErrorMessage, getErrorName } from './caught-error.js';
 import { state } from './state.js';
-import { getCachedKey, updateKeyCache, encryptedSetItem } from './crypto.js';
+import { getCachedKey, updateKeyCache, encryptedSetCredentialItem } from './crypto.js';
 import { hashString, isDebugMode, showNotification } from './utils.js';
 import { hasAIProvider, callClaudeAPI } from './api.js';
 import { isValidLensUrl as isValidLensUrlImpl } from './lens-url.js';
@@ -101,7 +101,7 @@ export function saveLensConfig(partial) {
 }
 export function getLensKey() { return getCachedKey(SECRET_KEY) || ''; }
 export async function saveLensKey(key) {
-  await encryptedSetItem(SECRET_KEY, key);
+  await encryptedSetCredentialItem(SECRET_KEY, key);
   updateKeyCache(SECRET_KEY, key);
   clearLensCache();
   // External-server hasLens() gates on getLensKey(); refresh the chat header
@@ -111,7 +111,7 @@ export async function saveLensKey(key) {
 }
 export async function removeLens() {
   localStorage.removeItem(CONFIG_KEY);
-  await encryptedSetItem(SECRET_KEY, '');
+  await encryptedSetCredentialItem(SECRET_KEY, '');
   updateKeyCache(SECRET_KEY, '');
   clearLensCache();
   updateLensStatus({ state: 'idle', lastChunkCount: 0, lastError: null, sourceName: '' });

--- a/js/lens.js
+++ b/js/lens.js
@@ -3,7 +3,12 @@
 // User-configured RAG endpoint that backs the Interpretive Lens with retrieved chunks.
 import { getErrorMessage, getErrorName } from './caught-error.js';
 import { state } from './state.js';
-import { getCachedKey, updateKeyCache, encryptedSetCredentialItem } from './crypto.js';
+import {
+  encryptedRemoveItem,
+  encryptedSetCredentialItem,
+  getCachedKey,
+  updateKeyCache,
+} from './crypto.js';
 import { hashString, isDebugMode, showNotification } from './utils.js';
 import { hasAIProvider, callClaudeAPI } from './api.js';
 import { isValidLensUrl as isValidLensUrlImpl } from './lens-url.js';
@@ -111,8 +116,7 @@ export async function saveLensKey(key) {
 }
 export async function removeLens() {
   localStorage.removeItem(CONFIG_KEY);
-  await encryptedSetCredentialItem(SECRET_KEY, '');
-  updateKeyCache(SECRET_KEY, '');
+  await encryptedRemoveItem(SECRET_KEY);
   clearLensCache();
   updateLensStatus({ state: 'idle', lastChunkCount: 0, lastError: null, sourceName: '' });
 }

--- a/js/pii.js
+++ b/js/pii.js
@@ -49,20 +49,32 @@ export const FAKE_DOCTORS = [
   'MUDr. Šimková', 'MUDr. Veselý', 'MUDr. Kopecký', 'MUDr. Marková'
 ];
 
-export function randomPick(arr) { return arr[Math.floor(Math.random() * arr.length)]; }
-export function randomDigits(n) { let s = ''; for (let i = 0; i < n; i++) s += Math.floor(Math.random() * 10); return s; }
+const UINT32_RANGE = 0x100000000;
+
+export function secureRandomInt(maxExclusive) {
+  if (!Number.isSafeInteger(maxExclusive) || maxExclusive < 1 || maxExclusive > UINT32_RANGE) {
+    throw new RangeError('secureRandomInt requires an integer between 1 and 2^32');
+  }
+  const unbiasedLimit = Math.floor(UINT32_RANGE / maxExclusive) * maxExclusive;
+  const sample = new Uint32Array(1);
+  do crypto.getRandomValues(sample); while (sample[0] >= unbiasedLimit);
+  return sample[0] % maxExclusive;
+}
+
+export function randomPick(arr) { return arr.length ? arr[secureRandomInt(arr.length)] : undefined; }
+export function randomDigits(n) { let s = ''; for (let i = 0; i < n; i++) s += secureRandomInt(10); return s; }
 export function fakeBirthNumber() {
-  const y = 50 + Math.floor(Math.random() * 50);
-  const m = 1 + Math.floor(Math.random() * 12);
-  const d = 1 + Math.floor(Math.random() * 28);
+  const y = 50 + secureRandomInt(50);
+  const m = 1 + secureRandomInt(12);
+  const d = 1 + secureRandomInt(28);
   return `${String(y).padStart(2,'0')}${String(m).padStart(2,'0')}${String(d).padStart(2,'0')}/${randomDigits(4)}`;
 }
 export function fakePhone() { return `+420 7${randomDigits(2)} ${randomDigits(3)} ${randomDigits(3)}`; }
 export function fakeEmail() { return `user${randomDigits(4)}@mail.com`; }
 export function fakeDate() {
-  const y = 1960 + Math.floor(Math.random() * 40);
-  const m = 1 + Math.floor(Math.random() * 12);
-  const d = 1 + Math.floor(Math.random() * 28);
+  const y = 1960 + secureRandomInt(40);
+  const m = 1 + secureRandomInt(12);
+  const d = 1 + secureRandomInt(28);
   return `${String(d).padStart(2,'0')}.${String(m).padStart(2,'0')}.${y}`;
 }
 export function fakePatientId() { return randomDigits(10); }
@@ -443,7 +455,7 @@ export function obfuscatePDFText(pdfText) {
     { pattern: /^(.*?\b(?:[cč][ií]slo\s*(?:poji[sš]t[eě]n|insurance)|insurance\s*(?:no|number|id)|poji[sš][tť]ovna|member\s*id|group\s*(?:no|number|id)|policy)\b[:\s]+)(.+)$/gim, gen: () => randomDigits(10) },
     { pattern: /^(.*?\b(?:id\s*pacienta|patient\s*id|[cč][ií]slo\s*pacienta|account\s*(?:no|number)|acct|MRN|medical\s*record)\b[:\s]+)(.+)$/gim, gen: () => fakePatientId() },
     { pattern: /^(.*?\b(?:specimen\s*(?:id|no|number)|accession\s*(?:no|number)|control\s*(?:id|no|number)|requisition)\b[:\s]+)(.+)$/gim, gen: () => randomDigits(10) },
-    { pattern: /^(.*?\b(?:age|v[eě]k)\b[:\s]+)(\d{1,3}\b.*)$/gim, gen: () => `${20 + Math.floor(Math.random() * 50)}` },
+    { pattern: /^(.*?\b(?:age|v[eě]k)\b[:\s]+)(\d{1,3}\b.*)$/gim, gen: () => `${20 + secureRandomInt(50)}` },
   ];
 
   for (const { pattern, gen } of labelReplacements) {

--- a/js/settings-privacy.js
+++ b/js/settings-privacy.js
@@ -175,10 +175,10 @@ export function renderSunDataSourceSettings() {
   </div>`;
 }
 
-function setMeteoMode(mode) {
+async function setMeteoMode(mode) {
   const cfg = getSettingsMeteoConfig();
   cfg.mode = mode;
-  if (!saveSettingsMeteoConfig(cfg)) {
+  if (!await saveSettingsMeteoConfig(cfg)) {
     notifyMeteoSaveUnavailable();
     return;
   }
@@ -187,24 +187,24 @@ function setMeteoMode(mode) {
 }
 
 function notifyMeteoSaveUnavailable() {
-  showNotification('Sun data-source settings are still loading. Try again in a moment.', 'warning');
+  showNotification('Sun data-source settings could not be saved securely. Try again in a moment.', 'warning');
 }
 
-function saveMeteoSelfhost() {
+async function saveMeteoSelfhost() {
   const cfg = getSettingsMeteoConfig();
   const url = /** @type {HTMLInputElement | null} */ (document.getElementById('meteo-selfhost-url'))?.value?.trim() || '';
   const bearer = /** @type {HTMLInputElement | null} */ (document.getElementById('meteo-selfhost-bearer'))?.value?.trim() || '';
   cfg.selfhostUrl = url;
   cfg.selfhostBearer = bearer;
-  if (!saveSettingsMeteoConfig(cfg)) {
+  if (!await saveSettingsMeteoConfig(cfg)) {
     notifyMeteoSaveUnavailable();
   }
 }
 
-function toggleMeteoRounding(enabled) {
+async function toggleMeteoRounding(enabled) {
   const cfg = getSettingsMeteoConfig();
   cfg.privacyRounding = enabled ? 0.1 : 0;
-  if (!saveSettingsMeteoConfig(cfg)) {
+  if (!await saveSettingsMeteoConfig(cfg)) {
     notifyMeteoSaveUnavailable();
   }
 }
@@ -218,17 +218,17 @@ function closestSunDataSourceControl(event) {
   return el instanceof HTMLElement && el.closest('#sun-data-source-section') ? el : null;
 }
 
-function handleSunDataSourceChange(event) {
+async function handleSunDataSourceChange(event) {
   const el = closestSunDataSourceControl(event);
   if (!el) return;
   const action = el.dataset.sunSourceAction;
   if (action === 'set-meteo-mode') {
     const mode = (el instanceof HTMLSelectElement || el instanceof HTMLInputElement) ? el.value || 'auto' : 'auto';
-    setMeteoMode(mode);
+    await setMeteoMode(mode);
   } else if (action === 'save-meteo-selfhost') {
-    saveMeteoSelfhost();
+    await saveMeteoSelfhost();
   } else if (action === 'toggle-meteo-rounding') {
-    toggleMeteoRounding(el instanceof HTMLInputElement && el.checked);
+    await toggleMeteoRounding(el instanceof HTMLInputElement && el.checked);
   }
 }
 

--- a/js/settings-runtime.js
+++ b/js/settings-runtime.js
@@ -11,6 +11,10 @@ const DEFAULT_METEO_CONFIG = Object.freeze({
   privacyRounding: 0.1,
 });
 
+/** @type {{
+ *   getMeteoConfig: (() => Record<string, any>) | null,
+ *   saveMeteoConfig: ((config: Record<string, any>) => boolean | void | Promise<boolean | void>) | null,
+ * }} */
 const settingsRuntimeDeps = {
   getMeteoConfig: /** @type {null | typeof getMeteoConfig} */ (getMeteoConfig),
   saveMeteoConfig: /** @type {null | typeof saveMeteoConfig} */ (saveMeteoConfig),
@@ -19,7 +23,7 @@ const settingsRuntimeDeps = {
 /**
  * @param {{
  *   getMeteoConfig?: (() => Record<string, any>) | null,
- *   saveMeteoConfig?: ((config: Record<string, any>) => void) | null,
+ *   saveMeteoConfig?: ((config: Record<string, any>) => boolean | void | Promise<boolean | void>) | null,
  * }} [deps]
  */
 export function configureSettingsRuntimeDeps(deps = {}) {
@@ -116,14 +120,13 @@ export function getSettingsMeteoConfig() {
 
 /**
  * @param {Record<string, any>} config
- * @returns {boolean}
+ * @returns {Promise<boolean>}
  */
-export function saveSettingsMeteoConfig(config) {
+export async function saveSettingsMeteoConfig(config) {
   const writeMeteoConfig = settingsRuntimeDeps.saveMeteoConfig;
   if (!writeMeteoConfig) return false;
   try {
-    writeMeteoConfig(config);
-    return true;
+    return await writeMeteoConfig(config) !== false;
   } catch {
     return false;
   }

--- a/js/sun-uvdata-config.js
+++ b/js/sun-uvdata-config.js
@@ -25,6 +25,11 @@ let _warnedAboutEmptySelfhost = false;
 // keep calling getMeteoConfig() synchronously even though the at-rest
 // representation is AES-GCM-encrypted via encryptedGetItem.
 let _meteoConfigCache = null;
+// Serialize encrypted writes so rapid settings changes cannot finish out of
+// order. The previous durable envelope remains in place until its replacement
+// has been encrypted successfully.
+let _meteoPersistTail = Promise.resolve();
+let _meteoPendingSaves = 0;
 
 // Build a sanitized config from a parsed JSON value. Allowlist-style — only
 // the four known fields, type-checked. Defence-in-depth against a stored
@@ -97,7 +102,7 @@ export async function initMeteoConfigCache() {
     if (needsPersist) {
       // Persist via saveMeteoConfig so legacy plaintext lands in the
       // encrypted envelope on its first migration save.
-      saveMeteoConfig(cfg);
+      await saveMeteoConfig(cfg);
     }
   } catch (e) {
     _meteoConfigCache = defaultConfig();
@@ -105,6 +110,12 @@ export async function initMeteoConfigCache() {
 }
 
 export function getMeteoConfig() {
+  // While a queued secure write is pending, the cache is the newest value;
+  // localStorage intentionally still contains the previous durable record.
+  if (_meteoPendingSaves > 0 && _meteoConfigCache) {
+    const { cfg } = _applyConfigRuntimeFixups(Object.assign({}, _meteoConfigCache));
+    return cfg;
+  }
   // Read localStorage every call so direct writes (tests, cross-tab)
   // are observed without cache invalidation gymnastics. Only the
   // encrypted-envelope path needs the cache (decryption is async; the
@@ -150,15 +161,21 @@ export function saveMeteoConfig(cfg) {
   // Cache update first — keeps the synchronous getMeteoConfig contract
   // working immediately while the encrypted write completes.
   _meteoConfigCache = _buildConfigFromParsed(cfg);
-  const json = JSON.stringify(cfg);
-  // Remove any legacy/plain previous value before starting the asynchronous
-  // device/passphrase encryption. Synchronous readers use the cache above
-  // during this short gap, so the public API remains synchronous without a
-  // momentary clear-text write.
-  try { localStorage.removeItem(STORAGE_KEY); } catch {}
-  void encryptedSetCredentialItem(STORAGE_KEY, json).catch(error => {
-    console.warn('[meteo] secure config persistence failed', error);
-  });
+  const json = JSON.stringify(_meteoConfigCache);
+  _meteoPendingSaves += 1;
+  const write = _meteoPersistTail.then(() => encryptedSetCredentialItem(STORAGE_KEY, json));
+  const result = write.then(
+    () => true,
+    error => {
+      console.warn('[meteo] secure config persistence failed', error);
+      return false;
+    },
+  ).finally(() => { _meteoPendingSaves -= 1; });
+  // Keep the queue live after a failed write so a later settings change can
+  // retry. `result` always resolves and therefore is also safe to ignore at
+  // legacy synchronous call sites.
+  _meteoPersistTail = result.then(() => undefined);
+  return result;
 }
 
 function defaultConfig() {

--- a/js/sun-uvdata-config.js
+++ b/js/sun-uvdata-config.js
@@ -1,21 +1,21 @@
 // @ts-check
 // sun-uvdata-config.js - encrypted Sun/UV data source config storage.
 
-import { encryptedGetItem, encryptedSetItem, getEncryptionEnabled } from './crypto.js';
+import { encryptedGetItem, encryptedSetCredentialItem } from './crypto.js';
 
 //
 // Storage: meteo config (mode, selfhostUrl, selfhostBearer, privacyRounding)
-// is encrypted at rest via crypto.js's encryptedSetItem / encryptedGetItem.
+// is always encrypted at rest via crypto.js's credential storage wrapper.
 // `selfhostBearer` is sensitive — same threat-model class as the AI provider
 // keys. The key `labcharts-meteo-config` is in `SENSITIVE_PATTERNS` (crypto.js)
-// so encryptedSetItem auto-encrypts when the user has encryption enabled.
+// so it is device-encrypted even when profile encryption is disabled.
 //
 // To preserve the existing synchronous getMeteoConfig() API (sun-context.js,
 // settings.js, the Sun-data-source picker all call it from sync paths),
 // the decrypted config is cached in module state, refreshed at startup
 // via initMeteoConfigCache(), and re-refreshed on encryption-state changes
-// (disableEncryption / passphrase change). Cache miss falls back to a raw
-// localStorage read which is correct for users without encryption enabled.
+// (disableEncryption / passphrase change). Legacy plaintext reads remain
+// supported long enough for startup migration.
 //
 
 const STORAGE_KEY = 'labcharts-meteo-config';
@@ -76,11 +76,11 @@ function _applyConfigRuntimeFixups(cfg) {
 }
 
 // Async loader — decrypts via crypto.js's encryptedGetItem (which routes
-// through the session key when encryption is enabled, falls through to
-// raw localStorage otherwise). Called at startup from main.js's init
+// through either the passphrase key or the device-local credential key).
+// Called at startup from main.js's init
 // sequence, and after encryption-state changes. Migration of pre-encrypt
 // plaintext configs is automatic: encryptedGetItem returns the plaintext
-// on first read, then saveMeteoConfig's encryptedSetItem writes it back
+// on first read, then saveMeteoConfig's credential wrapper writes it back
 // in the new envelope.
 export async function initMeteoConfigCache() {
   try {
@@ -112,12 +112,18 @@ export function getMeteoConfig() {
   // stay synchronous).
   let raw;
   try { raw = localStorage.getItem(STORAGE_KEY); } catch { raw = null; }
-  if (!raw) return defaultConfig();
+  if (!raw) {
+    if (_meteoConfigCache) {
+      const { cfg } = _applyConfigRuntimeFixups(Object.assign({}, _meteoConfigCache));
+      return cfg;
+    }
+    return defaultConfig();
+  }
   // Encrypted envelope — return the decrypted form from the cache that
   // initMeteoConfigCache populated at startup. If the cache is empty
   // (race window or test env), fall back to defaults rather than treat
   // ciphertext as JSON.
-  if (typeof raw === 'string' && raw.startsWith('v1:')) {
+  if (typeof raw === 'string' && (raw.startsWith('v1:') || raw.startsWith('d1:'))) {
     if (_meteoConfigCache) {
       const { cfg } = _applyConfigRuntimeFixups(Object.assign({}, _meteoConfigCache));
       return cfg;
@@ -132,7 +138,7 @@ export function getMeteoConfig() {
     const cfg = _buildConfigFromParsed(parsed);
     const { cfg: out, needsPersist } = _applyConfigRuntimeFixups(cfg);
     if (needsPersist) {
-      try { saveMeteoConfig(out); } catch {}
+      try { void saveMeteoConfig(out); } catch {}
     }
     return out;
   } catch (e) {
@@ -142,32 +148,17 @@ export function getMeteoConfig() {
 
 export function saveMeteoConfig(cfg) {
   // Cache update first — keeps the synchronous getMeteoConfig contract
-  // working immediately. Read sequence: getMeteoConfig hits localStorage,
-  // sees the value below, parses inline. Cache only matters as a fallback
-  // for the encrypted-envelope branch where parsing inline would fail.
+  // working immediately while the encrypted write completes.
   _meteoConfigCache = _buildConfigFromParsed(cfg);
   const json = JSON.stringify(cfg);
-  // Sync plaintext write when encryption is OFF — getMeteoConfig
-  // observes the new value immediately on next read (covers tests + the
-  // common no-encryption case). When encryption is ON, skip the sync
-  // plaintext write so we don't briefly expose the bearer on disk; reads
-  // in the gap fall back to the in-memory cache populated above.
-  let encryptionOn = false;
-  try { encryptionOn = getEncryptionEnabled(); } catch {}
-  if (!encryptionOn) {
-    try { localStorage.setItem(STORAGE_KEY, json); } catch {}
-    return;
-  }
-  // Encryption ON — async write through encryptedSetItem so the bearer
-  // is encrypted at rest. Fire-and-forget; existing callers don't await.
-  (async () => {
-    try {
-      await encryptedSetItem(STORAGE_KEY, json);
-    } catch (_) {
-      // Last-resort fallback so a crypto.js failure doesn't lose the save
-      try { localStorage.setItem(STORAGE_KEY, json); } catch {}
-    }
-  })();
+  // Remove any legacy/plain previous value before starting the asynchronous
+  // device/passphrase encryption. Synchronous readers use the cache above
+  // during this short gap, so the public API remains synchronous without a
+  // momentary clear-text write.
+  try { localStorage.removeItem(STORAGE_KEY); } catch {}
+  void encryptedSetCredentialItem(STORAGE_KEY, json).catch(error => {
+    console.warn('[meteo] secure config persistence failed', error);
+  });
 }
 
 function defaultConfig() {

--- a/js/wearables-credential-vault.js
+++ b/js/wearables-credential-vault.js
@@ -1,5 +1,5 @@
 // @ts-check
-// wearables-credential-vault.js — always-encrypted, device-local OAuth secrets
+// wearables-credential-vault.js — always-encrypted, device-local app secrets
 //
 // Every wearable connection is treated as sensitive. The normal wearable
 // connection record lives inside importedData, so it is deliberately
@@ -22,6 +22,7 @@ const RECORD_PREFIX = 'credential-vault-record:v1:';
 const GENERATION_PREFIX = 'credential-vault-generation:v1:';
 const LOCAL_MARKER_PREFIX = 'labcharts-wearable-credential-local:';
 const LOCAL_GENERATION_PREFIX = 'labcharts-wearable-credential-generation:';
+const APP_CREDENTIAL_PROFILE_ID = 'credential-vault';
 
 export const VAULTED_CREDENTIAL_ADAPTERS = new Set([
   'oura', 'whoop', 'withings', 'ultrahuman', 'fitbit', 'google_health', 'polar',
@@ -29,6 +30,48 @@ export const VAULTED_CREDENTIAL_ADAPTERS = new Set([
 
 export function usesWearableCredentialVault(adapterId) {
   return VAULTED_CREDENTIAL_ADAPTERS.has(adapterId);
+}
+
+function vaultBytesToBase64(bytes) {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+function vaultBytesFromBase64(value) {
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index++) bytes[index] = binary.charCodeAt(index);
+  return bytes;
+}
+
+// General app credentials share the proven non-extractable wearable vault
+// primitive but use a dedicated device-local profile database. Including the
+// storage key inside the authenticated payload prevents envelope substitution.
+export async function encryptDeviceCredential(storageKey, plaintext) {
+  const envelope = await encryptWearableDeviceLocalValue(APP_CREDENTIAL_PROFILE_ID, {
+    storageKey,
+    plaintext: String(plaintext),
+  });
+  return `d1:${vaultBytesToBase64(envelope.iv)}:${vaultBytesToBase64(new Uint8Array(envelope.ciphertext))}`;
+}
+
+export async function decryptDeviceCredential(storageKey, value) {
+  if (typeof value !== 'string' || !value.startsWith('d1:')) return null;
+  const parts = value.split(':');
+  if (parts.length !== 3) return null;
+  try {
+    const decrypted = await decryptWearableDeviceLocalValue(APP_CREDENTIAL_PROFILE_ID, {
+      version: 1,
+      iv: vaultBytesFromBase64(parts[1]),
+      ciphertext: vaultBytesFromBase64(parts[2]),
+    });
+    return decrypted?.storageKey === storageKey && typeof decrypted.plaintext === 'string'
+      ? decrypted.plaintext
+      : null;
+  } catch {
+    return null;
+  }
 }
 
 export function wearableCredentialDisconnectedError(displayName = 'Wearable') {

--- a/scripts/build-production.mjs
+++ b/scripts/build-production.mjs
@@ -36,6 +36,7 @@ const FATAL_BUILD_WARNINGS = new Set(['INEFFECTIVE_DYNAMIC_IMPORT']);
 const LAZY_SYNC_CHUNK_MODULES = new Set([
   path.join(ROOT, 'js', 'routstr-balance-settlement.js'),
   path.join(ROOT, 'js', 'sync-apply.js'),
+  path.join(ROOT, 'js', 'wearables-credential-vault.js'),
 ]);
 
 export function handleBuildLog(level, log, defaultHandler) {

--- a/scripts/cold-load-budget.json
+++ b/scripts/cold-load-budget.json
@@ -5,7 +5,7 @@
   "maximums": {
     "requests": 304,
     "transferBytes": 1193220,
-    "decodedBytes": 3090000
+    "decodedBytes": 3096000
   },
   "reference": {
     "requests": 276,

--- a/scripts/production-build-budget.json
+++ b/scripts/production-build-budget.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "maximums": {
     "startupJavaScriptFiles": 2,
-    "startupDecodedBytes": 1153664,
+    "startupDecodedBytes": 1156330,
     "outputJavaScriptFiles": 150,
     "outputDecodedBytes": 4675000
   },
@@ -12,6 +12,7 @@
     "outputJavaScriptFiles": 134,
     "outputDecodedBytes": 3958886,
     "extensionOwnedTransportStartupDecodedBytes": 1152664,
+    "deviceCredentialProtectionStartupDecodedBytes": 1155330,
     "absolutePathRelocationAllowanceBytes": 1000
   },
   "referenceCommit": "807732a8",

--- a/tests/api-provider-storage-runtime.test.js
+++ b/tests/api-provider-storage-runtime.test.js
@@ -131,7 +131,7 @@ describe('api provider storage runtime adapter', () => {
     expect(cryptoSrc).toContain("from './crypto-key-cache.js'");
     expect(cryptoSrc).toContain("export { getCachedKey, updateKeyCache } from './crypto-key-cache.js'");
     expect(appShellHooksSrc).toContain("from './api-provider-storage-runtime.js'");
-    expect(appShellHooksSrc).toContain('configureApiProviderStorageRuntimeDeps({ encryptedSetItem })');
+    expect(appShellHooksSrc).toContain('configureApiProviderStorageRuntimeDeps({ encryptedSetItem: encryptedSetCredentialItem })');
     expect(/\bwindow(?:\.|\s*\[)/.test(storageSrc)).toBe(false);
     expect(/\bwindow(?:\.|\s*\[)/.test(runtimeSrc)).toBe(false);
     expect(swSrc).toContain("'/js/api-provider-storage-runtime.js'");

--- a/tests/data-wipe.test.js
+++ b/tests/data-wipe.test.js
@@ -79,6 +79,7 @@ describe('eraseAllLocalAppData', () => {
       'labcharts-cycle-orphaned-profile',
       'labcharts-blobs',
       'labcharts-backups',
+      'labcharts-wearables-credential-vault',
       'labcharts-future-store',
       'getbased-cashu',
     ];
@@ -127,6 +128,7 @@ describe('eraseAllLocalAppData', () => {
       'labcharts-cycle-active-profile',
       'labcharts-cycle-default',
       'labcharts-wearables-active-profile',
+      'labcharts-wearables-credential-vault',
       'labcharts-wearables-default',
     ]);
     expect(localStorage.getItem('labcharts-private')).toBeNull();
@@ -168,6 +170,7 @@ describe('eraseAllLocalAppData', () => {
     expect(deleteDatabase).toHaveBeenCalledWith('labcharts-wearables-default');
     expect(deleteDatabase).toHaveBeenCalledWith('labcharts-cycle-default');
     expect(deleteDatabase).toHaveBeenCalledWith('labcharts-blobs');
+    expect(deleteDatabase).toHaveBeenCalledWith('labcharts-wearables-credential-vault');
     expect(deleteDatabase).toHaveBeenCalledWith('getbased-cashu');
     expect(globalThis.caches.delete).not.toHaveBeenCalled();
   });

--- a/tests/playwright/crypto-browser-coverage.spec.js
+++ b/tests/playwright/crypto-browser-coverage.spec.js
@@ -64,6 +64,26 @@ test('crypto storage wrappers cover encryption cache blob and enable disable flo
         && cryptoStore.isEncryptedValue('v1:a:b') === true
         && cryptoStore.isEncryptedValue('plain') === false;
 
+      const wearablesStore = await import('/js/wearables-store.js');
+      const originalIndexedDbOpen = indexedDB.open;
+      localStorage.setItem('labcharts-api-key', 'volatile-legacy-secret');
+      cryptoStore.updateKeyCache('labcharts-api-key', null);
+      wearablesStore.resetWearablesDB('credential-vault');
+      let startupSurvivedVaultFailure = false;
+      try {
+        indexedDB.open = () => { throw new Error('simulated credential vault failure'); };
+        await cryptoStore.initEncryption();
+        startupSurvivedVaultFailure = true;
+      } finally {
+        indexedDB.open = originalIndexedDbOpen;
+        wearablesStore.resetWearablesDB('credential-vault');
+      }
+      outcomes.startupSurvivesVaultFailureWithoutPlaintext =
+        startupSurvivedVaultFailure
+        && localStorage.getItem('labcharts-api-key') === null
+        && cryptoStore.getCachedKey('labcharts-api-key') === 'volatile-legacy-secret';
+      await cryptoStore.encryptedRemoveItem('labcharts-api-key');
+
       localStorage.setItem('labcharts-openrouter-key', 'legacy-plaintext-secret');
       cryptoStore.updateKeyCache('labcharts-openrouter-key', null);
       await cryptoStore.initEncryption();

--- a/tests/playwright/crypto-browser-coverage.spec.js
+++ b/tests/playwright/crypto-browser-coverage.spec.js
@@ -42,6 +42,7 @@ test('crypto storage wrappers cover encryption cache blob and enable disable flo
       'labcharts-encryption-salt',
       'labcharts-api-key',
       'labcharts-venice-key',
+      'labcharts-openrouter-key',
       importedKey,
       customPersonaKey,
     ];
@@ -62,6 +63,26 @@ test('crypto storage wrappers cover encryption cache blob and enable disable flo
         && cryptoStore.getEncryptionEnabled() === false
         && cryptoStore.isEncryptedValue('v1:a:b') === true
         && cryptoStore.isEncryptedValue('plain') === false;
+
+      localStorage.setItem('labcharts-openrouter-key', 'legacy-plaintext-secret');
+      cryptoStore.updateKeyCache('labcharts-openrouter-key', null);
+      await cryptoStore.initEncryption();
+      const migratedLegacyCredential = localStorage.getItem('labcharts-openrouter-key');
+      outcomes.startupMigratesLegacyPlaintextCredentials =
+        migratedLegacyCredential?.startsWith('d1:') === true
+        && !migratedLegacyCredential.includes('legacy-plaintext-secret')
+        && await cryptoStore.encryptedGetItem('labcharts-openrouter-key') === 'legacy-plaintext-secret'
+        && cryptoStore.getCachedKey('labcharts-openrouter-key') === 'legacy-plaintext-secret';
+      await cryptoStore.encryptedRemoveItem('labcharts-openrouter-key');
+
+      await cryptoStore.encryptedSetItem('labcharts-api-key', 'device-protected-secret');
+      const deviceProtectedRaw = localStorage.getItem('labcharts-api-key');
+      outcomes.credentialsUseDeviceEncryptionWhenProfileEncryptionIsOff =
+        deviceProtectedRaw?.startsWith('d1:') === true
+        && !deviceProtectedRaw.includes('device-protected-secret')
+        && await cryptoStore.encryptedGetItem('labcharts-api-key') === 'device-protected-secret'
+        && cryptoStore.getCachedKey('labcharts-api-key') === 'device-protected-secret';
+      await cryptoStore.encryptedRemoveItem('labcharts-api-key');
 
       localStorage.setItem(importedKey, JSON.stringify({ entries: [{ date: '2026-06-09' }] }));
       const migratedBlobValue = await cryptoStore.encryptedGetItem(importedKey);
@@ -98,7 +119,7 @@ test('crypto storage wrappers cover encryption cache blob and enable disable flo
         cryptoStore.isEncryptedObject(envelope) === true
         && plainEnvelope.score === 42
         && wrongKeyValue === null
-        && cryptoStore.getCachedKey('labcharts-api-key') === rawApiKey;
+        && cryptoStore.getCachedKey('labcharts-api-key') === null;
 
       const clearedSessionKey = await cryptoStore._setTestSessionKey(null);
       outcomes.sessionKeyClearReturnsNull = clearedSessionKey === null;
@@ -156,11 +177,14 @@ test('crypto storage wrappers cover encryption cache blob and enable disable flo
       await waitFor(() => !!document.getElementById('confirm-ok'), 'disable confirmation');
       click('#confirm-ok');
       await disablePromise;
+      const deviceEncryptedVenice = localStorage.getItem('labcharts-venice-key');
       outcomes.disableDecryptsAndClearsSession =
         cryptoStore.getEncryptionEnabled() === false
         && cryptoStore.isUnlocked() === false
         && localStorage.getItem('labcharts-encryption-salt') === null
-        && localStorage.getItem('labcharts-venice-key') === 'plain-venice-key'
+        && deviceEncryptedVenice?.startsWith('d1:') === true
+        && !deviceEncryptedVenice.includes('plain-venice-key')
+        && await cryptoStore.encryptedGetItem('labcharts-venice-key') === 'plain-venice-key'
         && JSON.parse(localStorage.getItem(customPersonaKey) || '[]')[0]?.id === 'custom_existing'
         && document.getElementById('encryption-section')?.textContent.includes('Encryption is OFF') === true
         && document.getElementById('notification-container')?.textContent.includes('Encryption disabled') === true;

--- a/tests/playwright/provider-coverage-batch.spec.js
+++ b/tests/playwright/provider-coverage-batch.spec.js
@@ -602,8 +602,11 @@ test('provider panels cover provider switching key saves balances custom API and
       `;
       await panels.handleSaveRoutstrKey();
       await wait(0);
+      const storedRoutstrKey = localStorage.getItem('labcharts-routstr-key');
       const routstrSaveRendersModels = document.getElementById('routstr-key-status')?.textContent.includes('Connected')
-        && localStorage.getItem('labcharts-routstr-key') === 'sk-routstr-good'
+        && storedRoutstrKey?.startsWith('d1:') === true
+        && !storedRoutstrKey.includes('sk-routstr-good')
+        && await cryptoStore.encryptedGetItem('labcharts-routstr-key') === 'sk-routstr-good'
         && document.getElementById('routstr-model-select')?.value === 'claude-sonnet-5'
         && JSON.parse(localStorage.getItem('labcharts-routstr-vision-models') || '[]').includes('claude-sonnet-4.6');
 

--- a/tests/playwright/settings-browser-coverage.spec.js
+++ b/tests/playwright/settings-browser-coverage.spec.js
@@ -209,6 +209,7 @@ test('settings browser coverage exercises delegates for themes tweaks privacy us
       const selfhostRadio = sunSection.querySelector('input[value="selfhost"]');
       selfhostRadio.checked = true;
       selfhostRadio.dispatchEvent(new Event('change', { bubbles: true }));
+      await wait(0);
       results.setMeteoMode = meteoConfig.mode === 'selfhost'
         && document.getElementById('meteo-selfhost-fields').style.display === '';
 
@@ -216,12 +217,14 @@ test('settings browser coverage exercises delegates for themes tweaks privacy us
       document.getElementById('meteo-selfhost-url').dispatchEvent(new Event('change', { bubbles: true }));
       document.getElementById('meteo-selfhost-bearer').value = ' token-123 ';
       document.getElementById('meteo-selfhost-bearer').dispatchEvent(new Event('change', { bubbles: true }));
+      await wait(0);
       results.saveMeteoSelfhost = meteoConfig.selfhostUrl === 'https://meteo.example.test'
         && meteoConfig.selfhostBearer === 'token-123';
 
       const roundingToggle = document.getElementById('meteo-privacy-rounding');
       roundingToggle.checked = false;
       roundingToggle.dispatchEvent(new Event('change', { bubbles: true }));
+      await wait(0);
       results.toggleMeteoRounding = meteoConfig.privacyRounding === 0
         && savedMeteoConfigs.some(cfg => cfg.privacyRounding === 0);
 

--- a/tests/playwright/startup-oauth-browser-coverage.spec.js
+++ b/tests/playwright/startup-oauth-browser-coverage.spec.js
@@ -162,7 +162,10 @@ test('startup OAuth browser coverage handles OpenRouter and wearable callback ro
         && authRequest.body?.code === 'live-code'
         && authRequest.body?.code_verifier === 'verifier-ok'
         && authRequest.body?.code_challenge_method === 'S256';
-      outcomes.successSavesKeyProviderAndClearsSession = localStorage.getItem('labcharts-openrouter-key') === 'or-live-key'
+      const storedOpenRouterKey = localStorage.getItem('labcharts-openrouter-key');
+      outcomes.successSavesKeyProviderAndClearsSession = storedOpenRouterKey?.startsWith('d1:') === true
+        && !storedOpenRouterKey.includes('or-live-key')
+        && await cryptoStore.encryptedGetItem('labcharts-openrouter-key') === 'or-live-key'
         && localStorage.getItem('labcharts-ai-provider') === 'openrouter'
         && sessionStorage.getItem('or_pkce_verifier') === null
         && sessionStorage.getItem('or_oauth_state') === null

--- a/tests/playwright/sun-uvdata-browser-coverage.spec.js
+++ b/tests/playwright/sun-uvdata-browser-coverage.spec.js
@@ -47,6 +47,15 @@ test('sun uvdata browser coverage handles config cache module API and purging', 
       localStorage.setItem('meteo:v5:keep-a', 'fresh-cache');
 
       const mod = await import(sunUrl);
+      const cryptoStore = await import('/js/crypto.js');
+      const waitForSecureConfig = async () => {
+        for (let attempt = 0; attempt < 100; attempt += 1) {
+          const raw = localStorage.getItem(storageKey);
+          if (raw?.startsWith('d1:') || raw?.startsWith('v1:')) return raw;
+          await new Promise(resolve => setTimeout(resolve, 10));
+        }
+        return null;
+      };
 
       outcomes.importSweepsOnlyLegacyMeteoCache =
         localStorage.getItem('meteo:legacy-a') === null
@@ -84,17 +93,21 @@ test('sun uvdata browser coverage handles config cache module API and purging', 
         extra: 'ignored',
       }));
       const migrated = mod.getMeteoConfig();
-      const persistedMigration = JSON.parse(localStorage.getItem(storageKey));
+      const migratedEnvelope = await waitForSecureConfig();
+      const persistedMigration = JSON.parse(await cryptoStore.encryptedGetItem(storageKey));
       outcomes.legacyModeMigratesAndSanitizesStoredConfig =
         migrated.mode === 'auto'
         && migrated.selfhostUrl === 'https://legacy.example/uv'
         && migrated.selfhostBearer === ''
         && migrated.privacyRounding === 0.25
+        && migratedEnvelope?.startsWith('d1:')
+        && !migratedEnvelope.includes('legacy.example')
         && persistedMigration.mode === 'auto'
         && persistedMigration.extra === undefined;
 
       localStorage.setItem(storageKey, JSON.stringify({ mode: 'manual', privacyRounding: 0.1 }));
       outcomes.legacyManualModeMigratesToAuto = mod.getMeteoConfig().mode === 'auto';
+      await waitForSecureConfig();
 
       const warnings = [];
       console.warn = (...args) => warnings.push(args.join(' '));
@@ -118,6 +131,7 @@ test('sun uvdata browser coverage handles config cache module API and purging', 
         selfhostBearer: 'secret-token',
         privacyRounding: 0.25,
       });
+      await waitForSecureConfig();
       localStorage.setItem(storageKey, 'v1:opaque-encrypted-envelope');
       const encryptedFallback = mod.getMeteoConfig();
       outcomes.encryptedEnvelopeUsesCachedDecryptedConfig =

--- a/tests/playwright/sun-uvdata-browser-coverage.spec.js
+++ b/tests/playwright/sun-uvdata-browser-coverage.spec.js
@@ -18,6 +18,8 @@ test('sun uvdata browser coverage handles config cache module API and purging', 
     const outcomes = {};
     const storageKey = 'labcharts-meteo-config';
     const originalConfig = localStorage.getItem(storageKey);
+    const originalEncryptionEnabled = localStorage.getItem('labcharts-encryption-enabled');
+    const originalWearablesTest = window.__WEARABLES_TEST;
     const originalWarn = console.warn;
     const cleanup = () => {
       const keys = [];
@@ -140,6 +142,44 @@ test('sun uvdata browser coverage handles config cache module API and purging', 
         && encryptedFallback.selfhostBearer === 'secret-token'
         && encryptedFallback.privacyRounding === 0.25;
 
+      localStorage.removeItem('labcharts-encryption-enabled');
+      const firstSave = mod.saveMeteoConfig({
+        mode: 'selfhost',
+        selfhostUrl: 'https://first.example',
+        selfhostBearer: 'first-token',
+        privacyRounding: 0.1,
+      });
+      const latestSave = mod.saveMeteoConfig({
+        mode: 'selfhost',
+        selfhostUrl: 'https://latest.example',
+        selfhostBearer: 'latest-token',
+        privacyRounding: 0.5,
+      });
+      const orderedSaveResults = await Promise.all([firstSave, latestSave]);
+      const latestDurableRaw = localStorage.getItem(storageKey);
+      const latestDurableConfig = JSON.parse(await cryptoStore.encryptedGetItem(storageKey));
+
+      window.__WEARABLES_TEST = true;
+      localStorage.setItem('labcharts-encryption-enabled', 'true');
+      await cryptoStore._setTestSessionKey(null);
+      const failedSaveResult = await mod.saveMeteoConfig({
+        mode: 'open-meteo',
+        selfhostUrl: 'https://unsaved.example',
+        selfhostBearer: 'unsaved-token',
+        privacyRounding: 0,
+      });
+      const durableRawAfterFailure = localStorage.getItem(storageKey);
+      localStorage.removeItem('labcharts-encryption-enabled');
+      await mod.initMeteoConfigCache();
+      outcomes.secureConfigSavesAreOrderedAndPreserveLastDurableValue =
+        orderedSaveResults.every(Boolean)
+        && latestDurableRaw?.startsWith('d1:') === true
+        && !latestDurableRaw.includes('latest-token')
+        && latestDurableConfig.selfhostUrl === 'https://latest.example'
+        && failedSaveResult === false
+        && durableRawAfterFailure === latestDurableRaw
+        && mod.getMeteoConfig().selfhostUrl === 'https://latest.example';
+
       localStorage.setItem('meteo:v1:keep-a', '{}');
       localStorage.setItem('meteo:v5:purge-a', '{}');
       localStorage.setItem('meteo:v5:purge-b', '{}');
@@ -172,6 +212,10 @@ test('sun uvdata browser coverage handles config cache module API and purging', 
       cleanup();
       if (originalConfig == null) localStorage.removeItem(storageKey);
       else localStorage.setItem(storageKey, originalConfig);
+      if (originalEncryptionEnabled == null) localStorage.removeItem('labcharts-encryption-enabled');
+      else localStorage.setItem('labcharts-encryption-enabled', originalEncryptionEnabled);
+      if (originalWearablesTest === undefined) delete window.__WEARABLES_TEST;
+      else window.__WEARABLES_TEST = originalWearablesTest;
     }
 
     return outcomes;

--- a/tests/sync-runtime.test.js
+++ b/tests/sync-runtime.test.js
@@ -356,7 +356,8 @@ describe('sync apply runtime behavior', () => {
       'edition-profile-a': 'transition-meta',
     });
     expect(localStorage.getItem('edition-key-source')).toBe('remote-transition');
-    expect(localStorage.getItem('edition-profile-a')).toBe('transition-meta');
+    expect(localStorage.getItem('edition-profile-a')).toMatch(/^d1:/);
+    await expect(encryptedGetItem('edition-profile-a')).resolves.toBe('transition-meta');
     await vi.waitFor(() => expect(applied).toHaveBeenCalledWith({
       settings: {
         'edition-key-source': 'remote-transition',
@@ -416,7 +417,8 @@ describe('sync apply runtime behavior', () => {
     });
 
     expect(localStorage.getItem('labcharts-ai-provider')).toBe('openrouter');
-    expect(localStorage.getItem('labcharts-openrouter-key')).toBe('sk-remote');
+    expect(localStorage.getItem('labcharts-openrouter-key')).toMatch(/^d1:/);
+    await expect(encryptedGetItem('labcharts-openrouter-key')).resolves.toBe('sk-remote');
     expect(localStorage.getItem('labcharts-custom-url')).toBeNull();
     expect(updateChatHeaderModel).toHaveBeenCalledTimes(1);
     expect(refreshWebSearchToggle).toHaveBeenCalledTimes(1);

--- a/tests/test-crypto.js
+++ b/tests/test-crypto.js
@@ -76,7 +76,7 @@ await profileModule.initProfilesCache();
 console.log('1. Module exports');
 const cryptoExports = [
   'initEncryption', 'initBroadcastChannel', 'getEncryptionEnabled', 'isUnlocked',
-  'encryptedSetItem', 'encryptedGetItem', 'showEnableEncryptionModal',
+  'encryptedSetItem', 'encryptedSetCredentialItem', 'encryptedGetItem', 'showEnableEncryptionModal',
   'maybeShowEncryptionNudge', 'maybeShowBackupNudge', 'disableEncryption',
   'changePassphrase', 'broadcastDataChanged', 'renderEncryptionSection',
   'renderBackupSection', 'isSensitiveKey', 'getCachedKey', 'updateKeyCache',
@@ -216,6 +216,30 @@ try {
   localStorage.removeItem(testKey);
 } catch (e) {
   assert('Non-sensitive key plaintext storage', false, e.message);
+}
+
+// ═══════════════════════════════════════════════
+// 5b. Credentials use always-on device encryption
+// ═══════════════════════════════════════════════
+console.log('5b. Device-encrypted credentials');
+try {
+  const credentialKey = 'labcharts-api-key';
+  localStorage.removeItem('labcharts-encryption-enabled');
+  await cryptoModule.encryptedSetItem(credentialKey, 'device-secret-123');
+  const stored = localStorage.getItem(credentialKey);
+  assert('Credential is device-encrypted when profile encryption is off',
+    stored?.startsWith('d1:') === true && !stored.includes('device-secret-123'));
+  assert('Device-encrypted credential decrypts through the storage wrapper',
+    await cryptoModule.encryptedGetItem(credentialKey) === 'device-secret-123');
+  assert('Device-encrypted credential remains synchronously cached',
+    cryptoModule.getCachedKey(credentialKey) === 'device-secret-123');
+  localStorage.setItem('labcharts-venice-key', stored);
+  assert('Device credential envelopes cannot be substituted under another key',
+    await cryptoModule.encryptedGetItem('labcharts-venice-key') === null);
+  await cryptoModule.encryptedRemoveItem('labcharts-venice-key');
+  await cryptoModule.encryptedRemoveItem(credentialKey);
+} catch (e) {
+  assert('Device-encrypted credential storage', false, e.message);
 }
 
 // ═══════════════════════════════════════════════
@@ -726,6 +750,15 @@ try {
     const firstProfile = snapshot.profiles[0];
     assert('buildBackupSnapshot profile has keys', typeof firstProfile.keys === 'object');
   }
+  await cryptoModule.encryptedSetItem('labcharts-venice-key', 'portable-backup-secret');
+  const rawCredential = localStorage.getItem('labcharts-venice-key');
+  const fullSnapshot = await backupModule.buildFullBackupSnapshot();
+  assert('Unencrypted full backup omits device-encrypted credentials',
+    !Object.hasOwn(fullSnapshot.settings, 'labcharts-venice-key'));
+  assert('Building an unencrypted backup leaves the local credential device-encrypted',
+    rawCredential?.startsWith('d1:') === true
+      && localStorage.getItem('labcharts-venice-key') === rawCredential);
+  await cryptoModule.encryptedRemoveItem('labcharts-venice-key');
 } catch (e) {
   assert('buildBackupSnapshot', false, e.message);
 }

--- a/tests/test-custom-lens.js
+++ b/tests/test-custom-lens.js
@@ -72,6 +72,7 @@ assert('request body includes top_k field', lensSrc.includes('top_k: topK'));
 assert('sends Bearer auth header', lensSrc.includes('`Bearer ${key}`'));
 assert('cache key includes profileId', lensSrc.includes('profileId'));
 assert('saveLensKey uses dedicated credential storage', lensSrc.includes('encryptedSetCredentialItem(SECRET_KEY'));
+assert('removeLens deletes the encrypted credential', lensSrc.includes('encryptedRemoveItem(SECRET_KEY)'));
 assert('getLensKey uses getCachedKey', lensSrc.includes('getCachedKey(SECRET_KEY)') || lensSrc.includes("getCachedKey('labcharts-lens-key')"));
 // testProbe — configurable test query, replaces hardcoded probe.
 assert('DEFAULT_TEST_PROBE constant defined', lensSrc.includes('DEFAULT_TEST_PROBE ='));

--- a/tests/test-custom-lens.js
+++ b/tests/test-custom-lens.js
@@ -71,7 +71,7 @@ assert('request body includes query field', lensSrc.includes('query: hint'));
 assert('request body includes top_k field', lensSrc.includes('top_k: topK'));
 assert('sends Bearer auth header', lensSrc.includes('`Bearer ${key}`'));
 assert('cache key includes profileId', lensSrc.includes('profileId'));
-assert('saveLensKey uses encryptedSetItem', lensSrc.includes("encryptedSetItem('labcharts-lens-key'") || lensSrc.includes('encryptedSetItem(SECRET_KEY'));
+assert('saveLensKey uses dedicated credential storage', lensSrc.includes('encryptedSetCredentialItem(SECRET_KEY'));
 assert('getLensKey uses getCachedKey', lensSrc.includes('getCachedKey(SECRET_KEY)') || lensSrc.includes("getCachedKey('labcharts-lens-key')"));
 // testProbe — configurable test query, replaces hardcoded probe.
 assert('DEFAULT_TEST_PROBE constant defined', lensSrc.includes('DEFAULT_TEST_PROBE ='));

--- a/tests/test-export-import.js
+++ b/tests/test-export-import.js
@@ -523,7 +523,7 @@ return (async function() {
   assert('Bundle export always includes chat', exportSrc.includes('if (chat) entry.chat = chat'));
 
   // ═══════════════════════════════════════
-  // 13b. Backup includes Custom API settings (regression: #116)
+  // 13b. Backup includes portable Custom API settings (regression: #116)
   // ═══════════════════════════════════════
   console.log('%c 13b. Backup includes Custom API settings (#116) ', 'font-weight:bold;color:#f59e0b');
 
@@ -533,7 +533,9 @@ return (async function() {
   assert('GLOBAL_SETTINGS_KEYS includes labcharts-custom-model', backupSrc.includes("'labcharts-custom-model'"));
   assert('GLOBAL_SETTINGS_KEYS includes labcharts-custom-models', backupSrc.includes("'labcharts-custom-models'"));
 
-  // Functional roundtrip: seed Custom API settings → snapshot → wipe → restore
+  // Unencrypted backups retain portable provider configuration but omit the
+  // device-bound credential. Passphrase-encrypted backups cover credential
+  // portability in the dedicated backup tests.
   const _origCustomKey = localStorage.getItem('labcharts-custom-key');
   const _origCustomUrl = localStorage.getItem('labcharts-custom-url');
   const _origCustomModel = localStorage.getItem('labcharts-custom-model');
@@ -545,7 +547,7 @@ return (async function() {
   assert('buildBackupSnapshot module export works', !!snap);
   assert('buildBackupSnapshot stays off window', !('buildBackupSnapshot' in window));
   if (snap) {
-    assert('snapshot.settings carries custom-key', snap.settings['labcharts-custom-key'] === 'sk-roundtrip-test');
+    assert('unencrypted snapshot omits custom-key', !('labcharts-custom-key' in snap.settings));
     assert('snapshot.settings carries custom-url', snap.settings['labcharts-custom-url'] === 'https://api.example.com/v1');
     assert('snapshot.settings carries custom-model', snap.settings['labcharts-custom-model'] === 'gpt-test');
   }

--- a/tests/test-openrouter.js
+++ b/tests/test-openrouter.js
@@ -239,11 +239,13 @@ assert('providerPanels.handleRemoveOpenRouterKey is function', typeof providerPa
 assert('providerPanels.renderOpenRouterModelDropdown is function', typeof providerPanels.renderOpenRouterModelDropdown === 'function');
 assert('providerPanels.updateOpenRouterModelPricing is function', typeof providerPanels.updateOpenRouterModelPricing === 'function');
 
-// ─── 8. Key/model management (localStorage) ───
+// ─── 8. Key/model management (encrypted localStorage) ───
 console.log('\n8. Key/model management');
 const oldKey = localStorage.getItem('labcharts-openrouter-key');
 await api.saveOpenRouterKey('test-key-123');
-assert('saveOpenRouterKey stores to localStorage', localStorage.getItem('labcharts-openrouter-key') === 'test-key-123');
+const storedOpenRouterKey = localStorage.getItem('labcharts-openrouter-key');
+assert('saveOpenRouterKey encrypts the localStorage value', storedOpenRouterKey?.startsWith('d1:') && storedOpenRouterKey !== 'test-key-123');
+assert('encryptedGetItem decrypts the saved key', await cryptoModule.encryptedGetItem('labcharts-openrouter-key') === 'test-key-123');
 assert('getOpenRouterKey returns saved key', api.getOpenRouterKey() === 'test-key-123');
 assert('hasOpenRouterKey returns true with key', api.hasOpenRouterKey() === true);
 localStorage.removeItem('labcharts-openrouter-key');

--- a/tests/test-pii.js
+++ b/tests/test-pii.js
@@ -21,9 +21,20 @@ function assert(name, condition, detail) {
 console.log('=== PII Obfuscation Tests ===\n');
 
 const piiModule = await import('../js/pii.js');
-const { obfuscatePDFText, buildPIIDiffHTML } = piiModule;
+const { obfuscatePDFText, buildPIIDiffHTML, secureRandomInt } = piiModule;
 const piiSrc = read('js/pii.js');
 const piiReviewSrc = read('js/pii-review.js');
+
+const secureSamples = Array.from({ length: 128 }, () => secureRandomInt(7));
+assert('PII random integers stay inside the requested range',
+  secureSamples.every(value => Number.isInteger(value) && value >= 0 && value < 7));
+assert('PII generators do not use Math.random', !piiSrc.includes('Math.random'));
+try {
+  secureRandomInt(0);
+  assert('secureRandomInt rejects an empty range', false, 'did not throw');
+} catch (error) {
+  assert('secureRandomInt rejects an empty range', error instanceof RangeError);
+}
 
   // Extract the function and test it by running obfuscation with known names
   // Czech format

--- a/tests/test-settings-delegated-actions.js
+++ b/tests/test-settings-delegated-actions.js
@@ -206,10 +206,10 @@ assert('Sun data-source delegate is installed on document change',
 assert('Sun data-source delegate is scoped to its section',
   /function closestSunDataSourceControl[\s\S]*closest\('#sun-data-source-section'\)/.test(privacySrc));
 assert('Sun data-source save handlers surface unavailable runtime saves',
-  /function notifyMeteoSaveUnavailable\(\)[\s\S]*Sun data-source settings are still loading/.test(privacySrc) &&
-    /function setMeteoMode\(mode\)[\s\S]*if \(!saveSettingsMeteoConfig\(cfg\)\) \{[\s\S]*notifyMeteoSaveUnavailable\(\);[\s\S]*return;[\s\S]*\}/.test(privacySrc) &&
-    /function saveMeteoSelfhost\(\)[\s\S]*if \(!saveSettingsMeteoConfig\(cfg\)\) \{[\s\S]*notifyMeteoSaveUnavailable\(\);[\s\S]*\}/.test(privacySrc) &&
-    /function toggleMeteoRounding\(enabled\)[\s\S]*if \(!saveSettingsMeteoConfig\(cfg\)\) \{[\s\S]*notifyMeteoSaveUnavailable\(\);[\s\S]*\}/.test(privacySrc));
+  /function notifyMeteoSaveUnavailable\(\)[\s\S]*could not be saved securely/.test(privacySrc) &&
+    /async function setMeteoMode\(mode\)[\s\S]*if \(!await saveSettingsMeteoConfig\(cfg\)\) \{[\s\S]*notifyMeteoSaveUnavailable\(\);[\s\S]*return;[\s\S]*\}/.test(privacySrc) &&
+    /async function saveMeteoSelfhost\(\)[\s\S]*if \(!await saveSettingsMeteoConfig\(cfg\)\) \{[\s\S]*notifyMeteoSaveUnavailable\(\);[\s\S]*\}/.test(privacySrc) &&
+    /async function toggleMeteoRounding\(enabled\)[\s\S]*if \(!await saveSettingsMeteoConfig\(cfg\)\) \{[\s\S]*notifyMeteoSaveUnavailable\(\);[\s\S]*\}/.test(privacySrc));
 assert('Legacy Sun data-source window handlers are removed',
   !src.includes('window._setMeteoMode')
     && !src.includes('window._saveMeteoSelfhost')

--- a/tests/test-settings-runtime.js
+++ b/tests/test-settings-runtime.js
@@ -43,7 +43,7 @@ try {
   assert('missing getMeteoConfig returns defaults',
     getSettingsMeteoConfig().mode === 'auto');
   assert('missing saveMeteoConfig reports unavailable',
-    saveSettingsMeteoConfig({ mode: 'open-meteo' }) === false);
+    await saveSettingsMeteoConfig({ mode: 'open-meteo' }) === false);
 
   configureSettingsRuntimeDeps({
     getMeteoConfig: () => ({ mode: 'open-meteo', privacyRounding: 0 }),
@@ -67,8 +67,14 @@ try {
     },
   });
   assert('runtime saveMeteoConfig reports success',
-    saveSettingsMeteoConfig({ mode: 'selfhost' }) === true &&
+    await saveSettingsMeteoConfig({ mode: 'selfhost' }) === true &&
       savedConfig?.mode === 'selfhost');
+
+  configureSettingsRuntimeDeps({
+    saveMeteoConfig: async () => false,
+  });
+  assert('async saveMeteoConfig failures report unavailable',
+    await saveSettingsMeteoConfig({ mode: 'selfhost' }) === false);
 
   configureSettingsRuntimeDeps({
     saveMeteoConfig: () => {
@@ -76,7 +82,7 @@ try {
     },
   });
   assert('thrown saveMeteoConfig reports unavailable',
-    saveSettingsMeteoConfig({ mode: 'open-meteo' }) === false);
+    await saveSettingsMeteoConfig({ mode: 'open-meteo' }) === false);
 } finally {
   configureSettingsRuntimeDeps(originalSettingsRuntimeDeps);
 }

--- a/tests/test-sun-uvdata.js
+++ b/tests/test-sun-uvdata.js
@@ -383,6 +383,10 @@ const {
   assert('non-meter source capped at 0.99',
     computeUVConfidence({ source: 'selfhost', snapshotAgeSec: 0, cloudCover: 0, zenithDeg: 30, uvIndex: 8 }) <= 0.99);
 
+  // Drain earlier fire-and-forget callers before exercising direct
+  // localStorage writes that stand in for cross-tab updates.
+  await saveMeteoConfig(origCfg);
+
   // ─── 9. getMeteoConfig — selfhost-with-empty-URL sanity fallback ─────
   // Regression: a config with mode=selfhost but selfhostUrl='' silently
   // fell through to Open-Meteo every request. Picker still showed

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.17.1';
+self.APP_VERSION = '1.17.2';


### PR DESCRIPTION
## Summary

- replace PII Math.random usage with unbiased Web Crypto randomness
- always encrypt stored credentials using profile encryption or a device-local non-extractable key, including migration of legacy plaintext values
- omit credentials from unencrypted backups, protect restore paths and dependent settings, and release the fix as 1.17.2

This addresses the 21 open CodeQL findings: clear-text credential storage and insecure randomness.

## Verification

- node tests/test-crypto.js (314 passed)
- node tests/test-pii.js (47 passed)
- node tests/test-custom-lens.js (192 passed)
- focused storage/build tests (18 passed)
- focused Playwright coverage (10 passed)
- typecheck:checkjs and typecheck:service-worker
- architecture:check, production:check, quality, and git diff --check