### PR TITLE
Recommend GLM 5.3 Flash across providers

### DIFF
--- a/js/api-models.js
+++ b/js/api-models.js
@@ -66,19 +66,19 @@ const OPENROUTER_RECOMMENDED = [
   'anthropic/claude-opus-5', 'anthropic/claude-opus-4.7',
   'openai/gpt-5.6-sol', 'openai/gpt-5.4',
   'google/gemini-3.5-flash', 'google/gemini-3-flash-preview',
-  'z-ai/glm-5.2',
+  'z-ai/glm-5.3-flash',
   'moonshotai/kimi-k3',
   'x-ai/grok-4',
 ];
 const OPENROUTER_DEFAULT_CANDIDATES = ['openai/gpt-5.6-sol', 'anthropic/claude-sonnet-5', 'anthropic/claude-sonnet-4.6'];
 
 // Routstr uses bare model IDs (no provider prefix, dots: claude-sonnet-4.6)
-const ROUTSTR_RECOMMENDED = ['claude-sonnet-5', 'claude-sonnet-4.6', 'claude-opus-5', 'claude-opus-4.7', 'gpt-5.5', 'gpt-5.4', 'gemini-3.5-flash', 'gemini-3-flash-preview', 'glm-5.2', 'z-ai/glm-5.2', 'kimi-k3', 'moonshotai/kimi-k3', 'x-ai/grok-4.3', 'grok-4.3', 'grok-4'];
-const ROUTSTR_PRIVATE_RECOMMENDED = ['tinfoil-gemma4-31b', 'tinfoil-kimi-k2-6', 'tinfoil-deepseek-v4-pro', 'tinfoil-glm-5-2'];
+const ROUTSTR_RECOMMENDED = ['claude-sonnet-5', 'claude-sonnet-4.6', 'claude-opus-5', 'claude-opus-4.7', 'gpt-5.5', 'gpt-5.4', 'gemini-3.5-flash', 'gemini-3-flash-preview', 'glm-5.3-flash', 'z-ai/glm-5.3-flash', 'kimi-k3', 'moonshotai/kimi-k3', 'x-ai/grok-4.3', 'grok-4.3', 'grok-4'];
+const ROUTSTR_PRIVATE_RECOMMENDED = ['tinfoil-gemma4-31b', 'tinfoil-kimi-k2-6', 'tinfoil-deepseek-v4-pro', 'tinfoil-glm-5-3-flash'];
 
 // PPQ uses bare model IDs for regular routing and private/ IDs for Tinfoil TEE models.
