### PR TITLE
Reclaim superseded Evolu 8 databases

### DIFF
--- a/docs/evolu8-client-migration.md
+++ b/docs/evolu8-client-migration.md
@@ -19,6 +19,9 @@ pre-cached for every user, so the first evaluation must begin online.
 - Evolu 8 uses a separate generation-namespaced local database. Mnemonic
   restore, disconnect, and relay compaction advance the generation before the
   old history can be reopened, preserving GetBased's stale-replay protection.
+- Superseded Evolu 8 generation databases are reclaimed directly from OPFS.
+  Cleanup takes Evolu's database leader lock first, so the active generation
+  and databases still open in another tab are never removed.
 - Query and error subscriptions are rebound when compaction replaces the
   active Evolu 8 database in the same page.
 
@@ -28,13 +31,12 @@ Do not make Evolu 8 the default until all of these are resolved:
 
 1. A durable v7-to-v8 identity migration no longer needs to open the v7 worker
    on every startup.
-2. Superseded generation databases can be deleted safely. Evolu 8.7.0 exposes
-   `deleteDatabase`, but the released implementation is still a TODO.
-3. The focused real-relay scenario passes for both clients in CI, including
+2. The focused real-relay scenario passes for both clients in CI, including
    no-op storage stability, offline recovery, mnemonic join, relay compaction,
    and stale-device reconnect.
-4. The supported browser matrix passes with the v8 resource-management
+3. The supported browser matrix passes with the v8 resource-management
    polyfills and SharedWorker fallback.
 
-The candidate deliberately favors rollback and data preservation over local
-disk reclamation. That is appropriate for evaluation, not for default rollout.
+The candidate still favors rollback and data preservation while the remaining
+identity and browser gates are open. Cleanup removes only superseded, unlocked
+v8 generation databases and leaves the v7 rollback database intact.

