### PR TITLE
Fix cross-device restore re-deletion and clear-all convergence

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -9,9 +9,9 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 
 | Metric | Current |
 | --- | ---: |
-| Modules | 702 |
-| Internal import edges | 2996 |
-| Dynamic internal edges | 92 |
+| Modules | 703 |
+| Internal import edges | 3002 |
+| Dynamic internal edges | 93 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
 | Largest cyclic component | 0 |
@@ -67,8 +67,8 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 | [`js/api.js`](js/api.js) | 69 | [`js/wearables-connect.js`](js/wearables-connect.js) | 27 |
 | [`js/profile.js`](js/profile.js) | 47 | [`js/pdf-import.js`](js/pdf-import.js) | 26 |
 | [`js/schema.js`](js/schema.js) | 37 | [`js/lab-context.js`](js/lab-context.js) | 24 |
-| [`js/crypto.js`](js/crypto.js) | 33 | [`js/views.js`](js/views.js) | 22 |
-| [`js/data-merge.js`](js/data-merge.js) | 33 | [`js/export.js`](js/export.js) | 21 |
+| [`js/crypto.js`](js/crypto.js) | 33 | [`js/export.js`](js/export.js) | 23 |
+| [`js/data-merge.js`](js/data-merge.js) | 33 | [`js/views.js`](js/views.js) | 22 |
 | [`js/utils-runtime.js`](js/utils-runtime.js) | 21 | [`js/dashboard-view-composition.js`](js/dashboard-view-composition.js) | 20 |
 | [`js/constants.js`](js/constants.js) | 20 | [`js/marker-detail-modal-impl.js`](js/marker-detail-modal-impl.js) | 20 |
 | [`js/proxy-runtime.js`](js/proxy-runtime.js) | 20 | [`js/marker-schema/index.js`](js/marker-schema/index.js) | 20 |
@@ -335,6 +335,12 @@ Native browser modules shipped with the static application.
 
 </details>
 
+<details><summary><code>clear</code> family — 1 module</summary>
+
+- [`js/clear-all-profile-reset.js`](js/clear-all-profile-reset.js) → [`js/profile-sync-policy.js`](js/profile-sync-policy.js), [`js/unique-id.js`](js/unique-id.js)
+
+</details>
+
 <details><summary><code>client</code> family — 4 modules</summary>
 
 - [`js/client-list-form.js`](js/client-list-form.js) → [`js/client-list-runtime.js`](js/client-list-runtime.js), [`js/constants.js`](js/constants.js), [`js/nav.js`](js/nav.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/url-safety.js`](js/url-safety.js), [`js/utils.js`](js/utils.js)
@@ -505,7 +511,7 @@ Native browser modules shipped with the static application.
 - [`js/export-report-html.js`](js/export-report-html.js) → [`js/export-report.js`](js/export-report.js), [`js/marker-analysis.js`](js/marker-analysis.js), [`js/state.js`](js/state.js), [`js/supplement-impact.js`](js/supplement-impact.js), [`js/supplement-medication-domain.js`](js/supplement-medication-domain.js), [`js/unit-profiles.js`](js/unit-profiles.js), [`js/utils.js`](js/utils.js)
 - [`js/export-report.js`](js/export-report.js) → [`js/api.js`](js/api.js), [`js/cycle.js`](js/cycle.js), [`js/data.js`](js/data.js), [`js/export-report-data.js`](js/export-report-data.js), [`js/marker-analysis.js`](js/marker-analysis.js), [`js/profile.js`](js/profile.js), [`js/schema.js`](js/schema.js), [`js/state.js`](js/state.js), [`js/supplement-medication-domain.js`](js/supplement-medication-domain.js), [`js/utils.js`](js/utils.js), [`js/wearables-formatters.js`](js/wearables-formatters.js)
 - [`js/export-runtime.js`](js/export-runtime.js) → [`js/cashu-wallet.js`](js/cashu-wallet.js) *(dynamic)*, [`js/crypto.js`](js/crypto.js), [`js/state.js`](js/state.js)
-- [`js/export.js`](js/export.js) → [`js/biology-score-context-ai.js`](js/biology-score-context-ai.js) *(dynamic)*, [`js/caught-error.js`](js/caught-error.js), [`js/context-cards.js`](js/context-cards.js) *(dynamic)*, [`js/crypto.js`](js/crypto.js), [`js/custom-marker-identity.js`](js/custom-marker-identity.js), [`js/data.js`](js/data.js), [`js/demo-nutrition.js`](js/demo-nutrition.js), [`js/export-import.js`](js/export-import.js) *(dynamic)*, [`js/export-report-builder.js`](js/export-report-builder.js) *(dynamic)*, [`js/export-report-html.js`](js/export-report-html.js), [`js/export-report.js`](js/export-report.js), [`js/export-runtime.js`](js/export-runtime.js), [`js/lab-entry-mutations.js`](js/lab-entry-mutations.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/marker-placement.js`](js/marker-placement.js), [`js/nostr-discovery.js`](js/nostr-discovery.js), [`js/nutrition-store.js`](js/nutrition-store.js) *(dynamic)*, [`js/profile-storage-cleanup.js`](js/profile-storage-cleanup.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/utils.js`](js/utils.js)
+- [`js/export.js`](js/export.js) → [`js/biology-score-context-ai.js`](js/biology-score-context-ai.js) *(dynamic)*, [`js/caught-error.js`](js/caught-error.js), [`js/clear-all-profile-reset.js`](js/clear-all-profile-reset.js), [`js/context-cards.js`](js/context-cards.js) *(dynamic)*, [`js/crypto.js`](js/crypto.js), [`js/custom-marker-identity.js`](js/custom-marker-identity.js), [`js/data.js`](js/data.js), [`js/demo-nutrition.js`](js/demo-nutrition.js), [`js/export-import.js`](js/export-import.js) *(dynamic)*, [`js/export-report-builder.js`](js/export-report-builder.js) *(dynamic)*, [`js/export-report-html.js`](js/export-report-html.js), [`js/export-report.js`](js/export-report.js), [`js/export-runtime.js`](js/export-runtime.js), [`js/lab-entry-mutations.js`](js/lab-entry-mutations.js), [`js/lab-entry.js`](js/lab-entry.js), [`js/marker-placement.js`](js/marker-placement.js), [`js/nostr-discovery.js`](js/nostr-discovery.js), [`js/nutrition-store.js`](js/nutrition-store.js) *(dynamic)*, [`js/profile-storage-cleanup.js`](js/profile-storage-cleanup.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/sync.js`](js/sync.js) *(dynamic)*, [`js/utils.js`](js/utils.js)
 
 </details>
 
@@ -1142,7 +1148,7 @@ Native browser modules shipped with the static application.
 - [`js/sync-environment.js`](js/sync-environment.js) → [`js/utils-runtime.js`](js/utils-runtime.js)
 - [`js/sync-evolu8-candidate.js`](js/sync-evolu8-candidate.js) → [`js/sync-evolu8-identity-vault.js`](js/sync-evolu8-identity-vault.js), [`js/sync-runtime.js`](js/sync-runtime.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-evolu8-identity-vault.js`](js/sync-evolu8-identity-vault.js) → no in-scope imports
-- [`js/sync-identity.js`](js/sync-identity.js) → [`js/sync-backup-restore-state.js`](js/sync-backup-restore-state.js), [`js/sync-disable-cleanup.js`](js/sync-disable-cleanup.js), [`js/sync-runtime.js`](js/sync-runtime.js), [`js/sync-settings-state.js`](js/sync-settings-state.js), [`js/utils.js`](js/utils.js)
+- [`js/sync-identity.js`](js/sync-identity.js) → [`js/profile-sync-policy.js`](js/profile-sync-policy.js), [`js/sync-backup-restore-state.js`](js/sync-backup-restore-state.js), [`js/sync-disable-cleanup.js`](js/sync-disable-cleanup.js), [`js/sync-runtime.js`](js/sync-runtime.js), [`js/sync-settings-state.js`](js/sync-settings-state.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-init.js`](js/sync-init.js) → [`js/sync-environment.js`](js/sync-environment.js), [`js/sync-evolu8-candidate.js`](js/sync-evolu8-candidate.js) *(dynamic)*, [`js/sync-identity.js`](js/sync-identity.js), [`js/sync-pull-rebroadcast.js`](js/sync-pull-rebroadcast.js), [`js/sync-recovery.js`](js/sync-recovery.js), [`js/sync-relay-health.js`](js/sync-relay-health.js), [`js/sync-runtime.js`](js/sync-runtime.js), [`js/sync-schema.js`](js/sync-schema.js), [`js/sync-settings-state.js`](js/sync-settings-state.js), [`js/sync-subscriptions.js`](js/sync-subscriptions.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-lifecycle.js`](js/sync-lifecycle.js) → [`js/sync-actions.js`](js/sync-actions.js), [`js/sync-backup-restore-state.js`](js/sync-backup-restore-state.js), [`js/sync-disable-cleanup.js`](js/sync-disable-cleanup.js), [`js/sync-environment.js`](js/sync-environment.js), [`js/sync-init.js`](js/sync-init.js), [`js/sync-pull.js`](js/sync-pull.js), [`js/sync-runtime.js`](js/sync-runtime.js), [`js/sync-save-hooks.js`](js/sync-save-hooks.js), [`js/sync-settings-state.js`](js/sync-settings-state.js), [`js/sync-state.js`](js/sync-state.js), [`js/sync-subscriptions.js`](js/sync-subscriptions.js), [`js/sync-ui.js`](js/sync-ui.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-messenger.js`](js/sync-messenger.js) → [`js/profile-sync-policy.js`](js/profile-sync-policy.js), [`js/state.js`](js/state.js), [`js/utils-runtime.js`](js/utils-runtime.js), [`js/utils.js`](js/utils.js)
@@ -1169,7 +1175,7 @@ Native browser modules shipped with the static application.
 - [`js/sync-state.js`](js/sync-state.js) → no in-scope imports
 - [`js/sync-storage-cleanup.js`](js/sync-storage-cleanup.js) → [`js/caught-error.js`](js/caught-error.js), [`js/data-merge.js`](js/data-merge.js), [`js/state.js`](js/state.js), [`js/sync-state.js`](js/sync-state.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-subscriptions.js`](js/sync-subscriptions.js) → no in-scope imports
-- [`js/sync-tombstones.js`](js/sync-tombstones.js) → [`js/crypto.js`](js/crypto.js), [`js/profile-storage-cleanup.js`](js/profile-storage-cleanup.js), [`js/profile-storage-key.js`](js/profile-storage-key.js), [`js/profile-sync-policy.js`](js/profile-sync-policy.js), [`js/state.js`](js/state.js), [`js/sync-dirty-state.js`](js/sync-dirty-state.js), [`js/sync-payload.js`](js/sync-payload.js), [`js/unique-id.js`](js/unique-id.js), [`js/utils.js`](js/utils.js)
+- [`js/sync-tombstones.js`](js/sync-tombstones.js) → [`js/crypto.js`](js/crypto.js), [`js/profile-storage-cleanup.js`](js/profile-storage-cleanup.js), [`js/profile-storage-key.js`](js/profile-storage-key.js), [`js/profile-sync-policy.js`](js/profile-sync-policy.js), [`js/state.js`](js/state.js), [`js/sync-dirty-state.js`](js/sync-dirty-state.js), [`js/sync-payload.js`](js/sync-payload.js), [`js/sync-profile-fields.js`](js/sync-profile-fields.js), [`js/unique-id.js`](js/unique-id.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-ui.js`](js/sync-ui.js) → [`js/settings-runtime-bridge.js`](js/settings-runtime-bridge.js), [`js/sync-environment.js`](js/sync-environment.js), [`js/sync-relay-health.js`](js/sync-relay-health.js), [`js/sync-state.js`](js/sync-state.js), [`js/utils.js`](js/utils.js)
 - [`js/sync.js`](js/sync.js) → [`js/sync-actions.js`](js/sync-actions.js), [`js/sync-cutover.js`](js/sync-cutover.js), [`js/sync-diagnose-ui.js`](js/sync-diagnose-ui.js), [`js/sync-diagnostics.js`](js/sync-diagnostics.js), [`js/sync-environment.js`](js/sync-environment.js), [`js/sync-identity.js`](js/sync-identity.js), [`js/sync-init.js`](js/sync-init.js), [`js/sync-messenger.js`](js/sync-messenger.js), [`js/sync-relay-health.js`](js/sync-relay-health.js), [`js/sync-save-hooks.js`](js/sync-save-hooks.js), [`js/sync-settings-state.js`](js/sync-settings-state.js), [`js/sync-state.js`](js/sync-state.js), [`js/sync-storage-cleanup.js`](js/sync-storage-cleanup.js), [`js/sync-tombstones.js`](js/sync-tombstones.js), [`js/sync-ui.js`](js/sync-ui.js)
 

