### PR TITLE
test: automate Evolu 8 promotion gates

### DIFF
--- a/.github/workflows/sync-compat.yml
+++ b/.github/workflows/sync-compat.yml
@@ -109,9 +109,24 @@ jobs:
           retention-days: 7
 
   browsers:
-    name: Evolu 8 browser engines
-    runs-on: ubuntu-latest
+    name: Evolu 8 (${{ matrix.browser }})
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - browser: chromium
+            project: chromium-evolu8
+            os: ubuntu-latest
+          - browser: firefox
+            project: firefox-evolu8
+            os: ubuntu-latest
+          # Playwright's Linux WPE-WebKit port omits navigator.storage/OPFS.
+          # The macOS port exercises the storage path shipped by Safari.
+          - browser: webkit
+            project: webkit-evolu8
+            os: macos-latest
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -124,17 +139,22 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Install browser engines
-        run: npx playwright install --with-deps chromium firefox webkit
+      - name: Install browser engine and Linux dependencies
+        if: runner.os == 'Linux'
+        run: npx playwright install --with-deps ${{ matrix.browser }}
+
+      - name: Install browser engine
+        if: runner.os == 'macOS'
+        run: npx playwright install ${{ matrix.browser }}
 
       - name: Run Evolu 8 browser compatibility suite
-        run: npm run test:evolu8-browsers
+        run: npm run test:evolu8-browsers -- --project=${{ matrix.project }}
 
       - name: Upload browser logs on failure
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: evolu8-browser-logs
+          name: evolu8-${{ matrix.browser }}-logs
           path: |
             /tmp/getbased-evolu8-browser-results
             /tmp/dev-server.log