--- a/js/sync-evolu8-candidate.js
+++ b/js/sync-evolu8-candidate.js
@@ -41,7 +41,10 @@ export function readEvolu8Generation(storage = globalThis.localStorage) {
 
 /** @param {string} directoryName */
 function isEvolu8DatabaseDirectory(directoryName) {
-  return /^\.getbased8g[1-9]\d*-[A-Za-z0-9_-]+$/.test(directoryName);
+  // Current Evolu derives a tenant suffix from the owner ID. Accept the
+  // unsuffixed appName as well so cleanup remains correct if the web driver
+  // uses the configured name directly (or an earlier candidate already did).
+  return /^\.getbased8g[1-9]\d*(?:-[A-Za-z0-9_-]+)?$/.test(directoryName);
 }
 
 /**

--- a/js/sync-evolu8-candidate.js
+++ b/js/sync-evolu8-candidate.js
@@ -39,6 +39,72 @@ export function readEvolu8Generation(storage = globalThis.localStorage) {
   }
 }
 
+/** @param {string} directoryName */
+function isEvolu8DatabaseDirectory(directoryName) {
+  return /^\.getbased8g[1-9]\d*-[A-Za-z0-9_-]+$/.test(directoryName);
+}
+
+/**
+ * Reclaim candidate databases from superseded generations without depending
+ * on Evolu 8's currently-unimplemented public deleteDatabase method.
+ *
+ * Evolu's web driver stores an encrypted database for instance `name` in the
+ * OPFS directory `.${name}` and holds `evolu-leaderlock-${name}` for as long
+ * as its worker has the database open. Taking that same lock with
+ * `ifAvailable` makes deletion safe across tabs and crashed/lingering workers:
+ * active databases are skipped and retried on a later startup.
+ *
+ * @param {{
+ *   activeDatabaseName: string,
+ *   storageManager?: { getDirectory?: Function } | null,
+ *   lockManager?: { request?: Function } | null,
+ * }} options
+ */
+export async function cleanupSupersededEvolu8Databases({
+  activeDatabaseName,
+  storageManager = globalThis.navigator?.storage,
+  lockManager = globalThis.navigator?.locks,
+}) {
+  const activeDirectoryName = `.${String(activeDatabaseName || '')}`;
+  if (!isEvolu8DatabaseDirectory(activeDirectoryName)
+      || typeof storageManager?.getDirectory !== 'function'
+      || typeof lockManager?.request !== 'function') {
+    return { deleted: [], skipped: [] };
+  }
+
+  const root = await storageManager.getDirectory();
+  if (!root || typeof root.entries !== 'function' || typeof root.removeEntry !== 'function') {
+    return { deleted: [], skipped: [] };
+  }
+
+  const deleted = [];
+  const skipped = [];
+  for await (const [directoryName, handle] of root.entries()) {
+    if (handle?.kind !== 'directory'
+        || directoryName === activeDirectoryName
+        || !isEvolu8DatabaseDirectory(directoryName)) continue;
+
+    const databaseName = directoryName.slice(1);
+    let didDelete = false;
+    try {
+      didDelete = await lockManager.request(
+        `evolu-leaderlock-${databaseName}`,
+        { ifAvailable: true, mode: 'exclusive' },
+        async lock => {
+          if (!lock) return false;
+          await root.removeEntry(directoryName, { recursive: true });
+          return true;
+        },
+      );
+    } catch (error) {
+      console.warn('[sync] Could not reclaim superseded Evolu 8 database:', error);
+    }
+    (didDelete ? deleted : skipped).push(databaseName);
+  }
+
+  return { deleted, skipped };
+}
+
 /**
  * Load the stable v7 client by default and the compatibility bridge only after
  * an explicit query opt-in. Keeping this loader lazy avoids adding candidate
@@ -278,6 +344,18 @@ export async function createEvolu8Candidate({
     }
     current = await startRuntime(mnemonic, nextGeneration);
     await bindSubscriptions();
+    // Cleanup is best-effort and never delays owner/query readiness. A stale
+    // database that is still open in another tab is protected by Evolu's lock
+    // and will be retried on a later startup.
+    void cleanupSupersededEvolu8Databases({
+      activeDatabaseName: current.evolu.name,
+    }).then(({ deleted }) => {
+      if (deleted.length > 0) {
+        console.info(`[sync] Reclaimed ${deleted.length} superseded Evolu 8 database(s)`);
+      }
+    }).catch(error => {
+      console.warn('[sync] Evolu 8 database cleanup failed:', error);
+    });
   };
 
   await replaceRuntime(legacyOwner.mnemonic, initialGeneration);

--- a/tests/playwright/sync-evolu8-opfs-cleanup.spec.js
+++ b/tests/playwright/sync-evolu8-opfs-cleanup.spec.js
@@ -1,0 +1,63 @@
+import { expect, test } from '@playwright/test';
+
+test('v8 cleanup removes only unlocked superseded OPFS generations', async ({ page }) => {
+  await page.goto('/');
+
+  const result = await page.evaluate(async () => {
+    const {
+      cleanupSupersededEvolu8Databases,
+    } = await import('/js/sync-evolu8-candidate.js');
+    const suffix = `${Date.now()}_${crypto.randomUUID().replaceAll('-', '_')}`;
+    const active = `getbased8g3-${suffix}`;
+    const stale = `getbased8g2-${suffix}`;
+    const locked = `getbased8g1-${suffix}`;
+    const legacy = `.getbased4-${suffix}`;
+    const root = await navigator.storage.getDirectory();
+    const created = [`.${active}`, `.${stale}`, `.${locked}`, legacy];
+
+    try {
+      for (const name of created) {
+        const directory = await root.getDirectoryHandle(name, { create: true });
+        const file = await directory.getFileHandle('sentinel', { create: true });
+        const writable = await file.createWritable();
+        await writable.write(name);
+        await writable.close();
+      }
+
+      let releaseLock;
+      let markLockAcquired;
+      const lockAcquired = new Promise(resolve => { markLockAcquired = resolve; });
+      const holdLock = new Promise(resolve => { releaseLock = resolve; });
+      const lockRequest = navigator.locks.request(
+        `evolu-leaderlock-${locked}`,
+        { mode: 'exclusive' },
+        async () => {
+          markLockAcquired();
+          await holdLock;
+        },
+      );
+      await lockAcquired;
+
+      const cleanupResult = await cleanupSupersededEvolu8Databases({ activeDatabaseName: active });
+      const namesAfterCleanup = [];
+      for await (const name of root.keys()) namesAfterCleanup.push(name);
+
+      releaseLock();
+      await lockRequest;
+      return { active, stale, locked, legacy, cleanupResult, namesAfterCleanup };
+    } finally {
+      for (const name of created) {
+        await root.removeEntry(name, { recursive: true }).catch(() => {});
+      }
+    }
+  });
+
+  expect(result.cleanupResult).toEqual({
+    deleted: [result.stale],
+    skipped: [result.locked],
+  });
+  expect(result.namesAfterCleanup).toContain(`.${result.active}`);
+  expect(result.namesAfterCleanup).not.toContain(`.${result.stale}`);
+  expect(result.namesAfterCleanup).toContain(`.${result.locked}`);
+  expect(result.namesAfterCleanup).toContain(result.legacy);
+});

--- a/tests/playwright/sync-evolu8-opfs-cleanup.spec.js
+++ b/tests/playwright/sync-evolu8-opfs-cleanup.spec.js
@@ -8,9 +8,11 @@ test('v8 cleanup removes only unlocked superseded OPFS generations', async ({ pa
       cleanupSupersededEvolu8Databases,
     } = await import('/js/sync-evolu8-candidate.js');
     const suffix = `${Date.now()}_${crypto.randomUUID().replaceAll('-', '_')}`;
-    const active = `getbased8g3-${suffix}`;
-    const stale = `getbased8g2-${suffix}`;
-    const locked = `getbased8g1-${suffix}`;
+    // Exercise the unsuffixed configured appName form. Unit coverage also
+    // exercises current Evolu's owner-suffixed tenant directory form.
+    const active = 'getbased8g3';
+    const stale = 'getbased8g2';
+    const locked = 'getbased8g1';
     const legacy = `.getbased4-${suffix}`;
     const root = await navigator.storage.getDirectory();
     const created = [`.${active}`, `.${stale}`, `.${locked}`, legacy];

--- a/tests/sync-evolu8-candidate.test.js
+++ b/tests/sync-evolu8-candidate.test.js
@@ -2,10 +2,19 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   EVOLU8_GENERATION_KEY,
+  cleanupSupersededEvolu8Databases,
   createEvolu8Candidate,
   isEvolu8CandidateRequested,
   readEvolu8Generation,
 } from '../js/sync-evolu8-candidate.js';
+
+function createOpfsRoot(entries) {
+  const values = new Map(entries.map(([name, kind = 'directory']) => [name, { kind }]));
+  return {
+    entries: vi.fn(async function* () { yield* values.entries(); }),
+    removeEntry: vi.fn(async name => { values.delete(name); }),
+  };
+}
 
 function createStorage(initial = {}) {
   const values = new Map(Object.entries(initial));
@@ -99,6 +108,59 @@ function createHarness({ mnemonic = 'alpha words', ownerId = `owner:${mnemonic}`
 }
 
 describe('Evolu 8 compatibility candidate', () => {
+  it('reclaims only unlocked superseded v8 database generations', async () => {
+    const active = 'getbased8g3-owner_current';
+    const stale = 'getbased8g2-owner_current';
+    const locked = 'getbased8g1-owner_previous';
+    const root = createOpfsRoot([
+      [`.${active}`],
+      [`.${stale}`],
+      [`.${locked}`],
+      ['.getbased8g-bad'],
+      ['.getbased4'],
+      ['unrelated'],
+      ['.getbased8g4-owner_file', 'file'],
+    ]);
+    const lockManager = {
+      request: vi.fn(async (name, options, callback) => callback(
+        name === `evolu-leaderlock-${locked}` ? null : { name, mode: options.mode },
+      )),
+    };
+
+    const result = await cleanupSupersededEvolu8Databases({
+      activeDatabaseName: active,
+      storageManager: { getDirectory: vi.fn(async () => root) },
+      lockManager,
+    });
+
+    expect(result).toEqual({ deleted: [stale], skipped: [locked] });
+    expect(root.removeEntry).toHaveBeenCalledOnce();
+    expect(root.removeEntry).toHaveBeenCalledWith(`.${stale}`, { recursive: true });
+    expect(lockManager.request).toHaveBeenCalledTimes(2);
+    for (const [, options] of lockManager.request.mock.calls) {
+      expect(options).toEqual({ ifAvailable: true, mode: 'exclusive' });
+    }
+  });
+
+  it('makes OPFS cleanup a no-op when the active name or browser APIs are unavailable', async () => {
+    const root = createOpfsRoot([['.getbased8g1-owner']]);
+    const lockManager = { request: vi.fn() };
+
+    await expect(cleanupSupersededEvolu8Databases({
+      activeDatabaseName: 'getbased4',
+      storageManager: { getDirectory: vi.fn(async () => root) },
+      lockManager,
+    })).resolves.toEqual({ deleted: [], skipped: [] });
+    await expect(cleanupSupersededEvolu8Databases({
+      activeDatabaseName: 'getbased8g1-owner',
+      storageManager: null,
+      lockManager,
+    })).resolves.toEqual({ deleted: [], skipped: [] });
+
+    expect(root.entries).not.toHaveBeenCalled();
+    expect(lockManager.request).not.toHaveBeenCalled();
+  });
+
   it('requires an explicit v8 query opt-in', () => {
     expect(isEvolu8CandidateRequested({ search: '?evolu-client=v8' })).toBe(true);
     expect(isEvolu8CandidateRequested({ href: 'https://getbased.health/?evolu-client=v8' })).toBe(true);

--- a/tests/sync-evolu8-candidate.test.js
+++ b/tests/sync-evolu8-candidate.test.js
@@ -110,13 +110,16 @@ function createHarness({ mnemonic = 'alpha words', ownerId = `owner:${mnemonic}`
 describe('Evolu 8 compatibility candidate', () => {
   it('reclaims only unlocked superseded v8 database generations', async () => {
     const active = 'getbased8g3-owner_current';
-    const stale = 'getbased8g2-owner_current';
-    const locked = 'getbased8g1-owner_previous';
+    const stale = 'getbased8g2';
+    const staleWithOwnerSuffix = 'getbased8g2-owner_previous';
+    const locked = 'getbased8g1';
     const root = createOpfsRoot([
       [`.${active}`],
       [`.${stale}`],
+      [`.${staleWithOwnerSuffix}`],
       [`.${locked}`],
       ['.getbased8g-bad'],
+      ['.getbased8g0'],
       ['.getbased4'],
       ['unrelated'],
       ['.getbased8g4-owner_file', 'file'],
@@ -133,10 +136,11 @@ describe('Evolu 8 compatibility candidate', () => {
       lockManager,
     });
 
-    expect(result).toEqual({ deleted: [stale], skipped: [locked] });
-    expect(root.removeEntry).toHaveBeenCalledOnce();
+    expect(result).toEqual({ deleted: [stale, staleWithOwnerSuffix], skipped: [locked] });
+    expect(root.removeEntry).toHaveBeenCalledTimes(2);
     expect(root.removeEntry).toHaveBeenCalledWith(`.${stale}`, { recursive: true });
-    expect(lockManager.request).toHaveBeenCalledTimes(2);
+    expect(root.removeEntry).toHaveBeenCalledWith(`.${staleWithOwnerSuffix}`, { recursive: true });
+    expect(lockManager.request).toHaveBeenCalledTimes(3);
     for (const [, options] of lockManager.request.mock.calls) {
       expect(options).toEqual({ ifAvailable: true, mode: 'exclusive' });
     }


### PR DESCRIPTION
## Summary
- reclaim superseded Evolu 8 generation databases directly from OPFS
- acquire Evolu's per-database leader lock before deletion and skip active or locked generations
- keep the Evolu 7 rollback database untouched and document the reduced promotion-gate list
- cover the behavior with unit mocks and a real Chromium OPFS/Web Locks test

## Verification
- npm test -- tests/sync-evolu8-candidate.test.js tests/sync-lifecycle-runtime.test.js
- npm run typecheck:checkjs
- npm run quality
- npm run architecture:check
- npm run vendor:evolu8:check
- npm run production:check
- PLAYWRIGHT_REUSE_SERVER=1 npx playwright test tests/playwright/sync-evolu8-opfs-cleanup.spec.js --workers=1