--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -10,8 +10,8 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | Metric | Current |
 | --- | ---: |
 | Modules | 703 |
-| Internal import edges | 3002 |
-| Dynamic internal edges | 93 |
+| Internal import edges | 3006 |
+| Dynamic internal edges | 96 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
 | Largest cyclic component | 0 |
@@ -67,7 +67,7 @@ High fan-in modules have many dependants; high fan-out modules coordinate many d
 | [`js/api.js`](js/api.js) | 69 | [`js/wearables-connect.js`](js/wearables-connect.js) | 27 |
 | [`js/profile.js`](js/profile.js) | 47 | [`js/pdf-import.js`](js/pdf-import.js) | 26 |
 | [`js/schema.js`](js/schema.js) | 37 | [`js/lab-context.js`](js/lab-context.js) | 24 |
-| [`js/crypto.js`](js/crypto.js) | 33 | [`js/export.js`](js/export.js) | 23 |
+| [`js/crypto.js`](js/crypto.js) | 34 | [`js/export.js`](js/export.js) | 23 |
 | [`js/data-merge.js`](js/data-merge.js) | 33 | [`js/views.js`](js/views.js) | 22 |
 | [`js/utils-runtime.js`](js/utils-runtime.js) | 21 | [`js/dashboard-view-composition.js`](js/dashboard-view-composition.js) | 20 |
 | [`js/constants.js`](js/constants.js) | 20 | [`js/marker-detail-modal-impl.js`](js/marker-detail-modal-impl.js) | 20 |
@@ -337,7 +337,7 @@ Native browser modules shipped with the static application.
 
 <details><summary><code>clear</code> family — 1 module</summary>
 
-- [`js/clear-all-profile-reset.js`](js/clear-all-profile-reset.js) → [`js/profile-sync-policy.js`](js/profile-sync-policy.js), [`js/unique-id.js`](js/unique-id.js)
+- [`js/clear-all-profile-reset.js`](js/clear-all-profile-reset.js) → [`js/crypto.js`](js/crypto.js), [`js/profile-storage-key.js`](js/profile-storage-key.js), [`js/profile-sync-policy.js`](js/profile-sync-policy.js), [`js/sync-payload.js`](js/sync-payload.js), [`js/sync-profile-fields.js`](js/sync-profile-fields.js), [`js/unique-id.js`](js/unique-id.js)
 
 </details>
 
@@ -1148,7 +1148,7 @@ Native browser modules shipped with the static application.
 - [`js/sync-environment.js`](js/sync-environment.js) → [`js/utils-runtime.js`](js/utils-runtime.js)
 - [`js/sync-evolu8-candidate.js`](js/sync-evolu8-candidate.js) → [`js/sync-evolu8-identity-vault.js`](js/sync-evolu8-identity-vault.js), [`js/sync-runtime.js`](js/sync-runtime.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-evolu8-identity-vault.js`](js/sync-evolu8-identity-vault.js) → no in-scope imports
-- [`js/sync-identity.js`](js/sync-identity.js) → [`js/profile-sync-policy.js`](js/profile-sync-policy.js), [`js/sync-backup-restore-state.js`](js/sync-backup-restore-state.js), [`js/sync-disable-cleanup.js`](js/sync-disable-cleanup.js), [`js/sync-runtime.js`](js/sync-runtime.js), [`js/sync-settings-state.js`](js/sync-settings-state.js), [`js/utils.js`](js/utils.js)
+- [`js/sync-identity.js`](js/sync-identity.js) → [`js/clear-all-profile-reset.js`](js/clear-all-profile-reset.js) *(dynamic)*, [`js/sync-backup-restore-state.js`](js/sync-backup-restore-state.js), [`js/sync-disable-cleanup.js`](js/sync-disable-cleanup.js), [`js/sync-runtime.js`](js/sync-runtime.js), [`js/sync-settings-state.js`](js/sync-settings-state.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-init.js`](js/sync-init.js) → [`js/sync-environment.js`](js/sync-environment.js), [`js/sync-evolu8-candidate.js`](js/sync-evolu8-candidate.js) *(dynamic)*, [`js/sync-identity.js`](js/sync-identity.js), [`js/sync-pull-rebroadcast.js`](js/sync-pull-rebroadcast.js), [`js/sync-recovery.js`](js/sync-recovery.js), [`js/sync-relay-health.js`](js/sync-relay-health.js), [`js/sync-runtime.js`](js/sync-runtime.js), [`js/sync-schema.js`](js/sync-schema.js), [`js/sync-settings-state.js`](js/sync-settings-state.js), [`js/sync-subscriptions.js`](js/sync-subscriptions.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-lifecycle.js`](js/sync-lifecycle.js) → [`js/sync-actions.js`](js/sync-actions.js), [`js/sync-backup-restore-state.js`](js/sync-backup-restore-state.js), [`js/sync-disable-cleanup.js`](js/sync-disable-cleanup.js), [`js/sync-environment.js`](js/sync-environment.js), [`js/sync-init.js`](js/sync-init.js), [`js/sync-pull.js`](js/sync-pull.js), [`js/sync-runtime.js`](js/sync-runtime.js), [`js/sync-save-hooks.js`](js/sync-save-hooks.js), [`js/sync-settings-state.js`](js/sync-settings-state.js), [`js/sync-state.js`](js/sync-state.js), [`js/sync-subscriptions.js`](js/sync-subscriptions.js), [`js/sync-ui.js`](js/sync-ui.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-messenger.js`](js/sync-messenger.js) → [`js/profile-sync-policy.js`](js/profile-sync-policy.js), [`js/state.js`](js/state.js), [`js/utils-runtime.js`](js/utils-runtime.js), [`js/utils.js`](js/utils.js)
@@ -1160,7 +1160,7 @@ Native browser modules shipped with the static application.
 - [`js/sync-pull-active-refresh-runtime.js`](js/sync-pull-active-refresh-runtime.js) → no in-scope imports
 - [`js/sync-pull-active-refresh.js`](js/sync-pull-active-refresh.js) → [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/sync-pull-active-refresh-runtime.js`](js/sync-pull-active-refresh-runtime.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-pull-maintenance.js`](js/sync-pull-maintenance.js) → no in-scope imports
-- [`js/sync-pull-merge.js`](js/sync-pull-merge.js) → [`js/biology-score-context-ai.js`](js/biology-score-context-ai.js), [`js/caught-error.js`](js/caught-error.js), [`js/crypto.js`](js/crypto.js), [`js/data-merge.js`](js/data-merge.js), [`js/nutrition-sync-sanitize.js`](js/nutrition-sync-sanitize.js), [`js/profile-sync-policy.js`](js/profile-sync-policy.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/sync-delta.js`](js/sync-delta.js), [`js/sync-identity.js`](js/sync-identity.js), [`js/sync-payload.js`](js/sync-payload.js), [`js/sync-profile-fields.js`](js/sync-profile-fields.js)
+- [`js/sync-pull-merge.js`](js/sync-pull-merge.js) → [`js/biology-score-context-ai.js`](js/biology-score-context-ai.js), [`js/caught-error.js`](js/caught-error.js), [`js/clear-all-profile-reset.js`](js/clear-all-profile-reset.js) *(dynamic)*, [`js/crypto.js`](js/crypto.js), [`js/data-merge.js`](js/data-merge.js), [`js/nutrition-sync-sanitize.js`](js/nutrition-sync-sanitize.js), [`js/profile-sync-policy.js`](js/profile-sync-policy.js), [`js/profile.js`](js/profile.js), [`js/state.js`](js/state.js), [`js/sync-delta.js`](js/sync-delta.js), [`js/sync-identity.js`](js/sync-identity.js), [`js/sync-payload.js`](js/sync-payload.js), [`js/sync-profile-fields.js`](js/sync-profile-fields.js)
 - [`js/sync-pull-rebroadcast.js`](js/sync-pull-rebroadcast.js) → [`js/state.js`](js/state.js), [`js/sync-state.js`](js/sync-state.js)
 - [`js/sync-pull.js`](js/sync-pull.js) → [`js/nutrition-sync-sanitize.js`](js/nutrition-sync-sanitize.js), [`js/profile-sync-policy.js`](js/profile-sync-policy.js), [`js/sync-apply.js`](js/sync-apply.js) *(dynamic)*, [`js/sync-backup-restore-state.js`](js/sync-backup-restore-state.js), [`js/sync-chat-apply.js`](js/sync-chat-apply.js), [`js/sync-identity.js`](js/sync-identity.js), [`js/sync-origin-state.js`](js/sync-origin-state.js), [`js/sync-payload.js`](js/sync-payload.js), [`js/sync-pull-active-refresh.js`](js/sync-pull-active-refresh.js), [`js/sync-pull-maintenance.js`](js/sync-pull-maintenance.js), [`js/sync-pull-merge.js`](js/sync-pull-merge.js), [`js/sync-pull-rebroadcast.js`](js/sync-pull-rebroadcast.js), [`js/sync-state.js`](js/sync-state.js), [`js/sync-tombstones.js`](js/sync-tombstones.js)
 - [`js/sync-push-deltas.js`](js/sync-push-deltas.js) → [`js/caught-error.js`](js/caught-error.js), [`js/data-merge.js`](js/data-merge.js), [`js/sync-delta.js`](js/sync-delta.js)
@@ -1175,7 +1175,7 @@ Native browser modules shipped with the static application.
 - [`js/sync-state.js`](js/sync-state.js) → no in-scope imports
 - [`js/sync-storage-cleanup.js`](js/sync-storage-cleanup.js) → [`js/caught-error.js`](js/caught-error.js), [`js/data-merge.js`](js/data-merge.js), [`js/state.js`](js/state.js), [`js/sync-state.js`](js/sync-state.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-subscriptions.js`](js/sync-subscriptions.js) → no in-scope imports
