### PR TITLE
Fix report height and BMI unit handling

### DIFF
--- a/js/changelog-impl.js
+++ b/js/changelog-impl.js
@@ -11,6 +11,12 @@ const changelogDelegateRoots = new WeakSet();
 
 const CHANGELOG = [
   {
+    version: '1.17.3', date: '2026-08-21', title: 'Height and BMI stay accurate in reports',
+    items: [
+      '<b>Reports now interpret saved height consistently.</b> Heights entered in inches display correctly in feet and inches, and BMI continues to use the canonical metric value.',
+    ]
+  },
+  {
     version: '1.17.2', date: '2026-08-21', title: 'Credentials stay protected on this device',
     items: [
       '<b>Saved provider credentials are now encrypted even when profile encryption is off.</b> Existing keys migrate automatically, unencrypted backups omit credentials, and generated privacy replacements now use secure browser randomness.',

--- a/js/export-report.js
+++ b/js/export-report.js
@@ -221,9 +221,8 @@ function getReportHeightInfo(profile) {
 
 function getReportHeightMeters(heightInfo) {
   if (!heightInfo?.height) return null;
-  const unit = String(heightInfo.unit || 'cm').toLowerCase();
-  if (unit === 'in' || unit === 'inch' || unit === 'inches') return heightInfo.height * 0.0254;
-  if (unit === 'm' || unit === 'meter' || unit === 'meters') return heightInfo.height;
+  // Profile height is stored canonically in centimeters. The saved unit is
+  // only the user's display preference.
   return heightInfo.height / 100;
 }
 
@@ -231,12 +230,12 @@ function formatReportHeightLabel(heightInfo) {
   if (!heightInfo?.height) return '';
   const unit = String(heightInfo.unit || 'cm').toLowerCase();
   if (unit === 'in' || unit === 'inch' || unit === 'inches') {
-    const totalInches = Math.round(heightInfo.height);
+    const totalInches = Math.round(heightInfo.height / 2.54);
     const feet = Math.floor(totalInches / 12);
     const inches = totalInches % 12;
     return `${feet} ft ${inches} in`;
   }
-  if (unit === 'm' || unit === 'meter' || unit === 'meters') return `${formatValue(heightInfo.height)} m`;
+  if (unit === 'm' || unit === 'meter' || unit === 'meters') return `${formatValue(heightInfo.height / 100)} m`;
   return `${formatValue(heightInfo.height)} cm`;
 }
 

--- a/tests/playwright/report-export-browser-coverage.spec.js
+++ b/tests/playwright/report-export-browser-coverage.spec.js
@@ -437,7 +437,9 @@ test('report payload and HTML cover filtered context genetics and supplement bra
         tags: ['coverage', 'reports'],
         notes: 'Profile notes for report context',
         location: { city: 'Prague', country: 'CZ', zip: '11000' },
-        height: 65,
+        // Profile heights are stored canonically in centimeters even when
+        // inches are the selected display unit.
+        height: 65 * 2.54,
         heightUnit: 'in',
       }]);
 
@@ -462,6 +464,7 @@ test('report payload and HTML cover filtered context genetics and supplement bra
         && contextByTitle['Diet & Digestion']?.includes('avoid <wheat>') === true
         && contextByTitle['Health Goals']?.includes('[high] Improve glucose variability') === true
         && contextByTitle['Menstrual Cycle']?.includes('very irregular') === true
+        && contextByTitle.Biometrics?.includes('Height: 5 ft 5 in') === true
         && contextByTitle.Biometrics?.includes('Latest weight: 180 lb') === true;
 
       const headerProfile = report.getReportHeaderProfile('Fallback Profile');
@@ -476,7 +479,7 @@ test('report payload and HTML cover filtered context genetics and supplement bra
       outcomes.headerFactsIncludeProfileAndBiometricDetails = factMap.Location === 'Prague, CZ, 11000'
         && factMap.Height === '5 ft 5 in'
         && factMap.Weight.includes('180 lb')
-        && factMap.BMI
+        && factMap.BMI.includes('30.0')
         && factMap['Blood pressure'].includes('116/74')
         && factMap['Resting pulse'].includes('58 bpm')
         && factMap['Body fat'].includes('18.5%');

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.17.2';
+self.APP_VERSION = '1.17.3';


### PR DESCRIPTION
Closes #1565
Closes #1566

## Summary
- treat saved profile height as canonical centimeters during report calculations
- convert canonical centimeters only at feet/inches and meter display boundaries
- add regression coverage using the real US-height storage shape
- release the correction as v1.17.3 with a user-facing changelog entry

## Root cause
Profile editors store height canonically in centimeters while retaining heightUnit as the display preference. Report generation interpreted the canonical value as inches a second time, producing values such as 16 ft 1 in and BMI 3.7 for a 76-inch profile.

## Verification
- PORT=8001 npx playwright test tests/playwright/report-export-browser-coverage.spec.js --workers=1
- PORT=8001 npx playwright test tests/playwright/core-browser-flows.spec.js --grep export/import --workers=1
- node tests/test-biometrics.js
- node tests/test-changelog.js
- node tests/test-client-list-delegated-actions.js
- npm test -- tests/report-export-html-runtime.test.js
- npm run typecheck:checkjs
- npm run quality
- npm run production:check
- git diff --check