--- a/.github/workflows/sync-compat.yml
+++ b/.github/workflows/sync-compat.yml
@@ -1,0 +1,142 @@
+name: Sync compatibility
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  transport:
+    name: Transport (${{ matrix.evolu-client }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        evolu-client: [v7, v8]
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Check out pinned disposable relay
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          repository: elkimek/getbased-relay
+          ref: 256261261c9422d803623da219820d341fbc01f0
+          path: .ci/getbased-relay
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            .ci/getbased-relay/package-lock.json
+
+      - name: Install app and relay dependencies
+        run: |
+          npm ci
+          npm ci --prefix .ci/getbased-relay
+          npm run build --prefix .ci/getbased-relay
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run real-relay transport scenario
+        shell: bash
+        run: |
+          set -euo pipefail
+          client="${{ matrix.evolu-client }}"
+          relay_data_dir="${RUNNER_TEMP}/getbased-relay-${client}"
+          relay_log="${RUNNER_TEMP}/getbased-relay-${client}.log"
+          mkdir -p "${relay_data_dir}"
+          env \
+            DATA_DIR="${relay_data_dir}" \
+            RELAY_PORT=4000 \
+            ADMIN_PORT=4002 \
+            SELF_PORT=4003 \
+            SELF_BIND=127.0.0.1 \
+            SELF_ENABLED=true \
+            QUOTA_PER_OWNER_MB=10 \
+            QUOTA_GLOBAL_MB=100 \
+            LOG_LEVEL=info \
+            LOG_FORMAT=text \
+            node .ci/getbased-relay/dist/index.js >"${relay_log}" 2>&1 &
+          relay_pid=$!
+          cleanup_relay() {
+            kill "${relay_pid}" 2>/dev/null || true
+            wait "${relay_pid}" 2>/dev/null || true
+          }
+          trap cleanup_relay EXIT
+
+          relay_ready=0
+          for attempt in {1..40}; do
+            if curl --fail --silent http://127.0.0.1:4002/health >/dev/null; then
+              relay_ready=1
+              break
+            fi
+            if ! kill -0 "${relay_pid}" 2>/dev/null; then break; fi
+            sleep 0.25
+          done
+          if [[ "${relay_ready}" != "1" ]]; then
+            cat "${relay_log}"
+            exit 1
+          fi
+
+          env \
+            SYNC_TRANSPORT_E2E=1 \
+            SYNC_TRANSPORT_EVOLU_CLIENT="${client}" \
+            SYNC_TRANSPORT_RELAY=ws://127.0.0.1:4000 \
+            SYNC_TRANSPORT_SELF_URL=http://127.0.0.1:4003 \
+            npx playwright test tests/playwright/sync-relay-transport-e2e.spec.js --workers=1
+
+      - name: Upload transport logs on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: sync-transport-${{ matrix.evolu-client }}-logs
+          path: |
+            ${{ runner.temp }}/getbased-relay-${{ matrix.evolu-client }}.log
+            /tmp/getbased-playwright-results
+            /tmp/dev-server.log
+          if-no-files-found: ignore
+          retention-days: 7
+
+  browsers:
+    name: Evolu 8 browser engines
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install browser engines
+        run: npx playwright install --with-deps chromium firefox webkit
+
+      - name: Run Evolu 8 browser compatibility suite
+        run: npm run test:evolu8-browsers
+
+      - name: Upload browser logs on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: evolu8-browser-logs
+          path: |
+            /tmp/getbased-evolu8-browser-results
+            /tmp/dev-server.log
+          if-no-files-found: ignore
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ npm run sbom
 npm run quality
 npm test -- tests/<relevant-test>.test.js
 npx playwright test tests/playwright/<relevant-spec>.spec.js
+npm run test:evolu8-browsers
 npm run test:firefox
 npm run performance:check
 npm run production:check
@@ -167,6 +168,7 @@ npm run production:check
 Default to tests related to the current change. GitHub Actions runs the exhaustive browser and combined-coverage matrix so local development does not repeatedly create high volumes of temporary Chromium and V8 coverage data.
 `./run-tests.sh` runs both type checkers, verifies the architecture map, vendored browser assets and their supply-chain inventory, and the static module graph, starts an isolated local server, runs the Node/Vitest tests, checks the dev-server origin guard, and runs every Playwright browser assertion. It is blocked outside CI unless the high-write run is explicitly acknowledged with `GETBASED_ALLOW_HIGH_WRITE_TESTS=1`.
 `COVERAGE=1 ./run-tests.sh` also combines Vitest and Playwright V8 function coverage and enforces the committed ratchet in `scripts/coverage-baseline.json`; CI runs this mode on every change.
+`npm run test:evolu8-browsers` runs the focused Evolu 8 startup, durable-identity, resource-management-polyfill, and one-tab fallback checks in Chromium, Firefox, and WebKit.
 `npm run test:firefox` runs the focused Firefox critical-flow suite; install its browser binary once with `npx playwright install firefox`.
 `npm run performance:check` runs the focused cold mobile-load check and enforces the committed request-count, compressed-transfer, and decoded-byte ceilings.
 `npm run production:check` builds the deploy artifact in a temporary directory and enforces the production startup, lazy-chunk, and PWA app-shell precache resource/decoded-byte budgets without changing the worktree.

--- a/docs/evolu8-client-migration.md
+++ b/docs/evolu8-client-migration.md
@@ -45,8 +45,9 @@ Do not make Evolu 8 the default unless all of these checks remain green:
 2. Its browser matrix starts and reloads v8 in Linux Chromium and Firefox plus
    macOS WebKit, then repeats the run with resource-management globals and
    native SharedWorker removed to exercise Evolu's one-tab fallback and
-   contention warning. WebKit runs on macOS because Playwright's Linux WPE port
-   does not expose the `navigator.storage` OPFS entry point shipped by Safari.
+   contention warning. WebKit runs on macOS with a persistent browser profile:
+   Playwright's Linux WPE port lacks the `navigator.storage` OPFS entry point,
+   and WebKit deliberately withholds OPFS from its default private context.
 
 These automated gates make the next safe step a separate, reviewable default
 cutover rather than combining compatibility validation with rollout. Cleanup

--- a/docs/evolu8-client-migration.md
+++ b/docs/evolu8-client-migration.md
@@ -36,14 +36,17 @@ pre-cached for every user, so the first evaluation must begin online.
 
 ## Promotion gates
 
-Do not make Evolu 8 the default until all of these are resolved:
+Do not make Evolu 8 the default unless all of these checks remain green:
 
-1. The focused real-relay scenario passes for both clients in CI, including
+1. The `Sync compatibility` CI workflow runs the focused real-relay scenario
+   against the pinned `getbased-relay` revision for both clients, including
    no-op storage stability, offline recovery, mnemonic join, relay compaction,
    and stale-device reconnect.
-2. The supported browser matrix passes with the v8 resource-management
-   polyfills and SharedWorker fallback.
+2. Its browser job starts and reloads v8 in Chromium, Firefox, and WebKit, then
+   repeats the run with resource-management globals and native SharedWorker
+   removed to exercise Evolu's one-tab fallback and contention warning.
 
-The candidate still favors rollback and data preservation while the remaining
-relay and browser gates are open. Cleanup removes only superseded, unlocked v8
-generation databases and leaves the v7 rollback database intact.
+These automated gates make the next safe step a separate, reviewable default
+cutover rather than combining compatibility validation with rollout. Cleanup
+removes only superseded, unlocked v8 generation databases and leaves the v7
+rollback database intact.

--- a/docs/evolu8-client-migration.md
+++ b/docs/evolu8-client-migration.md
@@ -42,9 +42,11 @@ Do not make Evolu 8 the default unless all of these checks remain green:
    against the pinned `getbased-relay` revision for both clients, including
    no-op storage stability, offline recovery, mnemonic join, relay compaction,
    and stale-device reconnect.
-2. Its browser job starts and reloads v8 in Chromium, Firefox, and WebKit, then
-   repeats the run with resource-management globals and native SharedWorker
-   removed to exercise Evolu's one-tab fallback and contention warning.
+2. Its browser matrix starts and reloads v8 in Linux Chromium and Firefox plus
+   macOS WebKit, then repeats the run with resource-management globals and
+   native SharedWorker removed to exercise Evolu's one-tab fallback and
+   contention warning. WebKit runs on macOS because Playwright's Linux WPE port
+   does not expose the `navigator.storage` OPFS entry point shipped by Safari.
 
 These automated gates make the next safe step a separate, reviewable default
 cutover rather than combining compatibility validation with rollout. Cleanup

--- a/js/sync-actions.js
+++ b/js/sync-actions.js
@@ -76,6 +76,23 @@ export async function pushCurrentProfile() {
   return result;
 }
 
+async function pushCurrentProfileWhenIdle() {
+  const deadline = Date.now() + 30_000;
+  let result;
+  do {
+    while (_isSyncing() && Date.now() < deadline) {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    }
+    result = await pushCurrentProfile();
+    if (result?.reason !== 'in-flight') return result;
+    // A pull can schedule a union rebroadcast just before it resolves. If
+    // that timer wins the race with this manual push, wait for it instead of
+    // reporting a false failure (or asking the user to press Sync again).
+    if (Date.now() < deadline) await new Promise(resolve => setTimeout(resolve, 50));
+  } while (Date.now() < deadline);
+  return result;
+}
+
 // "Force resend" - bypasses the _syncing guard so a wedged in-flight flag
 // doesn't silently no-op the push.
 export async function forceResendCurrentProfile() {
@@ -94,11 +111,7 @@ export async function syncNow() {
   // durable local edit before it ever reaches Evolu. Flush dirty local state
   // first; clean devices still pull first so they cannot publish stale data.
   if (getSyncDirtyToken(state.currentProfile)) {
-    const deadline = Date.now() + 30_000;
-    while (_isSyncing() && Date.now() < deadline) {
-      await new Promise(resolve => setTimeout(resolve, 50));
-    }
-    const localResult = await pushCurrentProfile();
+    const localResult = await pushCurrentProfileWhenIdle();
     if (!localResult?.ok) return localResult;
     try {
       await _forcePull();
@@ -107,7 +120,7 @@ export async function syncNow() {
       logSyncEvent('skip', 'Manual pull failed — local changes were still committed');
       return localResult;
     }
-    return pushCurrentProfile();
+    return pushCurrentProfileWhenIdle();
   }
   // Apply any already-received remote state before publishing the local
   // snapshot. Pull-then-push matches first-enable behavior and avoids sending
@@ -118,7 +131,7 @@ export async function syncNow() {
     console.warn('[sync] Manual pull failed; continuing with local push:', error);
     logSyncEvent('skip', 'Manual pull failed — local push still attempted');
   }
-  return pushCurrentProfile();
+  return pushCurrentProfileWhenIdle();
 }
 
 // Push all profiles on first enable.
@@ -250,13 +263,44 @@ export async function prepareRelayCompaction() {
   await _forcePull();
 }
 
+function cloneRelayRebuildData(importedData) {
+  if (typeof structuredClone === 'function') return structuredClone(importedData);
+  return JSON.parse(JSON.stringify(importedData));
+}
+
 export async function rebuildOwnerRelayState() {
-  await _resetLocalSyncHistoryForRelayRebuild();
   const allProfiles = _getProfiles();
   const profiles = allProfiles.filter(profile => !getProfileSyncBlockReason(profile?.id, allProfiles));
+  // Capture every source profile before resetting Evolu. restoreAppOwner can
+  // synchronously fire empty/new-database subscriptions; reading
+  // state.importedData afterward lets those callbacks replace the canonical
+  // compaction source while the rebuild is in progress.
+  const snapshots = [];
+  for (const profile of profiles) {
+    const importedData = profile.id === state.currentProfile
+      ? (state.importedData || _createDefaultProfileData())
+      : await readProfileImportedData(profile.id);
+    if (!importedData) {
+      throw new Error(`Could not capture local data for profile ${String(profile?.id || '').slice(0, 8)}; relay rebuild stopped safely`);
+    }
+    snapshots.push({ profile, importedData: cloneRelayRebuildData(importedData) });
+  }
+
+  await _resetLocalSyncHistoryForRelayRebuild();
   for (const profile of profiles) prepareProfileForRelayRebuild(profile?.id);
-  const summary = await pushSelectedProfiles(profiles, { force: true });
-  if (summary.failed > 0 || summary.succeeded === 0) {
+  const summary = { total: snapshots.length, succeeded: 0, failed: 0, skipped: 0 };
+  for (const { profile, importedData } of snapshots) {
+    try {
+      const result = await _pushProfile(profile.id, importedData, { force: true });
+      if (result?.skipped) summary.skipped++;
+      else if (result?.ok === true) summary.succeeded++;
+      else summary.failed++;
+    } catch (error) {
+      summary.failed++;
+      console.error('[sync] Relay rebuild push failed for profile:', profile.id, error);
+    }
+  }
+  if (summary.failed > 0 || summary.skipped > 0 || summary.succeeded !== summary.total) {
     throw new Error(`Relay rebuild incomplete (${summary.succeeded}/${summary.total} profiles sent)`);
   }
   return summary;

--- a/js/sync-environment.js
+++ b/js/sync-environment.js
@@ -36,10 +36,10 @@ export function checkRelayConnection(timeout = 4000) {
  * when it isn't. Used to fail-fast with a clear message instead of letting
  * Evolu's worker hang for 30s on a missing primitive.
  *
- * Evolu uses dedicated Workers coordinated across tabs via BroadcastChannel
- * + navigator.locks (see createSharedWebWorker in evolu-bundle.js - the
- * "Shared" in the name refers to cross-tab sharing, not the SharedWorker
- * API). So the real requirements are locks + OPFS + WebCrypto.
+ * Evolu 7 uses dedicated Workers coordinated via BroadcastChannel and Web
+ * Locks. Evolu 8 uses SharedWorker when available and installs a Web Worker
+ * one-tab fallback when it is not. Both paths still require locks, OPFS, and
+ * WebCrypto, so SharedWorker itself is not a capability gate.
  */
 export function getSyncBlocker() {
   if (!navigator.locks?.request) return 'navigator.locks not available — browser missing Web Locks API';

--- a/js/sync-pull-rebroadcast.js
+++ b/js/sync-pull-rebroadcast.js
@@ -13,7 +13,6 @@ function dbg(debug, ...args) {
 
 /** @param {{
  *   profileId?: string,
- *   merged?: any,
  *   needsRebroadcast?: boolean,
  *   pushProfile?: (...args: any[]) => any,
  *   debug?: (...args: any[]) => any,
@@ -21,7 +20,6 @@ function dbg(debug, ...args) {
  */
 export function maybeScheduleRebroadcast({
   profileId,
-  merged,
   needsRebroadcast,
   pushProfile,
   debug,
@@ -52,17 +50,21 @@ export function maybeScheduleRebroadcast({
   dbg(debug, `Row ${profileId.slice(0,8)}: rebroadcast — local had unsynced rows`);
   logSyncEvent('rebroadcast', `Rebroadcast ${profileId.slice(0,8)}`);
 
-  // Snapshot importedData at SCHEDULE time and re-verify the
-  // active profile when the timer fires. Without these, a profile
-  // switch in the 100ms gap would push the new active profile's
-  // state.importedData into the *original* profile's relay row.
-  const snapshotImported = merged;
+  // Re-verify the active profile when the timer fires, then publish its latest
+  // state. Capturing `merged` here is unsafe: another pull or local edit can
+  // replace state.importedData during the 100ms gap, and the delayed stale
+  // snapshot would then regress scalar fields on every device.
   setTimeout(() => {
     if (profileId !== state.currentProfile) {
       dbg(debug, `Rebroadcast aborted — active profile switched`);
       return;
     }
-    pushProfile(profileId, snapshotImported);
+    const latestImported = state.importedData;
+    if (!latestImported || typeof latestImported !== 'object') {
+      dbg(debug, `Rebroadcast aborted — active profile data unavailable`);
+      return;
+    }
+    pushProfile(profileId, latestImported);
   }, 100);
   return true;
 }

--- a/js/sync-pull.js
+++ b/js/sync-pull.js
@@ -368,7 +368,6 @@ export async function onSyncReceived() {
 
         maybeScheduleRebroadcast({
           profileId,
-          merged,
           needsRebroadcast,
           pushProfile: _pushProfile,
           debug: dbg,

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "supply-chain:check": "node scripts/supply-chain.mjs --check",
     "supply-chain:snapshot": "node scripts/supply-chain.mjs --snapshot",
     "test": "vitest run",
+    "test:evolu8-browsers": "playwright test --config=playwright.evolu8.config.js",
     "test:firefox": "playwright test --config=playwright.firefox.config.js",
     "test:playwright": "node scripts/local-full-suite-guard.mjs && playwright test",
     "typecheck": "tsc -p tsconfig.json",

--- a/playwright.evolu8.config.js
+++ b/playwright.evolu8.config.js
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from '@playwright/test';
+import baseConfig from './playwright.config.js';
+
+const { launchOptions: chromiumLaunchOptions, ...sharedUse } = baseConfig.use || {};
+
+export default defineConfig({
+  ...baseConfig,
+  testDir: './tests/evolu8-browser',
+  outputDir: process.env.PLAYWRIGHT_EVOLU8_OUTPUT_DIR || '/tmp/getbased-evolu8-browser-results',
+  fullyParallel: false,
+  workers: 1,
+  timeout: 60_000,
+  use: {
+    ...sharedUse,
+    serviceWorkers: 'block',
+  },
+  projects: [
+    {
+      name: 'chromium-evolu8',
+      use: {
+        ...devices['Desktop Chrome'],
+        launchOptions: chromiumLaunchOptions,
+      },
+    },
+    {
+      name: 'firefox-evolu8',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'webkit-evolu8',
+      use: { ...devices['Desktop Safari'] },
+    },
+  ],
+});

--- a/tests/evolu8-browser/smoke.spec.js
+++ b/tests/evolu8-browser/smoke.spec.js
@@ -1,0 +1,108 @@
+import { expect, test } from '@playwright/test';
+
+const LEGACY_BUNDLE = '**/vendor/evolu/evolu-bundle.js';
+const ONE_TAB_ERROR = 'Evolu 8 requires this app to stay open in only one tab in this browser';
+
+async function configureCandidate(context, { forceFallback = false } = {}) {
+  await context.addInitScript(({ forceOneTabFallback }) => {
+    localStorage.setItem('labcharts-sync-enabled', 'true');
+    localStorage.setItem('labcharts-sync-relay', 'ws://127.0.0.1:9');
+    if (!forceOneTabFallback) return;
+
+    const replaceGlobal = (name, value) => {
+      try {
+        Object.defineProperty(globalThis, name, {
+          configurable: true,
+          writable: true,
+          value,
+        });
+      } catch {}
+    };
+    replaceGlobal('SharedWorker', undefined);
+    replaceGlobal('DisposableStack', undefined);
+    replaceGlobal('AsyncDisposableStack', undefined);
+    replaceGlobal('SuppressedError', undefined);
+    globalThis.__evolu8FallbackForced = typeof globalThis.SharedWorker === 'undefined';
+  }, { forceOneTabFallback: forceFallback });
+}
+
+async function readRuntime(page) {
+  return page.evaluate(async () => {
+    const runtime = await import('/js/sync-runtime.js');
+    const owner = runtime.getSyncAppOwner();
+    return {
+      clientVersion: runtime.getSyncEvolu()?.__evoluClientVersion || null,
+      error: runtime.getSyncAppOwnerError(),
+      ownerId: owner?.id ? String(owner.id) : null,
+    };
+  });
+}
+
+async function waitForOwner(page) {
+  await expect.poll(async () => (await readRuntime(page)).ownerId, {
+    timeout: 30_000,
+    intervals: [100, 250, 500, 1000],
+  }).not.toBeNull();
+  return readRuntime(page);
+}
+
+test('starts v8 and reuses its durable identity without the v7 worker', async ({ context, page }) => {
+  await configureCandidate(context);
+  const pageErrors = [];
+  page.on('pageerror', error => pageErrors.push(error.message));
+  let blockLegacy = false;
+  let legacyRequests = 0;
+  await page.route(LEGACY_BUNDLE, route => {
+    legacyRequests += 1;
+    return blockLegacy ? route.abort() : route.continue();
+  });
+
+  await page.goto('/app?evolu-client=v8', { waitUntil: 'domcontentloaded' });
+  const first = await waitForOwner(page);
+  expect(first.clientVersion).toBe(8);
+  expect(legacyRequests).toBeGreaterThan(0);
+
+  blockLegacy = true;
+  legacyRequests = 0;
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  const second = await waitForOwner(page);
+
+  expect(second.ownerId).toBe(first.ownerId);
+  expect(second.clientVersion).toBe(8);
+  expect(legacyRequests).toBe(0);
+  expect(pageErrors).toEqual([]);
+});
+
+test('polyfills resource management and enforces the one-tab worker fallback', async ({ context, page }) => {
+  await configureCandidate(context, { forceFallback: true });
+  const pageErrors = [];
+  page.on('pageerror', error => pageErrors.push(error.message));
+
+  await page.goto('/app?evolu-client=v8', { waitUntil: 'domcontentloaded' });
+  const first = await waitForOwner(page);
+  expect(first.clientVersion).toBe(8);
+  expect(await page.evaluate(() => ({
+    asyncDisposableStack: typeof globalThis.AsyncDisposableStack,
+    disposableStack: typeof globalThis.DisposableStack,
+    fallbackForced: globalThis.__evolu8FallbackForced,
+    sharedWorker: typeof globalThis.SharedWorker,
+    suppressedError: typeof globalThis.SuppressedError,
+  }))).toEqual({
+    asyncDisposableStack: 'function',
+    disposableStack: 'function',
+    fallbackForced: true,
+    sharedWorker: 'function',
+    suppressedError: 'function',
+  });
+
+  const secondPage = await context.newPage();
+  secondPage.on('pageerror', error => pageErrors.push(error.message));
+  await secondPage.goto('/app?evolu-client=v8', { waitUntil: 'domcontentloaded' });
+  await expect.poll(async () => (await readRuntime(secondPage)).error, {
+    timeout: 30_000,
+    intervals: [100, 250, 500, 1000],
+  }).toBe(ONE_TAB_ERROR);
+
+  await secondPage.close();
+  expect(pageErrors).toEqual([]);
+});

--- a/tests/evolu8-browser/smoke.spec.js
+++ b/tests/evolu8-browser/smoke.spec.js
@@ -2,10 +2,13 @@ import { expect, test } from '@playwright/test';
 
 const LEGACY_BUNDLE = '**/vendor/evolu/evolu-bundle.js';
 const ONE_TAB_ERROR = 'Evolu 8 requires this app to stay open in only one tab in this browser';
+const TEST_IDENTITY = {
+  ownerId: 'BSf-8mxNjgk72yD-D7rr1A',
+  mnemonic: 'oven federal awkward resist alter sound social version apart misery differ power buyer cloud avocado amount lady wedding silent nest fragile blanket oval fame',
+};
 
 async function configureCandidate(context, { forceFallback = false } = {}) {
   await context.addInitScript(({ forceOneTabFallback }) => {
-    localStorage.setItem('labcharts-sync-enabled', 'true');
     localStorage.setItem('labcharts-sync-relay', 'ws://127.0.0.1:9');
     if (!forceOneTabFallback) return;
 
@@ -26,6 +29,14 @@ async function configureCandidate(context, { forceFallback = false } = {}) {
   }, { forceOneTabFallback: forceFallback });
 }
 
+async function seedCandidateIdentity(page) {
+  await page.evaluate(async identity => {
+    const { createEvolu8IdentityVault } = await import('/js/sync-evolu8-identity-vault.js');
+    await createEvolu8IdentityVault().write(identity);
+    localStorage.setItem('labcharts-sync-enabled', 'true');
+  }, TEST_IDENTITY);
+}
+
 async function readRuntime(page) {
   return page.evaluate(async () => {
     const runtime = await import('/js/sync-runtime.js');
@@ -39,30 +50,35 @@ async function readRuntime(page) {
 }
 
 async function waitForOwner(page) {
-  await expect.poll(async () => (await readRuntime(page)).ownerId, {
+  await expect.poll(async () => {
+    const runtime = await readRuntime(page);
+    if (runtime.error) throw new Error(runtime.error);
+    return runtime.ownerId;
+  }, {
     timeout: 30_000,
     intervals: [100, 250, 500, 1000],
   }).not.toBeNull();
   return readRuntime(page);
 }
 
-test('starts v8 and reuses its durable identity without the v7 worker', async ({ context, page }) => {
+test('starts v8 from its durable identity without the v7 worker', async ({ context, page }) => {
   await configureCandidate(context);
   const pageErrors = [];
   page.on('pageerror', error => pageErrors.push(error.message));
-  let blockLegacy = false;
   let legacyRequests = 0;
   await page.route(LEGACY_BUNDLE, route => {
     legacyRequests += 1;
-    return blockLegacy ? route.abort() : route.continue();
+    return route.abort();
   });
 
   await page.goto('/app?evolu-client=v8', { waitUntil: 'domcontentloaded' });
+  await seedCandidateIdentity(page);
+  await page.reload({ waitUntil: 'domcontentloaded' });
   const first = await waitForOwner(page);
   expect(first.clientVersion).toBe(8);
-  expect(legacyRequests).toBeGreaterThan(0);
+  expect(first.ownerId).toBe(TEST_IDENTITY.ownerId);
+  expect(legacyRequests).toBe(0);
 
-  blockLegacy = true;
   legacyRequests = 0;
   await page.reload({ waitUntil: 'domcontentloaded' });
   const second = await waitForOwner(page);
@@ -77,10 +93,19 @@ test('polyfills resource management and enforces the one-tab worker fallback', a
   await configureCandidate(context, { forceFallback: true });
   const pageErrors = [];
   page.on('pageerror', error => pageErrors.push(error.message));
+  let legacyRequests = 0;
+  await page.route(LEGACY_BUNDLE, route => {
+    legacyRequests += 1;
+    return route.abort();
+  });
 
   await page.goto('/app?evolu-client=v8', { waitUntil: 'domcontentloaded' });
+  await seedCandidateIdentity(page);
+  await page.reload({ waitUntil: 'domcontentloaded' });
   const first = await waitForOwner(page);
   expect(first.clientVersion).toBe(8);
+  expect(first.ownerId).toBe(TEST_IDENTITY.ownerId);
+  expect(legacyRequests).toBe(0);
   expect(await page.evaluate(() => ({
     asyncDisposableStack: typeof globalThis.AsyncDisposableStack,
     disposableStack: typeof globalThis.DisposableStack,

--- a/tests/evolu8-browser/smoke.spec.js
+++ b/tests/evolu8-browser/smoke.spec.js
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { devices, expect, test } from '@playwright/test';
 
 const LEGACY_BUNDLE = '**/vendor/evolu/evolu-bundle.js';
 const ONE_TAB_ERROR = 'Evolu 8 requires this app to stay open in only one tab in this browser';
@@ -9,7 +9,7 @@ const TEST_IDENTITY = {
 
 async function configureCandidate(context, { forceFallback = false } = {}) {
   await context.addInitScript(({ forceOneTabFallback }) => {
-    localStorage.setItem('labcharts-sync-relay', 'ws://127.0.0.1:9');
+    localStorage.setItem('labcharts-sync-relay', 'ws://127.0.0.1:41999');
     if (!forceOneTabFallback) return;
 
     const replaceGlobal = (name, value) => {
@@ -37,6 +37,34 @@ async function seedCandidateIdentity(page) {
   }, TEST_IDENTITY);
 }
 
+async function getCompatibleBrowserPage({ browserName, context, page, playwright }, testInfo) {
+  if (browserName !== 'webkit') {
+    return { context, page, close: async () => {} };
+  }
+
+  // WebKit intentionally withholds OPFS in private browsing, while Playwright
+  // test contexts are incognito-style. A persistent profile matches normal
+  // Safari storage behavior without mocking any filesystem API.
+  const persistentContext = await playwright.webkit.launchPersistentContext(
+    testInfo.outputPath('webkit-profile'),
+    {
+      ...devices['Desktop Safari'],
+      baseURL: String(testInfo.project.use.baseURL),
+      serviceWorkers: 'block',
+    },
+  );
+  await persistentContext.tracing.start({ screenshots: true, snapshots: true, sources: true });
+  const persistentPage = persistentContext.pages()[0] || await persistentContext.newPage();
+  return {
+    context: persistentContext,
+    page: persistentPage,
+    close: async () => {
+      await persistentContext.tracing.stop({ path: testInfo.outputPath('trace.zip') }).catch(() => {});
+      await persistentContext.close();
+    },
+  };
+}
+
 async function readRuntime(page) {
   return page.evaluate(async () => {
     const runtime = await import('/js/sync-runtime.js');
@@ -61,73 +89,93 @@ async function waitForOwner(page) {
   return readRuntime(page);
 }
 
-test('starts v8 from its durable identity without the v7 worker', async ({ context, page }) => {
-  await configureCandidate(context);
-  const pageErrors = [];
-  page.on('pageerror', error => pageErrors.push(error.message));
-  let legacyRequests = 0;
-  await page.route(LEGACY_BUNDLE, route => {
-    legacyRequests += 1;
-    return route.abort();
-  });
+test('starts v8 from its durable identity without the v7 worker', async ({
+  browserName, context: defaultContext, page: defaultPage, playwright,
+}, testInfo) => {
+  const browserPage = await getCompatibleBrowserPage({
+    browserName, context: defaultContext, page: defaultPage, playwright,
+  }, testInfo);
+  const { context, page } = browserPage;
+  try {
+    await configureCandidate(context);
+    const pageErrors = [];
+    page.on('pageerror', error => pageErrors.push(error.message));
+    let legacyRequests = 0;
+    await page.route(LEGACY_BUNDLE, route => {
+      legacyRequests += 1;
+      return route.abort();
+    });
 
-  await page.goto('/app?evolu-client=v8', { waitUntil: 'domcontentloaded' });
-  await seedCandidateIdentity(page);
-  await page.reload({ waitUntil: 'domcontentloaded' });
-  const first = await waitForOwner(page);
-  expect(first.clientVersion).toBe(8);
-  expect(first.ownerId).toBe(TEST_IDENTITY.ownerId);
-  expect(legacyRequests).toBe(0);
+    await page.goto('/app?evolu-client=v8', { waitUntil: 'domcontentloaded' });
+    await seedCandidateIdentity(page);
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    const first = await waitForOwner(page);
+    expect(first.clientVersion).toBe(8);
+    expect(first.ownerId).toBe(TEST_IDENTITY.ownerId);
+    expect(legacyRequests).toBe(0);
 
-  legacyRequests = 0;
-  await page.reload({ waitUntil: 'domcontentloaded' });
-  const second = await waitForOwner(page);
+    legacyRequests = 0;
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    const second = await waitForOwner(page);
 
-  expect(second.ownerId).toBe(first.ownerId);
-  expect(second.clientVersion).toBe(8);
-  expect(legacyRequests).toBe(0);
-  expect(pageErrors).toEqual([]);
+    expect(second.ownerId).toBe(first.ownerId);
+    expect(second.clientVersion).toBe(8);
+    expect(legacyRequests).toBe(0);
+    expect(pageErrors).toEqual([]);
+  } finally {
+    await browserPage.close();
+  }
 });
 
-test('polyfills resource management and enforces the one-tab worker fallback', async ({ context, page }) => {
-  await configureCandidate(context, { forceFallback: true });
-  const pageErrors = [];
-  page.on('pageerror', error => pageErrors.push(error.message));
-  let legacyRequests = 0;
-  await page.route(LEGACY_BUNDLE, route => {
-    legacyRequests += 1;
-    return route.abort();
-  });
+test('polyfills resource management and enforces the one-tab worker fallback', async ({
+  browserName, context: defaultContext, page: defaultPage, playwright,
+}, testInfo) => {
+  const browserPage = await getCompatibleBrowserPage({
+    browserName, context: defaultContext, page: defaultPage, playwright,
+  }, testInfo);
+  const { context, page } = browserPage;
+  try {
+    await configureCandidate(context, { forceFallback: true });
+    const pageErrors = [];
+    page.on('pageerror', error => pageErrors.push(error.message));
+    let legacyRequests = 0;
+    await page.route(LEGACY_BUNDLE, route => {
+      legacyRequests += 1;
+      return route.abort();
+    });
 
-  await page.goto('/app?evolu-client=v8', { waitUntil: 'domcontentloaded' });
-  await seedCandidateIdentity(page);
-  await page.reload({ waitUntil: 'domcontentloaded' });
-  const first = await waitForOwner(page);
-  expect(first.clientVersion).toBe(8);
-  expect(first.ownerId).toBe(TEST_IDENTITY.ownerId);
-  expect(legacyRequests).toBe(0);
-  expect(await page.evaluate(() => ({
-    asyncDisposableStack: typeof globalThis.AsyncDisposableStack,
-    disposableStack: typeof globalThis.DisposableStack,
-    fallbackForced: globalThis.__evolu8FallbackForced,
-    sharedWorker: typeof globalThis.SharedWorker,
-    suppressedError: typeof globalThis.SuppressedError,
-  }))).toEqual({
-    asyncDisposableStack: 'function',
-    disposableStack: 'function',
-    fallbackForced: true,
-    sharedWorker: 'function',
-    suppressedError: 'function',
-  });
+    await page.goto('/app?evolu-client=v8', { waitUntil: 'domcontentloaded' });
+    await seedCandidateIdentity(page);
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    const first = await waitForOwner(page);
+    expect(first.clientVersion).toBe(8);
+    expect(first.ownerId).toBe(TEST_IDENTITY.ownerId);
+    expect(legacyRequests).toBe(0);
+    expect(await page.evaluate(() => ({
+      asyncDisposableStack: typeof globalThis.AsyncDisposableStack,
+      disposableStack: typeof globalThis.DisposableStack,
+      fallbackForced: globalThis.__evolu8FallbackForced,
+      sharedWorker: typeof globalThis.SharedWorker,
+      suppressedError: typeof globalThis.SuppressedError,
+    }))).toEqual({
+      asyncDisposableStack: 'function',
+      disposableStack: 'function',
+      fallbackForced: true,
+      sharedWorker: 'function',
+      suppressedError: 'function',
+    });
 
-  const secondPage = await context.newPage();
-  secondPage.on('pageerror', error => pageErrors.push(error.message));
-  await secondPage.goto('/app?evolu-client=v8', { waitUntil: 'domcontentloaded' });
-  await expect.poll(async () => (await readRuntime(secondPage)).error, {
-    timeout: 30_000,
-    intervals: [100, 250, 500, 1000],
-  }).toBe(ONE_TAB_ERROR);
+    const secondPage = await context.newPage();
+    secondPage.on('pageerror', error => pageErrors.push(error.message));
+    await secondPage.goto('/app?evolu-client=v8', { waitUntil: 'domcontentloaded' });
+    await expect.poll(async () => (await readRuntime(secondPage)).error, {
+      timeout: 30_000,
+      intervals: [100, 250, 500, 1000],
+    }).toBe(ONE_TAB_ERROR);
 
-  await secondPage.close();
-  expect(pageErrors).toEqual([]);
+    await secondPage.close();
+    expect(pageErrors).toEqual([]);
+  } finally {
+    await browserPage.close();
+  }
 });

--- a/tests/evolu8-browser/smoke.spec.js
+++ b/tests/evolu8-browser/smoke.spec.js
@@ -53,15 +53,11 @@ async function getCompatibleBrowserPage({ browserName, context, page, playwright
       serviceWorkers: 'block',
     },
   );
-  await persistentContext.tracing.start({ screenshots: true, snapshots: true, sources: true });
   const persistentPage = persistentContext.pages()[0] || await persistentContext.newPage();
   return {
     context: persistentContext,
     page: persistentPage,
-    close: async () => {
-      await persistentContext.tracing.stop({ path: testInfo.outputPath('trace.zip') }).catch(() => {});
-      await persistentContext.close();
-    },
+    close: async () => persistentContext.close(),
   };
 }
 

--- a/tests/playwright/sync-helper-browser-coverage.spec.js
+++ b/tests/playwright/sync-helper-browser-coverage.spec.js
@@ -174,32 +174,30 @@ test('sync apply cutover cleanup and rebroadcast helpers cover guarded browser p
       const skippedNoNeed = rebroadcast.maybeScheduleRebroadcast({
         profileId,
         needsRebroadcast: false,
-        merged: { value: 1 },
         pushProfile: () => { pushed.push('unexpected'); },
       });
       syncState.updateSyncStatus({ push: 'pending' });
       const skippedPending = rebroadcast.maybeScheduleRebroadcast({
         profileId,
         needsRebroadcast: true,
-        merged: { value: 2 },
         pushProfile: () => { pushed.push('pending'); },
         debug: () => { throw new Error('debug should be swallowed'); },
       });
       syncState.resetSyncStatus();
+      state.importedData = { value: 3 };
       const scheduled = rebroadcast.maybeScheduleRebroadcast({
         profileId,
         needsRebroadcast: true,
-        merged: { value: 3 },
         pushProfile: (id, data) => { pushed.push({ id, data: clone(data) }); },
         debug: (...args) => { debugCalls.push(args.join(' ')); },
       });
+      state.importedData = { value: 33 };
       await new Promise(resolve => setTimeout(resolve, 140));
       const abortedProfileId = `${profileId}-abort`;
       state.currentProfile = abortedProfileId;
       const scheduledAbort = rebroadcast.maybeScheduleRebroadcast({
         profileId: abortedProfileId,
         needsRebroadcast: true,
-        merged: { value: 4 },
         pushProfile: (id, data) => { pushed.push({ id, data: clone(data) }); },
         debug: (...args) => { debugCalls.push(args.join(' ')); },
       });
@@ -212,7 +210,7 @@ test('sync apply cutover cleanup and rebroadcast helpers cover guarded browser p
         && scheduledAbort === true
         && pushed.length === 1
         && pushed[0].id === profileId
-        && pushed[0].data.value === 3
+        && pushed[0].data.value === 33
         && debugCalls.some(message => message.includes('rebroadcast'))
         && debugCalls.some(message => message.includes('active profile switched'));
     } finally {

--- a/tests/playwright/sync-relay-transport-e2e.spec.js
+++ b/tests/playwright/sync-relay-transport-e2e.spec.js
@@ -209,11 +209,11 @@ async function waitForStableRelayStorage(page, { minimumMessages = 1 } = {}) {
 }
 
 async function contextNotes(page) {
-  return page.evaluate(async () => (await import('/js/state.js')).state.importedData.contextNotes || '');
+  return page.evaluate(async () => (await import('/js/state.js')).state.importedData?.contextNotes || '');
 }
 
 async function noteTexts(page) {
-  return page.evaluate(async () => ((await import('/js/state.js')).state.importedData.notes || [])
+  return page.evaluate(async () => ((await import('/js/state.js')).state.importedData?.notes || [])
     .map(note => note.text).sort());
 }
 
@@ -289,10 +289,14 @@ test('real relay converges devices, resists no-op bloat, recovers offline, and r
     await waitForNotes(deviceB.page, [
       'baseline-note', 'from-device-a', 'concurrent-a', 'concurrent-b',
     ]);
+    await waitForContext(deviceA.page, OFFLINE_CONTEXT);
+    await waitForContext(deviceB.page, OFFLINE_CONTEXT);
 
     await setSyntheticData(deviceA.page, 'delete-baseline');
     expect((await syncNow(deviceA.page))?.ok).toBe(true);
     await waitForNotes(deviceB.page, ['from-device-a', 'concurrent-a', 'concurrent-b']);
+    await waitForContext(deviceA.page, OFFLINE_CONTEXT);
+    await waitForContext(deviceB.page, OFFLINE_CONTEXT);
 
     // Keep a fully-synced paired device offline across compaction. Its local
     // Evolu log still contains every discarded relay message, which is the
@@ -311,6 +315,7 @@ test('real relay converges devices, resists no-op bloat, recovers offline, and r
     expect(rebuilt.failed).toBe(0);
     const afterRebuild = await waitForStableRelayStorage(deviceA.page);
     expect(afterRebuild.messageCount).toBeGreaterThan(0);
+    await waitForContext(deviceA.page, OFFLINE_CONTEXT);
 
     const deviceC = await createDevice(browser, 'device C');
     devices.push(deviceC);

--- a/tests/sync-actions.test.js
+++ b/tests/sync-actions.test.js
@@ -236,6 +236,28 @@ describe('sync action profile dependencies', () => {
     }
   });
 
+  it('waits and retries when a pull-side rebroadcast wins the manual-push race', async () => {
+    const pushProfile = vi.fn()
+      .mockResolvedValueOnce({ ok: false, skipped: true, reason: 'in-flight' })
+      .mockResolvedValueOnce({ ok: true });
+    configureSyncActions({
+      forcePull: async () => {},
+      pushProfile,
+      isSyncing: () => false,
+    });
+
+    try {
+      await expect(syncNow()).resolves.toEqual({ ok: true });
+      expect(pushProfile).toHaveBeenCalledTimes(2);
+    } finally {
+      configureSyncActions({
+        forcePull: async () => {},
+        pushProfile: async () => {},
+        isSyncing: () => false,
+      });
+    }
+  });
+
   it('flushes dirty local state before pulling, then publishes the merge', async () => {
     const previousProfile = state.currentProfile;
     const profileId = 'dirty-manual-sync';
@@ -380,7 +402,12 @@ describe('sync action profile dependencies', () => {
     const previousImportedData = state.importedData;
     const profileId = 'rebuild-profile';
     const pushProfile = vi.fn().mockResolvedValue({ ok: true });
-    const resetLocalSyncHistoryForRelayRebuild = vi.fn().mockResolvedValue(true);
+    const resetLocalSyncHistoryForRelayRebuild = vi.fn(async () => {
+      // Evolu reset callbacks may replace live state before rebuild pushing.
+      // The captured pre-reset snapshot must remain authoritative.
+      state.importedData = { entries: [], notes: [{ id: 'regressed-during-reset' }] };
+      return true;
+    });
     state.currentProfile = profileId;
     state.importedData = { entries: [], notes: [] };
     localStorage.setItem(`labcharts-${profileId}-sync-cutover-v2`, '1');
@@ -396,7 +423,11 @@ describe('sync action profile dependencies', () => {
       expect(result).toEqual({ total: 1, succeeded: 1, failed: 0, skipped: 0 });
       expect(localStorage.getItem(`labcharts-${profileId}-sync-cutover-v2`)).toBeNull();
       expect(localStorage.getItem(`labcharts-${profileId}-delta-entries`)).toBeNull();
-      expect(pushProfile).toHaveBeenCalledWith(profileId, state.importedData, { force: true });
+      expect(pushProfile).toHaveBeenCalledWith(
+        profileId,
+        { entries: [], notes: [] },
+        { force: true },
+      );
       expect(resetLocalSyncHistoryForRelayRebuild).toHaveBeenCalledOnce();
       expect(resetLocalSyncHistoryForRelayRebuild.mock.invocationCallOrder[0])
         .toBeLessThan(pushProfile.mock.invocationCallOrder[0]);

--- a/tests/sync-runtime.test.js
+++ b/tests/sync-runtime.test.js
@@ -995,6 +995,7 @@ describe('sync cleanup and rebroadcast runtime behavior', () => {
   it('schedules rebroadcasts only for active profiles with available budget and idle push state', async () => {
     vi.useFakeTimers();
     const previousProfile = state.currentProfile;
+    const previousImportedData = state.importedData;
     state.currentProfile = PROFILE_ID;
     try {
       resetSyncStatus();
@@ -1002,18 +1003,20 @@ describe('sync cleanup and rebroadcast runtime behavior', () => {
       const pushProfileSpy = vi.fn();
       const debug = vi.fn();
       const merged = { sunSessions: [{ id: 'sun-1' }] };
+      state.importedData = merged;
 
       expect(maybeScheduleRebroadcast({
         profileId: PROFILE_ID,
-        merged,
         needsRebroadcast: true,
         pushProfile: pushProfileSpy,
         debug,
       })).toBe(true);
       expect(pushProfileSpy).not.toHaveBeenCalled();
 
+      const latest = { sunSessions: [{ id: 'sun-1' }], contextNotes: 'newer local value' };
+      state.importedData = latest;
       await vi.advanceTimersByTimeAsync(100);
-      expect(pushProfileSpy).toHaveBeenCalledWith(PROFILE_ID, merged);
+      expect(pushProfileSpy).toHaveBeenCalledWith(PROFILE_ID, latest);
       expect(getRecentSyncEvents().at(-1)).toMatchObject({
         kind: 'rebroadcast',
         text: `Rebroadcast ${PROFILE_ID.slice(0, 8)}`,
@@ -1022,7 +1025,6 @@ describe('sync cleanup and rebroadcast runtime behavior', () => {
       updateSyncStatus({ push: 'pending' });
       expect(maybeScheduleRebroadcast({
         profileId: PROFILE_ID,
-        merged,
         needsRebroadcast: true,
         pushProfile: pushProfileSpy,
         debug,
@@ -1034,18 +1036,16 @@ describe('sync cleanup and rebroadcast runtime behavior', () => {
       state.currentProfile = 'other-profile';
       expect(maybeScheduleRebroadcast({
         profileId: PROFILE_ID,
-        merged,
         needsRebroadcast: true,
         pushProfile: pushProfileSpy,
         debug,
       })).toBe(false);
 
       state.currentProfile = PROFILE_ID;
-      maybeScheduleRebroadcast({ profileId: PROFILE_ID, merged, needsRebroadcast: true, pushProfile: pushProfileSpy });
-      maybeScheduleRebroadcast({ profileId: PROFILE_ID, merged, needsRebroadcast: true, pushProfile: pushProfileSpy });
+      maybeScheduleRebroadcast({ profileId: PROFILE_ID, needsRebroadcast: true, pushProfile: pushProfileSpy });
+      maybeScheduleRebroadcast({ profileId: PROFILE_ID, needsRebroadcast: true, pushProfile: pushProfileSpy });
       expect(maybeScheduleRebroadcast({
         profileId: PROFILE_ID,
-        merged,
         needsRebroadcast: true,
         pushProfile: pushProfileSpy,
         debug,
@@ -1056,6 +1056,7 @@ describe('sync cleanup and rebroadcast runtime behavior', () => {
       });
     } finally {
       state.currentProfile = previousProfile;
+      state.importedData = previousImportedData;
     }
   });
 });


### PR DESCRIPTION
## Summary
- run the existing real-relay transport scenario against both Evolu 7 and 8 using a pinned disposable relay
- validate Evolu 8 startup, durable identity reuse, resource-management polyfills, and one-tab fallback in Chromium, Firefox, and WebKit
- document the automated gates that must stay green before the separate default-client cutover

## Local verification
- real-relay transport scenario: v7 passed, v8 passed
- Evolu 8 browser suite: Chromium passed, Firefox passed
- WebKit execution deferred to CI because this host lacks libevent-2.1-7t64 and libavif16 and cannot install them without interactive sudo
- focused Vitest: 18 passed
- npm run typecheck:checkjs
- npm run architecture:check
- npm run production:check
- npm run quality
- git diff --check