### PR TITLE
Improve local voice streaming and settings UX

### DIFF
--- a/css/chat-actions.css
+++ b/css/chat-actions.css
@@ -75,6 +75,14 @@
   cursor: pointer;
   opacity: .72;
 }
+.chat-action-btn.busy > svg {
+  animation: chat-action-spin .8s linear infinite;
+  transform-origin: center;
+}
+@keyframes chat-action-spin { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: reduce) {
+  .chat-action-btn.busy > svg { animation: none; }
+}
 .chat-action-btn svg,
 .chat-action-more-popover svg {
   width: 14px; height: 14px; fill: none; stroke: currentColor; stroke-width: 2;

--- a/css/settings.css
+++ b/css/settings.css
@@ -1105,7 +1105,11 @@
   color: var(--text-primary);
 }
 .settings-modal .voice-overview .settings-section {
-  padding-top: 4px;
+  margin-top: 2px;
+  padding: 11px 13px;
+  border: 1px solid color-mix(in srgb, var(--green) 24%, var(--border));
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--green) 5%, var(--bg-card));
 }
 .settings-modal .voice-overview .settings-copy-title::before {
   content: '';
@@ -1117,6 +1121,88 @@
   background: var(--green);
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--green) 13%, transparent);
   vertical-align: 1px;