-- [`js/sync-tombstones.js`](js/sync-tombstones.js) → [`js/crypto.js`](js/crypto.js), [`js/profile-storage-cleanup.js`](js/profile-storage-cleanup.js), [`js/profile-storage-key.js`](js/profile-storage-key.js), [`js/profile-sync-policy.js`](js/profile-sync-policy.js), [`js/state.js`](js/state.js), [`js/sync-dirty-state.js`](js/sync-dirty-state.js), [`js/sync-payload.js`](js/sync-payload.js), [`js/sync-profile-fields.js`](js/sync-profile-fields.js), [`js/unique-id.js`](js/unique-id.js), [`js/utils.js`](js/utils.js)
+- [`js/sync-tombstones.js`](js/sync-tombstones.js) → [`js/clear-all-profile-reset.js`](js/clear-all-profile-reset.js) *(dynamic)*, [`js/crypto.js`](js/crypto.js), [`js/profile-storage-cleanup.js`](js/profile-storage-cleanup.js), [`js/profile-storage-key.js`](js/profile-storage-key.js), [`js/profile-sync-policy.js`](js/profile-sync-policy.js), [`js/state.js`](js/state.js), [`js/sync-dirty-state.js`](js/sync-dirty-state.js), [`js/sync-payload.js`](js/sync-payload.js), [`js/utils.js`](js/utils.js)
 - [`js/sync-ui.js`](js/sync-ui.js) → [`js/settings-runtime-bridge.js`](js/settings-runtime-bridge.js), [`js/sync-environment.js`](js/sync-environment.js), [`js/sync-relay-health.js`](js/sync-relay-health.js), [`js/sync-state.js`](js/sync-state.js), [`js/utils.js`](js/utils.js)
 - [`js/sync.js`](js/sync.js) → [`js/sync-actions.js`](js/sync-actions.js), [`js/sync-cutover.js`](js/sync-cutover.js), [`js/sync-diagnose-ui.js`](js/sync-diagnose-ui.js), [`js/sync-diagnostics.js`](js/sync-diagnostics.js), [`js/sync-environment.js`](js/sync-environment.js), [`js/sync-identity.js`](js/sync-identity.js), [`js/sync-init.js`](js/sync-init.js), [`js/sync-messenger.js`](js/sync-messenger.js), [`js/sync-relay-health.js`](js/sync-relay-health.js), [`js/sync-save-hooks.js`](js/sync-save-hooks.js), [`js/sync-settings-state.js`](js/sync-settings-state.js), [`js/sync-state.js`](js/sync-state.js), [`js/sync-storage-cleanup.js`](js/sync-storage-cleanup.js), [`js/sync-tombstones.js`](js/sync-tombstones.js), [`js/sync-ui.js`](js/sync-ui.js)
 

--- a/js/clear-all-profile-reset.js
+++ b/js/clear-all-profile-reset.js
@@ -1,0 +1,52 @@
+// @ts-check
+// clear-all-profile-reset.js — profile identity helpers for a durable clear-all.
+
+import { markLocalProfileDeleteIntent } from './profile-sync-policy.js';
+import { createUniqueId } from './unique-id.js';
+
+/** @param {string} [name] @param {number} [now] */
+export function createClearedProfileRecord(name = 'Profile 1', now = Date.now()) {
+  return {
+    id: createUniqueId('p_'),
+    name,
+    sex: null,
+    dob: null,
+    location: { country: '', zip: '' },
+    tags: [],
+    notes: '',
+    status: 'active',
+    avatar: null,
+    height: null,
+    heightUnit: 'cm',
+    createdAt: now,
+    lastUpdated: now,
+    pinned: false,
+  };
+}
+
+/**
+ * A clear-all is an explicit deletion, not an empty update. Remember that
+ * decision before yielding to any sync work so an incoming live row cannot
+ * recreate one of the cleared profiles.
+ * @param {Array<string | null | undefined>} profileIds
+ */
+export function markClearedProfilesForSync(profileIds) {
+  const marked = [];
+  const validIds = profileIds.filter(profileId => (
+    typeof profileId === 'string' && /^[A-Za-z0-9_-]{1,128}$/.test(profileId)
+  ));
+  for (const profileId of new Set(validIds)) {
+    if (markLocalProfileDeleteIntent(profileId, 'clear-all')) marked.push(profileId);
+  }
+  return marked;
+}
+
+/**
+ * Relay propagation is best-effort. Durable delete intents above make an
+ * offline/paused browser retry when those old rows are encountered later.
+ * @param {string[]} profileIds
+ * @param {(profileId: string) => Promise<any> | any} deleteProfileFromRelay
+ */
+export async function propagateClearedProfilesToRelay(profileIds, deleteProfileFromRelay) {
+  return Promise.allSettled(profileIds.map(profileId => deleteProfileFromRelay(profileId)));
+}

--- a/js/clear-all-profile-reset.js
+++ b/js/clear-all-profile-reset.js
@@ -1,7 +1,14 @@
 // @ts-check
 // clear-all-profile-reset.js — profile identity helpers for a durable clear-all.
 
-import { markLocalProfileDeleteIntent } from './profile-sync-policy.js';
+import { encryptedGetItem } from './crypto.js';
+import { profileStorageKey } from './profile-storage-key.js';
+import {
+  isDemoProfileRecord, markLocalProfileDeleteIntent, PROFILE_DELETE_INTENT_PREFIX,
+  TOMBSTONE_QUARANTINE_PREFIX,
+} from './profile-sync-policy.js';
+import { parseSyncPayload } from './sync-payload.js';
+import { SYNC_PROFILE_FIELDS } from './sync-profile-fields.js';
 import { createUniqueId } from './unique-id.js';
 
 /** @param {string} [name] @param {number} [now] */
