### PR TITLE
Fix mobile consent scrolling and hide empty lab columns

### DIFF
--- a/css/app-shell.css
+++ b/css/app-shell.css
@@ -183,6 +183,10 @@ body.analytics-consent-visible .version-update-banner { bottom: 78px; }
 }
 .legal-consent-modal {
   width: min(620px, 100%);
+  max-height: 100%;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
   background: var(--bg-secondary, #171a22);
   border: 1px solid var(--border, #2d3138);
   border-radius: 18px;

--- a/js/category-view-renderers.js
+++ b/js/category-view-renderers.js
@@ -235,20 +235,30 @@ export function renderScrollableTableShell(kind, wrapperClass, tableClass, colgr
   </div>`;
 }
 
+function populatedDateColumnIndexes(markerEntries, labels) {
+  return labels
+    .map((_, index) => index)
+    .filter(index => markerEntries.some(([, marker]) => {
+      const value = marker.values?.[index];
+      return value !== null && value !== undefined;
+    }));
+}
+
 export function renderTableView(cat, dateLabels, categoryKey, dates) {
   const labels = cat.singleDate ? [cat.singleDateLabel || "N/A"] : dateLabels;
   // Hide markers with no values at all — sidebar still lists them with 0 count.
   const markerEntries = Object.entries(cat.markers).filter(([, m]) =>
-    m.values && m.values.some(v => v !== null)
+    m.values && m.values.some(v => v !== null && v !== undefined)
   );
   if (markerEntries.length === 0) {
     return `<div class="data-table-wrapper"><div style="padding:32px;text-align:center;color:var(--text-muted)">No data yet for this category. Use the sidebar to add a value or import a PDF.</div></div>`;
   }
+  const dateColumnIndexes = populatedDateColumnIndexes(markerEntries, labels);
   const colgroup = renderTableColgroup([
     'gb-col-marker',
     'gb-col-unit',
     'gb-col-reference',
-    ...labels.map(() => 'gb-col-date'),
+    ...dateColumnIndexes.map(() => 'gb-col-date'),
     'gb-col-trend',
     'gb-col-range',
   ]);
@@ -257,7 +267,7 @@ export function renderTableView(cat, dateLabels, categoryKey, dates) {
   // call site (renderTableView's contract: dateLabels passed in are safe).
   // Pre-escape lives at the boundary so CodeQL's taint analysis sees the
   // sanitizer at the call site (it doesn't trace across function calls).
-  for (const d of labels) headHtml += `<th>${d}</th>`;
+  for (const index of dateColumnIndexes) headHtml += `<th>${labels[index]}</th>`;
   headHtml += `<th>Trend</th><th>Range</th></tr>`;
   let bodyHtml = '';
   for (const [key, marker] of markerEntries) {
@@ -271,17 +281,18 @@ export function renderTableView(cat, dateLabels, categoryKey, dates) {
     bodyHtml += `<tr${rowClick}><td class="marker-name">${escapeHTML(marker.name)}</td>
       <td class="unit-col">${escapeHTML(marker.unit)}</td>
       <td class="ref-col">${refCell}</td>`;
-    for (let i = 0; i < marker.values.length; i++) {
+    for (const i of dateColumnIndexes) {
       const v = marker.values[i];
       const ri = getEffectiveRangeForDate(marker, i);
-      const s = v !== null ? getStatus(v, ri.min, ri.max) : "missing";
+      const hasValue = v !== null && v !== undefined;
+      const s = hasValue ? getStatus(v, ri.min, ri.max) : "missing";
       // Empty cells: click → add a value for THIS column's date (not today).
       // Skip for singleDate categories where the "date" is a synthetic label.
       const colDate = (dates && !cat.singleDate) ? dates[i] : null;
-      const emptyClick = (v === null && id && colDate)
+      const emptyClick = (!hasValue && id && colDate)
         ? ` ${markerDetailActionAttrs('open-manual-entry', { id, date: colDate })} style="cursor:cell" title="Add value for ${dateLabels[i] || escapeHTML(colDate)}"`
         : '';
-      bodyHtml += `<td class="value-cell val-${s}"${emptyClick}>${v !== null ? formatValue(v) : "—"}</td>`;
+      bodyHtml += `<td class="value-cell val-${s}"${emptyClick}>${hasValue ? formatValue(v) : "—"}</td>`;
     }
     const li = getLatestValueIndex(marker.values);
     const trendRange = li !== -1 ? getEffectiveRangeForDate(marker, li) : r;
@@ -294,41 +305,43 @@ export function renderTableView(cat, dateLabels, categoryKey, dates) {
     } else bodyHtml += `<td>—</td>`;
     bodyHtml += `</tr>`;
   }
-  const minWidth = 180 + 86 + 128 + labels.length * 104 + 78 + 112;
+  const minWidth = 180 + 86 + 128 + dateColumnIndexes.length * 104 + 78 + 112;
   return renderScrollableTableShell('data', 'data-table-wrapper', 'data-table', colgroup, headHtml, bodyHtml, minWidth);
 }
 
 export function renderHeatmapView(cat, dateLabels, categoryKey) {
   const labels = cat.singleDate ? [cat.singleDateLabel || "N/A"] : dateLabels;
   const markerEntries = Object.entries(cat.markers).filter(([, m]) =>
-    m.values && m.values.some(v => v !== null)
+    m.values && m.values.some(v => v !== null && v !== undefined)
   );
   if (markerEntries.length === 0) {
     return `<div class="heatmap-wrapper"><div style="padding:32px;text-align:center;color:var(--text-muted)">No data yet for this category. Use the sidebar to add a value or import a PDF.</div></div>`;
   }
+  const dateColumnIndexes = populatedDateColumnIndexes(markerEntries, labels);
   const colgroup = renderTableColgroup([
     'gb-col-marker',
-    ...labels.map(() => 'gb-col-date'),
+    ...dateColumnIndexes.map(() => 'gb-col-date'),
   ]);
   let headHtml = `<tr><th>Biomarker</th>`;
   // Labels pre-escaped at the showCategory call boundary — see renderTableView.
-  for (const d of labels) headHtml += `<th>${d}</th>`;
+  for (const index of dateColumnIndexes) headHtml += `<th>${labels[index]}</th>`;
   headHtml += `</tr>`;
   let bodyHtml = '';
   for (const [key, marker] of markerEntries) {
     const id = categoryKey + "_" + key;
     state.markerRegistry[id] = marker;
     bodyHtml += `<tr><td role="button" tabindex="0" aria-label="${escapeHTML(marker.name)}" style="cursor:pointer" ${markerDetailActionAttrs('show-detail-modal', { id })}>${escapeHTML(marker.name)}</td>`;
-    for (let i = 0; i < marker.values.length; i++) {
+    for (const i of dateColumnIndexes) {
       const v = marker.values[i];
       const ri = getEffectiveRangeForDate(marker, i);
-      const s = v !== null ? getStatus(v, ri.min, ri.max) : "missing";
-      const cellLabel = `${escapeHTML(marker.name)} ${labels[i] || ''}: ${v !== null ? formatValue(v) : 'no value'}`;
-      bodyHtml += `<td class="heatmap-${s}" role="button" tabindex="0" aria-label="${cellLabel}" ${markerDetailActionAttrs('show-detail-modal', { id })}>${v !== null ? formatValue(v) : "—"}</td>`;
+      const hasValue = v !== null && v !== undefined;
+      const s = hasValue ? getStatus(v, ri.min, ri.max) : "missing";
+      const cellLabel = `${escapeHTML(marker.name)} ${labels[i] || ''}: ${hasValue ? formatValue(v) : 'no value'}`;
+      bodyHtml += `<td class="heatmap-${s}" role="button" tabindex="0" aria-label="${cellLabel}" ${markerDetailActionAttrs('show-detail-modal', { id })}>${hasValue ? formatValue(v) : "—"}</td>`;
     }
     bodyHtml += `</tr>`;
   }
-  const minWidth = 180 + labels.length * 104;
+  const minWidth = 180 + dateColumnIndexes.length * 104;
   return renderScrollableTableShell('heatmap', 'heatmap-wrapper', 'heatmap-table', colgroup, headHtml, bodyHtml, minWidth);
 }
 

--- a/js/changelog-impl.js
+++ b/js/changelog-impl.js
@@ -11,6 +11,12 @@ const changelogDelegateRoots = new WeakSet();
 
 const CHANGELOG = [
   {
+    version: '1.17.4', date: '2026-08-24', title: 'Lab units for Australia and New Zealand',
+    items: [
+      '<b>Lab results can now use common Australian and New Zealand units.</b> Choose Australia / NZ in Settings → Display to keep charts, tables, marker details, reports, and manual entry aligned with local pathology reports.',
+    ]
+  },
+  {
     version: '1.17.3', date: '2026-08-21', title: 'Height and BMI stay accurate in reports',
     items: [
       '<b>Reports now interpret saved height consistently.</b> Heights entered in inches display correctly in feet and inches, and BMI continues to use the canonical metric value.',

--- a/tests/playwright/legal-consent-startup.spec.js
+++ b/tests/playwright/legal-consent-startup.spec.js
@@ -10,7 +10,7 @@ const CURRENT_ACCEPTANCE = {
 };
 
 test.use({
-  viewport: { width: 412, height: 844 },
+  viewport: { width: 375, height: 667 },
   seedLegalAcceptance: false,
 });
 
@@ -36,6 +36,21 @@ test('fresh visitor can accept the prerendered legal gate before the main module
   await expect(page.locator('#legal-consent-title')).toHaveText('Accept Terms & Privacy');
   await expect(page.locator('[data-legal-path="/terms"]')).toHaveAttribute('href', '/terms');
   await expect(page.locator('[data-legal-path="/privacy"]')).toHaveAttribute('href', '/privacy');
+
+  const mobileLayout = await page.locator('.legal-consent-modal').evaluate(modal => {
+    const bounds = modal.getBoundingClientRect();
+    return {
+      top: bounds.top,
+      bottom: bounds.bottom,
+      viewportHeight: window.innerHeight,
+      scrollable: modal.scrollHeight > modal.clientHeight,
+      overflowY: getComputedStyle(modal).overflowY,
+    };
+  });
+  expect(mobileLayout.top).toBeGreaterThanOrEqual(0);
+  expect(mobileLayout.bottom).toBeLessThanOrEqual(mobileLayout.viewportHeight);
+  expect(mobileLayout.scrollable).toBe(true);
+  expect(mobileLayout.overflowY).toBe('auto');
 
   const acceptButton = page.locator('[data-legal-consent-action="accept"]');
   await expect(acceptButton).toBeDisabled();

--- a/tests/test-table-heatmap-empty.js
+++ b/tests/test-table-heatmap-empty.js
@@ -29,7 +29,7 @@ const views = await import('../js/views.js');
     singleDate: null,
     singleDateLabel: null,
     markers: {
-      hasData: { name: 'Has Data', unit: 'mg/dl', values: [null, 5, null, 7], refMin: 0, refMax: 10, dates: [] },
+      hasData: { name: 'Has Data', unit: 'mg/dl', values: [undefined, 5, null, 7], refMin: 0, refMax: 10, dates: [] },
       sparseData: { name: 'Sparse Data', unit: 'mg/dl', values: [null, null, 3, null], refMin: 0, refMax: 10, dates: [] },
       noData: { name: 'No Data', unit: 'mg/dl', values: [null, null, null, null], refMin: 0, refMax: 10, dates: [] },
       anotherEmpty: { name: 'Another Empty', unit: 'mg/dl', values: [null, null, null, null], refMin: 0, refMax: 10, dates: [] },
@@ -58,6 +58,11 @@ const views = await import('../js/views.js');
   assert('Table render includes the "Sparse Data" marker (has 1 non-null)', tableHtml.includes('Sparse Data'));
   assert('Table render OMITS the "No Data" marker', !tableHtml.includes('No Data'));
   assert('Table render OMITS the "Another Empty" marker', !tableHtml.includes('Another Empty'));
+  assert('Table render omits a date column with no marker values', !tableHtml.includes('Jan 1'));
+  assert('Table render keeps date columns with at least one marker value',
+    tableHtml.includes('Feb 1') && tableHtml.includes('Mar 1') && tableHtml.includes('Apr 1'));
+  assert('Table rows render cells only for populated date columns',
+    (tableHtml.match(/class="value-cell/g) || []).length === 6);
 
   const emptyTable = views.renderTableView(allEmptyCat, dateLabels, 'empty', dates);
   assert('All-empty category renders an empty-state message',
@@ -77,6 +82,11 @@ const views = await import('../js/views.js');
   assert('Heatmap render includes the "Sparse Data" marker', heatHtml.includes('Sparse Data'));
   assert('Heatmap render OMITS the "No Data" marker', !heatHtml.includes('No Data'));
   assert('Heatmap render OMITS the "Another Empty" marker', !heatHtml.includes('Another Empty'));
+  assert('Heatmap render omits a date column with no marker values', !heatHtml.includes('Jan 1'));
+  assert('Heatmap render keeps date columns with at least one marker value',
+    heatHtml.includes('Feb 1') && heatHtml.includes('Mar 1') && heatHtml.includes('Apr 1'));
+  assert('Heatmap rows render cells only for populated date columns',
+    (heatHtml.match(/class="heatmap-(?:normal|high|low|missing|unrated)"/g) || []).length === 6);
 
   const emptyHeat = views.renderHeatmapView(allEmptyCat, dateLabels, 'empty');
   assert('All-empty heatmap renders empty-state message',
@@ -89,10 +99,10 @@ const views = await import('../js/views.js');
   // ═══════════════════════════════════════
   console.log('%c 3. Filter logic shape ', 'font-weight:bold;color:#f59e0b');
   const categoryViewRenderersSrc = read('js/category-view-renderers.js');
-  assert('renderTableView filters with m.values.some(v => v !== null)',
-    /renderTableView[\s\S]{0,800}m\.values\.some\(v => v !== null\)/.test(categoryViewRenderersSrc));
-  assert('renderHeatmapView filters with m.values.some(v => v !== null)',
-    /renderHeatmapView[\s\S]{0,800}m\.values\.some\(v => v !== null\)/.test(categoryViewRenderersSrc));
+  assert('Table/Heatmap share populated-date column filtering',
+    (categoryViewRenderersSrc.match(/const dateColumnIndexes = populatedDateColumnIndexes\(markerEntries, labels\)/g) || []).length === 2);
+  assert('Populated-date filtering treats null and undefined as missing',
+    /value !== null && value !== undefined/.test(categoryViewRenderersSrc));
 
 console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
 process.exit(fail > 0 ? 1 : 0);

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.17.3';
+self.APP_VERSION = '1.17.4';


### PR DESCRIPTION
## Summary

- keep the Terms and Privacy consent dialog within short mobile viewports and make it touch-scrollable
- omit dates with no marker values from category Table and Heatmap modes while preserving sparse populated dates and original date indexes
- bump the app patch version to 1.17.4 and add the Australia/New Zealand unit-system release note from PR #1575

## Testing

- `PLAYWRIGHT_REUSE_SERVER=1 npx playwright test tests/playwright/legal-consent-startup.spec.js --workers=1`
- `node tests/test-table-heatmap-empty.js`
- `node tests/test-a11y-phase3.js`
- `node tests/test-manual-entry-flow.js`
- `node tests/test-phase-ranges.js`
- `node tests/test-changelog.js`
- `npm run typecheck:checkjs`
- `npm run quality`
- `npm run production:check`

Closes #1576.