+}
+.settings-modal .voice-service-card,
+.settings-modal .voice-task-card {
+  overflow: hidden;
+  padding: 0 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--bg-card) 72%, transparent);
+}
+.settings-modal .voice-service-card .settings-section:last-child,
+.settings-modal .voice-task-card .settings-section:last-child {
+  border-bottom: 0;
+}
+.settings-modal .voice-task-block {
+  margin-top: 24px;
+}
+.settings-modal .voice-task-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  margin: 0 2px 8px;
+}
+.settings-modal .voice-task-heading h3 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 14px;
+  font-weight: 650;
+}
+.settings-modal .voice-task-heading h3 span {
+  display: inline-block;
+  margin-left: 5px;
+  padding: 2px 5px;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: .08em;
+  vertical-align: 1px;
+}
+.settings-modal .voice-task-heading p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 10.5px;
+  line-height: 1.4;
+  text-align: right;
+}
+.settings-modal .voice-advanced-connections {
+  margin-top: 24px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--bg-card) 60%, transparent);
+}
+.settings-modal .voice-advanced-connections > summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 13px 14px;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+.settings-modal .voice-advanced-connections > summary strong,
+.settings-modal .voice-advanced-connections > summary small {
+  display: block;
+}
+.settings-modal .voice-advanced-connections > summary strong {
+  font-size: 12px;
+}
+.settings-modal .voice-advanced-connections > summary small {
+  margin-top: 3px;
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 400;
+}
+.settings-modal .voice-advanced-connections[open] > summary {
+  border-bottom: 1px solid var(--border);
+}
+.settings-modal .voice-advanced-connections .voice-connections {
+  padding: 0 14px 8px;
 }
 .settings-modal .voice-control {
   display: block;
@@ -1922,6 +2008,21 @@ label.sync-settings-toggle input:disabled + .sync-settings-toggle-slider { opaci
   .settings-modal .voice-control,
   .settings-modal .voice-control-stack {
     width: 100%;
+  }
+  .settings-modal .voice-service-card,
+  .settings-modal .voice-task-card {
+    padding: 0 12px;
+  }
+  .settings-modal .voice-task-heading {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 3px;
+  }
+  .settings-modal .voice-task-heading p {
+    text-align: left;
+  }
+  .settings-modal .voice-advanced-connections .voice-connections {
+    padding-inline: 12px;
   }
   .settings-modal .voice-connection-card summary {
     align-items: flex-start;

--- a/js/app-chat-hooks.js
+++ b/js/app-chat-hooks.js
@@ -47,7 +47,12 @@ import { updateChatNudge } from './chat-nudge.js';
 import {
   updateChatHeaderModel,
 } from './chat-personalities.js';
-import { stopVoiceActivity, toggleMessageSpeech } from './voice-loader.js';
+import {
+  isVoicePlaybackActive,
+  restoreVoicePlaybackUi,
+  stopVoiceActivity,
+  toggleMessageSpeech,
+} from './voice-loader.js';
 import { switchToThread } from './chat-threads.js';
 let initialized = false;
 
@@ -66,7 +71,9 @@ export function configureAppChatHooks(deps = {}) {
     setOnboardingFocus: deps.setOnboardingFocus,
   });
   configureChatPanel({
+    isVoicePlaybackActive,
     refreshMobileDashboardActiveTab: deps.refreshMobileDashboardActiveTab,
+    restoreVoicePlaybackUi,
     stopVoiceActivity,
   });
   configureChatRuntimeCallbacks({

--- a/js/changelog-impl.js
+++ b/js/changelog-impl.js
@@ -9,8 +9,8 @@ const CHANGELOG_ACTION_ATTR = 'data-changelog-action';
 const changelogDelegateRoots = new WeakSet();
 
 const CHANGELOG = [
-  { version: '1.18.6', date: '2026-08-30', title: 'Cross-device sync moves to the newer engine', items: [
-    '<b>Encrypted Sync now uses Evolu 8 by default.</b> Existing recovery words and relay identities carry forward automatically, while compatibility checks continue to exercise the previous client as a rollback path.', '<b>Sync recovery has stronger storage safeguards.</b> The app avoids stale rebroadcasts and preserves a complete snapshot when rebuilding relay history, reducing duplicate growth without dropping newer device changes.' ] },
+  { version: '1.18.7', date: '2026-09-01', title: 'On-device voice is clearer and more reliable', items: ['<b>Local speech behaves better across phones and computers.</b> Android defaults to the stable CPU path, failed GPU runs recover safely when possible, and Whisper Medium is available again.', '<b>Kokoro starts as soon as its first sentence is ready.</b> Playback continues outside the chat panel and clearly shows when the next sentence is still being generated.', '<b>Voice settings are easier to understand.</b> Speech-to-text and text-to-speech have focused sections, model storage explains CPU and GPU weight files, and advanced connections stay collapsed until needed.'] },
+  { version: '1.18.6', date: '2026-08-30', title: 'Cross-device sync moves to the newer engine', items: ['<b>Encrypted Sync now uses Evolu 8 by default.</b> Existing recovery words and relay identities carry forward automatically, while compatibility checks continue to exercise the previous client as a rollback path.', '<b>Sync recovery has stronger storage safeguards.</b> The app avoids stale rebroadcasts and preserves a complete snapshot when rebuilding relay history, reducing duplicate growth without dropping newer device changes.'] },
   {
     version: '1.18.2', date: '2026-08-28', title: 'WHOOP sync is current and securely stored',
     items: [

--- a/js/chat-icons.js
+++ b/js/chat-icons.js
@@ -43,6 +43,8 @@ function createChatIcon(kind) {
     path('M11 5 6 9H2v6h4l5 4Z');
     path('M15.5 8.5a5 5 0 0 1 0 7');
     path('M18 6a9 9 0 0 1 0 12');
+  } else if (kind === 'loading') {
+    path('M21 12a9 9 0 1 1-9-9');
   } else {
     path('M18 6 6 18');
     path('m6 6 12 12');

--- a/js/chat-panel.js
+++ b/js/chat-panel.js
@@ -49,15 +49,19 @@ let useChatPresentationStylesheetRetryUrl = false;
 /** @type {{
  *   restoreDiscussionContinuePrompt: (() => void) | null,
  *   isChatStreaming: (() => boolean) | null,
+ *   isVoicePlaybackActive: (() => boolean) | null,
  *   refreshMobileDashboardActiveTab: (() => void) | null,
  *   restoreChatGenerationUI: (() => boolean) | null,
- *   stopVoiceActivity: (() => void) | null,
+ *   restoreVoicePlaybackUi: (() => boolean) | null,
+ *   stopVoiceActivity: ((options?: { preservePlayback?: boolean }) => void) | null,
  * }} */
 const panelCallbacks = {
   restoreDiscussionContinuePrompt: null,
   isChatStreaming: null,
+  isVoicePlaybackActive: null,
   refreshMobileDashboardActiveTab: null,
   restoreChatGenerationUI: null,
+  restoreVoicePlaybackUi: null,
   stopVoiceActivity: null,
 };
 let chatThreadInputBlocked = false;
@@ -81,7 +85,7 @@ function updateChatPanelAccessibility(panel, open) {
   setChatBackgroundInert(open && mobile);
 }
 
-/** @param {{ restoreDiscussionContinuePrompt?: (() => void) | null, isChatStreaming?: (() => boolean) | null, refreshMobileDashboardActiveTab?: (() => void) | null, restoreChatGenerationUI?: (() => boolean) | null, stopVoiceActivity?: (() => void) | null }} [callbacks] */
+/** @param {{ restoreDiscussionContinuePrompt?: (() => void) | null, isChatStreaming?: (() => boolean) | null, isVoicePlaybackActive?: (() => boolean) | null, refreshMobileDashboardActiveTab?: (() => void) | null, restoreChatGenerationUI?: (() => boolean) | null, restoreVoicePlaybackUi?: (() => boolean) | null, stopVoiceActivity?: ((options?: { preservePlayback?: boolean }) => void) | null }} [callbacks] */
 export function configureChatPanel(callbacks = {}) {
   const previous = { ...panelCallbacks };
   Object.assign(panelCallbacks, callbacks);
@@ -294,11 +298,14 @@ export async function openChatPanel(prefillMessage) {
   // An in-flight answer exists only in the live request/typewriter state
   // until it finishes. Reloading the persisted thread here would erase that
   // partial response and typing indicator while the request kept running,
-  // making the latest user message look interrupted and retryable.
+  // making the latest user message look interrupted and retryable. Replacing
+  // message objects during speech would likewise invalidate its active turn.
   const generationInProgress = panelCallbacks.isChatStreaming?.() === true;
+  const voicePlaybackInProgress = panelCallbacks.isVoicePlaybackActive?.() === true;
+  const liveSessionInProgress = generationInProgress || voicePlaybackInProgress;
   // Load threads and ensure active thread
   let threadsLoaded = true;
-  if (!generationInProgress) {
+  if (!liveSessionInProgress) {
     threadsLoaded = await loadChatThreads();
     chatThreadInputBlocked = threadsLoaded === false;
     if (threadsLoaded !== false) ensureActiveThread();
@@ -306,7 +313,7 @@ export async function openChatPanel(prefillMessage) {
   restoreRailState();
   renderThreadList();
   renderSavedSummaries();
-  if (!generationInProgress && threadsLoaded !== false) await loadChatHistory();
+  if (!liveSessionInProgress && threadsLoaded !== false) await loadChatHistory();
   if (!generationInProgress) panelCallbacks.restoreDiscussionContinuePrompt?.();
   updateChatInputState();
   initChatComposer();
@@ -316,6 +323,7 @@ export async function openChatPanel(prefillMessage) {
     if (prefillMessage) setChatInputValue(prefillMessage, { focus: true });
     else await restoreChatDraft(undefined, { focus: true });
   }
+  panelCallbacks.restoreVoicePlaybackUi?.();
   return true;
 }
 
@@ -341,7 +349,7 @@ export function updateChatInputState() {
 
 export function closeChatPanel() {
   chatPanelIntent += 1;
-  panelCallbacks.stopVoiceActivity?.();
+  panelCallbacks.stopVoiceActivity?.({ preservePlayback: true });
   stopMobileChatViewportSync();
   const panel = document.getElementById('chat-panel');
   panel?.classList.remove('open');

--- a/js/settings-voice-hardware.js
+++ b/js/settings-voice-hardware.js
@@ -5,6 +5,7 @@ import { LOCAL_VOICE_BACKENDS } from './voice-model-catalog.js';
 import {
   getLocalVoiceModelStatus,
   initialLocalVoiceBackend,
+  isAndroidDevice,
   isMobileVoiceDevice,
   resolveLocalBackend,
 } from './voice-local-engine.js';
@@ -75,14 +76,18 @@ function renderHardwareRow(settings, kind) {
   return `
     <div class="settings-section voice-setting-row" data-voice-visible="${input ? 'input' : 'output'}:browser-local">
       <div class="settings-copy">
-        <div class="settings-copy-title">Processing</div>
+        <div class="settings-copy-title">Processor</div>
         <div class="settings-copy-desc" ${description}></div>
       </div>
       <label class="voice-control">
-        <span class="sr-only">${input ? 'Transcription' : 'Speech'} processing</span>
+        <span class="sr-only">${input ? 'STT' : 'TTS'} processor</span>
         <select class="api-key-input" data-voice-setting="${setting}">
           ${LOCAL_VOICE_BACKENDS.map(option => (
-            `<option value="${option.id}"${selected(settings[setting], option.id)}>${option.label}</option>`
+            `<option value="${option.id}"${selected(settings[setting], option.id)}>${
+              option.id === 'webgpu' && isAndroidDevice()
+                ? 'Graphics processor (GPU · experimental)'
+                : option.label
+            }</option>`
           )).join('')}
         </select>
       </label>
@@ -107,7 +112,15 @@ async function refreshHardwareDescription(panel, settings, kind) {
   const description = panel.querySelector(selector);
   if (!description) return;
   if (settings[setting] === 'wasm') {
-    description.textContent = 'Uses your computer’s main processor. This is often fastest on powerful CPUs.';
+    description.textContent = isAndroidDevice()
+      ? 'Uses your device’s main processor. This is the stable choice on Android.'
+      : 'Uses your computer’s main processor. This is often fastest on powerful CPUs.';
+    return;
+  }
+  if (isAndroidDevice()) {
+    description.textContent = settings[setting] === 'webgpu'
+      ? 'Experimental on Android. Mobile graphics processing may be slower or crash when browser memory is limited.'
+      : 'Automatic uses the main processor on Android for speed and stability.';
     return;
   }
   description.textContent = 'Checking graphics support…';

--- a/js/settings-voice-model-controller.js
+++ b/js/settings-voice-model-controller.js
@@ -8,11 +8,14 @@ import {
   getLocalVoiceModelStatus,
   installLocalVoiceModel,
   isLocalVoiceModelReady,
-  preferredLocalVoiceBackend,
   removeLocalVoiceModel,
   verifyLocalVoiceModelReady,
 } from './voice-local-engine.js';
-import { LOCAL_STT_MODELS, LOCAL_TTS_MODELS } from './voice-model-catalog.js';
+import {
+  LOCAL_STT_MODELS,
+  LOCAL_TTS_MODELS,
+  getLocalModelStorageCopy,
+} from './voice-model-catalog.js';
 import { getVoiceSettings } from './voice-settings-storage.js';
 
 /** @typedef {{ id: number, model: string, backend: string }} ModelOperation */
@@ -33,9 +36,12 @@ function selectedBackend(kind) {
 export function localModelUiStatus(kind, modelId) {
   const backend = selectedBackend(kind);
   if (!isLocalVoiceModelReady(kind, modelId, backend)) {
-    return getLocalVoiceModelStatus(kind, modelId)
-      ? 'Download needed for the selected processing mode'
-      : 'Not downloaded yet';
+    const status = getLocalVoiceModelStatus(kind, modelId);
+    if (!status) return 'Not downloaded yet';
+    if (kind !== 'tts') return 'Ready to use with either processor';
+    const selected = backend === 'webgpu' ? 'GPU' : 'CPU';
+    const other = selected === 'GPU' ? 'CPU' : 'GPU';
+    return `${selected} weights need a separate download · ${other} weights remain stored`;
   }
   return localModelStatusText(getLocalVoiceModelStatus(kind, modelId), kind);
 }
@@ -116,10 +122,7 @@ export function refreshLocalModelDetails(panel, kind) {
   const description = row.querySelector('.settings-copy-desc');
   if (title) title.textContent = model.label;
   if (description) {
-    const gpu = kind === 'tts'
-      && preferredLocalVoiceBackend(kind, model.id, selectedBackend(kind)) === 'webgpu';
-    const downloadMB = gpu ? model.gpuDownloadMB : model.downloadMB;
-    description.textContent = `${kind === 'tts' ? 'Speech' : 'Transcription'} · about ${downloadMB} MB · ${model.license}`;
+    description.textContent = getLocalModelStorageCopy(kind, model.id, selectedBackend(kind));
   }
   const progress = row.querySelector(`[data-voice-model-progress="${kind}"]`);
   if (progress instanceof HTMLElement) progress.hidden = true;
@@ -180,8 +183,8 @@ async function installModel(panel, button) {
   } catch (error) {
     const detail = getErrorMessage(error, 'Unknown model error');
     const message = backend === 'webgpu'
-      ? `Could not use graphics processing. Choose Automatic or Main processor and retry. ${detail}`
-      : 'Could not prepare this model. Check your connection and available browser storage, then retry.';
+      ? `Could not use experimental graphics processing. Choose Automatic or Main processor and retry. ${detail}`
+      : `Could not prepare this model. ${detail}`;
     if (isSelectedModelOperation(kind, operation)) {
       updateModelStatus(panel, kind, message, 'error');
       const status = panel.querySelector(`[data-voice-model-status="${kind}"]`);

--- a/js/settings-voice-panel.js
+++ b/js/settings-voice-panel.js
@@ -93,6 +93,8 @@ function refreshOutputLanguageControl(panel, settings) {
   const select = panel.querySelector('[data-voice-setting="outputLanguage"]');
   if (!(select instanceof HTMLSelectElement)) return;
   const local = resolveVoiceProviderId('tts', settings.outputProvider) === 'browser-local';
+  const row = panel.querySelector('[data-voice-output-language-row]');
+  if (row instanceof HTMLElement) row.hidden = local;
   select.disabled = local;
   select.value = local ? 'en' : settings.outputLanguage;
   const description = panel.querySelector('[data-voice-output-language-description]');

--- a/js/settings-voice-view.js
+++ b/js/settings-voice-view.js
@@ -10,13 +10,13 @@ import { escapeAttr, escapeHTML } from './utils.js';
 import { readVoiceCatalog } from './voice-catalog-storage.js';
 import {
   isLocalVoiceModelReady,
-  preferredLocalVoiceBackend,
 } from './voice-local-engine.js';
 import {
   KOKORO_VOICES,
   LOCAL_STT_MODELS,
   VOICE_LANGUAGES,
   getLocalModel,
+  getLocalModelStorageCopy,
 } from './voice-model-catalog.js';
 import {
   openRouterVoiceCatalogId,
@@ -119,8 +119,8 @@ function renderProviderNotice() {
       <div class="settings-section">
         <div class="settings-action-row">
           <div class="settings-copy">
-            <div class="settings-copy-title">Private by default</div>
-            <div class="settings-copy-desc">Choose On this device to keep recordings and messages in this browser. Automatic follows your AI provider when it supports voice; other services receive only what you ask them to process.</div>
+            <div class="settings-copy-title">Voice can stay on this device</div>
+            <div class="settings-copy-desc">Choose On this device to keep recordings and reply text in this browser. Automatic follows your chat service when it supports speech.</div>
           </div>
         </div>
       </div>
@@ -130,12 +130,12 @@ function renderProviderNotice() {
 function renderServiceSection(settings) {
   const automatic = getAutomaticVoiceStatus();
   return `
-    <div class="settings-group-title">Voice service</div>
-    <div class="settings-row voice-settings-list">
+    <div class="settings-group-title">Service</div>
+    <div class="settings-row voice-settings-list voice-service-card">
       <div class="settings-section voice-setting-row" data-voice-mode="linked">
         <div class="settings-copy">
-          <div class="settings-copy-title">Where voice is processed</div>
-          <div class="settings-copy-desc">Choose one service for dictation and spoken replies.</div>
+          <div class="settings-copy-title">Default speech service</div>
+          <div class="settings-copy-desc">Used for both STT and TTS unless you separate them below.</div>
         </div>
         <label class="voice-control">
           <span class="sr-only">Voice service</span>
@@ -154,12 +154,12 @@ function renderServiceSection(settings) {
       <div class="settings-section">
         <div class="settings-action-row">
           <div class="settings-copy">
-            <div class="settings-copy-title">Use different services for dictation and listening</div>
-            <div class="settings-copy-desc">Useful when you want private on-device dictation with a different voice for spoken replies.</div>
+            <div class="settings-copy-title">Use separate STT and TTS services</div>
+            <div class="settings-copy-desc">For example, keep dictation on-device while using a cloud voice.</div>
           </div>
           <label class="toggle-switch">
             <input type="checkbox" data-voice-setting="providersLinked"
-              aria-label="Use different services for dictation and listening"${settings.providersLinked ? '' : ' checked'}>
+              aria-label="Use separate speech-to-text and text-to-speech services"${settings.providersLinked ? '' : ' checked'}>
             <span class="toggle-slider"></span>
           </label>
         </div>
@@ -174,12 +174,16 @@ function renderInputSection(settings) {
     && !localSttModel.multilingual;
   const selectedLanguage = locksLanguage ? 'en' : settings.inputLanguage;
   return `
-    <div class="settings-group-title">Voice input</div>
-    <div class="settings-row voice-settings-list">
+    <section class="voice-task-block" aria-labelledby="voice-stt-heading">
+      <header class="voice-task-heading">
+        <h3 id="voice-stt-heading">Speech-to-text <span>STT</span></h3>
+        <p>Dictation: turns what you say into text.</p>
+      </header>
+    <div class="settings-row voice-settings-list voice-task-card">
       <div class="settings-section voice-setting-row" data-voice-mode="separate">
         <div class="settings-copy">
-          <div class="settings-copy-title">Dictation service</div>
-          <div class="settings-copy-desc">Turns what you say into text in the composer.</div>
+          <div class="settings-copy-title">STT service</div>
+          <div class="settings-copy-desc">Service used for dictation.</div>
         </div>
         <label class="voice-control">
           <span class="sr-only">Dictation service</span>
@@ -204,8 +208,8 @@ function renderInputSection(settings) {
       </div>
       <div class="settings-section voice-setting-row" data-voice-visible="input:browser-local">
         <div class="settings-copy">
-          <div class="settings-copy-title">Quality and speed</div>
-          <div class="settings-copy-desc">Whisper Small is fastest and recommended for most devices. Medium adds accuracy with a smaller download than Large v3 Turbo. Actual speed varies by hardware and processing mode.</div>
+          <div class="settings-copy-title">Whisper model</div>
+          <div class="settings-copy-desc">Small is fastest. Medium adds accuracy with a smaller download than Large; actual speed depends on your processor.</div>
         </div>
         <label class="voice-control">
           <span class="sr-only">Transcription quality and speed</span>
@@ -229,6 +233,7 @@ function renderInputSection(settings) {
         <span class="voice-control">Whisper Large V3</span>
       </div>
       ${renderSttHardwareRow(settings)}
+      ${renderLocalModelRow('stt', localSttModel, settings)}
       <div class="settings-section voice-setting-row" data-voice-visible="input:local-server">
         <div class="settings-copy">
           <div class="settings-copy-title">Transcription model</div>
@@ -240,7 +245,8 @@ function renderInputSection(settings) {
             data-voice-setting="localServerSttModel" autocomplete="off" spellcheck="false">
         </label>
       </div>
-    </div>`;
+    </div>
+    </section>`;
 }
 
 function renderOutputSection(settings) {
@@ -253,12 +259,16 @@ function renderOutputSection(settings) {
   const openRouterCatalogCount = readVoiceCatalog(openRouterCatalogId).length;
   const veniceCatalogCount = readVoiceCatalog('venice').length;
   return `
-    <div class="settings-group-title">Voice output</div>
-    <div class="settings-row voice-settings-list">
+    <section class="voice-task-block" aria-labelledby="voice-tts-heading">
+      <header class="voice-task-heading">
+        <h3 id="voice-tts-heading">Text-to-speech <span>TTS</span></h3>
+        <p>Listening: turns assistant replies into audio.</p>
+      </header>
+    <div class="settings-row voice-settings-list voice-task-card">
       <div class="settings-section voice-setting-row" data-voice-mode="separate">
         <div class="settings-copy">
-          <div class="settings-copy-title">Spoken replies service</div>
-          <div class="settings-copy-desc">Turns assistant replies into audio.</div>
+          <div class="settings-copy-title">TTS service</div>
+          <div class="settings-copy-desc">Service used to read replies.</div>
         </div>
         <label class="voice-control">
           <span class="sr-only">Spoken replies service</span>
@@ -267,7 +277,7 @@ function renderOutputSection(settings) {
           </select>
         </label>
       </div>
-      <div class="settings-section voice-setting-row">
+      <div class="settings-section voice-setting-row" data-voice-output-language-row${localOutput ? ' hidden' : ''}>
         <div class="settings-copy">
           <div class="settings-copy-title">Reading language</div>
           <div class="settings-copy-desc" data-voice-output-language-description>${localOutput
@@ -294,6 +304,7 @@ function renderOutputSection(settings) {
         </label>
       </div>
       ${renderTtsHardwareRow(settings)}
+      ${renderLocalModelRow('tts', getLocalModel('tts', settings.localTtsModel), settings)}
       <div class="settings-section voice-setting-row" data-voice-visible="output:local-server">
         <div class="settings-copy">
           <div class="settings-copy-title">Speech model</div>
@@ -376,7 +387,8 @@ function renderOutputSection(settings) {
           </label>
         </div>
       </div>
-    </div>`;
+    </div>
+    </section>`;
 }
 
 function renderCloudVoiceRow(
@@ -417,45 +429,29 @@ function renderCloudVoiceRow(
     </div>`;
 }
 
-function renderLocalModels(settings) {
-  const sttModel = getLocalModel('stt', settings.localSttModel);
-  const ttsModel = getLocalModel('tts', settings.localTtsModel);
-  const renderModel = (kind, model, purpose) => {
-    const backend = kind === 'tts' ? settings.localTtsBackend : settings.localSttBackend;
-    const ready = isLocalVoiceModelReady(kind, model.id, backend);
-    const downloadMB = kind === 'tts'
-      && preferredLocalVoiceBackend(kind, model.id, backend) === 'webgpu'
-      ? model.gpuDownloadMB
-      : model.downloadMB;
-    return `
-      <div class="settings-section voice-model-row" data-voice-model-kind="${kind}">
-        <div class="settings-copy">
-          <div class="settings-copy-title">${escapeHTML(model.label)}</div>
-          <div class="settings-copy-desc">${purpose} · about ${downloadMB} MB · ${escapeHTML(model.license)}</div>
-          <div class="voice-model-state" data-state="${ready ? 'ready' : 'missing'}"
-            data-voice-model-status="${kind}">${localModelUiStatus(kind, model.id)}</div>
-          <div class="voice-model-progress" hidden data-voice-model-progress="${kind}">
-            <div class="voice-model-progress-track" role="progressbar"
-              aria-label="${escapeAttr(model.label)} download progress"><span></span></div>
-            <small>Preparing model…</small>
-          </div>
-        </div>
-        <div class="voice-model-actions">
-          <button type="button" class="import-btn settings-mini-btn"
-            data-voice-action="install-model" data-kind="${kind}"${ready ? ' disabled' : ''}>${ready ? 'Ready' : 'Download'}</button>
-          <button type="button" class="settings-link-btn"
-            data-voice-action="remove-model" data-kind="${kind}"${ready ? '' : ' disabled'}>Remove</button>
-        </div>
-      </div>`;
-  };
+function renderLocalModelRow(kind, model, settings) {
+  const backend = kind === 'tts' ? settings.localTtsBackend : settings.localSttBackend;
+  const ready = isLocalVoiceModelReady(kind, model.id, backend);
+  const direction = kind === 'tts' ? 'output' : 'input';
   return `
-    <div class="settings-group-title">Built-in local models</div>
-    <div class="settings-row voice-model-list">
-      ${renderModel('stt', sttModel, 'Transcription')}
-      ${renderModel('tts', ttsModel, 'Speech')}
-      <div class="voice-model-footnote">
-        Models download only when you choose Download. Voice actions never start a model download
-        automatically. If browser storage removes the files, Voice will ask you to download them again.
+    <div class="settings-section voice-model-row" data-voice-visible="${direction}:browser-local"
+      data-voice-model-kind="${kind}">
+      <div class="settings-copy">
+        <div class="settings-copy-title">${escapeHTML(model.label)}</div>
+        <div class="settings-copy-desc">${escapeHTML(getLocalModelStorageCopy(kind, model.id, backend))}</div>
+        <div class="voice-model-state" data-state="${ready ? 'ready' : 'missing'}"
+          data-voice-model-status="${kind}">${localModelUiStatus(kind, model.id)}</div>
+        <div class="voice-model-progress" hidden data-voice-model-progress="${kind}">
+          <div class="voice-model-progress-track" role="progressbar"
+            aria-label="${escapeAttr(model.label)} download progress"><span></span></div>
+          <small>Preparing model…</small>
+        </div>
+      </div>
+      <div class="voice-model-actions">
+        <button type="button" class="import-btn settings-mini-btn"
+          data-voice-action="install-model" data-kind="${kind}"${ready ? ' disabled' : ''}>${ready ? 'Ready' : 'Download'}</button>
+        <button type="button" class="settings-link-btn"
+          data-voice-action="remove-model" data-kind="${kind}"${ready ? '' : ' disabled'}>Remove files</button>
       </div>
     </div>`;
 }
@@ -510,7 +506,10 @@ function renderConnectionCard(provider, title, description, settings) {
 
 function renderConnections(settings) {
   return `
-    <div class="settings-group-title">Connections</div>
+    <details class="voice-advanced-connections">
+      <summary>
+        <span><strong>Advanced connections</strong><small>Local server and direct provider keys</small></span>
+      </summary>
     <div class="settings-row voice-connections">
       <div class="settings-section">
         <div class="settings-action-row">
@@ -529,7 +528,8 @@ function renderConnections(settings) {
       )}
       ${renderConnectionCard('xai', 'xAI', 'Cloud transcription and speech with your own key', settings)}
       ${renderConnectionCard('elevenlabs', 'ElevenLabs', 'Scribe transcription and multilingual voices', settings)}
-    </div>`;
+    </div>
+    </details>`;
 }
 
 export function renderVoiceSettingsPanel(active = false) {
@@ -540,7 +540,6 @@ export function renderVoiceSettingsPanel(active = false) {
       ${renderServiceSection(settings)}
       ${renderInputSection(settings)}
       ${renderOutputSection(settings)}
-      ${renderLocalModels(settings)}
       ${renderConnections(settings)}
     </div>`;
 }

--- a/js/voice-controller.js
+++ b/js/voice-controller.js
@@ -42,6 +42,8 @@ let speechAbortController = null;
 let autoReadActivationNoticeShown = false;
 /** @type {number | null} */
 let speakingMessageIndex = null;
+/** @type {'idle' | 'busy' | 'speaking' | 'waiting'} */
+let speechButtonMode = 'idle';
 let voiceActivityEpoch = 0;
 
 function chatVoiceButton() {
@@ -307,20 +309,28 @@ function speechButton(messageIndex) {
 }
 
 function setSpeechButton(messageIndex, mode) {
+  if (speakingMessageIndex === messageIndex || mode === 'idle') speechButtonMode = mode;
   const button = speechButton(messageIndex);
   if (!button) return;
   button.classList.toggle('speaking', mode === 'speaking');
-  button.classList.toggle('busy', mode === 'busy');
-  button.setAttribute('aria-pressed', String(mode === 'speaking'));
+  button.classList.toggle('busy', mode === 'busy' || mode === 'waiting');
+  button.setAttribute('aria-pressed', String(mode !== 'idle'));
   button.disabled = false;
   if (mode === 'speaking') {
     setIconButtonContent(button, 'stop', 'Stop');
+    button.setAttribute('aria-label', 'Stop reading');
     button.title = 'Stop reading';
   } else if (mode === 'busy') {
-    setIconButtonContent(button, 'stop', 'Cancel');
-    button.title = 'Cancel speech preparation';
+    setIconButtonContent(button, 'loading', 'Preparing…');
+    button.setAttribute('aria-label', 'Cancel speech preparation');
+    button.title = 'Generating speech · tap to cancel';
+  } else if (mode === 'waiting') {
+    setIconButtonContent(button, 'loading', 'Still generating…');
+    button.setAttribute('aria-label', 'Cancel speech generation');
+    button.title = 'Speech generation is still running · tap to cancel';
   } else {
     setIconButtonContent(button, 'volume', 'Listen');
+    button.setAttribute('aria-label', 'Read message aloud');
     button.title = 'Read message aloud';
   }
 }
@@ -454,14 +464,16 @@ export async function readAssistantMessage(messageIndex, { automatic = false } =
       // Mark an early prefetch failure as observed while preserving the
       // original promise so the loop still reports it after playback.
       if (nextSynthesis) void nextSynthesis.catch(() => undefined);
-      setSpeechButton(messageIndex, 'speaking');
       try {
         if (hasPcmStream) {
           await voicePlayer.playPcmStream(result.pcmStream, {
             signal: controller.signal,
             rate: 1,
+            onPlaybackStart: () => setSpeechButton(messageIndex, 'speaking'),
+            onPlaybackWaiting: () => setSpeechButton(messageIndex, 'waiting'),
           });
         } else if (hasStream) {
+          setSpeechButton(messageIndex, 'speaking');
           await voicePlayer.playStream(result.stream, {
             contentType: result.contentType,
             signal: controller.signal,
@@ -469,6 +481,7 @@ export async function readAssistantMessage(messageIndex, { automatic = false } =
             progressive: streamsProgressiveAudio && !automatic,
           });
         } else {
+          setSpeechButton(messageIndex, 'speaking');
           await voicePlayer.play(/** @type {Blob} */ (result.audio), {
             signal: controller.signal,
             rate: 1,
@@ -506,17 +519,37 @@ export function toggleMessageSpeech(messageIndex) {
   return readAssistantMessage(messageIndex);
 }
 
-export function stopVoiceActivity() {
+export function isVoicePlaybackActive() {
+  return speakingMessageIndex !== null
+    && !!speechAbortController
+    && !speechAbortController.signal.aborted;
+}
+
+export function restoreVoicePlaybackUi() {
+  if (!isVoicePlaybackActive() || speakingMessageIndex === null) return false;
+  setSpeechButton(
+    speakingMessageIndex,
+    speechButtonMode === 'idle' ? (voicePlayer.isPlaying ? 'speaking' : 'busy') : speechButtonMode,
+  );
+  return !!speechButton(speakingMessageIndex);
+}
+
+export function stopVoiceActivity({ preservePlayback = false } = {}) {
   const hadActivity = captureState !== 'idle' || speakingMessageIndex !== null;
-  voiceActivityEpoch += 1;
-  captureSession?.cancel();
-  captureSession = null;
-  clearCaptureTicker();
-  setCaptureUi('idle', '');
-  stopSpeechPlayback();
+  const hadCaptureActivity = captureState !== 'idle';
+  if (!preservePlayback || hadCaptureActivity) voiceActivityEpoch += 1;
+  if (hadCaptureActivity) {
+    captureSession?.cancel();
+    captureSession = null;
+    clearCaptureTicker();
+    setCaptureUi('idle', '');
+    speechAbortController?.abort();
+    speechAbortController = null;
+  }
+  if (!preservePlayback) stopSpeechPlayback();
   return hadActivity;
 }
 
 if (typeof globalThis.addEventListener === 'function') {
-  globalThis.addEventListener('pagehide', stopVoiceActivity);
+  globalThis.addEventListener('pagehide', () => stopVoiceActivity());
 }

--- a/js/voice-loader.js
+++ b/js/voice-loader.js
@@ -93,9 +93,17 @@ export function toggleMessageSpeech(messageIndex) {
   ));
 }
 
-export function stopVoiceActivity() {
+export function stopVoiceActivity(options) {
   voiceActivityEpoch += 1;
-  return voiceModule?.stopVoiceActivity() || false;
+  return voiceModule?.stopVoiceActivity(options) || false;
+}
+
+export function isVoicePlaybackActive() {
+  return voiceModule?.isVoicePlaybackActive() || false;
+}
+
+export function restoreVoicePlaybackUi() {
+  return voiceModule?.restoreVoicePlaybackUi() || false;
 }
 
 export function maybeAutoReadAssistantMessage(messageIndex) {

--- a/js/voice-local-engine.js
+++ b/js/voice-local-engine.js
@@ -18,7 +18,21 @@ const engineDeps = {
 const workers = { stt: null, tts: null };
 const inflight = { stt: new Map(), tts: new Map() };
 const queues = { stt: Promise.resolve(), tts: Promise.resolve() };
+const failedGpuModels = { stt: new Set(), tts: new Set() };
 let nextRequestId = 1;
+
+/**
+ * Android browsers expose WebGPU through the regular mobile GPU, not the
+ * device's NPU. Large local voice graphs can be slower than WASM or cause the
+ * browser GPU process to run out of memory, so Automatic stays on CPU there.
+ *
+ * @param {Navigator | { userAgent?: string, userAgentData?: { platform?: string } } | undefined} [navigatorLike]
+ */
+export function isAndroidDevice(navigatorLike = globalThis.navigator) {
+  const platform = String(/** @type {any} */ (navigatorLike)?.userAgentData?.platform || '');
+  const userAgent = String(navigatorLike?.userAgent || '');
+  return /android/i.test(`${platform} ${userAgent}`);
+}
 
 export function configureVoiceLocalEngine(deps = {}) {
   const previous = {
@@ -84,17 +98,34 @@ export function isMobileVoiceDevice(navigatorValue = globalThis.navigator) {
 
 export function initialLocalVoiceBackend(navigatorValue = globalThis.navigator) {
   const gpu = /** @type {any} */ (navigatorValue)?.gpu;
-  return isMobileVoiceDevice(navigatorValue) && typeof gpu?.requestAdapter === 'function'
+  return !isAndroidDevice(navigatorValue)
+    && isMobileVoiceDevice(navigatorValue)
+    && typeof gpu?.requestAdapter === 'function'
     ? 'webgpu'
     : 'wasm';
 }
 
+/**
+ * @param {string} [backend]
+ * @param {Record<string, any>} [performance]
+ * @param {'wasm' | 'webgpu' | { android?: boolean, initialBackend?: 'wasm' | 'webgpu' }} [initialBackendOrEnvironment]
+ */
 export function resolveLocalBackend(
   backend = 'auto',
   performance = {},
-  initialBackend = 'wasm',
+  initialBackendOrEnvironment = 'wasm',
 ) {
   if (backend !== 'auto') return backend;
+  const environment = typeof initialBackendOrEnvironment === 'object'
+    ? initialBackendOrEnvironment
+    : {};
+  const initialBackend = typeof initialBackendOrEnvironment === 'string'
+    ? initialBackendOrEnvironment
+    : environment.initialBackend || 'wasm';
+  const android = typeof environment.android === 'boolean'
+    ? environment.android
+    : isAndroidDevice();
+  if (android) return 'wasm';
   const score = measurement => {
     if (measurement == null) return Number.NaN;
     const normalized = Number(measurement?.realtimeFactor);
@@ -111,10 +142,12 @@ export function resolveLocalBackend(
 }
 
 export function preferredLocalVoiceBackend(kind, model, backend) {
+  if (backend === 'auto' && failedGpuModels[kind].has(String(model || ''))) return 'wasm';
   const status = getLocalVoiceModelStatus(kind, model);
   const performance = status?.performance || {};
   if (
     backend === 'auto'
+    && !isAndroidDevice()
     && !Object.keys(performance).length
     && status?.fallbackReason
     && ['wasm', 'webgpu'].includes(status.backend)
@@ -226,8 +259,11 @@ function ensureWorker(kind) {
       return;
     }
     inflight[kind].delete(message.id);
-    if (message.type === 'error') pending.reject(new Error(message.message || `Local ${kind} failed`));
-    else pending.resolve(message);
+    if (message.type === 'error') {
+      const error = new Error(message.message || `Local ${kind} failed`);
+      if (message.backend) /** @type {any} */ (error).voiceBackend = message.backend;
+      pending.reject(error);
+    } else pending.resolve(message);
   });
   worker.addEventListener('error', event => {
     const error = new Error(event.message || `Local ${kind} worker failed`);
@@ -272,7 +308,13 @@ function rawWorkerRequest(kind, payload, transfer = [], signal, onChunk) {
 
 function workerRequest(kind, payload, transfer = [], signal, onChunk) {
   const result = queues[kind].catch(() => undefined)
-    .then(() => rawWorkerRequest(kind, payload, transfer, signal, onChunk));
+    .then(() => {
+      // Whisper and Kokoro are large enough that retaining both workers can
+      // exhaust a mobile browser's CPU/GPU memory. Voice turns are sequential,
+      // so release the inactive model immediately before allocating this one.
+      terminateLocalVoiceWorker(kind === 'stt' ? 'tts' : 'stt');
+      return rawWorkerRequest(kind, payload, transfer, signal, onChunk);
+    });
   queues[kind] = result.catch(() => undefined);
   return result;
 }
@@ -284,7 +326,13 @@ export async function installLocalVoiceModel(kind, model, signal, backend = 'aut
   const preferredBackend = preferredLocalVoiceBackend(kind, model, backend);
   const result = await workerRequest(
     kind,
-    { type: 'init', model, backend, preferredBackend },
+    {
+      type: 'init',
+      model,
+      backend,
+      preferredBackend,
+      allowWebGpuFallback: !isAndroidDevice(),
+    },
     [],
     signal,
   );
@@ -305,19 +353,41 @@ export async function transcribeLocalAudio(samples, {
   const audio = samples instanceof Float32Array ? samples : new Float32Array(samples || []);
   const audioSeconds = audio.length / 16_000;
   const preferredBackend = preferredLocalVoiceBackend('stt', model, backend);
-  const result = await workerRequest(
-    'stt',
-    {
-      type: 'transcribe',
-      model,
-      language,
-      backend,
-      preferredBackend,
-      audio: audio.buffer,
-    },
-    [audio.buffer],
-    signal,
-  );
+  const request = (requestedBackend, requestedPreference, allowWebGpuFallback) => {
+    const transferableAudio = audio.slice();
+    return workerRequest(
+      'stt',
+      {
+        type: 'transcribe',
+        model,
+        language,
+        backend: requestedBackend,
+        preferredBackend: requestedPreference,
+        allowWebGpuFallback,
+        audio: transferableAudio.buffer,
+      },
+      [transferableAudio.buffer],
+      signal,
+    );
+  };
+  let result;
+  try {
+    result = await request(backend, preferredBackend, !isAndroidDevice());
+  } catch (error) {
+    const errorBackend = /** @type {any} */ (error)?.voiceBackend;
+    const mayBeGpuFailure = errorBackend === 'webgpu'
+      || backend === 'webgpu'
+      || (backend === 'auto' && preferredBackend === 'webgpu');
+    if (
+      !mayBeGpuFailure
+      || /** @type {any} */ (error)?.name === 'AbortError'
+      || !isLocalVoiceModelReady('stt', model, 'wasm')
+    ) throw error;
+    failedGpuModels.stt.add(String(model || ''));
+    terminateLocalVoiceWorker('stt');
+    result = await request('wasm', 'wasm', false);
+    result.fallbackReason = String(/** @type {any} */ (error)?.message || 'Graphics processing failed');
+  }
   rememberInstalled(
     'stt',
     result.model || model,
@@ -347,12 +417,39 @@ export async function synthesizeLocalSpeech(text, {
   signal,
 } = {}) {
   const preferredBackend = preferredLocalVoiceBackend('tts', model, backend);
-  const result = await workerRequest(
+  const request = (requestedBackend, requestedPreference, allowWebGpuFallback) => workerRequest(
     'tts',
-    { type: 'synthesize', model, voice, rate, backend, preferredBackend, text: String(text || '') },
+    {
+      type: 'synthesize',
+      model,
+      voice,
+      rate,
+      backend: requestedBackend,
+      preferredBackend: requestedPreference,
+      allowWebGpuFallback,
+      text: String(text || ''),
+    },
     [],
     signal,
   );
+  let result;
+  try {
+    result = await request(backend, preferredBackend, !isAndroidDevice());
+  } catch (error) {
+    const errorBackend = /** @type {any} */ (error)?.voiceBackend;
+    const mayBeGpuFailure = errorBackend === 'webgpu'
+      || backend === 'webgpu'
+      || (backend === 'auto' && preferredBackend === 'webgpu');
+    if (
+      !mayBeGpuFailure
+      || /** @type {any} */ (error)?.name === 'AbortError'
+      || !isLocalVoiceModelReady('tts', model, 'wasm')
+    ) throw error;
+    failedGpuModels.tts.add(String(model || ''));
+    terminateLocalVoiceWorker('tts');
+    result = await request('wasm', 'wasm', false);
+    result.fallbackReason = String(/** @type {any} */ (error)?.message || 'Graphics processing failed');
+  }
   rememberInstalled(
     'tts',
     result.model || model,
@@ -384,9 +481,19 @@ export function streamLocalSpeech(text, {
   signal,
 } = {}) {
   let cancelled = false;
+  const preferredBackend = preferredLocalVoiceBackend('tts', model, backend);
   const stream = new ReadableStream({
     start(controller) {
-      const request = workerRequest(
+      let emittedChunks = 0;
+      const onChunk = message => {
+        if (cancelled) return;
+        emittedChunks += 1;
+        controller.enqueue({
+          samples: new Float32Array(message.samples),
+          sampleRate: Number(message.sampleRate) || 24_000,
+        });
+      };
+      const request = (requestedBackend, requestedPreference, allowWebGpuFallback) => workerRequest(
         'tts',
         {
           type: 'synthesize',
@@ -394,21 +501,37 @@ export function streamLocalSpeech(text, {
           model,
           voice,
           rate,
-          backend,
-          preferredBackend: preferredLocalVoiceBackend('tts', model, backend),
+          backend: requestedBackend,
+          preferredBackend: requestedPreference,
+          allowWebGpuFallback,
           text: String(text || ''),
         },
         [],
         signal,
-        message => {
-          if (cancelled) return;
-          controller.enqueue({
-            samples: new Float32Array(message.samples),
-            sampleRate: Number(message.sampleRate) || 24_000,
-          });
-        },
+        onChunk,
       );
-      void request.then(result => {
+      const run = async () => {
+        try {
+          return await request(backend, preferredBackend, !isAndroidDevice());
+        } catch (error) {
+          const errorBackend = /** @type {any} */ (error)?.voiceBackend;
+          const mayBeGpuFailure = errorBackend === 'webgpu'
+            || backend === 'webgpu'
+            || (backend === 'auto' && preferredBackend === 'webgpu');
+          if (
+            emittedChunks > 0
+            || !mayBeGpuFailure
+            || /** @type {any} */ (error)?.name === 'AbortError'
+            || !isLocalVoiceModelReady('tts', model, 'wasm')
+          ) throw error;
+          failedGpuModels.tts.add(String(model || ''));
+          terminateLocalVoiceWorker('tts');
+          const result = await request('wasm', 'wasm', false);
+          result.fallbackReason = String(/** @type {any} */ (error)?.message || 'Graphics processing failed');
+          return result;
+        }
+      };
+      void run().then(result => {
         rememberInstalled(
           'tts',
           result.model || model,

--- a/js/voice-local-stt-worker.js
+++ b/js/voice-local-stt-worker.js
@@ -73,6 +73,7 @@ async function loadRecognizer(
   id,
   backendPreference = 'auto',
   preferredBackend = 'webgpu',
+  allowWebGpuFallback = true,
 ) {
   const requestedModel = String(model || DEFAULT_MODEL);
   const requestedBackend = normalizeBackend(backendPreference);
@@ -91,6 +92,9 @@ async function loadRecognizer(
   }
   await recognizer?.dispose?.().catch?.(() => {});
   recognizer = null;
+  activeModel = '';
+  activeBackend = '';
+  activeFallbackReason = '';
 
   if (isMockMode()) {
     activeModel = requestedModel;
@@ -102,7 +106,9 @@ async function loadRecognizer(
   const { pipeline } = await ensureTransformers();
   const modelConfig = getLocalModel('stt', requestedModel);
   const candidates = requestedBackend === 'auto'
-    ? [autoPreference, autoPreference === 'webgpu' ? 'wasm' : 'webgpu']
+    ? allowWebGpuFallback
+      ? [autoPreference, autoPreference === 'webgpu' ? 'wasm' : 'webgpu']
+      : ['wasm']
     : [requestedBackend];
   let fallbackReason = '';
   for (const backend of candidates) {
@@ -138,6 +144,7 @@ async function transcribe(message) {
     message.id,
     message.backend,
     message.preferredBackend,
+    message.allowWebGpuFallback,
   );
   if (isMockMode()) {
     return {
@@ -176,6 +183,7 @@ self.addEventListener('message', async event => {
         id,
         message.backend,
         message.preferredBackend,
+        message.allowWebGpuFallback,
       );
       self.postMessage({ type: 'ready', id, kind: 'stt', ...ready });
       return;
@@ -200,6 +208,7 @@ self.addEventListener('message', async event => {
       type: 'error',
       id,
       kind: 'stt',
+      backend: activeBackend || undefined,
       message: getErrorMessage(error, 'Local transcription failed'),
     });
   }

--- a/js/voice-local-tts-worker.js
+++ b/js/voice-local-tts-worker.js
@@ -89,44 +89,24 @@ async function prepareWebGpu() {
   if (!adapter) throw new Error('The browser could not access a graphics processor.');
 }
 
-async function validateWebGpuSpeech(tts) {
-  const audio = await tts.generate('This is a voice test.', { voice: 'af_heart' });
-  const raw = audio?.audio || audio?.data;
-  const samples = raw instanceof Float32Array ? raw : new Float32Array(raw || []);
-  let peak = 0;
-  let sumSquares = 0;
-  for (const sample of samples) {
-    if (!Number.isFinite(sample)) throw new Error('Graphics speech validation produced invalid audio.');
-    peak = Math.max(peak, Math.abs(sample));
-    sumSquares += sample * sample;
-  }
-  const rms = Math.sqrt(sumSquares / Math.max(1, samples.length));
-  if (samples.length < 12_000 || peak < 0.03 || peak > 0.95 || rms < 0.02) {
-    throw new Error('Graphics speech validation failed on this device. Use Automatic or Main processor.');
-  }
-}
-
 async function createSynthesizer(KokoroTTS, model, backend, id) {
   if (backend === 'webgpu') await prepareWebGpu();
-  const tts = await withoutUnknownLengthWarning(() => (
+  return withoutUnknownLengthWarning(() => (
     KokoroTTS.from_pretrained(model, {
       device: backend,
       dtype: backend === 'webgpu' ? 'fp32' : 'q8',
       progress_callback: progress => postProgress(id, progress),
     })
   ));
-  if (backend === 'webgpu') {
-    try {
-      await validateWebGpuSpeech(tts);
-    } catch (error) {
-      await tts?.model?.dispose?.().catch?.(() => {});
-      throw error;
-    }
-  }
-  return tts;
 }
 
-async function loadSynthesizer(model, id, backendPreference = 'auto', preferredBackend = 'wasm') {
+async function loadSynthesizer(
+  model,
+  id,
+  backendPreference = 'auto',
+  preferredBackend = 'wasm',
+  allowWebGpuFallback = true,
+) {
   const requestedModel = String(model || DEFAULT_MODEL);
   const requestedBackend = normalizeBackend(backendPreference);
   const autoPreference = ['webgpu', 'wasm'].includes(preferredBackend) ? preferredBackend : 'wasm';
@@ -142,6 +122,9 @@ async function loadSynthesizer(model, id, backendPreference = 'auto', preferredB
   }
   await synthesizer?.model?.dispose?.().catch?.(() => {});
   synthesizer = null;
+  activeModel = '';
+  activeBackend = '';
+  activeFallbackReason = '';
 
   if (isMockMode()) {
     activeModel = requestedModel;
@@ -152,7 +135,9 @@ async function loadSynthesizer(model, id, backendPreference = 'auto', preferredB
 
   const { KokoroTTS } = await ensureKokoro();
   const candidates = requestedBackend === 'auto'
-    ? [autoPreference, autoPreference === 'webgpu' ? 'wasm' : 'webgpu']
+    ? allowWebGpuFallback
+      ? [autoPreference, autoPreference === 'webgpu' ? 'wasm' : 'webgpu']
+      : ['wasm']
     : [requestedBackend];
   let fallbackReason = '';
   for (const backend of candidates) {
@@ -194,6 +179,7 @@ async function synthesize(message) {
     message.id,
     message.backend,
     message.preferredBackend,
+    message.allowWebGpuFallback,
   );
   if (isMockMode()) {
     const sampleRate = 24_000;
@@ -278,6 +264,7 @@ self.addEventListener('message', async event => {
         id,
         message.backend,
         message.preferredBackend,
+        message.allowWebGpuFallback,
       );
       self.postMessage({ type: 'ready', id, kind: 'tts', ...ready });
       return;
@@ -319,6 +306,7 @@ self.addEventListener('message', async event => {
       type: 'error',
       id,
       kind: 'tts',
+      backend: activeBackend || undefined,
       message: getErrorMessage(error, 'Local speech generation failed'),
     });
   }

--- a/js/voice-model-catalog.js
+++ b/js/voice-model-catalog.js
@@ -107,6 +107,20 @@ export function getLocalModel(kind, modelId) {
   return models.find(model => model.id === modelId) || models[0];
 }
 
+export function getLocalModelStorageCopy(kind, modelId, backend = 'auto') {
+  const model = getLocalModel(kind, modelId);
+  if (kind !== 'tts') {
+    return `One shared CPU/GPU file · about ${model.downloadMB} MB · ${model.license}`;
+  }
+  if (backend === 'webgpu') {
+    return `GPU weights · about ${model.gpuDownloadMB} MB · separate from the ${model.downloadMB} MB CPU weights`;
+  }
+  if (backend === 'wasm') {
+    return `CPU weights · about ${model.downloadMB} MB · separate from the ${model.gpuDownloadMB} MB GPU weights`;
+  }
+  return `Optimized weights · about ${model.downloadMB} MB on CPU or ${model.gpuDownloadMB} MB on GPU`;
+}
+
 export function resolveLocalSttLanguage(modelId, language = 'auto') {
   const model = getLocalModel('stt', modelId);
   return model.multilingual ? String(language || 'auto') : 'en';

--- a/js/voice-player.js
+++ b/js/voice-player.js
@@ -20,7 +20,7 @@ function waitForPromise(promise, timeoutMs, message) {
   return Promise.race([promise, timeout]).finally(() => clearTimeout(timeoutId));
 }
 
-function readStreamChunk(reader, signal, timeoutMs) {
+function readStreamChunk(reader, signal, timeoutMs = 120_000) {
   return new Promise((resolve, reject) => {
     let settled = false;
     const cleanup = () => {
@@ -35,7 +35,7 @@ function readStreamChunk(reader, signal, timeoutMs) {
     };
     const onAbort = () => finish(reject)(abortError(signal?.reason));
     const timeoutId = setTimeout(() => finish(reject)(new Error(
-      'Local speech generation stopped responding. Try the graphics processor, a shorter reply, or a hosted voice.',
+      'Local speech generation stopped responding. Try a shorter reply or another voice service.',
     )), timeoutMs);
     signal?.addEventListener('abort', onAbort, { once: true });
     reader.read().then(finish(resolve), finish(reject));
@@ -44,7 +44,7 @@ function readStreamChunk(reader, signal, timeoutMs) {
 
 export function trimPcmEdgeSilence(samples, sampleRate, {
   threshold = 0.0015,
-  keepSeconds = 0.12,
+  keepSeconds = 0.06,
 } = {}) {
   if (!(samples instanceof Float32Array) || !samples.length) return samples;
   let first = 0;
@@ -126,7 +126,6 @@ export class VoicePlayer {
    *   revokeObjectURL?: (url: string) => void,
    *   audioUnlockTimeoutMs?: number,
    *   pcmStallTimeoutMs?: number,
-   *   pcmInitialBufferSeconds?: number,
    * }} [options]
    */
   constructor(options = {}) {
@@ -145,10 +144,6 @@ export class VoicePlayer {
     this.revokeObjectURL = options.revokeObjectURL || (url => URL.revokeObjectURL(url));
     this.audioUnlockTimeoutMs = Math.max(1000, Number(options.audioUnlockTimeoutMs) || 5000);
     this.pcmStallTimeoutMs = Math.max(1000, Number(options.pcmStallTimeoutMs) || 120_000);
-    this.pcmInitialBufferSeconds = Math.max(
-      0,
-      Number(options.pcmInitialBufferSeconds) || 6,
-    );
     /** @type {HTMLAudioElement | null} */
     this.audio = null;
     /** @type {AudioContext | null} */
@@ -567,9 +562,19 @@ export class VoicePlayer {
    * Schedule local Float32 PCM chunks as soon as Kokoro emits them.
    *
    * @param {ReadableStream<{ samples: Float32Array, sampleRate: number }>} stream
-   * @param {{ signal?: AbortSignal, rate?: number }} [options]
+   * @param {{
+   *   signal?: AbortSignal,
+   *   rate?: number,
+   *   onPlaybackStart?: () => void,
+   *   onPlaybackWaiting?: () => void,
+   * }} [options]
    */
-  async playPcmStream(stream, { signal, rate = 1 } = {}) {
+  async playPcmStream(stream, {
+    signal,
+    rate = 1,
+    onPlaybackStart,
+    onPlaybackWaiting,
+  } = {}) {
     this.stop();
     if (signal?.aborted) throw abortError(signal.reason);
     this.audioContext ||= this.audioContextFactory();
@@ -588,9 +593,9 @@ export class VoicePlayer {
     let receivedSamples = 0;
     /** @type {Promise<void> | null} */
     let lastPlayback = null;
-    /** @type {Array<{ samples: Float32Array, sampleRate: number }>} */
-    const initialChunks = [];
-    let initialBufferSeconds = 0;
+    let playbackStarted = false;
+    let streamDone = false;
+    let waitingForChunk = false;
 
     const schedule = (samples, sampleRate) => {
       const buffer = context.createBuffer(1, samples.length, sampleRate);
@@ -608,14 +613,19 @@ export class VoicePlayer {
           source.onended = null;
           this.scheduledAudioSources.delete(source);
           try { source.disconnect(); } catch {}
+          if (!streamDone && this.scheduledAudioSources.size === 0) {
+            waitingForChunk = true;
+            try { onPlaybackWaiting?.(); } catch {}
+          }
           resolve();
         };
       });
       source.start(startTime);
-    };
-
-    const flushInitialChunks = () => {
-      for (const chunk of initialChunks.splice(0)) schedule(chunk.samples, chunk.sampleRate);
+      if (!playbackStarted || waitingForChunk) {
+        playbackStarted = true;
+        waitingForChunk = false;
+        try { onPlaybackStart?.(); } catch {}
+      }
     };
 
     try {
@@ -629,7 +639,7 @@ export class VoicePlayer {
           this.pcmStallTimeoutMs,
         );
         if (done) {
-          flushInitialChunks();
+          streamDone = true;
           break;
         }
         const rawSamples = value?.samples instanceof Float32Array
@@ -638,13 +648,7 @@ export class VoicePlayer {
         const sampleRate = Math.max(8_000, Number(value?.sampleRate) || 24_000);
         const samples = trimPcmEdgeSilence(rawSamples, sampleRate);
         if (!samples.length) continue;
-        if (initialChunks.length || !lastPlayback) {
-          initialChunks.push({ samples, sampleRate });
-          initialBufferSeconds += samples.length / sampleRate;
-          if (initialBufferSeconds >= this.pcmInitialBufferSeconds) flushInitialChunks();
-        } else {
-          schedule(samples, sampleRate);
-        }
+        schedule(samples, sampleRate);
       }
       if (internalController.signal.aborted) {
         throw abortError(internalController.signal.reason);

--- a/scripts/app-shell-budget.json
+++ b/scripts/app-shell-budget.json
@@ -3,7 +3,7 @@
   "scenario": "Production service-worker app-shell precache during PWA installation",
   "maximums": {
     "resources": 338,
-    "decodedBytes": 18160000
+    "decodedBytes": 18170000
   },
   "reference": {
     "resources": 277,
@@ -13,7 +13,8 @@
     "mealsNutritionFinalDecodedBytes": 15526961,
     "evolu8DefaultCutoverResources": 334,
     "evolu8DefaultCutoverDecodedBytes": 18016786,
-    "routeAwareAiConsentDecodedBytes": 18142674
+    "routeAwareAiConsentDecodedBytes": 18142674,
+    "voiceStreamingUxDecodedBytes": 18167190
   },
   "referenceCommit": "807732a8",
   "measuredAt": "2026-08-30"

--- a/scripts/production-build-budget.json
+++ b/scripts/production-build-budget.json
@@ -4,7 +4,7 @@
     "startupJavaScriptFiles": 2,
     "startupDecodedBytes": 1180000,
     "outputJavaScriptFiles": 158,
-    "outputDecodedBytes": 5020000
+    "outputDecodedBytes": 5025000
   },
   "reference": {
     "startupJavaScriptFiles": 2,
@@ -42,7 +42,8 @@
     "evolu8ScalarMergeStartupDecodedBytes": 1173660,
     "routeAwareAiConsentStartupDecodedBytes": 1177819,
     "routeAwareAiConsentOutputDecodedBytes": 5009169,
-    "onDeviceVoiceOutputDecodedBytes": 5017872
+    "onDeviceVoiceOutputDecodedBytes": 5017872,
+    "voiceStreamingUxOutputDecodedBytes": 5023375
   },
   "referenceCommit": "807732a8",
   "measuredAt": "2026-08-30"

--- a/tests/chat-runtime.test.js
+++ b/tests/chat-runtime.test.js
@@ -239,8 +239,10 @@ describe('chat presentation stylesheet runtime behavior', () => {
       expect(chatPanel.configureChatPanel({})).toEqual({
         restoreDiscussionContinuePrompt: null,
         isChatStreaming: null,
+        isVoicePlaybackActive: null,
         refreshMobileDashboardActiveTab: null,
         restoreChatGenerationUI: null,
+        restoreVoicePlaybackUi: null,
         stopVoiceActivity: null,
       });
       expect(chatPanel.isChatThreadInputBlocked()).toBe(false);

--- a/tests/playwright/voice-browser.spec.js
+++ b/tests/playwright/voice-browser.spec.js
@@ -163,9 +163,7 @@ test('browser-local voice routes first use to an explicit model download', async
   await expect(sttRow.locator('[data-voice-action="install-model"]')).toBeEnabled();
   await expect(sttRow.locator('[data-voice-action="install-model"]')).toBeFocused();
   await expect(sttRow.locator('[data-voice-action="remove-model"]')).toBeDisabled();
-  await expect(page.locator('.voice-model-footnote')).toContainText(
-    'never start a model download automatically',
-  );
+  await expect(sttRow).toContainText('One shared CPU/GPU file');
 });
 
 test('Automatic prefers WebGPU on a capable mobile browser without downloading a model', async ({ page }) => {
@@ -186,7 +184,7 @@ test('Automatic prefers WebGPU on a capable mobile browser without downloading a
     'Automatic will try the graphics processor first on this mobile device',
   );
   const ttsRow = page.locator('[data-voice-model-kind="tts"]');
-  await expect(ttsRow).toContainText('about 330 MB');
+  await expect(ttsRow).toContainText('about 95 MB on CPU or 330 MB on GPU');
   await expect(ttsRow.locator('[data-voice-action="install-model"]')).toHaveText('Download');
   await expect(ttsRow.locator('[data-voice-action="install-model"]')).toBeEnabled();
 });
@@ -403,11 +401,13 @@ test('Voice settings and chat STT/TTS controls work with a local compatible serv
 
   await openVoiceSettingsFromUi(page);
   await expect(page.locator('[data-tab-panel="voice"]')).toHaveClass(/\bactive\b/);
-  await expect(page.locator('[data-tab-panel="voice"]')).toContainText('Where voice is processed');
-  await expect(page.locator('[data-tab-panel="voice"]')).toContainText('Quality and speed');
-  await expect(page.locator('[data-tab-panel="voice"]')).toContainText('Processing');
+  await expect(page.locator('[data-tab-panel="voice"]')).toContainText('Default speech service');
+  await expect(page.locator('[data-tab-panel="voice"]')).toContainText('Speech-to-text');
+  await expect(page.locator('[data-tab-panel="voice"]')).toContainText('Text-to-speech');
+  await expect(page.locator('[data-tab-panel="voice"]')).toContainText('Whisper model');
+  await expect(page.locator('[data-tab-panel="voice"]')).toContainText('Processor');
   await expect(page.locator('[data-tab-panel="voice"]')).toContainText(
-    'Use different services for dictation and listening',
+    'Use separate STT and TTS services',
   );
   await expect(page.locator('[data-tab-panel="voice"]')).toContainText('Speaking speed');
   await expect(page.locator('[data-voice-shared-provider]')).toHaveValue('auto');
@@ -442,6 +442,7 @@ test('Voice settings and chat STT/TTS controls work with a local compatible serv
   await expect(page.locator('[data-voice-hardware-description]')).toContainText(
     'Automatic will use the main processor; it was about 4.0× faster in your tests.',
   );
+  await expect(outputLanguageSelect).toBeHidden();
   await expect(outputLanguageSelect).toBeDisabled();
   await expect(outputLanguageSelect).toHaveValue('en');
   await expect(speechHardwareSelect).toHaveValue('auto');
@@ -450,6 +451,7 @@ test('Voice settings and chat STT/TTS controls work with a local compatible serv
     'Automatic will use the graphics processor; it was about 2.0× faster in your tests.',
   );
   await page.locator('[data-voice-shared-provider]').selectOption('local-server');
+  await expect(outputLanguageSelect).toBeVisible();
   await expect(outputLanguageSelect).toBeEnabled();
   await page.locator('[data-voice-shared-provider]').selectOption('browser-local');
   await expect(sttModelSelect).toContainText('Recommended · Whisper Small');
@@ -760,6 +762,7 @@ test('cloud connection controls preserve masked keys, labels, and provider error
   });
   await openVoiceSettingsFromUi(page);
 
+  await page.locator('.voice-advanced-connections > summary').click();
   const xaiCard = page.locator('[data-voice-connection="xai"]');
   await xaiCard.locator('summary').click();
   const xaiKey = xaiCard.locator('[data-voice-key-input="xai"]');
@@ -820,8 +823,10 @@ test('Voice settings use standard responsive Settings rows without horizontal ov
   await page.goto('/app', { waitUntil: 'load' });
   await openVoiceSettingsFromUi(page);
 
-  await expect(page.locator('.voice-settings-list .settings-section')).toHaveCount(25);
-  await expect(page.locator('.voice-model-list .settings-section')).toHaveCount(2);
+  await expect(page.locator('.voice-task-card')).toHaveCount(2);
+  await expect(page.locator('.voice-model-row')).toHaveCount(2);
+  await expect(page.locator('[data-voice-setting="localTtsBuffering"]')).toHaveCount(0);
+  await expect(page.locator('.voice-advanced-connections')).not.toHaveAttribute('open', '');
   await expect(page.locator('[data-voice-setting="localVoice"] optgroup')).toHaveCount(2);
   await expect(page.locator('[data-voice-setting="localVoice"] optgroup').first())
     .toHaveAttribute('label', 'Female voices');

--- a/tests/voice-chat-runtime.test.js
+++ b/tests/voice-chat-runtime.test.js
@@ -18,18 +18,20 @@ import {
   buildActionBar,
   configureChatMessageActionDeps,
 } from '../js/chat-actions.js';
+import { closeChatPanel, configureChatPanel } from '../js/chat-panel.js';
 import {
   installVoiceSettingsPanel,
   renderVoiceSettingsPanel,
 } from '../js/settings-voice-panel.js';
 import { voiceProviderKeyStatus } from '../js/settings-voice-view.js';
 import { VoiceCaptureSession, preferredMimeType } from '../js/voice-capture.js';
+import { getVoiceSettings } from '../js/voice-settings-storage.js';
 import {
   configureVoiceLocalEngine,
   terminateLocalVoiceWorker,
   transcribeLocalAudio,
 } from '../js/voice-local-engine.js';
-import { VoicePlayer, trimPcmEdgeSilence } from '../js/voice-player.js';
+import { VoicePlayer, trimPcmEdgeSilence, voicePlayer } from '../js/voice-player.js';
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const realFetch = globalThis.fetch;
@@ -177,6 +179,22 @@ class FakeAudioContext {
     this.source = new FakeBufferSource();
     this.sources.push(this.source);
     return this.source;
+  }
+}
+
+class ManualAudioContext extends FakeAudioContext {
+  constructor() {
+    super();
+    this.sources = [];
+  }
+
+  createBufferSource() {
+    const source = new FakeBufferSource();
+    source.start = () => {};
+    source.finish = () => source.onended?.();
+    this.source = source;
+    this.sources.push(source);
+    return source;
   }
 }
 
@@ -440,35 +458,59 @@ describe('voice capture and playback primitives', () => {
     expect(player.scheduledAudioSources.size).toBe(0);
   });
 
-  it('buffers a short Kokoro opening until the following sentence is ready', async () => {
+  it('starts Kokoro playback immediately after the first chunk', async () => {
     const context = new FakeAudioContext();
     const player = new VoicePlayer({
       audioContextFactory: () => context,
-      pcmInitialBufferSeconds: 6,
     });
     let streamController;
     const stream = new ReadableStream({
       start(controller) { streamController = controller; },
     });
-    const playback = player.playPcmStream(stream);
-    streamController.enqueue({
-      samples: new Float32Array(16_000).fill(0.1),
-      sampleRate: 8_000,
-    });
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(context.createdBuffers).toHaveLength(0);
 
+    const onPlaybackStart = vi.fn();
+    const playback = player.playPcmStream(stream, {
+      onPlaybackStart,
+    });
     streamController.enqueue({
-      samples: new Float32Array(32_000).fill(0.1),
+      samples: new Float32Array(8_000).fill(0.1),
       sampleRate: 8_000,
     });
+    await vi.waitFor(() => expect(context.createdBuffers).toHaveLength(1));
+    expect(onPlaybackStart).toHaveBeenCalledOnce();
     streamController.close();
-    await expect(playback).resolves.toBe(true);
 
-    expect(context.createdBuffers).toHaveLength(2);
-    expect(context.sources[0].startTime).toBeCloseTo(0.03);
-    expect(context.sources[1].startTime).toBeCloseTo(2.03);
+    await expect(playback).resolves.toBe(true);
+  });
+
+  it('reports when local playback underruns and when speech resumes', async () => {
+    const context = new ManualAudioContext();
+    const player = new VoicePlayer({ audioContextFactory: () => context });
+    let streamController;
+    const stream = new ReadableStream({
+      start(controller) { streamController = controller; },
+    });
+    const onPlaybackStart = vi.fn();
+    const onPlaybackWaiting = vi.fn();
+    const playback = player.playPcmStream(stream, {
+      onPlaybackStart,
+      onPlaybackWaiting,
+    });
+
+    streamController.enqueue({ samples: new Float32Array(8_000).fill(0.1), sampleRate: 8_000 });
+    await vi.waitFor(() => expect(context.sources).toHaveLength(1));
+    expect(onPlaybackStart).toHaveBeenCalledOnce();
+    context.sources[0].finish();
+    expect(onPlaybackWaiting).toHaveBeenCalledOnce();
+
+    streamController.enqueue({ samples: new Float32Array(8_000).fill(0.1), sampleRate: 8_000 });
+    await vi.waitFor(() => expect(context.sources).toHaveLength(2));
+    expect(onPlaybackStart).toHaveBeenCalledTimes(2);
+    streamController.close();
+    await Promise.resolve();
+    context.sources[1].finish();
+
+    await expect(playback).resolves.toBe(true);
   });
 
   it('aborts a stalled local transcription worker', async () => {
@@ -497,8 +539,8 @@ describe('voice capture and playback primitives', () => {
     const samples = new Float32Array(24_000);
     samples.fill(0.2, 8_000, 16_000);
     const trimmed = trimPcmEdgeSilence(samples, 24_000);
-    expect(trimmed.length).toBe(8_000 + (2 * 2_880));
-    expect(trimmed[2_880]).toBeCloseTo(0.2);
+    expect(trimmed.length).toBe(8_000 + (2 * 1_440));
+    expect(trimmed[1_440]).toBeCloseTo(0.2);
   });
 });
 
@@ -597,7 +639,8 @@ describe('voice settings and chat controls', () => {
       const { readAssistantMessage } = await import('../js/voice-controller.js');
       const pending = readAssistantMessage(0);
       const button = document.getElementById('chat-listen-btn-0');
-      await vi.waitFor(() => expect(button?.textContent).toContain('Cancel'));
+      await vi.waitFor(() => expect(button?.textContent).toContain('Preparing'));
+      expect(button?.getAttribute('aria-label')).toContain('Cancel');
       await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalledOnce());
       expect(button?.disabled).toBe(false);
 
@@ -855,15 +898,24 @@ describe('voice settings and chat controls', () => {
     expect(localStorage.getItem('labcharts-voice-output-provider')).toBe('elevenlabs');
     expect(localStorage.getItem('labcharts-voice-providers-linked')).toBe('false');
     expect(panel.querySelector('[data-voice-visible="output:elevenlabs"]').hidden).toBe(false);
-    expect(panel.textContent).toContain('Use different services for dictation and listening');
+    expect(panel.textContent).toContain('Use separate STT and TTS services');
     expect(panel.querySelector(
       '[data-voice-action="install-model"][data-kind="stt"]',
     ).disabled).toBe(false);
     expect(panel.querySelector(
       '[data-voice-action="remove-model"][data-kind="stt"]',
     ).disabled).toBe(true);
-    expect(panel.querySelector('.voice-model-footnote').textContent.replace(/\s+/g, ' '))
-      .toContain('never start a model download automatically');
+    expect(panel.textContent).toContain('Speech-to-text');
+    expect(panel.textContent).toContain('Text-to-speech');
+    expect(panel.querySelector('.voice-advanced-connections').open).toBe(false);
+  });
+
+  it('keeps Kokoro playback immediate without exposing a buffering preference', () => {
+    document.body.innerHTML = `<main>${renderVoiceSettingsPanel(true)}</main>`;
+    installVoiceSettingsPanel(document);
+    expect(document.querySelector('[data-voice-setting="localTtsBuffering"]')).toBeNull();
+    expect(getVoiceSettings()).not.toHaveProperty('localTtsBuffering');
+    expect(document.body.textContent).not.toContain('Playback buffering');
   });
 
   it('requires the explicit Kokoro GPU weight download when processing changes', () => {
@@ -883,9 +935,30 @@ describe('voice settings and chat controls', () => {
     select.value = 'webgpu';
     select.dispatchEvent(new Event('change', { bubbles: true }));
     const row = document.querySelector('[data-voice-model-kind="tts"]');
-    expect(row.textContent).toContain('about 330 MB');
-    expect(row.textContent).toContain('Download needed for the selected processing mode');
+    expect(row.textContent).toContain('GPU weights · about 330 MB');
+    expect(row.textContent).toContain('separate from the 95 MB CPU weights');
+    expect(row.textContent).toContain('GPU weights need a separate download');
+    expect(row.textContent).toContain('CPU weights remain stored');
     expect(row.querySelector('[data-voice-action="install-model"]').disabled).toBe(false);
+  });
+
+  it('reuses one Whisper download when switching between CPU and GPU', () => {
+    const model = 'onnx-community/whisper-small';
+    localStorage.setItem('labcharts-voice-local-stt-backend', 'wasm');
+    localStorage.setItem(
+      `labcharts-voice-model-installed-stt-${encodeURIComponent(model)}`,
+      JSON.stringify({ version: '2', model, backend: 'wasm' }),
+    );
+    document.body.innerHTML = `<main>${renderVoiceSettingsPanel(true)}</main>`;
+    installVoiceSettingsPanel(document);
+    const select = document.querySelector('[data-voice-setting="localSttBackend"]');
+    select.value = 'webgpu';
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+
+    const row = document.querySelector('[data-voice-model-kind="stt"]');
+    expect(row.textContent).toContain('One shared CPU/GPU file');
+    expect(row.querySelector('[data-voice-action="install-model"]').disabled).toBe(true);
+    expect(row.querySelector('[data-voice-action="install-model"]').textContent).toBe('Ready');
   });
 
   it('keeps model progress and completion attached to the selection that started them', async () => {
@@ -952,6 +1025,116 @@ describe('voice settings and chat controls', () => {
     } finally {
       configureChatMessageActionDeps(previousDeps);
       state.chatHistory = original;
+    }
+  });
+
+  it('preserves speech playback when the chat panel closes', () => {
+    const stopVoiceActivity = vi.fn();
+    const previous = configureChatPanel({ stopVoiceActivity });
+    document.body.innerHTML = `
+      <aside id="chat-panel" class="open"></aside>
+      <div id="chat-backdrop" class="open"></div>
+      <button id="chat-fab" class="hidden"></button>
+    `;
+    try {
+      closeChatPanel();
+      expect(stopVoiceActivity).toHaveBeenCalledWith({ preservePlayback: true });
+      expect(document.getElementById('chat-panel').classList.contains('open')).toBe(false);
+    } finally {
+      configureChatPanel(previous);
+    }
+  });
+
+  it('shows cancellable preparation until local Kokoro audio actually starts', async () => {
+    const originalHistory = state.chatHistory;
+    const originalThreadId = state.currentThreadId;
+    const worker = new ControlledVoiceWorker();
+    const previousEngine = configureVoiceLocalEngine({ workerFactory: () => worker });
+    const model = 'onnx-community/Kokoro-82M-v1.0-ONNX';
+    localStorage.setItem('labcharts-voice-output-provider', 'browser-local');
+    localStorage.setItem('labcharts-voice-local-tts-backend', 'wasm');
+    localStorage.setItem(
+      `labcharts-voice-model-installed-tts-${encodeURIComponent(model)}`,
+      JSON.stringify({
+        version: '2',
+        model,
+        backend: 'wasm',
+        availableBackends: ['wasm'],
+      }),
+    );
+    state.currentThreadId = 'kokoro-loading-state-test';
+    state.chatHistory = [{ role: 'assistant', content: 'Read this sentence.' }];
+    document.body.innerHTML = buildActionBar(0);
+    const audioContext = new ManualAudioContext();
+    const previousAudioContext = voicePlayer.audioContext;
+    voicePlayer.audioContext = audioContext;
+    let controller;
+
+    try {
+      controller = await import('../js/voice-controller.js');
+      const reading = controller.readAssistantMessage(0);
+      let button = document.getElementById('chat-listen-btn-0');
+      await vi.waitFor(() => expect(worker.request?.type).toBe('synthesize'));
+      expect(button.classList.contains('busy')).toBe(true);
+      expect(button.textContent).toContain('Preparing…');
+      expect(button.disabled).toBe(false);
+      expect(button.getAttribute('aria-label')).toBe('Cancel speech preparation');
+
+      const samples = new Float32Array(8_000).fill(0.1);
+      worker.respond({
+        type: 'audio-chunk',
+        id: worker.request.id,
+        sampleRate: 8_000,
+        samples: samples.buffer,
+      });
+      await vi.waitFor(() => expect(button.classList.contains('speaking')).toBe(true));
+      expect(button.textContent).toContain('Stop');
+
+      audioContext.sources[0].finish();
+      await vi.waitFor(() => expect(button.textContent).toContain('Still generating…'));
+      expect(button.classList.contains('busy')).toBe(true);
+      expect(button.getAttribute('aria-label')).toBe('Cancel speech generation');
+
+      expect(controller.stopVoiceActivity({ preservePlayback: true })).toBe(true);
+      expect(button.textContent).toContain('Still generating…');
+
+      document.body.innerHTML = buildActionBar(0);
+      button = document.getElementById('chat-listen-btn-0');
+      expect(button.textContent).toContain('Listen');
+      expect(controller.isVoicePlaybackActive()).toBe(true);
+      expect(controller.restoreVoicePlaybackUi()).toBe(true);
+      expect(button.textContent).toContain('Still generating…');
+      expect(button.getAttribute('aria-label')).toBe('Cancel speech generation');
+
+      const nextSamples = new Float32Array(8_000).fill(0.1);
+      worker.respond({
+        type: 'audio-chunk',
+        id: worker.request.id,
+        sampleRate: 8_000,
+        samples: nextSamples.buffer,
+      });
+      await vi.waitFor(() => expect(button.classList.contains('speaking')).toBe(true));
+      worker.respond({
+        type: 'audio-done',
+        id: worker.request.id,
+        model,
+        backend: 'wasm',
+        sampleRate: 8_000,
+        inferenceMs: 100,
+        audioSeconds: 1,
+      });
+      await vi.waitFor(() => expect(audioContext.sources).toHaveLength(2));
+      audioContext.sources[1].finish();
+
+      await expect(reading).resolves.toBe(true);
+      expect(button.textContent).toContain('Listen');
+    } finally {
+      controller?.stopVoiceActivity();
+      terminateLocalVoiceWorker('tts');
+      configureVoiceLocalEngine(previousEngine);
+      voicePlayer.audioContext = previousAudioContext;
+      state.chatHistory = originalHistory;
+      state.currentThreadId = originalThreadId;
     }
   });
 

--- a/tests/voice-foundation.test.js
+++ b/tests/voice-foundation.test.js
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
@@ -31,13 +32,17 @@ import {
 import {
   initialLocalVoiceBackend,
   isLocalVoiceModelReady,
+  isAndroidDevice,
   isMobileVoiceDevice,
   preferredLocalVoiceBackend,
   removeLocalVoiceModel,
   resolveLocalBackend,
   verifyLocalVoiceModelReady,
 } from '../js/voice-local-engine.js';
-import { localModelStatusText } from '../js/settings-voice-hardware.js';
+import {
+  localModelStatusText,
+  renderSttHardwareRow,
+} from '../js/settings-voice-hardware.js';
 import { normalizeSpeechText, splitSpeechText } from '../js/voice-text.js';
 
 afterEach(() => {
@@ -154,6 +159,23 @@ describe('voice settings storage', () => {
     });
     expect(normalizeLocalVoiceServerUrl('javascript:alert(1)')).toBe('');
     expect(normalizeLocalVoiceServerUrl('not a url')).toBe('');
+  });
+
+  it('preserves explicit Android GPU choices while Automatic stays CPU-safe', () => {
+    vi.stubGlobal('navigator', {
+      userAgent: 'Mozilla/5.0 (Linux; Android 15; Pixel 8a) AppleWebKit/537.36',
+    });
+    localStorage.setItem(VOICE_STORAGE_KEYS.localSttBackend, 'webgpu');
+    localStorage.setItem(VOICE_STORAGE_KEYS.localTtsBackend, 'webgpu');
+
+    expect(getVoiceSettings()).toMatchObject({
+      localSttBackend: 'webgpu',
+      localTtsBackend: 'webgpu',
+    });
+    expect(renderSttHardwareRow(getVoiceSettings())).toContain(
+      'Graphics processor (GPU · experimental)',
+    );
+    expect(resolveLocalBackend('auto', {}, { android: true })).toBe('wasm');
   });
 
   it('routes provider credentials through encrypted storage and the memory cache', async () => {
@@ -322,7 +344,7 @@ describe('local transcription language', () => {
     expect(resolveLocalBackend('webgpu', { wasm: 1 })).toBe('webgpu');
   });
 
-  it('starts with WebGPU on capable mobile browsers and CPU elsewhere', () => {
+  it('starts with WebGPU on capable non-Android mobile browsers and CPU elsewhere', () => {
     const gpu = { requestAdapter: () => Promise.resolve({}) };
     const mobile = { userAgentData: { mobile: true }, gpu };
     const desktop = { userAgentData: { mobile: false }, gpu };
@@ -331,7 +353,7 @@ describe('local transcription language', () => {
     expect(isMobileVoiceDevice(mobile)).toBe(true);
     expect(isMobileVoiceDevice(android)).toBe(true);
     expect(initialLocalVoiceBackend(mobile)).toBe('webgpu');
-    expect(initialLocalVoiceBackend(android)).toBe('webgpu');
+    expect(initialLocalVoiceBackend(android)).toBe('wasm');
     expect(initialLocalVoiceBackend(desktop)).toBe('wasm');
     expect(initialLocalVoiceBackend({ userAgentData: { mobile: true } })).toBe('wasm');
     expect(resolveLocalBackend('auto', {}, 'webgpu')).toBe('webgpu');
@@ -352,6 +374,27 @@ describe('local transcription language', () => {
 
     expect(preferredLocalVoiceBackend('tts', model, 'auto')).toBe('wasm');
     expect(isLocalVoiceModelReady('tts', model, 'auto')).toBe(true);
+  });
+
+  it('keeps Automatic on CPU for Android even when an older GPU result was faster', () => {
+    const androidNavigator = {
+      userAgent: 'Mozilla/5.0 (Linux; Android 15; Pixel 8a) AppleWebKit/537.36',
+    };
+    expect(isAndroidDevice(androidNavigator)).toBe(true);
+    expect(resolveLocalBackend('auto', {
+      wasm: { realtimeFactor: 1.2 },
+      webgpu: { realtimeFactor: 0.4 },
+    }, { android: true })).toBe('wasm');
+    expect(resolveLocalBackend('webgpu', {}, { android: true })).toBe('webgpu');
+  });
+
+  it('does not synthesize a hidden Kokoro sentence while initializing WebGPU', () => {
+    const workerSource = readFileSync(
+      new URL('../js/voice-local-tts-worker.js', import.meta.url),
+      'utf8',
+    );
+    expect(workerSource).not.toContain('This is a voice test.');
+    expect(workerSource).toContain("requestAdapter({ powerPreference: 'high-performance' })");
   });
 
   it('requires an explicit Kokoro download for each weight variant', () => {

--- a/tests/voice-local-engine.test.js
+++ b/tests/voice-local-engine.test.js
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  configureVoiceLocalEngine,
+  getLocalVoiceModelStatus,
+  installLocalVoiceModel,
+  terminateLocalVoiceWorkers,
+  transcribeLocalAudio,
+} from '../js/voice-local-engine.js';
+
+class RespondingVoiceWorker extends EventTarget {
+  constructor(kind, respond) {
+    super();
+    this.kind = kind;
+    this.respondToRequest = respond;
+    this.requests = [];
+    this.terminated = false;
+  }
+
+  postMessage(request) {
+    this.requests.push(request);
+    queueMicrotask(() => {
+      if (!this.terminated || this.respondToRequest.respondAfterTermination) {
+        this.respondToRequest(this, request);
+      }
+    });
+  }
+
+  respond(data) {
+    const event = new Event('message');
+    Object.defineProperty(event, 'data', { value: data });
+    this.dispatchEvent(event);
+  }
+
+  terminate() {
+    this.terminated = true;
+  }
+}
+
+function workerKind(url) {
+  return String(url).includes('voice-local-tts-worker') ? 'tts' : 'stt';
+}
+
+afterEach(() => {
+  terminateLocalVoiceWorkers();
+  localStorage.clear();
+});
+
+describe('local voice worker memory safety', () => {
+  it('terminates the resident Whisper worker before allocating Kokoro', async () => {
+    const workers = [];
+    const previous = configureVoiceLocalEngine({
+      workerFactory: url => {
+        const kind = workerKind(url);
+        const worker = new RespondingVoiceWorker(kind, (instance, request) => {
+          instance.respond({
+            type: 'ready',
+            id: request.id,
+            kind,
+            model: request.model,
+            backend: 'wasm',
+          });
+        });
+        workers.push(worker);
+        return worker;
+      },
+    });
+    try {
+      await installLocalVoiceModel('stt', 'test-whisper-exclusive', undefined, 'wasm');
+      expect(workers).toHaveLength(1);
+      expect(workers[0].terminated).toBe(false);
+
+      await installLocalVoiceModel('tts', 'test-kokoro-exclusive', undefined, 'wasm');
+      expect(workers).toHaveLength(2);
+      expect(workers[0].kind).toBe('stt');
+      expect(workers[0].terminated).toBe(true);
+      expect(workers[1].kind).toBe('tts');
+    } finally {
+      terminateLocalVoiceWorkers();
+      configureVoiceLocalEngine(previous);
+    }
+  });
+
+  it('retries a recoverable Whisper GPU error on CPU with an intact audio buffer', async () => {
+    const model = 'test-whisper-gpu-fallback';
+    const marker = `labcharts-voice-model-installed-stt-${encodeURIComponent(model)}`;
+    localStorage.setItem(marker, JSON.stringify({
+      version: '2',
+      model,
+      backend: 'webgpu',
+      availableBackends: ['webgpu'],
+    }));
+    const workers = [];
+    const previous = configureVoiceLocalEngine({
+      workerFactory: url => {
+        const worker = new RespondingVoiceWorker(workerKind(url), (instance, request) => {
+          if (request.backend === 'webgpu') {
+            instance.respond({
+              type: 'error',
+              id: request.id,
+              backend: 'webgpu',
+              message: 'WebGPU device was lost',
+            });
+            return;
+          }
+          instance.respond({
+            type: 'transcript',
+            id: request.id,
+            model,
+            backend: 'wasm',
+            text: 'CPU fallback worked',
+            inferenceMs: 25,
+          });
+        });
+        workers.push(worker);
+        return worker;
+      },
+    });
+    try {
+      const samples = new Float32Array([0, 0.25, -0.25, 0.5]);
+      const result = await transcribeLocalAudio(samples, {
+        model,
+        language: 'en',
+        backend: 'webgpu',
+      });
+
+      expect(result).toMatchObject({
+        text: 'CPU fallback worked',
+        backend: 'wasm',
+        fallbackReason: 'WebGPU device was lost',
+      });
+      expect(workers).toHaveLength(2);
+      expect(workers[0].terminated).toBe(true);
+      expect(workers[1].requests[0].backend).toBe('wasm');
+      expect(workers[1].requests[0].audio.byteLength).toBe(samples.byteLength);
+      expect(getLocalVoiceModelStatus('stt', model)).toMatchObject({
+        backend: 'wasm',
+        availableBackends: expect.arrayContaining(['webgpu', 'wasm']),
+      });
+    } finally {
+      terminateLocalVoiceWorkers();
+      configureVoiceLocalEngine(previous);
+    }
+  });
+});

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.18.6';
+self.APP_VERSION = '1.18.7';


### PR DESCRIPTION
## Summary

- start Kokoro playback with the first generated PCM chunk, prefetch the next speech chunk during playback, and show preparation or underrun state on the Listen button
- keep speech playing when chat closes; release inactive Whisper/Kokoro workers and recover supported GPU failures on CPU
- default Android Automatic processing to CPU while retaining explicit experimental GPU selection and non-Android mobile WebGPU preference
- simplify Voice settings into STT and TTS sections, restore Whisper Medium, remove playback-buffering controls, and explain shared versus processor-specific model files

## Verification

- 83 focused Vitest tests
- full-app checkJs and strict-null ratchet
- architecture map check
- production bundle and app-shell budgets
- quality guardrails
- 4 focused Chromium voice settings/runtime checks