@@ -55,4 +62,89 @@ export function markClearedProfilesForSync(profileIds) {
  */
 export async function propagateClearedProfilesToRelay(profileIds, deleteProfileFromRelay) {
   return Promise.allSettled(profileIds.map(profileId => deleteProfileFromRelay(profileId)));
+}
+
+// Delete decisions are scoped to one Evolu owner. A new owner must not inherit
+// the old owner's durable intent/quarantine state for matching profile IDs.
+export function clearAllProfileSyncDeleteState() {
+  let cleared = 0;
+  try {
+    const keys = [];
+    for (let index = 0; index < localStorage.length; index++) {
+      const key = localStorage.key(index);
+      if (key && (key.startsWith(TOMBSTONE_QUARANTINE_PREFIX)
+        || key.startsWith(PROFILE_DELETE_INTENT_PREFIX))) keys.push(key);
+    }
+    for (const key of keys) {
+      localStorage.removeItem(key);
+      cleared++;
+    }
+  } catch {}
+  return cleared;
+}
+
+export function createSyncFallbackProfile(existingProfiles, replacedProfileId = '') {
+  const ids = new Set((existingProfiles || []).map(profile => profile?.id).filter(Boolean));
+  let id;
+  do id = createUniqueId('p_'); while (ids.has(id));
+  const now = Date.now();
+  const profile = {
+    id,
+    name: 'Profile 1',
+    sex: null,
+    dob: null,
+    location: { country: '', zip: '' },
+    tags: [],
+    notes: '',
+    status: 'active',
+    avatar: null,
+    height: null,
+    heightUnit: 'cm',
+    createdAt: now,
+    lastUpdated: now,
+    pinned: false,
+  };
+  // Local-only marker: a replacement row arriving moments later may discard
+  // this untouched safety profile without leaving two empty profiles behind.
+  if (replacedProfileId) profile._syncFallback = [replacedProfileId, now];
+  return profile;
+}
+
+export async function findRelayReplacementProfile(latestLiveRows, tombIds) {
+  for (const [profileId, row] of latestLiveRows) {
+    if (tombIds.has(profileId)) continue;
+    try {
+      const payload = await parseSyncPayload(row?.dataJson || '');
+      if (!payload?.profile || isDemoProfileRecord(payload.profile)) continue;
+      const replacement = createSyncFallbackProfile([{ id: profileId }]);
+      replacement.id = profileId;
+      for (const field of SYNC_PROFILE_FIELDS) {
+        if (Object.prototype.hasOwnProperty.call(payload.profile, field)) {
+          replacement[field] = payload.profile[field];
+        }
+      }
+      return replacement;
+    } catch {}
+  }
+  return null;
+}
+
+export async function removeUntouchedSyncFallback(profiles) {
+  for (const candidate of profiles) {
+    if (!candidate?._syncFallback?.[0]) continue;
+    const fallbackAt = Number(candidate._syncFallback[1] || 0);
+    if (!fallbackAt || Date.now() - fallbackAt > 120_000
+        || candidate.createdAt !== fallbackAt || candidate.lastUpdated !== fallbackAt) continue;
+    try {
+      const stored = await encryptedGetItem(profileStorageKey(candidate.id, 'imported'));
+      const prefix = `labcharts-${candidate.id}-`;
+      const hasScopedLocalState = Object.keys(localStorage)
+        .some(key => key.startsWith(prefix) && key !== `${prefix}lastViewV1`);
+      if (stored === null && !hasScopedLocalState) {
+        profiles.splice(profiles.indexOf(candidate), 1);
+        return candidate.id;
+      }
+    } catch {}
+  }
+  return '';
 }

--- a/js/clear-all-profile-reset.js
+++ b/js/clear-all-profile-reset.js
@@ -29,12 +29,18 @@ export function createClearedProfileRecord(name = 'Profile 1', now = Date.now())
  * decision before yielding to any sync work so an incoming live row cannot
  * recreate one of the cleared profiles.
  * @param {Array<string | null | undefined>} profileIds
+ * @returns {string[]}
  */
 export function markClearedProfilesForSync(profileIds) {
+  /** @type {string[]} */
+  const validIds = [];
+  for (const profileId of profileIds) {
+    if (typeof profileId === 'string' && /^[A-Za-z0-9_-]{1,128}$/.test(profileId)) {
+      validIds.push(profileId);
+    }
+  }
+  /** @type {string[]} */
   const marked = [];
-  const validIds = profileIds.filter(profileId => (
-    typeof profileId === 'string' && /^[A-Za-z0-9_-]{1,128}$/.test(profileId)
-  ));
   for (const profileId of new Set(validIds)) {
     if (markLocalProfileDeleteIntent(profileId, 'clear-all')) marked.push(profileId);
   }

--- a/js/export.js
+++ b/js/export.js
@@ -43,6 +43,11 @@ import {
   markDemoLoadingProfile,
   refreshImportRuntimeShell,
 } from './export-runtime.js';
+import {
+  createClearedProfileRecord,
+  markClearedProfilesForSync,
+  propagateClearedProfilesToRelay,
+} from './clear-all-profile-reset.js';
 
 /** @typedef {typeof import('./export-import.js')} ExportImportModule */
 /** @type {Promise<ExportImportModule> | null} */
@@ -491,18 +496,43 @@ export async function clearAllData() {
       for (const id of profileIds) {
         await clearProfileStorage(id);
       }
+
+      // Do not reuse a cleared profile id. Evolu stores profile metadata and
+      // profile-scoped items independently, so publishing an empty snapshot
+      // under the old id can still merge with older item rows and reconstruct
+      // data that the user explicitly cleared.
+      const clearedProfileIds = markClearedProfilesForSync(profileIds);
+      const freshProfile = createClearedProfileRecord(profiles[0]?.name || 'Profile 1');
+      await saveProfiles([freshProfile]);
+      state.importedData = createDefaultProfileData();
+      state.currentProfile = freshProfile.id;
+      localStorage.setItem('labcharts-active-profile', freshProfile.id);
+      const saved = await saveImportedData({ immediate: true, reason: 'clear-all' });
+      if (!saved) throw new Error('Could not persist the cleared profile.');
+
+      // Tombstone every old relay profile after the fresh local identity is
+      // durable. If sync is paused or offline, the delete-intent keys above
+      // keep old live rows blocked and retry their deletion on a later pull.
+      try {
+        const sync = await import('./sync.js');
+        let replacementPublished = false;
+        if (sync.isSyncEnabled()) {
+          const publishResult = await sync.syncNow();
+          replacementPublished = publishResult?.ok === true;
+        }
+        if (replacementPublished) {
+          await propagateClearedProfilesToRelay(clearedProfileIds, sync.deleteProfileFromRelay);
+        } else if (sync.isSyncEnabled()) {
+          console.warn('[export] Clear-all relay deletes deferred until the fresh profile is published.');
+        }
+      } catch (syncError) {
+        console.warn('[export] Clear-all relay propagation deferred:', syncError);
+      }
     } catch (error) {
       console.warn('[export] Clear-all storage cleanup failed:', error);
       showNotification('Data clearing was incomplete. Close other Get Based tabs and try again.', 'error', 8000);
       return;
     }
-    // Reset to single default profile
-    const defaultId = profiles[0]?.id || 'default';
-    const defaultName = profiles[0]?.name || 'Profile 1';
-    await saveProfiles([{ id: defaultId, name: defaultName, sex: null, dob: null, location: { country: '', zip: '' }, tags: [], notes: '', status: 'active', avatar: null, height: null, heightUnit: 'cm', createdAt: Date.now(), lastUpdated: Date.now(), pinned: false }]);
-    state.importedData = createDefaultProfileData();
-    state.currentProfile = defaultId;
-    localStorage.setItem('labcharts-active-profile', defaultId);
     localStorage.removeItem('labcharts-cashu-wallet-mint');
     localStorage.removeItem('labcharts-cashu-wallet-mnemonic');
     localStorage.removeItem('labcharts-routstr-node');

--- a/js/profile-sync-policy.js
+++ b/js/profile-sync-policy.js
@@ -69,6 +69,30 @@ export function clearProfileSyncDeleteState(profileId) {
 }
 
 /**
+ * Delete decisions belong to the Evolu owner under which they were made.
+ * When a browser joins or creates a different owner, retaining these keys
+ * lets an absent profile from the old owner immediately tombstone a matching
+ * profile ID in the new owner. Clear both durable delete layers atomically at
+ * the application boundary; Evolu's own rows remain isolated by owner.
+ */
+export function clearAllProfileSyncDeleteState() {
+  let cleared = 0;
+  try {
+    const keys = [];
+    for (let index = 0; index < localStorage.length; index++) {
+      const key = localStorage.key(index);
+      if (key && (key.startsWith(TOMBSTONE_QUARANTINE_PREFIX)
+        || key.startsWith(PROFILE_DELETE_INTENT_PREFIX))) keys.push(key);
+    }
+    for (const key of keys) {
+      localStorage.removeItem(key);
+      cleared++;
+    }
+  } catch {}
+  return cleared;
+}
+
+/**
  * @param {string | null | undefined} profileId
  * @param {any[]} [profiles]
  * @returns {'demo'|'delete-intent'|'pending-delete'|''}

--- a/js/profile-sync-policy.js
+++ b/js/profile-sync-policy.js
@@ -1,8 +1,8 @@
 // @ts-check
 // profile-sync-policy.js — durable profile admission rules shared by sync paths.
 
-const TOMBSTONE_QUARANTINE_PREFIX = 'labcharts-tombstone-pending-';
-const PROFILE_DELETE_INTENT_PREFIX = 'labcharts-profile-delete-intent-';
+export const TOMBSTONE_QUARANTINE_PREFIX = 'labcharts-tombstone-pending-';
+export const PROFILE_DELETE_INTENT_PREFIX = 'labcharts-profile-delete-intent-';
 
 /** @param {any} profile */
 export function isDemoProfileRecord(profile) {
@@ -66,30 +66,6 @@ export function clearProfileSyncDeleteState(profileId) {
   } catch {
     return intentCleared;
   }
-}
-
-/**
- * Delete decisions belong to the Evolu owner under which they were made.
- * When a browser joins or creates a different owner, retaining these keys
- * lets an absent profile from the old owner immediately tombstone a matching
- * profile ID in the new owner. Clear both durable delete layers atomically at
- * the application boundary; Evolu's own rows remain isolated by owner.
- */
-export function clearAllProfileSyncDeleteState() {
-  let cleared = 0;
-  try {
-    const keys = [];
-    for (let index = 0; index < localStorage.length; index++) {
-      const key = localStorage.key(index);
-      if (key && (key.startsWith(TOMBSTONE_QUARANTINE_PREFIX)
-        || key.startsWith(PROFILE_DELETE_INTENT_PREFIX))) keys.push(key);
-    }
-    for (const key of keys) {
-      localStorage.removeItem(key);
-      cleared++;
-    }
-  } catch {}
-  return cleared;
 }
 
 /**

--- a/js/sync-identity.js
+++ b/js/sync-identity.js
@@ -6,6 +6,7 @@ import {
   clearSyncDisableStorage,
 } from './sync-disable-cleanup.js';
 import { getPendingBackupRestoreProfileIds } from './sync-backup-restore-state.js';
+import { clearAllProfileSyncDeleteState } from './profile-sync-policy.js';
 import { scheduleSyncRuntimeReload } from './sync-runtime.js';
 import { setSyncEnabled } from './sync-settings-state.js';
 
@@ -186,20 +187,18 @@ export async function restoreFromMnemonic(mnemonic, options = {}) {
     return false;
   }
   const normalizedMnemonic = normalizeMnemonic(mnemonic);
+  const previousMnemonic = normalizeMnemonic(currentAppOwner()?.mnemonic || '');
+  const identityChanged = !previousMnemonic || previousMnemonic !== normalizedMnemonic;
   setRestoreNotice(options?.seedLocal ? 'seed-local' : 'join');
   try {
-    if (options?.seedLocal) {
-      await evolu.restoreAppOwner(normalizedMnemonic);
-    } else {
-      // Evolu defaults restoreAppOwner to reload immediately from inside its
-      // worker. That navigation happens before the returned promise resolves,
-      // so none of the join-finalization below would run. In particular, a
-      // first-time join starts with persist:false and would reload with sync
-      // still disabled, leaving the restored owner unable to pull relay data.
-      // Keep the reset in this page long enough to commit our application
-      // state, then use the controlled reload at the end of this function.
-      await evolu.restoreAppOwner(normalizedMnemonic, { reload: false });
-    }
+    // Evolu 7 defaults restoreAppOwner to reload immediately from inside its
+    // worker. That navigation happens before the returned promise resolves,
+    // so neither join finalization nor seedLocal's recovery push can finish.
+    // Evolu 8 already stays in-page, but accepts this compatibility option.
+    // Keep both clients in this page until GetBased schedules the controlled
+    // reload after committing all identity-transition state below.
+    await evolu.restoreAppOwner(normalizedMnemonic, { reload: false });
+    if (identityChanged) clearAllProfileSyncDeleteState();
     // First-time joins initialize Evolu provisionally. Persist sync only once
     // the requested identity has actually been accepted.
     setSyncEnabled(true);

--- a/js/sync-identity.js
+++ b/js/sync-identity.js
@@ -6,7 +6,6 @@ import {
   clearSyncDisableStorage,
 } from './sync-disable-cleanup.js';
 import { getPendingBackupRestoreProfileIds } from './sync-backup-restore-state.js';
-import { clearAllProfileSyncDeleteState } from './profile-sync-policy.js';
 import { scheduleSyncRuntimeReload } from './sync-runtime.js';
 import { setSyncEnabled } from './sync-settings-state.js';
 
@@ -191,14 +190,12 @@ export async function restoreFromMnemonic(mnemonic, options = {}) {
   const identityChanged = !previousMnemonic || previousMnemonic !== normalizedMnemonic;
   setRestoreNotice(options?.seedLocal ? 'seed-local' : 'join');
   try {
-    // Evolu 7 defaults restoreAppOwner to reload immediately from inside its
-    // worker. That navigation happens before the returned promise resolves,
-    // so neither join finalization nor seedLocal's recovery push can finish.
-    // Evolu 8 already stays in-page, but accepts this compatibility option.
-    // Keep both clients in this page until GetBased schedules the controlled
-    // reload after committing all identity-transition state below.
+    // Keep Evolu 7 from reloading before join/seed finalization. Evolu 8 also
+    // accepts this option; GetBased schedules the controlled reload below.
     await evolu.restoreAppOwner(normalizedMnemonic, { reload: false });
-    if (identityChanged) clearAllProfileSyncDeleteState();
+    if (identityChanged) {
+      (await import('./clear-all-profile-reset.js')).clearAllProfileSyncDeleteState();
+    }
     // First-time joins initialize Evolu provisionally. Persist sync only once
     // the requested identity has actually been accepted.
     setSyncEnabled(true);

--- a/js/sync-pull-merge.js
+++ b/js/sync-pull-merge.js
@@ -294,28 +294,8 @@ export async function mergePulledProfile(profileId, profile) {
     if (!changed) return false;
     local.lastUpdated = Date.now();
   } else {
-    let disposableFallbackId = '';
-    for (const candidate of profiles) {
-      if (!candidate?._syncFallback?.[0]) continue;
-      const fallbackAt = Number(candidate._syncFallback[1] || 0);
-      if (!fallbackAt || Date.now() - fallbackAt > 120_000
-          || candidate.createdAt !== fallbackAt || candidate.lastUpdated !== fallbackAt) continue;
-      try {
-        const stored = await encryptedGetItem(profileStorageKey(candidate.id, 'imported'));
-        const prefix = `labcharts-${candidate.id}-`;
-        // Loading the safety profile writes its last-view route as part of
-        // ordinary shell startup. It is navigation state, not user content.
-        const hasScopedLocalState = Object.keys(localStorage)
-          .some(key => key.startsWith(prefix) && key !== `${prefix}lastViewV1`);
-        if (stored === null && !hasScopedLocalState) {
-          disposableFallbackId = candidate.id;
-          break;
-        }
-      } catch {}
-    }
-    if (disposableFallbackId) {
-      profiles.splice(profiles.findIndex(candidate => candidate.id === disposableFallbackId), 1);
-    }
+    const disposableFallbackId = await (await import('./clear-all-profile-reset.js'))
+      .removeUntouchedSyncFallback(profiles);
     const newProfile = /** @type {any} */ ({ id: profileId, lastUpdated: Date.now() });
     for (const field of SYNC_PROFILE_FIELDS) {
       if (field in profile) newProfile[field] = profile[field];

--- a/js/sync-pull-merge.js
+++ b/js/sync-pull-merge.js
@@ -3,7 +3,9 @@
 
 import { getErrorMessage } from './caught-error.js';
 import { state } from './state.js';
-import { profileStorageKey, getProfiles, saveProfiles, migrateProfileData } from './profile.js';
+import {
+  getProfiles, loadProfile, migrateProfileData, profileStorageKey, saveProfiles,
+} from './profile.js';
 import { getEncryptionEnabled, encryptedSetItem, encryptedGetItem } from './crypto.js';
 import { mergeImportedData, localHasRowsRemoteLacks, preserveFreshLocalLabEntries } from './data-merge.js';
 import { parseSyncPayload } from './sync-payload.js';
@@ -292,11 +294,44 @@ export async function mergePulledProfile(profileId, profile) {
     if (!changed) return false;
     local.lastUpdated = Date.now();
   } else {
+    let disposableFallbackId = '';
+    for (const candidate of profiles) {
+      if (!candidate?._syncReplacementFallbackFor) continue;
+      const fallbackAt = Number(candidate._syncReplacementFallbackAt || 0);
+      if (!fallbackAt || Date.now() - fallbackAt > 120_000
+          || candidate.createdAt !== fallbackAt || candidate.lastUpdated !== fallbackAt) continue;
+      try {
+        const stored = await encryptedGetItem(profileStorageKey(candidate.id, 'imported'));
+        let hasScopedLocalState = false;
+        const prefix = `labcharts-${candidate.id}-`;
+        for (let index = 0; index < localStorage.length; index++) {
+          const key = localStorage.key(index);
+          // Loading the safety profile writes its last-view route as part of
+          // ordinary shell startup. It is navigation state, not user content.
+          if (key?.startsWith(prefix) && key !== `${prefix}lastViewV1`) {
+            hasScopedLocalState = true;
+            break;
+          }
+        }
+        if (stored === null && !hasScopedLocalState) {
+          disposableFallbackId = candidate.id;
+          break;
+        }
+      } catch {}
+    }
+    if (disposableFallbackId) {
+      profiles.splice(profiles.findIndex(candidate => candidate.id === disposableFallbackId), 1);
+    }
     const newProfile = /** @type {any} */ ({ id: profileId, lastUpdated: Date.now() });
     for (const field of SYNC_PROFILE_FIELDS) {
       if (field in profile) newProfile[field] = profile[field];
     }
     profiles.push(newProfile);
+    await saveProfiles(profiles);
+    if (disposableFallbackId && state.currentProfile === disposableFallbackId) {
+      await loadProfile(profileId);
+    }
+    return true;
   }
   await saveProfiles(profiles);
   return true;

--- a/js/sync-pull-merge.js
+++ b/js/sync-pull-merge.js
@@ -296,23 +296,17 @@ export async function mergePulledProfile(profileId, profile) {
   } else {
     let disposableFallbackId = '';
     for (const candidate of profiles) {
-      if (!candidate?._syncReplacementFallbackFor) continue;
-      const fallbackAt = Number(candidate._syncReplacementFallbackAt || 0);
+      if (!candidate?._syncFallback?.[0]) continue;
+      const fallbackAt = Number(candidate._syncFallback[1] || 0);
       if (!fallbackAt || Date.now() - fallbackAt > 120_000
           || candidate.createdAt !== fallbackAt || candidate.lastUpdated !== fallbackAt) continue;
       try {
         const stored = await encryptedGetItem(profileStorageKey(candidate.id, 'imported'));
-        let hasScopedLocalState = false;
         const prefix = `labcharts-${candidate.id}-`;
-        for (let index = 0; index < localStorage.length; index++) {
-          const key = localStorage.key(index);
-          // Loading the safety profile writes its last-view route as part of
-          // ordinary shell startup. It is navigation state, not user content.
-          if (key?.startsWith(prefix) && key !== `${prefix}lastViewV1`) {
-            hasScopedLocalState = true;
-            break;
-          }
-        }
+        // Loading the safety profile writes its last-view route as part of
+        // ordinary shell startup. It is navigation state, not user content.
+        const hasScopedLocalState = Object.keys(localStorage)
+          .some(key => key.startsWith(prefix) && key !== `${prefix}lastViewV1`);
         if (stored === null && !hasScopedLocalState) {
           disposableFallbackId = candidate.id;
           break;

--- a/js/sync-tombstones.js
+++ b/js/sync-tombstones.js
@@ -11,8 +11,9 @@ import { createUniqueId } from './unique-id.js';
 import { getSyncDirtyToken } from './sync-dirty-state.js';
 import {
   clearLocalProfileDeleteIntent, hasPendingProfileTombstone,
-  isDemoProfileId, markLocalProfileDeleteIntent,
+  isDemoProfileId, isDemoProfileRecord, markLocalProfileDeleteIntent,
 } from './profile-sync-policy.js';
+import { SYNC_PROFILE_FIELDS } from './sync-profile-fields.js';
 
 /** @type {() => any} */
 let _getEvolu = () => null;
@@ -135,12 +136,12 @@ async function latestRowsByProfileId(rows) {
   return latest;
 }
 
-function createFallbackProfile(existingProfiles) {
+function createFallbackProfile(existingProfiles, replacedProfileId = '') {
   const ids = new Set((existingProfiles || []).map(profile => profile?.id).filter(Boolean));
   let id;
   do id = createUniqueId('p_'); while (ids.has(id));
   const now = Date.now();
-  return {
+  const profile = {
     id,
     name: 'Profile 1',
     sex: null,
@@ -156,6 +157,37 @@ function createFallbackProfile(existingProfiles) {
     lastUpdated: now,
     pinned: false,
   };
+  // This marker is local-only (not in SYNC_PROFILE_FIELDS). If the deleting
+  // device has also published a replacement profile but its row arrives a
+  // moment later, the pull merge can discard this untouched safety profile
+  // instead of leaving the peer with two empty profiles.
+  if (replacedProfileId) {
+    profile._syncReplacementFallbackFor = replacedProfileId;
+    profile._syncReplacementFallbackAt = now;
+  }
+  return profile;
+}
+
+async function findRelayReplacementProfile(latestLiveRows, tombIds) {
+  for (const [profileId, row] of latestLiveRows) {
+    if (tombIds.has(profileId)) continue;
+    try {
+      const payload = await parseSyncPayload(row?.dataJson || '');
+      if (!payload?.profile || isDemoProfileRecord(payload.profile)) continue;
+      const now = Date.now();
+      const replacement = createFallbackProfile([{ id: profileId }]);
+      replacement.id = profileId;
+      replacement.createdAt = now;
+      replacement.lastUpdated = now;
+      for (const field of SYNC_PROFILE_FIELDS) {
+        if (Object.prototype.hasOwnProperty.call(payload.profile, field)) {
+          replacement[field] = payload.profile[field];
+        }
+      }
+      return replacement;
+    } catch {}
+  }
+  return null;
 }
 
 // Soft-delete a profile's row on the relay so other devices stop seeing it.
@@ -209,10 +241,15 @@ export async function applyRemoteTombstones() {
   for (const [profileId, tombstone] of latestTombstones) {
     const live = latestLiveRows.get(profileId);
     // A newer live row is an explicit Restore/Keep. An older tombstone must
-    // not erase it again on every subscription callback.
+    // not erase it again on every subscription callback. Retire the deleting
+    // browser's durable intent too; otherwise its pull loop rejects the newer
+    // live row and writes a fresh tombstone, creating a permanent delete loop.
     if (!live || rowClock(tombstone) >= rowClock(live)) tombIds.add(profileId);
-    else if (hasPendingProfileTombstone(profileId)) {
-      localStorage.removeItem(TOMBSTONE_QUARANTINE_KEY(profileId));
+    else {
+      if (hasPendingProfileTombstone(profileId)) {
+        localStorage.removeItem(TOMBSTONE_QUARANTINE_KEY(profileId));
+      }
+      clearLocalProfileDeleteIntent(profileId);
     }
   }
 
@@ -260,7 +297,14 @@ export async function applyRemoteTombstones() {
   if (wipedIds.length === 0) return;
 
   const survivors = profiles.filter(profile => !wipedIds.includes(profile.id));
-  if (survivors.length === 0) survivors.push(createFallbackProfile(profiles));
+  if (survivors.length === 0) {
+    // Clear-all publishes a fresh profile id and tombstones the old ids in the
+    // same relay window. Adopt that already-live replacement immediately;
+    // otherwise deleting the last local profile creates a second, browser-only
+    // fallback just before the pull loop materializes the intended fresh row.
+    const relayReplacement = await findRelayReplacementProfile(latestLiveRows, tombIds);
+    survivors.push(relayReplacement || createFallbackProfile(profiles, wipedIds.join(',')));
+  }
   await _saveProfiles(survivors);
   for (const id of wipedIds) localStorage.removeItem(TOMBSTONE_QUARANTINE_KEY(id));
   dbg(`Applied ${wipedIds.length} remote tombstone(s):`, wipedIds.join(', '));
@@ -298,7 +342,7 @@ export async function applyPendingTombstone(profileId) {
     throw error;
   }
   const survivors = profiles.filter(p => p.id !== profileId);
-  if (survivors.length === 0) survivors.push(createFallbackProfile(profiles));
+  if (survivors.length === 0) survivors.push(createFallbackProfile(profiles, profileId));
   await _saveProfiles(survivors);
   localStorage.removeItem(TOMBSTONE_QUARANTINE_KEY(profileId));
   if (state.currentProfile === profileId) await _loadProfile(survivors[0].id);

--- a/js/sync-tombstones.js
+++ b/js/sync-tombstones.js
@@ -162,8 +162,7 @@ function createFallbackProfile(existingProfiles, replacedProfileId = '') {
   // moment later, the pull merge can discard this untouched safety profile
   // instead of leaving the peer with two empty profiles.
   if (replacedProfileId) {
-    profile._syncReplacementFallbackFor = replacedProfileId;
-    profile._syncReplacementFallbackAt = now;
+    profile._syncFallback = [replacedProfileId, now];
   }
   return profile;
 }

--- a/js/sync-tombstones.js
+++ b/js/sync-tombstones.js
@@ -298,7 +298,7 @@ export async function applyRemoteTombstones() {
   const survivors = profiles.filter(profile => !wipedIds.includes(profile.id));
   if (survivors.length === 0) {
     // Clear-all publishes a fresh profile id and tombstones the old ids in the
-    // same relay window. Adopt that already-live replacement immediately;
+    // same relay update. Adopt that already-live replacement immediately;
     // otherwise deleting the last local profile creates a second, browser-only
     // fallback just before the pull loop materializes the intended fresh row.
     const relayReplacement = await findRelayReplacementProfile(latestLiveRows, tombIds);

--- a/js/sync-tombstones.js
+++ b/js/sync-tombstones.js
@@ -7,13 +7,11 @@ import { profileStorageKey } from './profile-storage-key.js';
 import { encryptedGetItem } from './crypto.js';
 import { parseSyncPayload } from './sync-payload.js';
 import { clearProfileStorage } from './profile-storage-cleanup.js';
-import { createUniqueId } from './unique-id.js';
 import { getSyncDirtyToken } from './sync-dirty-state.js';
 import {
   clearLocalProfileDeleteIntent, hasPendingProfileTombstone,
-  isDemoProfileId, isDemoProfileRecord, markLocalProfileDeleteIntent,
+  isDemoProfileId, markLocalProfileDeleteIntent,
 } from './profile-sync-policy.js';
-import { SYNC_PROFILE_FIELDS } from './sync-profile-fields.js';
 
 /** @type {() => any} */
 let _getEvolu = () => null;
@@ -35,6 +33,12 @@ let _saveProfiles = async () => {};
 let _loadProfile = () => {};
 /** @type {(...args: any[]) => any} */
 let _notify = showNotification;
+let profileResetModulePromise;
+
+function loadProfileResetModule() {
+  profileResetModulePromise ||= import('./clear-all-profile-reset.js');
+  return profileResetModulePromise;
+}
 
 /** @param {{
  *   getEvolu?: () => any,
@@ -136,59 +140,6 @@ async function latestRowsByProfileId(rows) {
   return latest;
 }
 
-function createFallbackProfile(existingProfiles, replacedProfileId = '') {
-  const ids = new Set((existingProfiles || []).map(profile => profile?.id).filter(Boolean));
-  let id;
-  do id = createUniqueId('p_'); while (ids.has(id));
-  const now = Date.now();
-  const profile = {
-    id,
-    name: 'Profile 1',
-    sex: null,
-    dob: null,
-    location: { country: '', zip: '' },
-    tags: [],
-    notes: '',
-    status: 'active',
-    avatar: null,
-    height: null,
-    heightUnit: 'cm',
-    createdAt: now,
-    lastUpdated: now,
-    pinned: false,
-  };
-  // This marker is local-only (not in SYNC_PROFILE_FIELDS). If the deleting
-  // device has also published a replacement profile but its row arrives a
-  // moment later, the pull merge can discard this untouched safety profile
-  // instead of leaving the peer with two empty profiles.
-  if (replacedProfileId) {
-    profile._syncFallback = [replacedProfileId, now];
-  }
-  return profile;
-}
-
-async function findRelayReplacementProfile(latestLiveRows, tombIds) {
-  for (const [profileId, row] of latestLiveRows) {
-    if (tombIds.has(profileId)) continue;
-    try {
-      const payload = await parseSyncPayload(row?.dataJson || '');
-      if (!payload?.profile || isDemoProfileRecord(payload.profile)) continue;
-      const now = Date.now();
-      const replacement = createFallbackProfile([{ id: profileId }]);
-      replacement.id = profileId;
-      replacement.createdAt = now;
-      replacement.lastUpdated = now;
-      for (const field of SYNC_PROFILE_FIELDS) {
-        if (Object.prototype.hasOwnProperty.call(payload.profile, field)) {
-          replacement[field] = payload.profile[field];
-        }
-      }
-      return replacement;
-    } catch {}
-  }
-  return null;
-}
-
 // Soft-delete a profile's row on the relay so other devices stop seeing it.
 // Local wipe alone is insufficient: otherwise any peer that pulls the old
 // Evolu row can resurrect the deleted profile.
@@ -239,10 +190,8 @@ export async function applyRemoteTombstones() {
   const tombIds = new Set();
   for (const [profileId, tombstone] of latestTombstones) {
     const live = latestLiveRows.get(profileId);
-    // A newer live row is an explicit Restore/Keep. An older tombstone must
-    // not erase it again on every subscription callback. Retire the deleting
-    // browser's durable intent too; otherwise its pull loop rejects the newer
-    // live row and writes a fresh tombstone, creating a permanent delete loop.
+    // A newer live row explicitly revives the profile. Retire both delete
+    // layers or this browser would reject and tombstone that row again.
     if (!live || rowClock(tombstone) >= rowClock(live)) tombIds.add(profileId);
     else {
       if (hasPendingProfileTombstone(profileId)) {
@@ -297,12 +246,11 @@ export async function applyRemoteTombstones() {
 
   const survivors = profiles.filter(profile => !wipedIds.includes(profile.id));
   if (survivors.length === 0) {
-    // Clear-all publishes a fresh profile id and tombstones the old ids in the
-    // same relay update. Adopt that already-live replacement immediately;
-    // otherwise deleting the last local profile creates a second, browser-only
-    // fallback just before the pull loop materializes the intended fresh row.
-    const relayReplacement = await findRelayReplacementProfile(latestLiveRows, tombIds);
-    survivors.push(relayReplacement || createFallbackProfile(profiles, wipedIds.join(',')));
+    // Adopt a clear-all replacement already in this batch; otherwise create a
+    // temporary fallback for the inbound pull to replace.
+    const profileReset = await loadProfileResetModule();
+    const relayReplacement = await profileReset.findRelayReplacementProfile(latestLiveRows, tombIds);
+    survivors.push(relayReplacement || profileReset.createSyncFallbackProfile(profiles, wipedIds.join(',')));
   }
   await _saveProfiles(survivors);
   for (const id of wipedIds) localStorage.removeItem(TOMBSTONE_QUARANTINE_KEY(id));
@@ -341,7 +289,9 @@ export async function applyPendingTombstone(profileId) {
     throw error;
   }
   const survivors = profiles.filter(p => p.id !== profileId);
-  if (survivors.length === 0) survivors.push(createFallbackProfile(profiles, profileId));
+  if (survivors.length === 0) {
+    survivors.push((await loadProfileResetModule()).createSyncFallbackProfile(profiles, profileId));
+  }
   await _saveProfiles(survivors);
   localStorage.removeItem(TOMBSTONE_QUARANTINE_KEY(profileId));
   if (state.currentProfile === profileId) await _loadProfile(survivors[0].id);

--- a/scripts/dom-sink-policy.json
+++ b/scripts/dom-sink-policy.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "scope": "Every non-generated JavaScript module under js/",
   "reviewRule": "Any added or modified HTML-writing sink requires security review and a policy refresh.",
-  "scannedFiles": 679,
+  "scannedFiles": 680,
   "sinkCount": 534,
   "files": {
     "js/backup.js": {

--- a/service-worker.js
+++ b/service-worker.js
@@ -233,7 +233,7 @@ const APP_SHELL = [ // Includes dynamic chat and Knowledge Base modules for firs
   '/js/pdf-import-unit-conversions.js',
   '/js/pdf-import-marker-normalization.js',
   '/js/pdf-import-persistence.js',
-  '/js/export.js',
+  '/js/export.js', '/js/clear-all-profile-reset.js',
   '/js/export-loader.js',
   '/js/export-import.js',
   '/js/export-runtime.js',

--- a/tests/clear-all-profile-reset.test.js
+++ b/tests/clear-all-profile-reset.test.js
@@ -3,6 +3,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  clearAllProfileSyncDeleteState,
   createClearedProfileRecord,
   markClearedProfilesForSync,
   propagateClearedProfilesToRelay,
@@ -14,6 +15,17 @@ afterEach(() => {
 });
 
 describe('clear-all profile reset', () => {
+  it('drops delete state from the previous sync owner only', () => {
+    localStorage.setItem('labcharts-profile-delete-intent-old-profile', '{}');
+    localStorage.setItem('labcharts-tombstone-pending-old-profile', '{}');
+    localStorage.setItem('labcharts-unrelated-setting', 'keep');
+
+    expect(clearAllProfileSyncDeleteState()).toBe(2);
+    expect(localStorage.getItem('labcharts-profile-delete-intent-old-profile')).toBeNull();
+    expect(localStorage.getItem('labcharts-tombstone-pending-old-profile')).toBeNull();
+    expect(localStorage.getItem('labcharts-unrelated-setting')).toBe('keep');
+  });
+
   it('creates a fresh empty profile identity instead of reusing a cleared id', () => {
     const profile = createClearedProfileRecord('Primary', 1234);
 

--- a/tests/clear-all-profile-reset.test.js
+++ b/tests/clear-all-profile-reset.test.js
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createClearedProfileRecord,
+  markClearedProfilesForSync,
+  propagateClearedProfilesToRelay,
+} from '../js/clear-all-profile-reset.js';
+
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe('clear-all profile reset', () => {
+  it('creates a fresh empty profile identity instead of reusing a cleared id', () => {
+    const profile = createClearedProfileRecord('Primary', 1234);
+
+    expect(profile).toMatchObject({
+      name: 'Primary',
+      createdAt: 1234,
+      lastUpdated: 1234,
+      status: 'active',
+    });
+    expect(profile.id).toMatch(/^p_[A-Za-z0-9_-]+$/);
+    expect(profile.id).not.toBe('default');
+  });
+
+  it('durably blocks every unique cleared profile before relay propagation', () => {
+    const marked = markClearedProfilesForSync([
+      'profile-a',
+      'profile-b',
+      'profile-a',
+      '',
+      '../invalid',
+    ]);
+
+    expect(marked).toEqual(['profile-a', 'profile-b']);
+    for (const profileId of marked) {
+      expect(JSON.parse(localStorage.getItem(`labcharts-profile-delete-intent-${profileId}`)))
+        .toMatchObject({ source: 'clear-all' });
+    }
+    expect(localStorage.getItem('labcharts-profile-delete-intent-../invalid')).toBeNull();
+  });
+
+  it('attempts every old relay profile even when one deletion fails', async () => {
+    const deleteProfileFromRelay = vi.fn(async profileId => {
+      if (profileId === 'profile-a') throw new Error('offline');
+      return { ok: true };
+    });
+
+    const results = await propagateClearedProfilesToRelay(
+      ['profile-a', 'profile-b'],
+      deleteProfileFromRelay,
+    );
+
+    expect(deleteProfileFromRelay).toHaveBeenCalledTimes(2);
+    expect(results.map(result => result.status)).toEqual(['rejected', 'fulfilled']);
+  });
+});

--- a/tests/playwright/sync-identity-browser-coverage.spec.js
+++ b/tests/playwright/sync-identity-browser-coverage.spec.js
@@ -65,6 +65,7 @@ test('sync identity browser coverage handles libraries getters pending restore a
       'pendingFlagReadsAndClears',
       'restoreJoinClearsSyncStorageAndMarksPending',
       'restoreSeedLocalClearsPendingAndSeeds',
+      'sameIdentityRestorePreservesPendingDelete',
       'restoreFailureNotifiesAndReturnsFalse',
       'restoreWithoutEvoluReturnsFalse',
     ];
@@ -178,9 +179,14 @@ test('sync identity browser coverage handles libraries getters pending restore a
         'labcharts-relay-quota-warned',
         identity.RESTORE_JOIN_PENDING_KEY,
       ];
+      const identityDeleteKeys = [
+        'labcharts-profile-delete-intent-old-owner-profile',
+        'labcharts-tombstone-pending-old-owner-profile',
+      ];
       const cleanupKeysClearedByJoinRestore = cleanupKeys
         .filter(key => key !== identity.RESTORE_JOIN_PENDING_KEY);
       for (const key of cleanupKeys) localStorage.setItem(key, 'remove-me');
+      for (const key of identityDeleteKeys) localStorage.setItem(key, 'remove-me');
       localStorage.setItem('coverage-keep-key', 'keep-me');
 
       scheduledDelays.length = 0;
@@ -203,6 +209,7 @@ test('sync identity browser coverage handles libraries getters pending restore a
         && seedCalls === 0
         && identity.isRestoreJoinPending() === true
         && cleanupKeysClearedByJoinRestore.every(key => localStorage.getItem(key) === null)
+        && identityDeleteKeys.every(key => localStorage.getItem(key) === null)
         && localStorage.getItem(identity.RESTORE_JOIN_PENDING_KEY) !== null
         && localStorage.getItem(identity.RESTORE_JOIN_PENDING_KEY) !== 'remove-me'
         && localStorage.getItem('coverage-keep-key') === 'keep-me'
@@ -212,15 +219,28 @@ test('sync identity browser coverage handles libraries getters pending restore a
 
       clearNotifications();
       scheduledDelays.length = 0;
+      for (const key of identityDeleteKeys) localStorage.setItem(key, 'remove-on-owner-change');
       const seededResult = await identity.restoreFromMnemonic('seed local mnemonic', { seedLocal: true });
       outcomes.restoreSeedLocalClearsPendingAndSeeds = seededResult === true
         && restoreCalls[1]?.mnemonic === 'seed local mnemonic'
-        && restoreCalls[1]?.options === undefined
+        && restoreCalls[1]?.options?.reload === false
         && seedCalls === 1
+        && identityDeleteKeys.every(key => localStorage.getItem(key) === null)
         && identity.isRestoreJoinPending() === false
         && scheduledDelays.includes(500)
         && notifications().includes('seeded this device')
         && identity.consumeSyncRestoreNotice()?.includes('data was republished') === true;
+
+      identity.configureSyncIdentity({
+        getAppOwner: () => ({ id: 'same-owner', mnemonic: 'same owner mnemonic' }),
+      });
+      for (const key of identityDeleteKeys) localStorage.setItem(key, 'preserve-on-same-owner');
+      const sameOwnerResult = await identity.restoreFromMnemonic(' same   owner\nmnemonic ', { seedLocal: true });
+      outcomes.sameIdentityRestorePreservesPendingDelete = sameOwnerResult === true
+        && restoreCalls[2]?.mnemonic === 'same owner mnemonic'
+        && restoreCalls[2]?.options?.reload === false
+        && identityDeleteKeys.every(key => localStorage.getItem(key) === 'preserve-on-same-owner');
+      for (const key of identityDeleteKeys) localStorage.removeItem(key);
 
       clearNotifications();
       identity.configureSyncIdentity({

--- a/tests/playwright/sync-pull-merge-browser-coverage.spec.js
+++ b/tests/playwright/sync-pull-merge-browser-coverage.spec.js
@@ -33,8 +33,11 @@ test('sync pull merge browser coverage exercises row recovery merge persistence 
     });
     const profileId = `sync-pull-merge-${Date.now()}`;
     const storedProfileId = `${profileId}_stored`;
+    const fallbackProfileId = `${profileId}_fallback`;
+    const replacementProfileId = `${profileId}_replacement`;
     const localKey = profileStore.profileStorageKey(profileId, 'imported');
     const storedKey = profileStore.profileStorageKey(storedProfileId, 'imported');
+    const replacementKey = profileStore.profileStorageKey(replacementProfileId, 'imported');
     const saved = {
       state: {
         currentProfile: state.currentProfile,
@@ -42,6 +45,7 @@ test('sync pull merge browser coverage exercises row recovery merge persistence 
         profiles: clone(state.profiles),
       },
       encryptionEnabled: localStorage.getItem('labcharts-encryption-enabled'),
+      activeProfile: localStorage.getItem('labcharts-active-profile'),
       profilesRaw: localStorage.getItem('labcharts-profiles'),
       restoreJoinPending: localStorage.getItem('labcharts-sync-restore-join-pending'),
     };
@@ -54,6 +58,7 @@ test('sync pull merge browser coverage exercises row recovery merge persistence 
       localStorage.setItem('labcharts-encryption-enabled', 'false');
       await cryptoStore.encryptedRemoveItem(localKey);
       await cryptoStore.encryptedRemoveItem(storedKey);
+      await cryptoStore.encryptedRemoveItem(replacementKey);
       localStorage.removeItem(`labcharts-${profileId}-sync-ts`);
       localStorage.removeItem(`labcharts-${storedProfileId}-sync-ts`);
       syncDelta.configureSyncDelta({
@@ -225,19 +230,49 @@ test('sync pull merge browser coverage exercises row recovery merge persistence 
         && addedProfile.color === '#abcdef'
         && !Object.prototype.hasOwnProperty.call(addedProfile, 'notes');
 
+      const fallbackAt = Date.now();
+      state.profiles = [{
+        id: fallbackProfileId,
+        name: 'Profile 1',
+        createdAt: fallbackAt,
+        lastUpdated: fallbackAt,
+        _syncReplacementFallbackFor: profileId,
+        _syncReplacementFallbackAt: fallbackAt,
+      }];
+      state.currentProfile = fallbackProfileId;
+      state.importedData = profileStore.createDefaultProfileData();
+      localStorage.setItem('labcharts-active-profile', fallbackProfileId);
+      localStorage.setItem(`labcharts-${fallbackProfileId}-lastViewV1`, 'dashboard');
+      await cryptoStore.encryptedSetItem(replacementKey, JSON.stringify({
+        ...profileStore.createDefaultProfileData(),
+        contextNotes: 'fresh relay replacement',
+      }));
+      const mergedReplacement = await pullMerge.mergePulledProfile(replacementProfileId, {
+        name: 'Fresh replacement',
+      });
+      outcomes.lateRelayReplacementRemovesOnlyUntouchedSafetyFallback =
+        mergedReplacement === true
+        && state.currentProfile === replacementProfileId
+        && state.importedData.contextNotes === 'fresh relay replacement'
+        && profileStore.getProfiles().length === 1
+        && profileStore.getProfiles()[0].id === replacementProfileId;
+
       outcomes.allOutcomesReached = true;
     } finally {
       state.currentProfile = saved.state.currentProfile;
       state.importedData = saved.state.importedData;
       state.profiles = saved.state.profiles;
       restoreLocalValue('labcharts-encryption-enabled', saved.encryptionEnabled);
+      restoreLocalValue('labcharts-active-profile', saved.activeProfile);
       restoreLocalValue('labcharts-profiles', saved.profilesRaw);
       restoreLocalValue('labcharts-sync-restore-join-pending', saved.restoreJoinPending);
       localStorage.removeItem(`labcharts-${profileId}-sync-ts`);
       localStorage.removeItem(`labcharts-${storedProfileId}-sync-ts`);
+      localStorage.removeItem(`labcharts-${fallbackProfileId}-lastViewV1`);
       localStorage.removeItem(storedKey);
       await cryptoStore.encryptedRemoveItem(localKey);
       await cryptoStore.encryptedRemoveItem(storedKey);
+      await cryptoStore.encryptedRemoveItem(replacementKey);
     }
 
     return outcomes;

--- a/tests/playwright/sync-pull-merge-browser-coverage.spec.js
+++ b/tests/playwright/sync-pull-merge-browser-coverage.spec.js
@@ -236,8 +236,7 @@ test('sync pull merge browser coverage exercises row recovery merge persistence 
         name: 'Profile 1',
         createdAt: fallbackAt,
         lastUpdated: fallbackAt,
-        _syncReplacementFallbackFor: profileId,
-        _syncReplacementFallbackAt: fallbackAt,
+        _syncFallback: [profileId, fallbackAt],
       }];
       state.currentProfile = fallbackProfileId;
       state.importedData = profileStore.createDefaultProfileData();

--- a/tests/playwright/sync-relay-transport-e2e.spec.js
+++ b/tests/playwright/sync-relay-transport-e2e.spec.js
@@ -125,6 +125,114 @@ async function joinIdentity(page, mnemonic, ownerId) {
   await waitForOwner(page, ownerId);
 }
 
+async function rotateIdentityWithLocalData(page) {
+  const previous = await waitForOwner(page);
+  const reloaded = page.waitForEvent('load', { timeout: 30_000 });
+  const rotated = await page.evaluate(async () => {
+    const { ensureBip39, restoreFromMnemonic } = await import('/js/sync-identity.js');
+    const bip39 = await ensureBip39();
+    const mnemonic = await bip39.generateMnemonic(256);
+    const ok = await restoreFromMnemonic(mnemonic, { seedLocal: true });
+    return { ok, mnemonic };
+  });
+  expect(rotated.ok).toBe(true);
+  await reloaded;
+  const next = await waitForOwner(page);
+  expect(next.ownerId).not.toBe(previous.ownerId);
+  expect(next.mnemonic).toBe(rotated.mnemonic);
+  return next;
+}
+
+async function profileIds(page) {
+  return page.evaluate(async () => (await import('/js/profile.js')).getProfiles().map(profile => profile.id));
+}
+
+async function profileDiagnostics(page) {
+  return page.evaluate(async () => {
+    const profiles = (await import('/js/profile.js')).getProfiles();
+    const keys = Array.from({ length: localStorage.length }, (_, index) => localStorage.key(index)).filter(Boolean);
+    return profiles.map(profile => ({
+      profile,
+      localKeys: keys.filter(key => key.includes(profile.id)),
+    }));
+  });
+}
+
+async function waitForProfilePresence(page, profileId, present) {
+  await expect.poll(async () => (await profileIds(page)).includes(profileId), {
+    timeout: 30_000,
+    intervals: [100, 250, 500, 1000],
+  }).toBe(present);
+}
+
+async function activateProfile(page, profileId) {
+  await page.evaluate(async id => (await import('/js/profile.js')).loadProfile(id), profileId);
+  await expect.poll(() => page.evaluate(async id => (
+    (await import('/js/state.js')).state.currentProfile === id
+  ), profileId), { timeout: 30_000 }).toBe(true);
+}
+
+async function captureProfileSnapshot(page, profileId) {
+  return page.evaluate(async id => {
+    const [{ state }, profileModule] = await Promise.all([
+      import('/js/state.js'),
+      import('/js/profile.js'),
+    ]);
+    const profile = profileModule.getProfiles().find(candidate => candidate.id === id);
+    if (!profile || state.currentProfile !== id) throw new Error(`Profile ${id} is not active`);
+    return {
+      profile: JSON.parse(JSON.stringify(profile)),
+      importedData: JSON.parse(JSON.stringify(state.importedData)),
+    };
+  }, profileId);
+}
+
+async function restoreProfileSnapshot(page, snapshot) {
+  await page.evaluate(async restored => {
+    const [crypto, storageKeys, profileModule, restoreState] = await Promise.all([
+      import('/js/crypto.js'),
+      import('/js/profile-storage-key.js'),
+      import('/js/profile.js'),
+      import('/js/sync-backup-restore-state.js'),
+    ]);
+    const profileId = restored.profile.id;
+    await crypto.encryptedSetItem(
+      storageKeys.profileStorageKey(profileId, 'imported'),
+      JSON.stringify(restored.importedData),
+    );
+    await profileModule.saveProfiles([restored.profile]);
+    localStorage.setItem('labcharts-active-profile', profileId);
+    restoreState.prepareRestoredProfilesForSync({ profiles: [{ profileId }] });
+  }, snapshot);
+  await page.reload({ waitUntil: 'domcontentloaded', timeout: 30_000 });
+  await waitForOwner(page);
+  await waitForProfilePresence(page, snapshot.profile.id, true);
+  await expect.poll(async () => page.evaluate(async id => (
+    (await import('/js/state.js')).state.currentProfile === id
+  ), snapshot.profile.id), { timeout: 30_000 }).toBe(true);
+}
+
+async function clearAllProfileData(page, oldProfileId) {
+  const clearPromise = page.evaluate(async () => (
+    (await import('/js/export.js')).clearAllData()
+  ));
+  await page.locator('#confirm-ok').click();
+  await clearPromise;
+  return page.evaluate(async oldId => {
+    const [{ state }, profileModule] = await Promise.all([
+      import('/js/state.js'),
+      import('/js/profile.js'),
+    ]);
+    return {
+      activeProfileId: state.currentProfile,
+      contextNotes: state.importedData?.contextNotes || '',
+      noteCount: state.importedData?.notes?.length || 0,
+      profileIds: profileModule.getProfiles().map(profile => profile.id),
+      oldDeleteIntent: localStorage.getItem(`labcharts-profile-delete-intent-${oldId}`),
+    };
+  }, oldProfileId);
+}
+
 async function setSyntheticData(page, action) {
   return page.evaluate(async requestedAction => {
     const [{ state }, dataModule, mergeModule] = await Promise.all([
@@ -415,5 +523,99 @@ test('real relay converges devices, resists no-op bloat, recovers offline, and r
     for (const device of devices.reverse()) {
       await device.context.close().catch(() => {});
     }
+  }
+});
+
+test('restored profiles survive old tombstones and a new sync identity', async ({ browser }) => {
+  test.setTimeout(300_000);
+  const devices = [];
+  const profileId = 'default';
+
+  try {
+    const deviceA = await createDevice(browser, 'restore device A');
+    devices.push(deviceA);
+    await setSyntheticData(deviceA.page, 'seed');
+    const originalIdentity = await enableNewIdentity(deviceA.page);
+    const snapshot = await captureProfileSnapshot(deviceA.page, profileId);
+
+    const deviceB = await createDevice(browser, 'restore device B');
+    devices.push(deviceB);
+    await joinIdentity(deviceB.page, originalIdentity.mnemonic, originalIdentity.ownerId);
+    await waitForNotes(deviceB.page, ['baseline-note']);
+
+    const deleted = await deviceB.page.evaluate(async id => {
+      const [sync, policy] = await Promise.all([
+        import('/js/sync.js'),
+        import('/js/profile-sync-policy.js'),
+      ]);
+      policy.markLocalProfileDeleteIntent(id, 'local');
+      return sync.deleteProfileFromRelay(id);
+    }, profileId);
+    expect(deleted).toMatchObject({ ok: true });
+    await waitForProfilePresence(deviceA.page, profileId, false);
+    await waitForProfilePresence(deviceB.page, profileId, false);
+
+    await restoreProfileSnapshot(deviceA.page, snapshot);
+    expect((await syncNow(deviceA.page))?.ok).toBe(true);
+    await waitForProfilePresence(deviceB.page, profileId, true);
+    await activateProfile(deviceB.page, profileId);
+    await waitForNotes(deviceA.page, ['baseline-note']);
+    await waitForNotes(deviceB.page, ['baseline-note']);
+    await expect.poll(() => deviceB.page.evaluate(id => ({
+      intent: localStorage.getItem(`labcharts-profile-delete-intent-${id}`),
+      pending: localStorage.getItem(`labcharts-tombstone-pending-${id}`),
+    }), profileId), { timeout: 30_000 }).toEqual({ intent: null, pending: null });
+
+    const rotatedIdentity = await rotateIdentityWithLocalData(deviceA.page);
+    await deviceB.page.evaluate(id => {
+      localStorage.setItem(`labcharts-profile-delete-intent-${id}`, JSON.stringify({ at: Date.now(), source: 'old-owner' }));
+      localStorage.setItem(`labcharts-tombstone-pending-${id}`, JSON.stringify({ at: Date.now(), source: 'old-owner' }));
+    }, profileId);
+    await joinIdentity(deviceB.page, rotatedIdentity.mnemonic, rotatedIdentity.ownerId);
+    await waitForProfilePresence(deviceB.page, profileId, true);
+    await activateProfile(deviceB.page, profileId);
+    await waitForNotes(deviceA.page, ['baseline-note']);
+    await waitForNotes(deviceB.page, ['baseline-note']);
+    expect(await deviceB.page.evaluate(id => ({
+      intent: localStorage.getItem(`labcharts-profile-delete-intent-${id}`),
+      pending: localStorage.getItem(`labcharts-tombstone-pending-${id}`),
+    }), profileId)).toEqual({ intent: null, pending: null });
+
+    expect((await syncNow(deviceB.page))?.ok).toBe(true);
+    expect((await syncNow(deviceA.page))?.ok).toBe(true);
+    await waitForProfilePresence(deviceA.page, profileId, true);
+    await waitForProfilePresence(deviceB.page, profileId, true);
+    const newOwnerTombstones = await deviceA.page.evaluate(async id => {
+      const runtime = await import('/js/sync-runtime.js');
+      return runtime.getSyncEvolu()?.getQueryRows(runtime.getSyncTombstoneQuery())
+        ?.filter(row => row?.profileId === id).length || 0;
+    }, profileId);
+    expect(newOwnerTombstones).toBe(0);
+
+    // "Clear all data" must be a synchronized replacement, not an empty
+    // update under the old id. Reusing the id lets older per-item rows rebuild
+    // the profile; deleting without a replacement makes the peer invent an
+    // extra local fallback profile.
+    const cleared = await clearAllProfileData(deviceA.page, profileId);
+    expect(cleared.activeProfileId).not.toBe(profileId);
+    expect(cleared.profileIds).toEqual([cleared.activeProfileId]);
+    expect(cleared.contextNotes).toBe('');
+    expect(cleared.noteCount).toBe(0);
+    expect(JSON.parse(cleared.oldDeleteIntent)).toMatchObject({ source: 'clear-all' });
+    expect((await syncNow(deviceA.page))?.ok).toBe(true);
+
+    await waitForProfilePresence(deviceB.page, profileId, false);
+    await waitForProfilePresence(deviceB.page, cleared.activeProfileId, true);
+    await activateProfile(deviceB.page, cleared.activeProfileId);
+    await waitForContext(deviceB.page, '');
+    await waitForNotes(deviceB.page, []);
+    const finalProfileIds = await profileIds(deviceB.page);
+    if (finalProfileIds.length !== 1 || finalProfileIds[0] !== cleared.activeProfileId) {
+      console.error('Clear-all profile diagnostics:', JSON.stringify(await profileDiagnostics(deviceB.page)));
+    }
+    expect(finalProfileIds).toEqual([cleared.activeProfileId]);
+    for (const device of devices) expect(device.errors).toEqual([]);
+  } finally {
+    await Promise.all(devices.map(device => device.context.close().catch(() => {})));
   }
 });

--- a/tests/sync-tombstones.test.js
+++ b/tests/sync-tombstones.test.js
@@ -17,7 +17,7 @@ import { state } from '../js/state.js';
 describe('sync tombstone profile dependencies', () => {
   afterEach(() => {
     localStorage.removeItem('labcharts-tombstone-pending-injected-profile');
-    for (const id of ['batch-a', 'batch-b', 'stale-profile', 'lastonly', 'dirty-local', 'active-restore']) {
+    for (const id of ['batch-a', 'batch-b', 'stale-profile', 'lastonly', 'replaced-old', 'replacement-new', 'dirty-local', 'active-restore']) {
       localStorage.removeItem(`labcharts-tombstone-pending-${id}`);
       localStorage.removeItem(`labcharts-profile-delete-intent-${id}`);
       localStorage.removeItem(`labcharts-${id}-sync-dirty`);
@@ -98,8 +98,9 @@ describe('sync tombstone profile dependencies', () => {
     }
   });
 
-  it('treats a newer live row as Keep and clears its obsolete pending delete', async () => {
+  it('treats a newer live row as Keep and retires obsolete local delete state', async () => {
     localStorage.setItem('labcharts-tombstone-pending-stale-profile', JSON.stringify({ at: 1 }));
+    localStorage.setItem('labcharts-profile-delete-intent-stale-profile', JSON.stringify({ at: 1 }));
     const saveProfiles = vi.fn();
     const previous = configureSyncTombstones({
       getEvolu: () => ({
@@ -116,6 +117,7 @@ describe('sync tombstone profile dependencies', () => {
     try {
       await applyRemoteTombstones();
       expect(localStorage.getItem('labcharts-tombstone-pending-stale-profile')).toBeNull();
+      expect(localStorage.getItem('labcharts-profile-delete-intent-stale-profile')).toBeNull();
       expect(saveProfiles).not.toHaveBeenCalled();
     } finally {
       configureSyncTombstones(previous);
@@ -198,8 +200,63 @@ describe('sync tombstone profile dependencies', () => {
       const replacement = saveProfiles.mock.calls[0][0][0];
       expect(replacement.id).not.toBe('lastonly');
       expect(replacement.tags).toEqual([]);
+      expect(replacement._syncReplacementFallbackFor).toBe('lastonly');
+      expect(replacement._syncReplacementFallbackAt).toBe(replacement.createdAt);
       expect(loadProfile).toHaveBeenCalledWith(replacement.id);
       expect(localStorage.getItem('labcharts-profile-delete-intent-lastonly')).not.toBeNull();
+    } finally {
+      state.currentProfile = oldCurrent;
+      configureSyncTombstones(previous);
+      configureProfileStorageCleanupDeps(cleanupPrevious);
+    }
+  });
+
+  it('adopts a fresh relay profile when clear-all tombstones the last old id', async () => {
+    const oldCurrent = state.currentProfile;
+    state.currentProfile = 'replaced-old';
+    const saveProfiles = vi.fn().mockResolvedValue(undefined);
+    const loadProfile = vi.fn().mockResolvedValue(undefined);
+    const cleanupPrevious = configureProfileStorageCleanupDeps({
+      encryptedRemoveItem: async () => {},
+      getBlobKeys: async () => [],
+      getDatabaseNames: async () => [],
+      deleteWearablesDB: async () => {},
+      deleteCycleDB: async () => {},
+      deleteNutritionDB: async () => {},
+    });
+    const rows = {
+      tombstones: [{
+        id: 'old-tombstone',
+        profileId: 'replaced-old',
+        syncedAt: '2026-08-31T08:00:00.000Z',
+      }],
+      profiles: [{
+        id: 'fresh-row',
+        profileId: 'replacement-new',
+        syncedAt: '2026-08-31T08:00:01.000Z',
+        dataJson: JSON.stringify({
+          _v: 3,
+          importedData: { entries: [] },
+          profile: { id: 'replacement-new', name: 'Primary', pinned: true },
+        }),
+      }],
+    };
+    const previous = configureSyncTombstones({
+      getEvolu: () => ({ getQueryRows: query => rows[query] || [] }),
+      getProfileQuery: () => 'profiles',
+      getTombstoneQuery: () => 'tombstones',
+      getProfiles: () => [{ id: 'replaced-old', name: 'Primary', tags: [] }],
+      saveProfiles,
+      loadProfile,
+    });
+
+    try {
+      await applyRemoteTombstones();
+      expect(saveProfiles).toHaveBeenCalledWith([
+        expect.objectContaining({ id: 'replacement-new', name: 'Primary', pinned: true }),
+      ]);
+      expect(loadProfile).toHaveBeenCalledWith('replacement-new');
+      expect(localStorage.getItem('labcharts-profile-delete-intent-replaced-old')).not.toBeNull();
     } finally {
       state.currentProfile = oldCurrent;
       configureSyncTombstones(previous);

--- a/tests/sync-tombstones.test.js
+++ b/tests/sync-tombstones.test.js
@@ -200,8 +200,7 @@ describe('sync tombstone profile dependencies', () => {
       const replacement = saveProfiles.mock.calls[0][0][0];
       expect(replacement.id).not.toBe('lastonly');
       expect(replacement.tags).toEqual([]);
-      expect(replacement._syncReplacementFallbackFor).toBe('lastonly');
-      expect(replacement._syncReplacementFallbackAt).toBe(replacement.createdAt);
+      expect(replacement._syncFallback).toEqual(['lastonly', replacement.createdAt]);
       expect(loadProfile).toHaveBeenCalledWith(replacement.id);
       expect(localStorage.getItem('labcharts-profile-delete-intent-lastonly')).not.toBeNull();
     } finally {

--- a/tests/test-export-import.js
+++ b/tests/test-export-import.js
@@ -452,10 +452,18 @@ return (async function() {
     exportSrc.includes('await listStoredProfileIds(profiles.map(profile => profile.id))'));
   assert('Awaits centralized profile storage cleanup',
     /for \(const id of profileIds\)[\s\S]{0,200}await clearProfileStorage\(id\)/.test(exportSrc));
-  assert('Awaits the profile-list reset', exportSrc.includes('await saveProfiles([{ id: defaultId'));
+  assert('Awaits the fresh profile-list reset',
+    exportSrc.includes('const freshProfile = createClearedProfileRecord') &&
+    exportSrc.includes('await saveProfiles([freshProfile])'));
   assert('Resets state.importedData from the canonical factory',
     exportSrc.includes('state.importedData = createDefaultProfileData()'));
-  assert('Resets to single default profile via saveProfiles', exportSrc.includes('saveProfiles([{'));
+  assert('Clear-all never reuses a synchronized profile identity',
+    exportSrc.includes('markClearedProfilesForSync(profileIds)') &&
+    exportSrc.includes("saveImportedData({ immediate: true, reason: 'clear-all' })"));
+  assert('Clear-all tombstones old relay profiles after persisting the fresh profile',
+    exportSrc.includes('const publishResult = await sync.syncNow()') &&
+    exportSrc.includes('if (replacementPublished)') &&
+    exportSrc.includes('propagateClearedProfilesToRelay(clearedProfileIds, sync.deleteProfileFromRelay)'));
   assert('Clears Cashu wallet DB through export runtime',
     exportSrc.includes('destroyWalletRuntimeDB') &&
     exportRuntimeSrc.includes("import('./cashu-wallet.js')") &&

--- a/tests/test-export-import.js
+++ b/tests/test-export-import.js
@@ -470,7 +470,7 @@ return (async function() {
     exportRuntimeSrc.includes("import('./cashu-wallet.js?lazy-retry=1')") &&
     exportRuntimeSrc.includes('await wallet.destroyWalletDB()'));
   assert('Clear-all fails closed when wallet deletion fails',
-    /try \{\s*\/\/ Delete the wallet first[\s\S]{0,260}await destroyWalletRuntimeDB\(\)[\s\S]{0,500}catch \(error\)[\s\S]{0,300}return;/.test(exportSrc)
+    /try \{\s*\/\/ Delete the wallet first[\s\S]{0,260}await destroyWalletRuntimeDB\(\)[\s\S]{0,2000}catch \(error\)[\s\S]{0,300}return;/.test(exportSrc)
     && !/try \{\s*await destroyWalletRuntimeDB\(\);\s*\} catch \{\}/.test(exportSrc));
   assert('Clears Cashu wallet mint', exportSrc.includes("localStorage.removeItem('labcharts-cashu-wallet-mint')"));
   assert('Calls navigate(dashboard) after clear through export runtime',

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -1046,7 +1046,7 @@ await import('../js/settings.js');
       restoredPush > receiveStart && restoredPush < tombstoneApply && tombstoneApply < dirtyPush);
   }
   assert('applyRemoteTombstones creates a fresh fallback when every profile is deleted',
-    /survivors\.length\s*===\s*0[\s\S]{0,500}createFallbackProfile/.test(syncTombstonesSrc));
+    /survivors\.length\s*===\s*0[\s\S]{0,500}createSyncFallbackProfile/.test(syncTombstonesSrc));
 
   // ═══════════════════════════════════════
   // 2. SYNC PAYLOAD FORMAT

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -167,6 +167,7 @@
     "js/export-import.js",
     "js/export-loader.js",
     "js/export.js",
+    "js/clear-all-profile-reset.js",
     "js/export-runtime.js",
     "js/import-drop-zone.js",
     "js/import-drop-zone-runtime.js",


### PR DESCRIPTION
## Summary
- retire stale local delete intent when a newer restored relay row wins
- scope delete intent and quarantine state to the active Evolu owner
- keep v7 and v8 identity restores in-page until GetBased commits transition state
- make Clear All publish a fresh profile identity and tombstone every retired profile
- converge late replacement rows without leaving an extra safety profile

## Verification
- 82 focused Vitest checks
- JS typecheck and production build check
- 10 focused browser checks plus late-fallback browser regression
- real disposable Evolu relay sequence on both v8 and v7 clients covering delete, snapshot restore, owner rotation, stale old-owner intent, and Clear All convergence