-const PPQ_RECOMMENDED = ['claude-sonnet-5', 'claude-sonnet-4.6', 'claude-opus-5', 'claude-opus-4.7', 'gpt-5.5', 'gpt-5.4', 'gemini-3.5-flash', 'gemini-3-flash-preview', 'z-ai/glm-5.2', 'glm-5.2', 'moonshotai/kimi-k3', 'kimi-k3', 'x-ai/grok-4.3', 'grok-4'];
-const PPQ_PRIVATE_RECOMMENDED = ['private/kimi-k3', 'private/kimi-k2-6', 'private/glm-5-2'];
+const PPQ_RECOMMENDED = ['claude-sonnet-5', 'claude-sonnet-4.6', 'claude-opus-5', 'claude-opus-4.7', 'gpt-5.5', 'gpt-5.4', 'gemini-3.5-flash', 'gemini-3-flash-preview', 'z-ai/glm-5.3-flash', 'glm-5.3-flash', 'moonshotai/kimi-k3', 'kimi-k3', 'x-ai/grok-4.3', 'grok-4'];
+const PPQ_PRIVATE_RECOMMENDED = ['private/kimi-k3', 'private/kimi-k2-6', 'private/glm-5-3-flash'];
 
 function normalizedModelId(modelId) {
   return String(modelId || '').toLowerCase().replace(/[_.]/g, '-');
@@ -93,7 +93,7 @@ function isCustomRecommendedModel(modelId) {
   return /(^|[/-])claude-(sonnet-4-6|opus-5|opus-4-7)($|[-:])/.test(normalizedModelId(modelId))
     || /(^|[/-])gpt-5-[45]($|[-:])/.test(normalizedModelId(modelId))
     || /(^|[/-])gemini-3-(5-flash|flash-preview)($|[-:])/.test(normalizedModelId(modelId))
-    || /(^|[/-])glm-5-2($|[-:])/.test(normalizedModelId(modelId))
+    || /(^|[/-])glm-5-3-flash($|[-:])/.test(normalizedModelId(modelId))
     || /(^|[/-])kimi-k3($|[-:])/.test(normalizedModelId(modelId))
     || /(^|[/-])grok-4($|[-:])/.test(normalizedModelId(modelId));
 }
@@ -129,10 +129,10 @@ export function findPreferredModel(models, preferredIds) {
 export function isRecommendedModel(provider, modelId) {
   if (provider === 'openrouter') return OPENROUTER_RECOMMENDED.some(function(prefix) { return modelStartsWithRecommended(modelId, prefix); });
   if (provider === 'venice') {
-    if (modelId.startsWith('e2ee-')) return /qwen3-5-122b|gpt-oss-120b|qwen3-30b|glm-5/.test(modelId);
+    if (modelId.startsWith('e2ee-')) return /qwen3-5-122b|gpt-oss-120b|qwen3-30b|glm-5-3-flash/.test(modelId);
     // claude-(sonnet-5|sonnet-4-6|opus-5|opus-4-7) is intentionally narrow. When newer
     // versions land, broaden the alternation rather than matching all 4.x.
-    return /^(claude-(sonnet-5|sonnet-4-6|opus-5|opus-4-7)|openai-gpt-5[2345](-codex)?|gemini-3-(5-flash|flash-preview)|zai-org-glm-5-2|z-ai-glm-5-2|glm-5-2|kimi-k3|grok-4[1-9]?)(-|$)/.test(modelId);
+    return /^(claude-(sonnet-5|sonnet-4-6|opus-5|opus-4-7)|openai-gpt-5[2345](-codex)?|gemini-3-(5-flash|flash-preview)|zai-org-glm-5-3-flash|z-ai-glm-5-3-flash|glm-5-3-flash|kimi-k3|grok-4[1-9]?)(-|$)/.test(modelId);
   }
   if (provider === 'routstr') {
     if (modelId.startsWith('tinfoil-')) return ROUTSTR_PRIVATE_RECOMMENDED.includes(modelId);

--- a/tests/api-provider-runtime.test.js
+++ b/tests/api-provider-runtime.test.js
@@ -110,10 +110,10 @@ describe('API provider runtime behavior', () => {
           architecture: { modality: 'text+image+file->text' },
         },
         {
-          id: 'z-ai/glm-5.2',
-          name: 'GLM 5.2',
-          pricing: { prompt: '0.000001', completion: '0.000003' },
-          architecture: { modality: 'text->text' },
+          id: 'z-ai/glm-5.3-flash',
+          name: 'GLM 5.3 Flash',
+          pricing: { prompt: '0.000000075', completion: '0.00000025' },
+          architecture: { modality: 'text+image+video->text' },
         },
         {
           id: 'moonshotai/kimi-k2.7-code',
@@ -146,7 +146,7 @@ describe('API provider runtime behavior', () => {
       'anthropic/claude-sonnet-4.6',
       'anthropic/claude-sonnet-5',
       'google/gemini-3.5-flash',
-      'z-ai/glm-5.2',
+      'z-ai/glm-5.3-flash',
       'openai/gpt-5.6-sol',
       'moonshotai/kimi-k3',
       'openai/gpt-5.5',
@@ -156,7 +156,7 @@ describe('API provider runtime behavior', () => {
       'anthropic/claude-sonnet-4.6': { input: 3, output: 15 },
       'anthropic/claude-sonnet-5': { input: 2, output: 10 },
       'google/gemini-3.5-flash': { input: 0.7, output: 3.75 },
-      'z-ai/glm-5.2': { input: 1, output: 3 },
+      'z-ai/glm-5.3-flash': { input: 0.075, output: 0.25 },
       'moonshotai/kimi-k2.7-code': { input: 0.56, output: 3.5 },
       'moonshotai/kimi-k3': { input: 3, output: 15 },
       'openai/gpt-5.6-sol': { input: 5, output: 30 },
@@ -164,6 +164,7 @@ describe('API provider runtime behavior', () => {
     expect(JSON.parse(localStorage.getItem('labcharts-openrouter-vision-models'))).toContain('anthropic/claude-sonnet-4.6');
     expect(JSON.parse(localStorage.getItem('labcharts-openrouter-vision-models'))).toContain('anthropic/claude-sonnet-5');
     expect(JSON.parse(localStorage.getItem('labcharts-openrouter-vision-models'))).toContain('google/gemini-3.5-flash');
+    expect(JSON.parse(localStorage.getItem('labcharts-openrouter-vision-models'))).toContain('z-ai/glm-5.3-flash');
     expect(JSON.parse(localStorage.getItem('labcharts-openrouter-vision-models'))).toContain('moonshotai/kimi-k3');
     expect(localStorage.getItem('labcharts-openrouter-model')).toBe('openai/gpt-5.6-sol');
 
@@ -191,7 +192,7 @@ describe('API provider runtime behavior', () => {
         { id: 'llama-3.1-8b', name: 'Llama', enabled: true, pricing: { prompt: '0.000001', completion: '0.000002' } },
         { id: 'claude-sonnet-4.6', name: 'Claude', enabled: true, pricing: { prompt: '0.000003', completion: '0.000015' }, architecture: { input_modalities: ['text', 'image'] } },
         { id: 'claude-sonnet-5', name: 'Claude 5', enabled: true, pricing: { prompt: '0.000002', completion: '0.000010' }, architecture: { input_modalities: ['text', 'image'] } },
-        { id: 'z-ai/glm-5.2', name: 'GLM 5.2', enabled: true, pricing: { prompt: '0.000001', completion: '0.000003' } },
+        { id: 'z-ai/glm-5.3-flash', name: 'GLM 5.3 Flash', enabled: true, pricing: { prompt: '0.000000075', completion: '0.00000025' }, architecture: { input_modalities: ['text', 'image', 'video'] } },
         { id: 'claude-sonnet-4.6-20260101', name: 'Claude duplicate', enabled: true },
         { id: 'grok-41-fast', name: 'Grok 4.1 Fast', enabled: true, pricing: { prompt: '0.00000025', completion: '0.00000063' } },
         { id: 'x-ai/grok-4.3', name: 'Grok 4.3', enabled: true, pricing: { prompt: '0.000003', completion: '0.000015' } },
@@ -204,15 +205,16 @@ describe('API provider runtime behavior', () => {
     const routstrModels = await fetchRoutstrModels();
 
     expect(fetch).toHaveBeenCalledWith('https://node.example.com/v1/models');
-    expect(routstrModels.map(m => m.id)).toEqual(['claude-sonnet-4.6', 'claude-sonnet-5', 'z-ai/glm-5.2', 'grok-41-fast', 'x-ai/grok-4.3', 'moonshotai/kimi-k3', 'llama-3.1-8b']);
+    expect(routstrModels.map(m => m.id)).toEqual(['claude-sonnet-4.6', 'claude-sonnet-5', 'z-ai/glm-5.3-flash', 'grok-41-fast', 'x-ai/grok-4.3', 'moonshotai/kimi-k3', 'llama-3.1-8b']);
     expect(localStorage.getItem('labcharts-routstr-model')).toBe('claude-sonnet-5');
     expect(JSON.parse(localStorage.getItem('labcharts-routstr-pricing'))['claude-sonnet-4.6']).toEqual({ input: 3, output: 15 });
     expect(JSON.parse(localStorage.getItem('labcharts-routstr-pricing'))['claude-sonnet-5']).toEqual({ input: 2, output: 10 });
-    expect(JSON.parse(localStorage.getItem('labcharts-routstr-pricing'))['z-ai/glm-5.2']).toEqual({ input: 1, output: 3 });
+    expect(JSON.parse(localStorage.getItem('labcharts-routstr-pricing'))['z-ai/glm-5.3-flash']).toEqual({ input: 0.075, output: 0.25 });
     expect(JSON.parse(localStorage.getItem('labcharts-routstr-pricing'))['x-ai/grok-4.3']).toEqual({ input: 3, output: 15 });
     expect(JSON.parse(localStorage.getItem('labcharts-routstr-pricing'))['moonshotai/kimi-k3']).toEqual({ input: 3, output: 15 });
     expect(JSON.parse(localStorage.getItem('labcharts-routstr-vision-models'))).toContain('claude-sonnet-4.6');
     expect(JSON.parse(localStorage.getItem('labcharts-routstr-vision-models'))).toContain('claude-sonnet-5');
+    expect(JSON.parse(localStorage.getItem('labcharts-routstr-vision-models'))).toContain('z-ai/glm-5.3-flash');
     expect(JSON.parse(localStorage.getItem('labcharts-routstr-vision-models'))).toContain('moonshotai/kimi-k3');
 
     fetch.mockResolvedValueOnce(jsonResponse({
@@ -221,7 +223,7 @@ describe('API provider runtime behavior', () => {
         { id: 'claude-sonnet-4.6', name: 'Claude', pricing: { input_per_1M_tokens: '3', output_per_1M_tokens: '15' }, architecture: { modality: 'image->text' } },
         { id: 'claude-sonnet-5', name: 'Claude Sonnet 5', pricing: { input_per_1M_tokens: '2', output_per_1M_tokens: '10' }, architecture: { modality: 'image->text' } },
         { id: 'google/gemini-3.5-flash', name: 'Gemini 3.5 Flash', pricing: { input_per_1M_tokens: '0.7', output_per_1M_tokens: '3.75' }, architecture: { modality: 'image->text' } },
-        { id: 'z-ai/glm-5.2', name: 'GLM 5.2', pricing: { input_per_1M_tokens: '1', output_per_1M_tokens: '3.2' } },
+        { id: 'glm-5.3-flash', name: 'GLM 5.3 Flash', pricing: { input_per_1M_tokens: '0.08', output_per_1M_tokens: '0.26' }, architecture: { input_modalities: ['text', 'image', 'video'] } },
         { id: 'x-ai/grok-4.3', name: 'Grok 4.3', pricing: { input_per_1M_tokens: '3', output_per_1M_tokens: '15' } },
         { id: 'grok-4.20', name: 'Grok 4.20', pricing: { input_per_1M_tokens: '2', output_per_1M_tokens: '10' } },
         { id: 'moonshotai/kimi-k2.7-code', name: 'Kimi K2.7 Code', pricing: { input_per_1M_tokens: '0.56', output_per_1M_tokens: '3.5' } },
@@ -232,17 +234,18 @@ describe('API provider runtime behavior', () => {
 
     const ppqModels = await fetchPpqModels('sk-ppq');
 
-    expect(ppqModels.map(m => m.id)).toEqual(['claude-sonnet-4.6', 'claude-sonnet-5', 'google/gemini-3.5-flash', 'z-ai/glm-5.2', 'grok-4.20', 'x-ai/grok-4.3', 'moonshotai/kimi-k3', 'moonshotai/kimi-k2.7-code', 'perplexity/sonar']);
+    expect(ppqModels.map(m => m.id)).toEqual(['claude-sonnet-4.6', 'claude-sonnet-5', 'google/gemini-3.5-flash', 'glm-5.3-flash', 'grok-4.20', 'x-ai/grok-4.3', 'moonshotai/kimi-k3', 'moonshotai/kimi-k2.7-code', 'perplexity/sonar']);
     expect(localStorage.getItem('labcharts-ppq-model')).toBe('claude-sonnet-5');
     expect(JSON.parse(localStorage.getItem('labcharts-ppq-pricing'))['claude-sonnet-4.6']).toEqual({ input: 3, output: 15 });
     expect(JSON.parse(localStorage.getItem('labcharts-ppq-pricing'))['claude-sonnet-5']).toEqual({ input: 2, output: 10 });
     expect(JSON.parse(localStorage.getItem('labcharts-ppq-pricing'))['google/gemini-3.5-flash']).toEqual({ input: 0.7, output: 3.75 });
-    expect(JSON.parse(localStorage.getItem('labcharts-ppq-pricing'))['z-ai/glm-5.2']).toEqual({ input: 1, output: 3.2 });
+    expect(JSON.parse(localStorage.getItem('labcharts-ppq-pricing'))['glm-5.3-flash']).toEqual({ input: 0.08, output: 0.26 });
     expect(JSON.parse(localStorage.getItem('labcharts-ppq-pricing'))['moonshotai/kimi-k2.7-code']).toEqual({ input: 0.56, output: 3.5 });
     expect(JSON.parse(localStorage.getItem('labcharts-ppq-pricing'))['moonshotai/kimi-k3']).toEqual({ input: 3.165, output: 15.825 });
     expect(JSON.parse(localStorage.getItem('labcharts-ppq-vision-models'))).toContain('claude-sonnet-4.6');
     expect(JSON.parse(localStorage.getItem('labcharts-ppq-vision-models'))).toContain('claude-sonnet-5');
     expect(JSON.parse(localStorage.getItem('labcharts-ppq-vision-models'))).toContain('google/gemini-3.5-flash');
+    expect(JSON.parse(localStorage.getItem('labcharts-ppq-vision-models'))).toContain('glm-5.3-flash');
     expect(JSON.parse(localStorage.getItem('labcharts-ppq-vision-models'))).toContain('moonshotai/kimi-k3');
   });
 
@@ -251,7 +254,7 @@ describe('API provider runtime behavior', () => {
     updateKeyCache('labcharts-custom-key', 'sk-custom');
     fetch.mockResolvedValueOnce(jsonResponse({
       data: [
-        { id: 'z-ai/glm-5.2', name: 'GLM 5.2' },
+        { id: 'z-ai/glm-5.3-flash', name: 'GLM 5.3 Flash' },
         { id: 'openai/gpt-5.5', name: 'GPT 5.5' },
         { id: 'anthropic/claude-sonnet-5', name: 'Claude Sonnet 5' },
       ],
@@ -276,11 +279,13 @@ describe('API provider runtime behavior', () => {
       data: [
         { id: 'e2ee-qwen3-5-122b-a10b', name: 'Qwen E2EE', type: 'text', model_spec: { capabilities: { supportsE2EE: true } } },
         { id: 'e2ee-glm-5-2-p', name: 'GLM 5.2 E2EE', type: 'text', model_spec: { capabilities: { supportsE2EE: true } } },
+        { id: 'z-ai-glm-5-3-flash', name: 'GLM 5.3 Flash', type: 'text', model_spec: { capabilities: { supportsE2EE: false, supportsVision: true } } },
         { id: 'llama-3.3-70b', name: 'Llama', type: 'text', model_spec: { capabilities: { supportsE2EE: false } } },
       ],
     }));
     await fetchVeniceModels('venice-key');
     expect(getVeniceModel()).toBe('e2ee-glm-5-2-p');
+    expect(JSON.parse(localStorage.getItem('labcharts-venice-vision-models'))).toContain('z-ai-glm-5-3-flash');
 
     setPpqPrivateMode(true);
     setPpqModel('missing-private-model');
@@ -521,7 +526,9 @@ describe('API provider runtime behavior', () => {
     expect(isRecommendedModel('openrouter', 'openai/gpt-5.6-sol')).toBe(true);
     expect(isRecommendedModel('openrouter', 'openai/gpt-5.5')).toBe(false);
     expect(isRecommendedModel('openrouter', 'google/gemini-3.5-flash')).toBe(true);
-    expect(isRecommendedModel('openrouter', 'z-ai/glm-5.2')).toBe(true);
+    expect(isRecommendedModel('openrouter', 'z-ai/glm-5.3-flash')).toBe(true);
+    expect(isRecommendedModel('openrouter', 'z-ai/glm-5.3')).toBe(false);
+    expect(isRecommendedModel('openrouter', 'z-ai/glm-5.2')).toBe(false);
     expect(isRecommendedModel('openrouter', 'moonshotai/kimi-k2.7-code')).toBe(false);
     expect(isRecommendedModel('openrouter', 'moonshotai/kimi-k2.6')).toBe(false);
     expect(isRecommendedModel('openrouter', 'moonshotai/kimi-k3')).toBe(true);
@@ -530,16 +537,26 @@ describe('API provider runtime behavior', () => {
     expect(isRecommendedModel('venice', 'claude-opus-5')).toBe(true);
     expect(isRecommendedModel('venice', 'claude-opus-4-8')).toBe(false);
     expect(isRecommendedModel('venice', 'gemini-3-5-flash')).toBe(true);
-    expect(isRecommendedModel('venice', 'zai-org-glm-5-2')).toBe(true);
+    expect(isRecommendedModel('venice', 'z-ai-glm-5-3-flash')).toBe(true);
+    expect(isRecommendedModel('venice', 'z-ai-glm-5-3')).toBe(false);
+    expect(isRecommendedModel('venice', 'zai-org-glm-5-2')).toBe(false);
     expect(isRecommendedModel('venice', 'kimi-k2-7-code')).toBe(false);
     expect(isRecommendedModel('venice', 'kimi-k2-6')).toBe(false);
     expect(isRecommendedModel('venice', 'kimi-k3')).toBe(true);
     expect(isRecommendedModel('venice', 'e2ee-qwen3-5-122b')).toBe(true);
+    expect(isRecommendedModel('venice', 'e2ee-glm-5-3-flash-p')).toBe(true);
+    expect(isRecommendedModel('venice', 'e2ee-glm-5-2-p')).toBe(false);
     expect(isRecommendedModel('routstr', 'claude-sonnet-5')).toBe(true);
     expect(isRecommendedModel('routstr', 'claude-sonnet-4.6')).toBe(true);
     expect(isRecommendedModel('routstr', 'claude-opus-5')).toBe(true);
     expect(isRecommendedModel('routstr', 'claude-opus-4.8')).toBe(false);
     expect(isRecommendedModel('routstr', 'x-ai/grok-4.3')).toBe(true);
+    expect(isRecommendedModel('routstr', 'z-ai/glm-5.3-flash')).toBe(true);
+    expect(isRecommendedModel('routstr', 'glm-5.3-flash')).toBe(true);
+    expect(isRecommendedModel('routstr', 'glm-5.3')).toBe(false);
+    expect(isRecommendedModel('routstr', 'z-ai/glm-5.2')).toBe(false);
+    expect(isRecommendedModel('routstr', 'tinfoil-glm-5-3-flash')).toBe(true);
+    expect(isRecommendedModel('routstr', 'tinfoil-glm-5-2')).toBe(false);
     expect(isRecommendedModel('routstr', 'moonshotai/kimi-k3')).toBe(true);
     expect(isRecommendedModel('routstr', 'moonshotai/kimi-k2.7-code')).toBe(false);
     expect(isRecommendedModel('routstr', 'moonshotai/kimi-k2.6')).toBe(false);
@@ -548,7 +565,12 @@ describe('API provider runtime behavior', () => {
     expect(isRecommendedModel('ppq', 'claude-opus-4.8')).toBe(false);
     expect(isRecommendedModel('ppq', 'x-ai/grok-4.3')).toBe(true);
     expect(isRecommendedModel('ppq', 'google/gemini-3.5-flash')).toBe(true);
-    expect(isRecommendedModel('ppq', 'z-ai/glm-5.2')).toBe(true);
+    expect(isRecommendedModel('ppq', 'z-ai/glm-5.3-flash')).toBe(true);
+    expect(isRecommendedModel('ppq', 'glm-5.3-flash')).toBe(true);
+    expect(isRecommendedModel('ppq', 'glm-5.3')).toBe(false);
+    expect(isRecommendedModel('ppq', 'z-ai/glm-5.2')).toBe(false);
+    expect(isRecommendedModel('ppq', 'private/glm-5-3-flash')).toBe(true);
+    expect(isRecommendedModel('ppq', 'private/glm-5-2')).toBe(false);
     expect(isRecommendedModel('ppq', 'moonshotai/kimi-k2.7-code')).toBe(false);
     expect(isRecommendedModel('ppq', 'moonshotai/kimi-k2.6')).toBe(false);
     expect(isRecommendedModel('ppq', 'moonshotai/kimi-k3')).toBe(true);
@@ -557,7 +579,10 @@ describe('API provider runtime behavior', () => {
     expect(isRecommendedModel('custom', 'anthropic/claude-opus-5')).toBe(true);
     expect(isRecommendedModel('custom', 'anthropic/claude-opus-4.8')).toBe(false);
     expect(isRecommendedModel('custom', 'gemini-3.5-flash')).toBe(true);
-    expect(isRecommendedModel('custom', 'z-ai/glm-5.2')).toBe(true);
+    expect(isRecommendedModel('custom', 'z-ai/glm-5.3-flash')).toBe(true);
+    expect(isRecommendedModel('custom', 'glm-5.3-flash')).toBe(true);
+    expect(isRecommendedModel('custom', 'z-ai/glm-5.3')).toBe(false);
+    expect(isRecommendedModel('custom', 'z-ai/glm-5.2')).toBe(false);
     expect(isRecommendedModel('custom', 'moonshotai/kimi-k2.7-code')).toBe(false);
     expect(isRecommendedModel('custom', 'moonshotai/kimi-k2.6')).toBe(false);
     expect(isRecommendedModel('custom', 'moonshotai/kimi-k3')).toBe(true);

--- a/tests/playwright/provider-coverage-batch.spec.js
+++ b/tests/playwright/provider-coverage-batch.spec.js
@@ -168,6 +168,8 @@ test('provider model controls cover dropdowns custom models and delegates', asyn
       controls.renderOpenRouterModelDropdown([
         { id: 'google/gemini-3.5-flash', name: 'Gemini 3.5 Flash' },
         { id: 'google/gemini-3.1-pro', name: 'Gemini 3.1 Pro' },
+        { id: 'z-ai/glm-5.3-flash', name: 'GLM 5.3 Flash' },
+        { id: 'z-ai/glm-5.3', name: 'GLM 5.3' },
         { id: 'z-ai/glm-5.2', name: 'GLM 5.2' },
         { id: 'moonshotai/kimi-k3', name: 'Kimi K3' },
         { id: 'moonshotai/kimi-k2.7-code', name: 'Kimi K2.7 Code' },
@@ -179,14 +181,18 @@ test('provider model controls cover dropdowns custom models and delegates', asyn
       const openRouterRecommendedGroup = document.querySelector('#openrouter-model-select optgroup[label="Recommended"]');
       const openRouterRecommended = !!openRouterRecommendedGroup?.querySelector('option[value="anthropic/claude-sonnet-5"]')
         && !!openRouterRecommendedGroup?.querySelector('option[value="google/gemini-3.5-flash"]')
-        && !!openRouterRecommendedGroup?.querySelector('option[value="z-ai/glm-5.2"]')
+        && !!openRouterRecommendedGroup?.querySelector('option[value="z-ai/glm-5.3-flash"]')
         && !!openRouterRecommendedGroup?.querySelector('option[value="moonshotai/kimi-k3"]')
         && !openRouterRecommendedGroup?.querySelector('option[value="anthropic/claude-sonnet-4.6"]')
         && !openRouterRecommendedGroup?.querySelector('option[value="google/gemini-3.1-pro"]')
+        && !openRouterRecommendedGroup?.querySelector('option[value="z-ai/glm-5.3"]')
+        && !openRouterRecommendedGroup?.querySelector('option[value="z-ai/glm-5.2"]')
         && !openRouterRecommendedGroup?.querySelector('option[value="moonshotai/kimi-k2.7-code"]')
         && !openRouterRecommendedGroup?.querySelector('option[value="moonshotai/kimi-k2.6"]')
         && !!document.querySelector('#openrouter-model-select optgroup[label="Other models"] option[value="anthropic/claude-sonnet-4.6"]')
         && !!document.querySelector('#openrouter-model-select optgroup[label="Other models"] option[value="google/gemini-3.1-pro"]')
+        && !!document.querySelector('#openrouter-model-select optgroup[label="Other models"] option[value="z-ai/glm-5.3"]')
+        && !!document.querySelector('#openrouter-model-select optgroup[label="Other models"] option[value="z-ai/glm-5.2"]')
         && !!document.querySelector('#openrouter-model-select optgroup[label="Other models"] option[value="moonshotai/kimi-k2.7-code"]')
         && !!document.querySelector('#openrouter-model-select optgroup[label="Other models"] option[value="moonshotai/kimi-k2.6"]');
       const openRouterPricing = (document.getElementById('openrouter-model-pricing')?.textContent || '').includes('$3.00/M in');
@@ -255,16 +261,24 @@ test('provider model controls cover dropdowns custom models and delegates', asyn
       controls.renderRoutstrModelDropdown([
         { id: 'grok-41-fast', name: 'Grok 4.1 Fast' },
         { id: 'x-ai/grok-4.3', name: 'Grok 4.3' },
+        { id: 'z-ai/glm-5.3-flash', name: 'GLM 5.3 Flash' },
+        { id: 'glm-5.3', name: 'GLM 5.3' },
+        { id: 'z-ai/glm-5.2', name: 'GLM 5.2' },
         { id: 'moonshotai/kimi-k3', name: 'Kimi K3' },
         { id: 'moonshotai/kimi-k2.7-code', name: 'Kimi K2.7 Code' },
       ]);
       const routstrRecommendedGroup = document.querySelector('#routstr-model-select optgroup[label="Recommended"]');
       const routstrLatestGrokRecommended = !!routstrRecommendedGroup?.querySelector('option[value="x-ai/grok-4.3"]')
+        && !!routstrRecommendedGroup?.querySelector('option[value="z-ai/glm-5.3-flash"]')
         && !!routstrRecommendedGroup?.querySelector('option[value="moonshotai/kimi-k3"]')
         && !routstrRecommendedGroup?.querySelector('option[value="grok-41-fast"]')
         && !routstrRecommendedGroup?.querySelector('option[value="moonshotai/kimi-k2.7-code"]')
+        && !routstrRecommendedGroup?.querySelector('option[value="glm-5.3"]')
+        && !routstrRecommendedGroup?.querySelector('option[value="z-ai/glm-5.2"]')
         && !!document.querySelector('#routstr-model-select optgroup[label="Other models"] option[value="grok-41-fast"]')
-        && !!document.querySelector('#routstr-model-select optgroup[label="Other models"] option[value="moonshotai/kimi-k2.7-code"]');
+        && !!document.querySelector('#routstr-model-select optgroup[label="Other models"] option[value="moonshotai/kimi-k2.7-code"]')
+        && !!document.querySelector('#routstr-model-select optgroup[label="Other models"] option[value="glm-5.3"]')
+        && !!document.querySelector('#routstr-model-select optgroup[label="Other models"] option[value="z-ai/glm-5.2"]');
 
       localStorage.setItem('labcharts-ppq-model', 'ppq-b');
       localStorage.setItem('labcharts-ppq-pricing', JSON.stringify({ 'ppq-b': { input: 0.5, output: 1.5 } }));
@@ -273,6 +287,8 @@ test('provider model controls cover dropdowns custom models and delegates', asyn
         { id: 'ppq-b', name: 'PPQ B' },
         { id: 'gemini-3-flash-preview', name: 'Gemini 3 Flash Preview' },
         { id: 'google/gemini-3.5-flash', name: 'Gemini 3.5 Flash' },
+        { id: 'glm-5.3-flash', name: 'GLM 5.3 Flash' },
+        { id: 'glm-5.3', name: 'GLM 5.3' },
         { id: 'z-ai/glm-5.2', name: 'GLM 5.2' },
         { id: 'moonshotai/kimi-k3', name: 'Kimi K3' },
         { id: 'moonshotai/kimi-k2.7-code', name: 'Kimi K2.7 Code' },
@@ -287,10 +303,14 @@ test('provider model controls cover dropdowns custom models and delegates', asyn
       const ppqLatestGeminiRecommended = !!ppqRecommendedGroup?.querySelector('option[value="google/gemini-3.5-flash"]')
         && !ppqRecommendedGroup?.querySelector('option[value="gemini-3-flash-preview"]')
         && !!document.querySelector('#ppq-model-select optgroup[label="Other models"] option[value="gemini-3-flash-preview"]');
-      const ppqLatestGlmKimiRecommended = !!ppqRecommendedGroup?.querySelector('option[value="z-ai/glm-5.2"]')
+      const ppqLatestGlmKimiRecommended = !!ppqRecommendedGroup?.querySelector('option[value="glm-5.3-flash"]')
         && !!ppqRecommendedGroup?.querySelector('option[value="moonshotai/kimi-k3"]')
+        && !ppqRecommendedGroup?.querySelector('option[value="glm-5.3"]')
+        && !ppqRecommendedGroup?.querySelector('option[value="z-ai/glm-5.2"]')
         && !ppqRecommendedGroup?.querySelector('option[value="moonshotai/kimi-k2.7-code"]')
         && !ppqRecommendedGroup?.querySelector('option[value="moonshotai/kimi-k2.6"]')
+        && !!document.querySelector('#ppq-model-select optgroup[label="Other models"] option[value="glm-5.3"]')
+        && !!document.querySelector('#ppq-model-select optgroup[label="Other models"] option[value="z-ai/glm-5.2"]')
         && !!document.querySelector('#ppq-model-select optgroup[label="Other models"] option[value="moonshotai/kimi-k2.7-code"]')
         && !!document.querySelector('#ppq-model-select optgroup[label="Other models"] option[value="moonshotai/kimi-k2.6"]');
       controls.updatePpqModelPricing('ppq-b');
@@ -300,16 +320,22 @@ test('provider model controls cover dropdowns custom models and delegates', asyn
       localStorage.setItem('labcharts-custom-model', 'outside-model');
       controls.renderCustomApiModelDropdown([
         { id: 'model-a', name: 'Model A' },
+        { id: 'z-ai/glm-5.3-flash', name: 'GLM 5.3 Flash' },
+        { id: 'z-ai/glm-5.3', name: 'GLM 5.3' },
         { id: 'z-ai/glm-5.2', name: 'GLM 5.2' },
         { id: 'moonshotai/kimi-k3', name: 'Kimi K3' },
         { id: 'moonshotai/kimi-k2.7-code', name: 'Kimi K2.7 Code' },
         { id: 'moonshotai/kimi-k2.6', name: 'Kimi K2.6' },
       ]);
       const customRecommendedGroup = document.querySelector('#custom-model-select optgroup[label="Recommended"]');
-      const customGlmKimiRecommended = !!customRecommendedGroup?.querySelector('option[value="z-ai/glm-5.2"]')
+      const customGlmKimiRecommended = !!customRecommendedGroup?.querySelector('option[value="z-ai/glm-5.3-flash"]')
         && !!customRecommendedGroup?.querySelector('option[value="moonshotai/kimi-k3"]')
+        && !customRecommendedGroup?.querySelector('option[value="z-ai/glm-5.3"]')
+        && !customRecommendedGroup?.querySelector('option[value="z-ai/glm-5.2"]')
         && !customRecommendedGroup?.querySelector('option[value="moonshotai/kimi-k2.7-code"]')
         && !customRecommendedGroup?.querySelector('option[value="moonshotai/kimi-k2.6"]')
+        && !!document.querySelector('#custom-model-select optgroup[label="Other models"] option[value="z-ai/glm-5.3"]')
+        && !!document.querySelector('#custom-model-select optgroup[label="Other models"] option[value="z-ai/glm-5.2"]')
         && !!document.querySelector('#custom-model-select optgroup[label="Other models"] option[value="moonshotai/kimi-k2.7-code"]')
         && !!document.querySelector('#custom-model-select optgroup[label="Other models"] option[value="moonshotai/kimi-k2.6"]');
       const customModelRenders = document.getElementById('custom-model-select')?.value === '__custom'

--- a/tests/playwright/routstr-private-tee-provider.spec.js
+++ b/tests/playwright/routstr-private-tee-provider.spec.js
@@ -88,6 +88,8 @@ test('Routstr Private TEE support appears after discovery and toggles through th
         privateModels: JSON.parse(localStorage.getItem('labcharts-routstr-private-models') || '[]').map(model => model.id),
         regularModels: JSON.parse(localStorage.getItem('labcharts-routstr-models') || '[]').map(model => model.id),
         modelOptions: Array.from(document.querySelectorAll('#routstr-model-select option')).map(option => option.value),
+        recommendedOptions: Array.from(document.querySelectorAll('#routstr-model-select optgroup[label="Recommended"] option')).map(option => option.value),
+        otherOptions: Array.from(document.querySelectorAll('#routstr-model-select optgroup[label="Other models"] option')).map(option => option.value),
         indicatorText: document.getElementById('routstr-private-indicator')?.textContent || '',
         balanceText: document.getElementById('routstr-node-balance')?.textContent || '',
         nodeBadgeText: badgeHost.textContent || '',
@@ -116,7 +118,9 @@ test('Routstr Private TEE support appears after discovery and toggles through th
   expect(result.selectedModel).toBe('tinfoil-gemma4-31b');
   expect(result.privateModels).toEqual(['tinfoil-gemma4-31b', 'tinfoil-glm-5-2', 'tinfoil-kimi-k2-6']);
   expect(result.regularModels).toEqual(['claude-sonnet-4.6']);
-  expect(result.modelOptions).toEqual(['tinfoil-gemma4-31b', 'tinfoil-glm-5-2', 'tinfoil-kimi-k2-6']);
+  expect(result.modelOptions).toEqual(['tinfoil-gemma4-31b', 'tinfoil-kimi-k2-6', 'tinfoil-glm-5-2']);
+  expect(result.recommendedOptions).toEqual(['tinfoil-gemma4-31b', 'tinfoil-kimi-k2-6']);
+  expect(result.otherOptions).toEqual(['tinfoil-glm-5-2']);
   expect(result.indicatorText).toContain('decrypted only inside a verified Tinfoil TEE');
   expect(result.indicatorText).toContain('session, selected model, and billing metadata');
   expect(result.balanceText).toContain('104 sats');

--- a/tests/test-custom-api.js
+++ b/tests/test-custom-api.js
@@ -57,7 +57,7 @@ assert('hasAIProvider custom requires URL', apiProviderStorageSrc.includes("hasC
 assert('getActiveModelId handles custom', apiModelsSrc.includes("provider === 'custom') return getCustomApiModel()"));
 assert('getActiveModelDisplay handles custom', apiModelsSrc.includes("provider === 'custom') return getCustomApiModelDisplay()"));
 assert('isRecommendedModel handles custom Sonnet 5', apiModelsSrc.includes("provider === 'custom'") && apiModelsSrc.includes('isCustomRecommendedModel'));
-assert('isRecommendedModel handles custom GLM and Kimi K3', apiModelsSrc.includes('glm-5-2') && apiModelsSrc.includes('kimi-k3'));
+assert('isRecommendedModel handles custom GLM 5.3 Flash and Kimi K3', apiModelsSrc.includes('glm-5-3-flash') && apiModelsSrc.includes('kimi-k3'));
 assert('callClaudeAPI handles custom', apiSrc.includes("provider === 'custom') return callCustomAPI("));
 assert('supportsWebSearch false for custom', apiModelsSrc.includes("provider === 'custom') return false"));
 assert('supportsVision true for custom', apiModelsSrc.includes("provider === 'custom') return true"));

--- a/tests/test-openrouter.js
+++ b/tests/test-openrouter.js
@@ -92,7 +92,7 @@ assert('Curated: qwen prefix', apiModelsSrc.includes("'qwen/qwen'"));
 assert('Curated: z-ai/glm-5 prefix', apiModelsSrc.includes("'z-ai/glm-5'"));
 assert('Curated: moonshotai Kimi family prefix', apiModelsSrc.includes("'moonshotai/kimi-'"));
 assert('Recommended: Kimi K3', apiModelsSrc.includes("'moonshotai/kimi-k3'"));
-assert('Recommended: GLM 5.2', apiModelsSrc.includes("'z-ai/glm-5.2'"));
+assert('Recommended: GLM 5.3 Flash', apiModelsSrc.includes("'z-ai/glm-5.3-flash'"));
 assert('Kimi K2.7 Code remains available but is no longer recommended', apiModelsSrc.includes("'moonshotai/kimi-'"));
 assert('Curated: x-ai/grok prefix', apiModelsSrc.includes("'x-ai/grok'"));
 assert('OPENROUTER_EXCLUDE exists', apiModelsSrc.includes('OPENROUTER_EXCLUDE'));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.17.4';
+self.APP_VERSION = '1.17.5';


### PR DESCRIPTION
## Summary
- recommend GLM 5.3 Flash for OpenRouter, Venice, Routstr, PPQ, and custom providers
- keep GLM 5.2 and base GLM 5.3 selectable but outside the Recommended group
- cover provider-specific IDs, private-catalog variants, vision metadata, and app-cache refresh

## Verification
- npm test -- tests/api-provider-runtime.test.js
- node tests/test-openrouter.js
- node tests/test-custom-api.js
- node tests/test-changelog.js
- PLAYWRIGHT_REUSE_SERVER=1 npx playwright test tests/playwright/provider-coverage-batch.spec.js
- git diff --check