### PR TITLE
Persist Evolu 8 identity handoff

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -9,8 +9,8 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 
 | Metric | Current |
 | --- | ---: |
-| Modules | 701 |
-| Internal import edges | 2992 |
+| Modules | 702 |
+| Internal import edges | 2993 |
 | Dynamic internal edges | 92 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -1095,7 +1095,7 @@ Native browser modules shipped with the static application.
 
 </details>
 
-<details><summary><code>sync</code> family — 74 modules</summary>
+<details><summary><code>sync</code> family — 75 modules</summary>
 
 - [`js/sync-actions.js`](js/sync-actions.js) → [`js/profile-sync-policy.js`](js/profile-sync-policy.js), [`js/state.js`](js/state.js), [`js/sync-cutover.js`](js/sync-cutover.js), [`js/sync-dirty-state.js`](js/sync-dirty-state.js), [`js/sync-messenger.js`](js/sync-messenger.js), [`js/sync-save-hooks.js`](js/sync-save-hooks.js), [`js/sync-state.js`](js/sync-state.js), [`js/sync-storage-cleanup.js`](js/sync-storage-cleanup.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-apply.js`](js/sync-apply.js) → [`js/app-extension-runtime.js`](js/app-extension-runtime.js), [`js/crypto.js`](js/crypto.js), [`js/sync-chat-apply.js`](js/sync-chat-apply.js), [`js/sync-payload-collectors.js`](js/sync-payload-collectors.js), [`js/sync-runtime.js`](js/sync-runtime.js), [`js/voice-settings-schema.js`](js/voice-settings-schema.js)
@@ -1140,7 +1140,8 @@ Native browser modules shipped with the static application.
 - [`js/sync-dirty-state.js`](js/sync-dirty-state.js) → no in-scope imports
 - [`js/sync-disable-cleanup.js`](js/sync-disable-cleanup.js) → no in-scope imports
 - [`js/sync-environment.js`](js/sync-environment.js) → [`js/utils-runtime.js`](js/utils-runtime.js)
-- [`js/sync-evolu8-candidate.js`](js/sync-evolu8-candidate.js) → [`js/sync-runtime.js`](js/sync-runtime.js), [`js/utils.js`](js/utils.js)
+- [`js/sync-evolu8-candidate.js`](js/sync-evolu8-candidate.js) → [`js/sync-evolu8-identity-vault.js`](js/sync-evolu8-identity-vault.js), [`js/sync-runtime.js`](js/sync-runtime.js), [`js/utils.js`](js/utils.js)
+- [`js/sync-evolu8-identity-vault.js`](js/sync-evolu8-identity-vault.js) → no in-scope imports
 - [`js/sync-identity.js`](js/sync-identity.js) → [`js/sync-backup-restore-state.js`](js/sync-backup-restore-state.js), [`js/sync-disable-cleanup.js`](js/sync-disable-cleanup.js), [`js/sync-runtime.js`](js/sync-runtime.js), [`js/sync-settings-state.js`](js/sync-settings-state.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-init.js`](js/sync-init.js) → [`js/sync-environment.js`](js/sync-environment.js), [`js/sync-evolu8-candidate.js`](js/sync-evolu8-candidate.js) *(dynamic)*, [`js/sync-identity.js`](js/sync-identity.js), [`js/sync-recovery.js`](js/sync-recovery.js), [`js/sync-relay-health.js`](js/sync-relay-health.js), [`js/sync-runtime.js`](js/sync-runtime.js), [`js/sync-schema.js`](js/sync-schema.js), [`js/sync-settings-state.js`](js/sync-settings-state.js), [`js/sync-subscriptions.js`](js/sync-subscriptions.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-lifecycle.js`](js/sync-lifecycle.js) → [`js/sync-actions.js`](js/sync-actions.js), [`js/sync-backup-restore-state.js`](js/sync-backup-restore-state.js), [`js/sync-disable-cleanup.js`](js/sync-disable-cleanup.js), [`js/sync-environment.js`](js/sync-environment.js), [`js/sync-init.js`](js/sync-init.js), [`js/sync-pull.js`](js/sync-pull.js), [`js/sync-runtime.js`](js/sync-runtime.js), [`js/sync-save-hooks.js`](js/sync-save-hooks.js), [`js/sync-settings-state.js`](js/sync-settings-state.js), [`js/sync-state.js`](js/sync-state.js), [`js/sync-subscriptions.js`](js/sync-subscriptions.js), [`js/sync-ui.js`](js/sync-ui.js), [`js/utils.js`](js/utils.js)

--- a/docs/evolu8-client-migration.md
+++ b/docs/evolu8-client-migration.md
@@ -9,13 +9,20 @@ pre-cached for every user, so the first evaluation must begin online.
 
 ## Compatibility design
 
-- The existing Evolu 7 SQLite database remains the temporary identity vault.
-  Its owner mnemonic is read through Evolu's API and is never copied into
-  `localStorage`.
+- On the first Evolu 8 opt-in, the v7 owner is verified against Evolu 8's
+  deterministic owner derivation and copied to a dedicated IndexedDB identity
+  vault. Subsequent v8 startups use that vault without opening the v7 worker.
+- The recovery mnemonic is never copied into `localStorage`. Local storage
+  holds only a random, non-secret commit token; removing that token
+  synchronously invalidates a stale or partially written vault record.
 - Evolu 8 deterministically derives the same owner ID and keys from that
   mnemonic, so it connects to the existing relay identity.
-- The Evolu 7 bridge runs with no transports. Only Evolu 8 connects to the
-  relay while the candidate is selected.
+- The Evolu 7 bridge is loaded with no transports only for the first handoff or
+  an identity restore/reset. Only Evolu 8 connects to the relay while the
+  candidate is selected.
+- Restore and reset invalidate the v8 vault before changing the durable v7
+  owner. The default v7 path applies the same guard, preserving a safe rollback
+  even after testing v8.
 - Evolu 8 uses a separate generation-namespaced local database. Mnemonic
   restore, disconnect, and relay compaction advance the generation before the
   old history can be reopened, preserving GetBased's stale-replay protection.
@@ -29,14 +36,12 @@ pre-cached for every user, so the first evaluation must begin online.
 
 Do not make Evolu 8 the default until all of these are resolved:
 
-1. A durable v7-to-v8 identity migration no longer needs to open the v7 worker
-   on every startup.
-2. The focused real-relay scenario passes for both clients in CI, including
+1. The focused real-relay scenario passes for both clients in CI, including
    no-op storage stability, offline recovery, mnemonic join, relay compaction,
    and stale-device reconnect.
-3. The supported browser matrix passes with the v8 resource-management
+2. The supported browser matrix passes with the v8 resource-management
    polyfills and SharedWorker fallback.
 
 The candidate still favors rollback and data preservation while the remaining
-identity and browser gates are open. Cleanup removes only superseded, unlocked
-v8 generation databases and leaves the v7 rollback database intact.
+relay and browser gates are open. Cleanup removes only superseded, unlocked v8
+generation databases and leaves the v7 rollback database intact.

--- a/docs/evolu8-client-migration.md
+++ b/docs/evolu8-client-migration.md
@@ -23,6 +23,8 @@ pre-cached for every user, so the first evaluation must begin online.
 - Restore and reset invalidate the v8 vault before changing the durable v7
   owner. The default v7 path applies the same guard, preserving a safe rollback
   even after testing v8.
+- Erasing all local application data deletes both the commit token and the
+  mnemonic-bearing IndexedDB vault.
 - Evolu 8 uses a separate generation-namespaced local database. Mnemonic
   restore, disconnect, and relay compaction advance the generation before the
   old history can be reopened, preserving GetBased's stale-replay protection.

--- a/js/data-wipe.js
+++ b/js/data-wipe.js
@@ -137,7 +137,7 @@ export async function eraseAllLocalAppData() {
   removeStorageKeys(globalThis.localStorage, localKeys, 'local storage', errors);
   removeStorageKeys(globalThis.sessionStorage, sessionKeys, 'session storage', errors);
   await deleteIndexedDBDatabasesByPrefix(
-    ['labcharts-', 'getbased-nutrition-'],
+    ['labcharts-', 'getbased-nutrition-', 'getbased-evolu8-'],
     [
       ...profileIds.flatMap(id => [
         `labcharts-wearables-${id}`,
@@ -147,6 +147,7 @@ export async function eraseAllLocalAppData() {
       'labcharts-backups',
       'labcharts-blobs',
       'labcharts-wearables-credential-vault',
+      'getbased-evolu8-identity',
     ],
     errors,
   );

--- a/js/sync-evolu8-candidate.js
+++ b/js/sync-evolu8-candidate.js
@@ -2,11 +2,12 @@
 // Experimental Evolu 8 compatibility adapter.
 //
 // Evolu 8 intentionally cannot open Evolu 7's local SQLite format and its
-// released web API does not yet implement deleteDatabase/resetAppOwner. Keep
-// the v7 database as the identity vault, then give every destructive reset a
-// fresh v8 database generation so pre-compaction history can never replay.
+// released web API does not yet implement deleteDatabase/resetAppOwner. A
+// durable browser vault avoids opening the v7 worker after the first identity
+// handoff; destructive identity changes load v7 lazily to preserve rollback.
 
 import { setSyncAppOwnerError } from './sync-runtime.js';
+import { createEvolu8IdentityVault } from './sync-evolu8-identity-vault.js';
 import { showNotification } from './utils.js';
 
 export const EVOLU8_CLIENT_QUERY_PARAM = 'evolu-client';
@@ -125,57 +126,102 @@ export async function createSyncEvoluClient({
   reloadUrl,
   enableLogging,
 }) {
-  const legacy = await import(EVOLU_BUNDLE_URL);
-  const legacySchema = createSyncSchema({
-    id: legacy.id,
-    nullOr: legacy.nullOr,
-    NonEmptyString: legacy.NonEmptyString,
-  });
+  const identityVault = createEvolu8IdentityVault();
   if (isEvolu8CandidateRequested()) {
     const evolu = await createEvolu8SyncClient({
-      legacy,
-      legacySchema,
       relay,
       reloadUrl,
       enableLogging,
       createSyncSchema,
+      identityVault,
     });
     console.warn('[sync] Running opt-in Evolu 8 compatibility candidate');
     return evolu;
   }
-  return legacy.createEvolu(legacy.evoluWebDeps)(legacySchema, {
-    name: legacy.SimpleName.orThrow('getbased4'),
+  const legacyEvolu = await createLegacyEvoluClient({
+    createSyncSchema,
     reloadUrl,
     enableLogging,
     transports: [{ type: 'WebSocket', url: relay }],
+  });
+  return guardLegacyIdentityChanges(legacyEvolu, identityVault);
+}
+
+/**
+ * @param {{
+ *   createSyncSchema: (types: any) => any,
+ *   reloadUrl: string,
+ *   enableLogging: boolean,
+ *   transports: Array<any>,
+ * }} options
+ */
+async function createLegacyEvoluClient({
+  createSyncSchema,
+  reloadUrl,
+  enableLogging,
+  transports,
+}) {
+  const legacy = await import(EVOLU_BUNDLE_URL);
+  const schema = createSyncSchema({
+    id: legacy.id,
+    nullOr: legacy.nullOr,
+    NonEmptyString: legacy.NonEmptyString,
+  });
+  return legacy.createEvolu(legacy.evoluWebDeps)(schema, {
+    name: legacy.SimpleName.orThrow('getbased4'),
+    reloadUrl,
+    enableLogging,
+    transports,
+  });
+}
+
+/**
+ * Invalidate the v8 identity commit before v7 changes its owner. Run the IDB
+ * deletion alongside the v7 mutation; token removal itself is synchronous.
+ * @param {any} legacyEvolu
+ * @param {{ invalidate: () => Promise<void> | void }} identityVault
+ */
+export function guardLegacyIdentityChanges(legacyEvolu, identityVault) {
+  const restoreAppOwner = (...args) => {
+    const invalidation = identityVault.invalidate();
+    return Promise.all([
+      Promise.resolve(invalidation),
+      Promise.resolve(legacyEvolu.restoreAppOwner(...args)),
+    ]).then(([, result]) => result);
+  };
+  const resetAppOwner = (...args) => {
+    const invalidation = identityVault.invalidate();
+    return Promise.all([
+      Promise.resolve(invalidation),
+      Promise.resolve(legacyEvolu.resetAppOwner(...args)),
+    ]).then(([, result]) => result);
+  };
+  return new Proxy(legacyEvolu, {
+    get(target, property, receiver) {
+      if (property === 'restoreAppOwner') return restoreAppOwner;
+      if (property === 'resetAppOwner') return resetAppOwner;
+      return Reflect.get(target, property, receiver);
+    },
   });
 }
 
 /**
  * Keep all candidate-only initialization out of the default startup bundle.
  * @param {{
- *   legacy: any,
- *   legacySchema: any,
  *   relay: string,
  *   reloadUrl: string,
  *   enableLogging: boolean,
  *   createSyncSchema: (types: any) => any,
+ *   identityVault?: { invalidate: () => Promise<void> | void, read: () => Promise<any>, write: (identity: any) => Promise<void> },
  * }} options
  */
 export async function createEvolu8SyncClient({
-  legacy,
-  legacySchema,
   relay,
   reloadUrl,
   enableLogging,
   createSyncSchema,
+  identityVault = createEvolu8IdentityVault(),
 }) {
-  const legacyEvolu = legacy.createEvolu(legacy.evoluWebDeps)(legacySchema, {
-    name: legacy.SimpleName.orThrow('getbased4'),
-    reloadUrl,
-    enableLogging,
-    transports: [],
-  });
   const modern = await import(EVOLU8_BUNDLE_URL);
   const modernSchema = createSyncSchema({
     id: modern.id,
@@ -184,8 +230,30 @@ export async function createEvolu8SyncClient({
     // type preserves the v7 wire schema without rejecting legacy values.
     NonEmptyString: modern.EvoluString,
   });
+  let initialIdentity = await identityVault.read();
+  if (initialIdentity) {
+    try {
+      const owner = createModernOwner(modern, initialIdentity.mnemonic);
+      if (owner.id !== initialIdentity.ownerId) throw new Error('owner mismatch');
+    } catch {
+      await identityVault.invalidate();
+      initialIdentity = null;
+    }
+  }
+  let legacyEvoluPromise = null;
+  const getLegacyEvolu = () => {
+    legacyEvoluPromise ??= createLegacyEvoluClient({
+      createSyncSchema,
+      reloadUrl,
+      enableLogging,
+      transports: [],
+    });
+    return legacyEvoluPromise;
+  };
   return createEvolu8Candidate({
-    legacyEvolu,
+    getLegacyEvolu,
+    initialIdentity,
+    identityVault,
     modern,
     schema: modernSchema,
     relay,
@@ -235,7 +303,10 @@ async function disposeResource(resource) {
 
 /**
  * @param {{
- *   legacyEvolu: any,
+ *   legacyEvolu?: any,
+ *   getLegacyEvolu?: () => Promise<any>,
+ *   initialIdentity?: { ownerId: string, mnemonic: string } | null,
+ *   identityVault?: { invalidate: () => Promise<void> | void, write: (identity: any) => Promise<void> },
  *   modern: any,
  *   schema: any,
  *   relay: string,
@@ -245,26 +316,52 @@ async function disposeResource(resource) {
  */
 export async function createEvolu8Candidate({
   legacyEvolu,
+  getLegacyEvolu,
+  initialIdentity = null,
+  identityVault = {
+    invalidate: () => Promise.resolve(),
+    write: async () => {},
+  },
   modern,
   schema,
   relay,
   storage = globalThis.localStorage,
   onSharedWorkerUnsupported,
 }) {
-  if (!legacyEvolu?.appOwner) throw new Error('Evolu 7 identity bridge is unavailable');
   modern.installPolyfills?.();
   const asyncDisposeSymbol = /** @type {any} */ (Symbol).asyncDispose;
-  let ownerTimeoutId;
-  const ownerTimeout = new Promise((_, reject) => {
-    ownerTimeoutId = setTimeout(() => reject(new Error('Evolu 7 identity bridge timed out')), 30_000);
-  });
-  let legacyOwner;
-  try {
-    legacyOwner = await Promise.race([legacyEvolu.appOwner, ownerTimeout]);
-  } finally {
-    clearTimeout(ownerTimeoutId);
+  let resolvedLegacyEvolu = legacyEvolu || null;
+  const resolveLegacyEvolu = async () => {
+    resolvedLegacyEvolu ??= await getLegacyEvolu?.();
+    if (!resolvedLegacyEvolu?.appOwner) throw new Error('Evolu 7 identity bridge is unavailable');
+    return resolvedLegacyEvolu;
+  };
+
+  if (!initialIdentity) {
+    const legacy = await resolveLegacyEvolu();
+    let ownerTimeoutId;
+    const ownerTimeout = new Promise((_, reject) => {
+      ownerTimeoutId = setTimeout(() => reject(new Error('Evolu 7 identity bridge timed out')), 30_000);
+    });
+    let legacyOwner;
+    try {
+      legacyOwner = await Promise.race([legacy.appOwner, ownerTimeout]);
+    } finally {
+      clearTimeout(ownerTimeoutId);
+    }
+    if (!legacyOwner?.mnemonic) throw new Error('Evolu 7 identity has no recovery mnemonic');
+    const modernOwner = createModernOwner(modern, legacyOwner.mnemonic);
+    if (legacyOwner.id && modernOwner.id !== legacyOwner.id) {
+      throw new Error('Evolu 8 derived a different owner ID from the Evolu 7 mnemonic');
+    }
+    initialIdentity = { ownerId: modernOwner.id, mnemonic: legacyOwner.mnemonic };
+    try {
+      await identityVault.invalidate();
+      await identityVault.write(initialIdentity);
+    } catch (error) {
+      console.warn('[sync] Evolu 8 identity handoff could not be persisted:', error);
+    }
   }
-  if (!legacyOwner?.mnemonic) throw new Error('Evolu 7 identity has no recovery mnemonic');
 
   const initialGeneration = readEvolu8Generation(storage);
   let current = null;
@@ -295,11 +392,9 @@ export async function createEvolu8Candidate({
     return nextGeneration;
   };
 
-  const startRuntime = async (mnemonic, nextGeneration) => {
-    const appOwner = createModernOwner(modern, mnemonic);
-    if (legacyOwner.id && appOwner.id !== legacyOwner.id && mnemonic === legacyOwner.mnemonic) {
-      throw new Error('Evolu 8 derived a different owner ID from the Evolu 7 mnemonic');
-    }
+  const startRuntime = async (identity, nextGeneration) => {
+    const appOwner = createModernOwner(modern, identity.mnemonic);
+    if (appOwner.id !== identity.ownerId) throw new Error('Evolu 8 identity vault owner mismatch');
     const deps = modern.createEvoluDeps({ onSharedWorkerUnsupported });
     const run = modern.createRun(deps);
     try {
@@ -336,7 +431,7 @@ export async function createEvolu8Candidate({
     }
   };
 
-  const replaceRuntime = async (mnemonic, nextGeneration) => {
+  const replaceRuntime = async (identity, nextGeneration) => {
     const previous = current;
     unbindSubscriptions();
     current = null;
@@ -345,7 +440,7 @@ export async function createEvolu8Candidate({
       await disposeResource(previous.run).catch(() => {});
       await disposeResource(previous.deps).catch(() => {});
     }
-    current = await startRuntime(mnemonic, nextGeneration);
+    current = await startRuntime(identity, nextGeneration);
     await bindSubscriptions();
     // Cleanup is best-effort and never delays owner/query readiness. A stale
     // database that is still open in another tab is protected by Evolu's lock
@@ -361,7 +456,7 @@ export async function createEvolu8Candidate({
     });
   };
 
-  await replaceRuntime(legacyOwner.mnemonic, initialGeneration);
+  await replaceRuntime(initialIdentity, initialGeneration);
   const createQuery = modern.createQueryBuilder(schema);
 
   const facade = {
@@ -401,15 +496,32 @@ export async function createEvolu8Candidate({
     },
     restoreAppOwner: async (mnemonic, _options = {}) => {
       const validatedMnemonic = modern.Mnemonic.orThrow(mnemonic);
+      const appOwner = createModernOwner(modern, validatedMnemonic);
+      const nextIdentity = { ownerId: appOwner.id, mnemonic: validatedMnemonic };
       const nextGeneration = consumeHistoryResetGeneration();
-      // v7 remains the durable identity vault during the compatibility phase.
-      // Always suppress its internal reload; GetBased owns reload sequencing.
-      await legacyEvolu.restoreAppOwner(validatedMnemonic, { reload: false });
-      await replaceRuntime(validatedMnemonic, nextGeneration);
+      // Keep the v7 rollback identity aligned, but load its worker only for an
+      // actual identity change. Token invalidation happens synchronously.
+      const invalidation = identityVault.invalidate();
+      const legacy = await resolveLegacyEvolu();
+      await Promise.all([
+        Promise.resolve(invalidation),
+        legacy.restoreAppOwner(validatedMnemonic, { reload: false }),
+      ]);
+      try {
+        await identityVault.write(nextIdentity);
+      } catch (error) {
+        console.warn('[sync] Evolu 8 restored identity could not be persisted:', error);
+      }
+      await replaceRuntime(nextIdentity, nextGeneration);
     },
     resetAppOwner: async (_options = {}) => {
       consumeHistoryResetGeneration();
-      await legacyEvolu.resetAppOwner({ reload: false });
+      const invalidation = identityVault.invalidate();
+      const legacy = await resolveLegacyEvolu();
+      await Promise.all([
+        Promise.resolve(invalidation),
+        legacy.resetAppOwner({ reload: false }),
+      ]);
       unbindSubscriptions();
       const previous = current;
       current = null;

--- a/js/sync-evolu8-identity-vault.js
+++ b/js/sync-evolu8-identity-vault.js
@@ -1,0 +1,170 @@
+// @ts-check
+// Durable browser identity handoff from Evolu 7 to Evolu 8.
+//
+// The recovery mnemonic stays in IndexedDB. localStorage contains only a
+// random, non-secret commit token so identity changes can invalidate the vault
+// synchronously before either Evolu generation mutates its durable owner.
+
+export const EVOLU8_IDENTITY_TOKEN_KEY = 'labcharts-sync-evolu8-identity-token';
+const DATABASE_NAME = 'getbased-evolu8-identity';
+const STORE_NAME = 'identity';
+const RECORD_KEY = 'app-owner';
+const RECORD_VERSION = 1;
+const OPERATION_TIMEOUT_MS = 5_000;
+
+/** @param {IDBFactory} indexedDb */
+function openVaultDatabase(indexedDb) {
+  return new Promise((resolve, reject) => {
+    const request = indexedDb.open(DATABASE_NAME, 1);
+    let settled = false;
+    const timeout = setTimeout(() => {
+      settled = true;
+      reject(new Error('Evolu 8 identity vault timed out'));
+    }, OPERATION_TIMEOUT_MS);
+    const finish = (callback) => {
+      if (settled) return false;
+      settled = true;
+      clearTimeout(timeout);
+      callback();
+      return true;
+    };
+    request.onupgradeneeded = () => {
+      if (!request.result.objectStoreNames.contains(STORE_NAME)) {
+        request.result.createObjectStore(STORE_NAME);
+      }
+    };
+    request.onsuccess = () => {
+      if (!finish(() => resolve(request.result))) request.result.close();
+    };
+    request.onerror = () => finish(() => reject(request.error || new Error('Identity vault open failed')));
+    request.onblocked = () => finish(() => reject(new Error('Evolu 8 identity vault is blocked')));
+  });
+}
+
+/**
+ * @param {IDBDatabase} database
+ * @param {IDBTransactionMode} mode
+ * @param {(store: IDBObjectStore) => IDBRequest | void} operation
+ */
+function runVaultTransaction(database, mode, operation) {
+  return new Promise((resolve, reject) => {
+    const transaction = database.transaction(STORE_NAME, mode);
+    let result;
+    let settled = false;
+    const finish = (callback) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      callback();
+    };
+    const timeout = setTimeout(() => {
+      try { transaction.abort(); } catch {}
+      finish(() => reject(new Error('Evolu 8 identity vault transaction timed out')));
+    }, OPERATION_TIMEOUT_MS);
+    try {
+      const request = operation(transaction.objectStore(STORE_NAME));
+      if (request) {
+        request.onsuccess = () => { result = request.result; };
+        request.onerror = () => {};
+      }
+    } catch (error) {
+      try { transaction.abort(); } catch {}
+      finish(() => reject(error));
+      return;
+    }
+    transaction.oncomplete = () => finish(() => resolve(result));
+    transaction.onabort = () => finish(() => reject(
+      transaction.error || new Error('Evolu 8 identity vault transaction aborted'),
+    ));
+    transaction.onerror = () => {};
+  });
+}
+
+/** @param {IDBFactory} indexedDb @param {IDBTransactionMode} mode @param {(store: IDBObjectStore) => IDBRequest | void} operation */
+async function accessVault(indexedDb, mode, operation) {
+  const database = /** @type {IDBDatabase} */ (await openVaultDatabase(indexedDb));
+  try {
+    return await runVaultTransaction(database, mode, operation);
+  } finally {
+    database.close();
+  }
+}
+
+function createCommitToken() {
+  if (typeof globalThis.crypto?.randomUUID === 'function') return globalThis.crypto.randomUUID();
+  const bytes = new Uint8Array(16);
+  globalThis.crypto?.getRandomValues?.(bytes);
+  return Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('')
+    || `${Date.now()}-${Math.random()}`;
+}
+
+/** @param {Storage | { getItem?: Function }} storage */
+function readCommitToken(storage) {
+  try { return String(storage?.getItem?.(EVOLU8_IDENTITY_TOKEN_KEY) || ''); } catch { return ''; }
+}
+
+/**
+ * @param {{
+ *   storage?: Storage | { getItem?: Function, setItem?: Function, removeItem?: Function },
+ *   indexedDb?: IDBFactory | null,
+ *   tokenFactory?: () => string,
+ * }} [options]
+ */
+export function createEvolu8IdentityVault({
+  storage = globalThis.localStorage,
+  indexedDb = globalThis.indexedDB,
+  tokenFactory = createCommitToken,
+} = {}) {
+  const read = async () => {
+    const token = readCommitToken(storage);
+    if (!token || !indexedDb) return null;
+    try {
+      const record = /** @type {any} */ (await accessVault(
+        indexedDb,
+        'readonly',
+        store => store.get(RECORD_KEY),
+      ));
+      if (record?.version !== RECORD_VERSION
+          || record?.token !== token
+          || typeof record?.ownerId !== 'string'
+          || !record.ownerId
+          || typeof record?.mnemonic !== 'string'
+          || !record.mnemonic) return null;
+      return { ownerId: record.ownerId, mnemonic: record.mnemonic };
+    } catch {
+      return null;
+    }
+  };
+
+  const write = async ({ ownerId, mnemonic }) => {
+    if (!indexedDb || typeof storage?.setItem !== 'function' || typeof storage?.getItem !== 'function') {
+      throw new Error('Evolu 8 identity vault storage is unavailable');
+    }
+    const token = String(tokenFactory() || '');
+    if (!token) throw new Error('Evolu 8 identity vault token is unavailable');
+    await accessVault(indexedDb, 'readwrite', store => store.put({
+      version: RECORD_VERSION,
+      token,
+      ownerId: String(ownerId),
+      mnemonic: String(mnemonic),
+    }, RECORD_KEY));
+    storage.setItem(EVOLU8_IDENTITY_TOKEN_KEY, token);
+    if (storage.getItem(EVOLU8_IDENTITY_TOKEN_KEY) !== token) {
+      throw new Error('Evolu 8 identity vault commit was not retained');
+    }
+  };
+
+  const invalidate = () => {
+    if (typeof storage?.removeItem !== 'function' || typeof storage?.getItem !== 'function') {
+      throw new Error('Evolu 8 identity vault cannot be invalidated');
+    }
+    storage.removeItem(EVOLU8_IDENTITY_TOKEN_KEY);
+    if (storage.getItem(EVOLU8_IDENTITY_TOKEN_KEY) !== null) {
+      throw new Error('Evolu 8 identity vault invalidation was not retained');
+    }
+    if (!indexedDb) return Promise.resolve();
+    return accessVault(indexedDb, 'readwrite', store => store.delete(RECORD_KEY)).catch(() => {});
+  };
+
+  return { invalidate, read, write };
+}

--- a/scripts/dom-sink-policy.json
+++ b/scripts/dom-sink-policy.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "scope": "Every non-generated JavaScript module under js/",
   "reviewRule": "Any added or modified HTML-writing sink requires security review and a policy refresh.",
-  "scannedFiles": 678,
+  "scannedFiles": 679,
   "sinkCount": 534,
   "files": {
     "js/backup.js": {

--- a/scripts/production-build-budget.json
+++ b/scripts/production-build-budget.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "maximums": {
     "startupJavaScriptFiles": 2,
-    "startupDecodedBytes": 1171000,
+    "startupDecodedBytes": 1172000,
     "outputJavaScriptFiles": 158,
     "outputDecodedBytes": 5000000
   },
@@ -35,7 +35,8 @@
     "mealsNutritionSyncRebaseOutputDecodedBytes": 4908949,
     "nutritionReportReadinessOutputDecodedBytes": 4955086,
     "whoopDeviceProtectionStartupDecodedBytes": 1170666,
-    "evolu8IdentityVaultOutputDecodedBytes": 4979131
+    "evolu8IdentityVaultOutputDecodedBytes": 4979169,
+    "evolu8IdentityVaultStartupDecodedBytes": 1170997
   },
   "referenceCommit": "807732a8",
   "measuredAt": "2026-08-30"

--- a/scripts/production-build-budget.json
+++ b/scripts/production-build-budget.json
@@ -4,7 +4,7 @@
     "startupJavaScriptFiles": 2,
     "startupDecodedBytes": 1171000,
     "outputJavaScriptFiles": 158,
-    "outputDecodedBytes": 4975000
+    "outputDecodedBytes": 5000000
   },
   "reference": {
     "startupJavaScriptFiles": 2,
@@ -34,8 +34,9 @@
     "mealsNutritionHydrationSerializationOutputDecodedBytes": 4908141,
     "mealsNutritionSyncRebaseOutputDecodedBytes": 4908949,
     "nutritionReportReadinessOutputDecodedBytes": 4955086,
-    "whoopDeviceProtectionStartupDecodedBytes": 1170666
+    "whoopDeviceProtectionStartupDecodedBytes": 1170666,
+    "evolu8IdentityVaultOutputDecodedBytes": 4979131
   },
   "referenceCommit": "807732a8",
-  "measuredAt": "2026-08-28"
+  "measuredAt": "2026-08-30"
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -464,7 +464,7 @@ const APP_SHELL = [ // Includes dynamic chat and Knowledge Base modules for firs
   '/js/sync-configure.js',
   '/js/sync-settings-state.js',
   '/js/sync-runtime.js',
-  '/js/sync-init.js', '/js/sync-evolu8-candidate.js',
+  '/js/sync-init.js', '/js/sync-evolu8-candidate.js', '/js/sync-evolu8-identity-vault.js',
   '/js/sync-lifecycle.js',
   '/js/sync-disable-cleanup.js',
   '/js/sync-backup-restore-state.js',

--- a/tests/data-wipe.test.js
+++ b/tests/data-wipe.test.js
@@ -84,6 +84,7 @@ describe('eraseAllLocalAppData', () => {
       'getbased-nutrition-default',
       'getbased-nutrition-active-profile',
       'getbased-nutrition-orphaned-profile',
+      'getbased-evolu8-identity',
       'getbased-cashu',
     ];
     await Promise.all([...appDatabases, 'third-party-database'].map(openDatabase));
@@ -126,6 +127,7 @@ describe('eraseAllLocalAppData', () => {
     const deletedNames = deleteDatabase.mock.calls.map(([name]) => name).sort();
     expect(deletedNames).toEqual([
       'getbased-cashu',
+      'getbased-evolu8-identity',
       'getbased-nutrition-active-profile',
       'getbased-nutrition-default',
       'labcharts-backups',
@@ -175,6 +177,7 @@ describe('eraseAllLocalAppData', () => {
     expect(deleteDatabase).toHaveBeenCalledWith('labcharts-wearables-default');
     expect(deleteDatabase).toHaveBeenCalledWith('labcharts-cycle-default');
     expect(deleteDatabase).toHaveBeenCalledWith('getbased-nutrition-default');
+    expect(deleteDatabase).toHaveBeenCalledWith('getbased-evolu8-identity');
     expect(deleteDatabase).toHaveBeenCalledWith('labcharts-blobs');
     expect(deleteDatabase).toHaveBeenCalledWith('labcharts-wearables-credential-vault');
     expect(deleteDatabase).toHaveBeenCalledWith('getbased-cashu');

--- a/tests/playwright/sync-evolu8-identity-vault.spec.js
+++ b/tests/playwright/sync-evolu8-identity-vault.spec.js
@@ -1,0 +1,60 @@
+import { expect, test } from '@playwright/test';
+
+const LEGACY_BUNDLE = '**/vendor/evolu/evolu-bundle.js';
+
+test('v8 repeat startup skips v7 and v7 restore invalidates the handoff', async ({ page }) => {
+  test.setTimeout(60_000);
+  await page.addInitScript(() => {
+    localStorage.setItem('labcharts-sync-enabled', 'true');
+    localStorage.setItem('labcharts-sync-relay', 'ws://127.0.0.1:9');
+  });
+  let blockLegacy = false;
+  let legacyRequests = 0;
+  await page.route(LEGACY_BUNDLE, route => {
+    legacyRequests += 1;
+    return blockLegacy ? route.abort() : route.continue();
+  });
+
+  const readOwner = () => page.evaluate(async () => {
+    const runtime = await import('/js/sync-runtime.js');
+    const owner = runtime.getSyncAppOwner();
+    return owner ? { id: String(owner.id), mnemonic: String(owner.mnemonic) } : null;
+  });
+
+  await page.goto('/app?evolu-client=v8', { waitUntil: 'domcontentloaded' });
+  await expect.poll(readOwner, { timeout: 30_000 }).not.toBeNull();
+  const firstOwner = await readOwner();
+  expect(firstOwner?.id).toBeTruthy();
+  expect(legacyRequests).toBeGreaterThan(0);
+  expect(await page.evaluate(mnemonic => Object.values(localStorage).includes(mnemonic), firstOwner.mnemonic))
+    .toBe(false);
+
+  blockLegacy = true;
+  legacyRequests = 0;
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await expect.poll(readOwner, { timeout: 30_000 }).not.toBeNull();
+  const secondOwner = await readOwner();
+
+  expect(secondOwner?.id).toBe(firstOwner?.id);
+  expect(legacyRequests).toBe(0);
+
+  blockLegacy = false;
+  legacyRequests = 0;
+  await page.goto('/app', { waitUntil: 'domcontentloaded' });
+  await expect.poll(readOwner, { timeout: 30_000 }).not.toBeNull();
+  expect((await readOwner())?.id).toBe(firstOwner?.id);
+  expect(legacyRequests).toBeGreaterThan(0);
+
+  await page.evaluate(async mnemonic => {
+    const runtime = await import('/js/sync-runtime.js');
+    await runtime.getSyncEvolu().restoreAppOwner(mnemonic, { reload: false });
+  }, firstOwner.mnemonic);
+  expect(await page.evaluate(() => localStorage.getItem('labcharts-sync-evolu8-identity-token')))
+    .toBeNull();
+
+  legacyRequests = 0;
+  await page.goto('/app?evolu-client=v8', { waitUntil: 'domcontentloaded' });
+  await expect.poll(readOwner, { timeout: 30_000 }).not.toBeNull();
+  expect((await readOwner())?.id).toBe(firstOwner?.id);
+  expect(legacyRequests).toBeGreaterThan(0);
+});

--- a/tests/sync-evolu8-candidate.test.js
+++ b/tests/sync-evolu8-candidate.test.js
@@ -4,6 +4,7 @@ import {
   EVOLU8_GENERATION_KEY,
   cleanupSupersededEvolu8Databases,
   createEvolu8Candidate,
+  guardLegacyIdentityChanges,
   isEvolu8CandidateRequested,
   readEvolu8Generation,
 } from '../js/sync-evolu8-candidate.js';
@@ -108,6 +109,104 @@ function createHarness({ mnemonic = 'alpha words', ownerId = `owner:${mnemonic}`
 }
 
 describe('Evolu 8 compatibility candidate', () => {
+  it('invalidates the v8 vault before legacy restore and reset mutations', async () => {
+    const events = [];
+    const legacy = {
+      name: 'getbased4',
+      restoreAppOwner: vi.fn(async () => { events.push('legacy:restore'); }),
+      resetAppOwner: vi.fn(async () => { events.push('legacy:reset'); }),
+    };
+    const identityVault = {
+      invalidate: vi.fn(() => { events.push('vault:invalidate'); return Promise.resolve(); }),
+    };
+    const guarded = guardLegacyIdentityChanges(legacy, identityVault);
+
+    expect(guarded.name).toBe('getbased4');
+    await guarded.restoreAppOwner('words', { reload: false });
+    await guarded.resetAppOwner({ reload: false });
+
+    expect(events).toEqual([
+      'vault:invalidate', 'legacy:restore',
+      'vault:invalidate', 'legacy:reset',
+    ]);
+  });
+
+  it('boots from a durable v8 identity without opening the v7 bridge', async () => {
+    const harness = createHarness();
+    const getLegacyEvolu = vi.fn(async () => harness.legacyEvolu);
+    const identityVault = {
+      invalidate: vi.fn(async () => {}),
+      write: vi.fn(async () => {}),
+    };
+    const evolu = await createEvolu8Candidate({
+      getLegacyEvolu,
+      initialIdentity: { ownerId: 'owner:alpha words', mnemonic: 'alpha words' },
+      identityVault,
+      modern: harness.modern,
+      schema: { profileData: {} },
+      relay: 'wss://relay.example',
+      storage: createStorage(),
+    });
+
+    await expect(evolu.appOwner).resolves.toMatchObject({ id: 'owner:alpha words' });
+    expect(getLegacyEvolu).not.toHaveBeenCalled();
+    expect(identityVault.invalidate).not.toHaveBeenCalled();
+    expect(identityVault.write).not.toHaveBeenCalled();
+  });
+
+  it('persists the first verified v7 identity handoff', async () => {
+    const harness = createHarness();
+    const identityVault = {
+      invalidate: vi.fn(async () => {}),
+      write: vi.fn(async () => {}),
+    };
+    await createEvolu8Candidate({
+      legacyEvolu: harness.legacyEvolu,
+      identityVault,
+      modern: harness.modern,
+      schema: { profileData: {} },
+      relay: 'wss://relay.example',
+      storage: createStorage(),
+    });
+
+    expect(identityVault.invalidate).toHaveBeenCalledOnce();
+    expect(identityVault.write).toHaveBeenCalledWith({
+      ownerId: 'owner:alpha words',
+      mnemonic: 'alpha words',
+    });
+  });
+
+  it('loads v7 lazily to align restore and reset identity changes', async () => {
+    const harness = createHarness();
+    const getLegacyEvolu = vi.fn(async () => harness.legacyEvolu);
+    const identityVault = {
+      invalidate: vi.fn(async () => {}),
+      write: vi.fn(async () => {}),
+    };
+    const evolu = await createEvolu8Candidate({
+      getLegacyEvolu,
+      initialIdentity: { ownerId: 'owner:alpha words', mnemonic: 'alpha words' },
+      identityVault,
+      modern: harness.modern,
+      schema: { profileData: {} },
+      relay: 'wss://relay.example',
+      storage: createStorage(),
+    });
+
+    await evolu.restoreAppOwner('beta words', { reload: false });
+    await evolu.resetAppOwner({ reload: false });
+
+    expect(getLegacyEvolu).toHaveBeenCalledOnce();
+    expect(harness.legacyEvolu.restoreAppOwner)
+      .toHaveBeenCalledWith('beta words', { reload: false });
+    expect(harness.legacyEvolu.resetAppOwner).toHaveBeenCalledWith({ reload: false });
+    expect(identityVault.invalidate).toHaveBeenCalledTimes(2);
+    expect(identityVault.write).toHaveBeenCalledWith({
+      ownerId: 'owner:beta words',
+      mnemonic: 'beta words',
+    });
+  });
+
   it('reclaims only unlocked superseded v8 database generations', async () => {
     const active = 'getbased8g3-owner_current';
     const stale = 'getbased8g2';

--- a/tests/sync-evolu8-identity-vault.test.js
+++ b/tests/sync-evolu8-identity-vault.test.js
@@ -1,0 +1,91 @@
+import { IDBFactory } from 'fake-indexeddb';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  EVOLU8_IDENTITY_TOKEN_KEY,
+  createEvolu8IdentityVault,
+} from '../js/sync-evolu8-identity-vault.js';
+
+function createStorage() {
+  const values = new Map();
+  return {
+    getItem: vi.fn(key => values.get(key) ?? null),
+    setItem: vi.fn((key, value) => values.set(key, value)),
+    removeItem: vi.fn(key => values.delete(key)),
+    values,
+  };
+}
+
+describe('Evolu 8 identity vault', () => {
+  it('commits and reads an identity without putting its mnemonic in localStorage', async () => {
+    const storage = createStorage();
+    const vault = createEvolu8IdentityVault({
+      storage,
+      indexedDb: new IDBFactory(),
+      tokenFactory: () => 'commit-token',
+    });
+
+    await vault.write({ ownerId: 'owner-1', mnemonic: 'alpha beta gamma' });
+
+    await expect(vault.read()).resolves.toEqual({
+      ownerId: 'owner-1',
+      mnemonic: 'alpha beta gamma',
+    });
+    expect(storage.values.get(EVOLU8_IDENTITY_TOKEN_KEY)).toBe('commit-token');
+    expect(JSON.stringify([...storage.values])).not.toContain('alpha beta gamma');
+  });
+
+  it('invalidates synchronously before deleting the IndexedDB record', async () => {
+    const storage = createStorage();
+    const vault = createEvolu8IdentityVault({
+      storage,
+      indexedDb: new IDBFactory(),
+      tokenFactory: () => 'commit-token',
+    });
+    await vault.write({ ownerId: 'owner-1', mnemonic: 'alpha beta gamma' });
+
+    const deletion = vault.invalidate();
+    expect(storage.getItem(EVOLU8_IDENTITY_TOKEN_KEY)).toBeNull();
+    await expect(vault.read()).resolves.toBeNull();
+    await deletion;
+  });
+
+  it('rejects a commit when localStorage does not retain its token', async () => {
+    const storage = createStorage();
+    storage.setItem.mockImplementation(() => {});
+    const vault = createEvolu8IdentityVault({
+      storage,
+      indexedDb: new IDBFactory(),
+      tokenFactory: () => 'lost-token',
+    });
+
+    await expect(vault.write({ ownerId: 'owner-1', mnemonic: 'alpha beta gamma' }))
+      .rejects.toThrow('commit was not retained');
+    await expect(vault.read()).resolves.toBeNull();
+  });
+
+  it('fails closed when invalidation cannot be retained', () => {
+    const storage = createStorage();
+    storage.values.set(EVOLU8_IDENTITY_TOKEN_KEY, 'old-token');
+    storage.removeItem.mockImplementation(() => {});
+    const vault = createEvolu8IdentityVault({ storage, indexedDb: new IDBFactory() });
+
+    expect(() => vault.invalidate()).toThrow('invalidation was not retained');
+  });
+
+  it('ignores missing browser storage and mismatched commit tokens', async () => {
+    const storage = createStorage();
+    const indexedDb = new IDBFactory();
+    const vault = createEvolu8IdentityVault({
+      storage,
+      indexedDb,
+      tokenFactory: () => 'first-token',
+    });
+    await vault.write({ ownerId: 'owner-1', mnemonic: 'alpha beta gamma' });
+    storage.values.set(EVOLU8_IDENTITY_TOKEN_KEY, 'different-token');
+
+    await expect(vault.read()).resolves.toBeNull();
+    await expect(createEvolu8IdentityVault({ storage, indexedDb: null }).read())
+      .resolves.toBeNull();
+  });
+});

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -489,6 +489,7 @@
     "js/sync-identity.js",
     "js/sync-origin-state.js",
     "js/sync-evolu8-candidate.js",
+    "js/sync-evolu8-identity-vault.js",
     "js/sync-init.js",
     "js/sync-lifecycle.js",
     "js/sync-runtime.js",


### PR DESCRIPTION
Summary:
- persist the verified v7 owner in an IndexedDB handoff vault with a non-secret localStorage commit token
- start repeat v8 sessions without loading the v7 worker, while loading v7 lazily for restore/reset rollback alignment
- cover first handoff, repeat startup, rollback invalidation, and existing OPFS cleanup; update migration gates and the measured lazy-output budget

Change-scoped verification:
- npm test -- tests/test-sync.js tests/production-build.test.js tests/sync-evolu8-candidate.test.js tests/sync-evolu8-identity-vault.test.js tests/sync-lifecycle-runtime.test.js
- npm run typecheck:checkjs
- npm run quality
- npm run architecture:check
- npm run vendor:evolu8:check
- npm run production:check
- PLAYWRIGHT_REUSE_SERVER=1 npx playwright test tests/playwright/sync-evolu8-opfs-cleanup.spec.js tests/playwright/sync-evolu8-identity-vault.spec.js --workers=1