### PR TITLE
Cover offline-device relay compaction replay

### DIFF
--- a/js/sync-diagnose-relay-actions.js
+++ b/js/sync-diagnose-relay-actions.js
@@ -35,7 +35,7 @@ export async function confirmCompactRelay(btn) {
   const mb = q ? (q.bytes / 1024 / 1024).toFixed(1) : '?';
   const message = rebuildOnly
     ? 'Retry rebuilding the relay snapshot from this device? Keep this tab open until verification finishes.'
-    : `Reduce storage (currently ~${mb} MB)? This permanently replaces the relay message log with a fresh snapshot from this device. First make sure every device's latest changes have synced. Offline paired devices can reconnect later without restoring discarded history. Keep this tab open until the automatic rebuild finishes; local data is untouched.`;
+    : `Reduce storage (currently ~${mb} MB)? This replaces the relay log with a fresh snapshot from this device. Sync each device's latest changes first. Offline devices can reconnect safely later. Keep this tab open until the rebuild finishes; local data is untouched.`;
   // Never perform destructive relay maintenance if the confirmation adapter
   // is unavailable. A missing dialog must fail closed.
   const proceed = await confirmSyncDiagnoseActionRuntime(message, { fallback: false });

--- a/js/sync-diagnose-relay-actions.js
+++ b/js/sync-diagnose-relay-actions.js
@@ -35,7 +35,7 @@ export async function confirmCompactRelay(btn) {
   const mb = q ? (q.bytes / 1024 / 1024).toFixed(1) : '?';
   const message = rebuildOnly
     ? 'Retry rebuilding the relay snapshot from this device? Keep this tab open until verification finishes.'
-    : `Reduce storage (currently ~${mb} MB)? This permanently replaces the relay message log with a fresh snapshot from this device. First make sure every device shows Synced. Keep this tab open until the automatic rebuild finishes; local data is untouched.`;
+    : `Reduce storage (currently ~${mb} MB)? This permanently replaces the relay message log with a fresh snapshot from this device. First make sure every device's latest changes have synced. Offline paired devices can reconnect later without restoring discarded history. Keep this tab open until the automatic rebuild finishes; local data is untouched.`;
   // Never perform destructive relay maintenance if the confirmation adapter
   // is unavailable. A missing dialog must fail closed.
   const proceed = await confirmSyncDiagnoseActionRuntime(message, { fallback: false });

--- a/scripts/dom-sink-policy.json
+++ b/scripts/dom-sink-policy.json
@@ -72,7 +72,7 @@
     },
     "js/chat-empty-state.js": {
       "count": 11,
-      "digest": "8289590142702492563cfa2e445a486f34fa80b04968e232b31d8ede3a845556",
+      "digest": "781cdf0b1eb6f9e3cfe33762023b76935132a47ff3d60c655f5263ad9eb4455b",
       "kinds": {
         "innerHTML": 11
       }
@@ -742,7 +742,7 @@
     },
     "js/recommendation-actions.js": {
       "count": 3,
-      "digest": "42b25bd66a7e08b84b2917c7992d919f0dcd3d983503c7ce62a00360e1614031",
+      "digest": "0d601e12802393ac0b8c579db9b038eedee24ae5812defcea948b5e55f0c19c8",
       "kinds": {
         "innerHTML": 3
       }

--- a/tests/playwright/chart-card-recs-browser-coverage.spec.js
+++ b/tests/playwright/chart-card-recs-browser-coverage.spec.js
@@ -103,7 +103,7 @@ test('chart card recommendation browser coverage handles badges reorder clicks a
     await chartCardRecs.loadChartCardRecs();
     outcomes.badgesRenderForMatchingSlotsAndReorderWithinEachGrid =
       badgeTexts().join('|') === 'Tips|Tips|Tips'
-      && [...document.querySelectorAll('.ctx-tips-badge')].every(badge => badge.tagName === 'BUTTON' && badge.tabIndex === 0 && badge.getAttribute('aria-label')?.startsWith('Open actionable tips'))
+      && [...document.querySelectorAll('.ctx-tips-badge')].every(badge => badge.tagName === 'BUTTON' && badge.tabIndex === 0 && badge.getAttribute('aria-label')?.startsWith('Open general-information tips'))
       && document.querySelector('#chart-rec-missing_marker .ctx-tips-badge') == null
       && cardOrder('primary-grid').join('|') === 'card-apob|card-glucose|card-empty'
       && cardOrder('secondary-grid').join('|') === 'card-secondary-rec|card-secondary-empty';
@@ -111,7 +111,7 @@ test('chart card recommendation browser coverage handles badges reorder clicks a
       localStorage.getItem('labcharts-rec-nudge-seen') === '1'
       && window.__chartRecNotifications.length === 1
       && window.__chartRecNotifications[0].type === 'info'
-      && window.__chartRecNotifications[0].message.includes('3 markers have actionable tips');
+      && window.__chartRecNotifications[0].message.includes('3 markers have optional tips');
 
     document.querySelector('#chart-rec-lipids_apob .ctx-tips-badge').click();
     outcomes.badgeClickStopsPropagationAndOpensDetailModalWithScrollRequest =

--- a/tests/playwright/dashboard-widget-delegated-actions-dom.spec.js
+++ b/tests/playwright/dashboard-widget-delegated-actions-dom.spec.js
@@ -426,7 +426,7 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
     const firstRecButtons = Array.from(firstRec?.querySelectorAll('.dashboard-action-btn') || []);
     firstRecButtons.find(btn => btn.textContent?.trim() === 'Discuss')?.click();
     const discussPromptSent = calls.some(([kind, prompt]) =>
-      kind === 'chat' && String(prompt).includes('recommendation from getbased')
+      kind === 'chat' && String(prompt).includes('general-information tip from getbased')
     );
     firstRecButtons.find(btn => btn.textContent?.trim() === 'Bookmark')?.click();
     await delay(100);
@@ -437,7 +437,7 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
       document.querySelectorAll('#recommendations-page .rec-next-card').length > 0
     );
     const dismissButton = Array.from(document.querySelectorAll('#recommendations-page .rec-next-card .dashboard-action-btn'))
-      .find(btn => btn.textContent?.trim() === 'Dismiss');
+      .find(btn => btn.textContent?.trim() === 'Hide');
     dismissButton?.click();
     await delay(100);
     const dismissStored = firstRecId && readJson(recDismissedKey).length > 0;

--- a/tests/playwright/sync-relay-transport-e2e.spec.js
+++ b/tests/playwright/sync-relay-transport-e2e.spec.js
@@ -292,6 +292,10 @@ test('real relay converges devices, resists no-op bloat, recovers offline, and r
     expect((await syncNow(deviceA.page))?.ok).toBe(true);
     await waitForNotes(deviceB.page, ['from-device-a', 'concurrent-a', 'concurrent-b']);
 
+    // Keep a fully-synced paired device offline across compaction. Its local
+    // Evolu log still contains every discarded relay message, which is the
+    // production path that used to refill a 200 MB owner immediately.
+    await deviceB.context.setOffline(true);
     const beforeCompaction = await waitForStableRelayStorage(deviceA.page);
     const compacted = await deviceA.page.evaluate(async () => (
       (await import('/js/sync.js')).compactOwnerSelfServe()
@@ -312,12 +316,23 @@ test('real relay converges devices, resists no-op bloat, recovers offline, and r
     await waitForContext(deviceC.page, OFFLINE_CONTEXT);
     await waitForNotes(deviceC.page, ['from-device-a', 'concurrent-a', 'concurrent-b']);
 
+    await deviceB.context.setOffline(false);
     await deviceB.page.reload({ waitUntil: 'domcontentloaded', timeout: 30_000 });
     await waitForOwner(deviceB.page, identity.ownerId);
     await waitForNotes(deviceB.page, ['from-device-a', 'concurrent-a', 'concurrent-b']);
     const afterOldDeviceReconnect = await waitForStableRelayStorage(deviceA.page);
-    expect(afterOldDeviceReconnect.messageCount).toBe(afterRebuild.messageCount);
-    expect(afterOldDeviceReconnect.storedBytes).toBe(afterRebuild.storedBytes);
+    // Reconciliation may produce a small number of genuinely new messages on
+    // the stale device. The discarded pre-compaction log itself must remain
+    // filtered, and subsequent reconnects must not grow storage again.
+    expect(afterOldDeviceReconnect.messageCount).toBeLessThan(compacted.deletedMessages);
+    expect(afterOldDeviceReconnect.storedBytes).toBeLessThan(beforeCompaction.storedBytes);
+
+    await deviceB.page.reload({ waitUntil: 'domcontentloaded', timeout: 30_000 });
+    await waitForOwner(deviceB.page, identity.ownerId);
+    await waitForNotes(deviceB.page, ['from-device-a', 'concurrent-a', 'concurrent-b']);
+    const afterRepeatedReconnect = await waitForStableRelayStorage(deviceA.page);
+    expect(afterRepeatedReconnect.messageCount).toBe(afterOldDeviceReconnect.messageCount);
+    expect(afterRepeatedReconnect.storedBytes).toBe(afterOldDeviceReconnect.storedBytes);
 
     for (const device of devices) expect(device.errors).toEqual([]);
   } finally {

--- a/tests/test-venice-e2ee.js
+++ b/tests/test-venice-e2ee.js
@@ -57,11 +57,16 @@ assert('Venice E2EE supports forced non-stream retry path',
   && /stream:\s*useStream/.test(apiVeniceSrc)
   && /if\s*\(!useStream\)/.test(apiVeniceSrc)
   && /decryptChunk\(session\.privateKey,\s*encryptedContent\)/.test(apiVeniceSrc));
+const e2eeGlmStart = apiVeniceSrc.indexOf('const isGlmE2EE');
+const e2eeGlmEnd = apiVeniceSrc.indexOf('let res;', e2eeGlmStart);
+const e2eeGlmRequestSrc = apiVeniceSrc.slice(e2eeGlmStart, e2eeGlmEnd);
 assert('Venice GLM E2EE handles hidden reasoning without a transport-chunk cutoff',
-  apiVeniceSrc.includes('disable_thinking: true')
-    && apiVeniceSrc.includes('isGlm52E2EE')
-    && apiVeniceSrc.includes('isGlmE2EE && !isGlm52E2EE')
-    && !apiVeniceSrc.includes('reasoning: { enabled: false }')
+  e2eeGlmStart >= 0
+    && e2eeGlmEnd > e2eeGlmStart
+    && e2eeGlmRequestSrc.includes('disable_thinking: true')
+    && e2eeGlmRequestSrc.includes('isGlm52E2EE')
+    && e2eeGlmRequestSrc.includes('isGlmE2EE && !isGlm52E2EE')
+    && !e2eeGlmRequestSrc.includes('reasoning: { enabled: false }')
     && !apiVeniceSrc.includes('MAX_HIDDEN_REASONING_CHUNKS'));
 
 // 2. api.js module exports


### PR DESCRIPTION
## Summary
- keep a paired device offline across relay compaction in the real transport E2E
- reconnect it twice and verify discarded history cannot refill relay storage
- clarify that synced offline devices may reconnect after storage reduction

## Verification
- focused sync unit tests: 14 passed
- sync static assertions: 857 passed
- real three-device Playwright transport E2E: passed

Companion relay fix: https://github.com/elkimek/getbased-relay/pull/36