### PR TITLE
Recommend Claude Fable 5.1 across providers

### DIFF
--- a/js/api-models.js
+++ b/js/api-models.js
@@ -70,6 +70,7 @@ export function modelMetadataSupportsVision(model) {
 
 // Curated: latest-gen medically capable models only (prefixes matched against IDs)
 const OPENROUTER_CURATED = [
+  'anthropic/claude-fable-5',
   'anthropic/claude-sonnet-5', 'anthropic/claude-sonnet-4',
   'anthropic/claude-opus-5', 'anthropic/claude-opus-4',
   'openai/gpt-5',
@@ -87,6 +88,7 @@ const OPENROUTER_CURATED = [
 // Anthropic: "claude-model-version" (hyphens: 4-6, with date suffix)
 // Venice: "model-version" (hyphens: 4-6, no provider prefix)
 const OPENROUTER_RECOMMENDED = [
+  'anthropic/claude-fable-5.1',
   'anthropic/claude-sonnet-5', 'anthropic/claude-sonnet-4.6',
   'anthropic/claude-opus-5', 'anthropic/claude-opus-4.7',
   'openai/gpt-5.6-sol', 'openai/gpt-5.6-terra', 'openai/gpt-5.6-luna', 'openai/gpt-5.4',
@@ -98,11 +100,11 @@ const OPENROUTER_RECOMMENDED = [
 const OPENROUTER_DEFAULT_CANDIDATES = ['openai/gpt-5.6-sol', 'anthropic/claude-sonnet-5', 'anthropic/claude-sonnet-4.6'];
 
 // Routstr uses bare model IDs (no provider prefix, dots: claude-sonnet-4.6)
-const ROUTSTR_RECOMMENDED = ['claude-sonnet-5', 'claude-sonnet-4.6', 'claude-opus-5', 'claude-opus-4.7', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna', 'openai/gpt-5.6-sol', 'openai/gpt-5.6-terra', 'openai/gpt-5.6-luna', 'gpt-5.5', 'gpt-5.4', 'gemini-3.7-flash', 'google/gemini-3.7-flash', 'gemini-3.6-flash', 'google/gemini-3.6-flash', 'gemini-3.5-flash', 'gemini-3-flash-preview', 'glm-5.3-flash', 'z-ai/glm-5.3-flash', 'kimi-k3', 'moonshotai/kimi-k3', 'x-ai/grok-4.3', 'grok-4.3', 'grok-4'];
+const ROUTSTR_RECOMMENDED = ['claude-fable-5.1', 'claude-sonnet-5', 'claude-sonnet-4.6', 'claude-opus-5', 'claude-opus-4.7', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna', 'openai/gpt-5.6-sol', 'openai/gpt-5.6-terra', 'openai/gpt-5.6-luna', 'gpt-5.5', 'gpt-5.4', 'gemini-3.7-flash', 'google/gemini-3.7-flash', 'gemini-3.6-flash', 'google/gemini-3.6-flash', 'gemini-3.5-flash', 'gemini-3-flash-preview', 'glm-5.3-flash', 'z-ai/glm-5.3-flash', 'kimi-k3', 'moonshotai/kimi-k3', 'x-ai/grok-4.3', 'grok-4.3', 'grok-4'];
 const ROUTSTR_PRIVATE_RECOMMENDED = ['tinfoil-gemma4-31b', 'tinfoil-kimi-k2-6', 'tinfoil-deepseek-v4-pro', 'tinfoil-glm-5-3-flash'];
 
 // PPQ uses bare model IDs for regular routing and private/ IDs for Tinfoil TEE models.
-const PPQ_RECOMMENDED = ['claude-sonnet-5', 'claude-sonnet-4.6', 'claude-opus-5', 'claude-opus-4.7', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna', 'openai/gpt-5.6-sol', 'openai/gpt-5.6-terra', 'openai/gpt-5.6-luna', 'gpt-5.5', 'gpt-5.4', 'gemini-3.7-flash', 'google/gemini-3.7-flash', 'gemini-3.6-flash', 'google/gemini-3.6-flash', 'gemini-3.5-flash', 'gemini-3-flash-preview', 'z-ai/glm-5.3-flash', 'glm-5.3-flash', 'moonshotai/kimi-k3', 'kimi-k3', 'x-ai/grok-4.3', 'grok-4'];
+const PPQ_RECOMMENDED = ['claude-fable-5.1', 'claude-sonnet-5', 'claude-sonnet-4.6', 'claude-opus-5', 'claude-opus-4.7', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna', 'openai/gpt-5.6-sol', 'openai/gpt-5.6-terra', 'openai/gpt-5.6-luna', 'gpt-5.5', 'gpt-5.4', 'gemini-3.7-flash', 'google/gemini-3.7-flash', 'gemini-3.6-flash', 'google/gemini-3.6-flash', 'gemini-3.5-flash', 'gemini-3-flash-preview', 'z-ai/glm-5.3-flash', 'glm-5.3-flash', 'moonshotai/kimi-k3', 'kimi-k3', 'x-ai/grok-4.3', 'grok-4'];
 const PPQ_PRIVATE_RECOMMENDED = ['private/kimi-k3', 'private/kimi-k2-6', 'private/glm-5-3-flash'];
 
 function normalizedModelId(modelId) {
@@ -113,7 +115,12 @@ function isClaudeSonnet5Model(modelId) {
   return /(^|[/-])claude-sonnet-5($|[-:])/.test(normalizedModelId(modelId));
 }
 
+function isClaudeFable51Model(modelId) {
+  return /(^|[/-])claude-fable-5-1($|[-:])/.test(normalizedModelId(modelId));
+}
+
 function isCustomRecommendedModel(modelId) {
+  if (isClaudeFable51Model(modelId)) return true;
   if (isClaudeSonnet5Model(modelId)) return true;
   return /(^|[/-])claude-(sonnet-4-6|opus-5|opus-4-7)($|[-:])/.test(normalizedModelId(modelId))
     || /(^|[/-])gpt-5-(?:[45]|6-(?:sol|terra|luna))($|[-:])/.test(normalizedModelId(modelId))
@@ -165,7 +172,8 @@ export function isRecommendedModel(provider, modelId) {
     if (modelId.startsWith('e2ee-')) return /qwen3-5-122b|gpt-oss-120b|qwen3-30b|glm-5-3-flash/.test(modelId);
     // claude-(sonnet-5|sonnet-4-6|opus-5|opus-4-7) is intentionally narrow. When newer
     // versions land, broaden the alternation rather than matching all 4.x.
-    return isVeniceRecommendedGpt5Model(modelId)
+    return isClaudeFable51Model(modelId)
+      || isVeniceRecommendedGpt5Model(modelId)
       || /^(claude-(sonnet-5|sonnet-4-6|opus-5|opus-4-7)|gemini-3-(7-flash|6-flash|5-flash|flash-preview)|zai-org-glm-5-3-flash|z-ai-glm-5-3-flash|glm-5-3-flash|kimi-k3|grok-4[1-9]?)(-|$)/.test(normalizedModelId(modelId));
   }
   if (provider === 'routstr') {

--- a/js/api-ppq.js
+++ b/js/api-ppq.js
@@ -25,7 +25,7 @@ import { callOpenAICompatibleAPI } from './api-openai-compatible.js';
 
 const apiWindow = /** @type {PpqApiWindow} */ (typeof window !== 'undefined' ? window : {});
 
-const PPQ_CURATED = ['claude-', 'gpt-5', 'gpt-4', 'gpt-oss', 'gemini-3', 'gemini-2', 'google/gemini-3', 'google/gemini-2', 'glm-5', 'z-ai/glm-5', 'moonshotai/kimi-', 'grok-', 'x-ai/grok-4', 'llama-', 'qwen', 'deepseek-', 'mistral-', 'kimi', 'perplexity'];
+const PPQ_CURATED = ['claude-', 'anthropic/claude-', 'gpt-5', 'gpt-4', 'gpt-oss', 'gemini-3', 'gemini-2', 'google/gemini-3', 'google/gemini-2', 'glm-5', 'z-ai/glm-5', 'moonshotai/kimi-', 'grok-', 'x-ai/grok-4', 'llama-', 'qwen', 'deepseek-', 'mistral-', 'kimi', 'perplexity'];
 const PPQ_DEFAULT_CANDIDATES = ['gpt-5.5', 'openai/gpt-5.5', 'claude-sonnet-5', 'claude-sonnet-4.6'];
 const PPQ_EXCLUDE = ['codex', 'audio', 'image', 'embed', 'tts', 'whisper', 'video', 'nano-banana'];
 // The PPQ API is authoritative for private-model availability, names, and

--- a/js/api-routstr.js
+++ b/js/api-routstr.js
@@ -20,7 +20,7 @@ import {
 import { callOpenAICompatibleAPI } from './api-openai-compatible.js';
 import { notifyRoutstrRequestSettled } from './routstr-balance-settlement.js';
 
-const ROUTSTR_CURATED = ['claude-', 'gpt-5', 'gpt-4', 'gemini-3', 'gemini-2', 'glm-5', 'z-ai/glm-5', 'kimi-', 'moonshotai/kimi-', 'grok-4', 'x-ai/grok-4', 'grok-3', 'llama-', 'qwen', 'deepseek-', 'mistral-', 'mimo-'];
+const ROUTSTR_CURATED = ['claude-', 'anthropic/claude-', 'gpt-5', 'gpt-4', 'gemini-3', 'gemini-2', 'glm-5', 'z-ai/glm-5', 'kimi-', 'moonshotai/kimi-', 'grok-4', 'x-ai/grok-4', 'grok-3', 'llama-', 'qwen', 'deepseek-', 'mistral-', 'mimo-'];
 const ROUTSTR_DEFAULT_CANDIDATES = ['gpt-5.5', 'openai/gpt-5.5', 'claude-sonnet-5', 'claude-sonnet-4.6'];
 const ROUTSTR_EXCLUDE = ['codex', 'audio', 'image', 'oss', 'safeguard', 'coder', 'embed', 'tts', 'whisper', 'beta', 'preview', 'free', 'gratis'];
 const ROUTSTR_PRIVATE_REQUEST_TIMEOUT_MS = 180000;

--- a/js/changelog-impl.js
+++ b/js/changelog-impl.js
@@ -9,10 +9,10 @@ const CHANGELOG_ACTION_ATTR = 'data-changelog-action';
 const changelogDelegateRoots = new WeakSet();
 
 const CHANGELOG = [
+  { version: '1.18.8', date: '2026-09-02', title: 'Claude Fable 5.1 joins recommended models', items: ['<b>Claude Fable 5.1 is recommended wherever it is available.</b> OpenRouter, Venice, Routstr, PPQ, and compatible custom providers recognize each provider\'s model ID format while continuing to source availability and pricing from live catalogs.'] },
   { version: '1.18.7', date: '2026-09-01', title: 'On-device voice is clearer and more reliable', items: ['<b>Local speech behaves better across phones and computers.</b> Android defaults to the stable CPU path, failed GPU runs recover safely when possible, and Whisper Medium is available again.', '<b>Kokoro starts as soon as its first sentence is ready.</b> Playback continues outside the chat panel and clearly shows when the next sentence is still being generated.', '<b>Voice settings are easier to understand.</b> Speech-to-text and text-to-speech have focused sections, model storage explains CPU and GPU weight files, and advanced connections stay collapsed until needed.'] },
   { version: '1.18.6', date: '2026-08-30', title: 'Cross-device sync moves to the newer engine', items: ['<b>Encrypted Sync now uses Evolu 8 by default.</b> Existing recovery words and relay identities carry forward automatically, while compatibility checks continue to exercise the previous client as a rollback path.', '<b>Sync recovery has stronger storage safeguards.</b> The app avoids stale rebroadcasts and preserves a complete snapshot when rebuilding relay history, reducing duplicate growth without dropping newer device changes.'] },
-  {
-    version: '1.18.2', date: '2026-08-28', title: 'WHOOP sync is current and securely stored',
+  { version: '1.18.2', date: '2026-08-28', title: 'WHOOP sync is current and securely stored',
     items: [
       '<b>Self-hosted WHOOP connections work with the current WHOOP API.</b> Recovery, sleep, strain, heart rate, and related daily readings once again line up with the correct day.',
       '<b>WHOOP data now has always-on device protection.</b> Imported rows and WHOOP-specific local profile values are AES-GCM encrypted even without an optional profile passphrase, and device-bound raw data stays out of portable backups.',

--- a/tests/api-provider-runtime.test.js
+++ b/tests/api-provider-runtime.test.js
@@ -96,6 +96,12 @@ describe('API provider runtime behavior', () => {
         },
         { id: 'openai/gpt-5.5', name: 'GPT 5.5' },
         {
+          id: 'anthropic/claude-fable-5.1',
+          name: 'Claude Fable 5.1',
+          pricing: { prompt: '0.000010', completion: '0.000050' },
+          architecture: { modality: 'text+image+file->text' },
+        },
+        {
           id: 'anthropic/claude-sonnet-4.6',
           name: 'Claude Sonnet 4.6',
           pricing: { prompt: '0.000003', completion: '0.000015' },
@@ -159,6 +165,7 @@ describe('API provider runtime behavior', () => {
       headers: { Authorization: 'Bearer sk-or' },
     });
     expect(models.map(m => m.id)).toEqual([
+      'anthropic/claude-fable-5.1',
       'anthropic/claude-sonnet-4.6',
       'anthropic/claude-sonnet-5',
       'google/gemini-3.5-flash',
@@ -170,6 +177,7 @@ describe('API provider runtime behavior', () => {
       'qwen/qwen3.8-27b',
     ]);
     expect(JSON.parse(localStorage.getItem('labcharts-openrouter-pricing'))).toMatchObject({
+      'anthropic/claude-fable-5.1': { input: 10, output: 50 },
       'anthropic/claude-sonnet-4.6': { input: 3, output: 15 },
       'anthropic/claude-sonnet-5': { input: 2, output: 10 },
       'google/gemini-3.5-flash': { input: 0.7, output: 3.75 },
@@ -180,6 +188,7 @@ describe('API provider runtime behavior', () => {
     });
     expect(JSON.parse(localStorage.getItem('labcharts-openrouter-pricing'))['qwen/qwen3.8-27b'].input).toBeCloseTo(0.4);
     expect(JSON.parse(localStorage.getItem('labcharts-openrouter-pricing'))['qwen/qwen3.8-27b'].output).toBe(3);
+    expect(JSON.parse(localStorage.getItem('labcharts-openrouter-vision-models'))).toContain('anthropic/claude-fable-5.1');
     expect(JSON.parse(localStorage.getItem('labcharts-openrouter-vision-models'))).toContain('anthropic/claude-sonnet-4.6');
     expect(JSON.parse(localStorage.getItem('labcharts-openrouter-vision-models'))).toContain('anthropic/claude-sonnet-5');
     expect(JSON.parse(localStorage.getItem('labcharts-openrouter-vision-models'))).toContain('google/gemini-3.5-flash');
@@ -215,6 +224,7 @@ describe('API provider runtime behavior', () => {
         { id: 'llama-3.1-8b', name: 'Llama', enabled: true, pricing: { prompt: '0.000001', completion: '0.000002' } },
         { id: 'claude-sonnet-4.6', name: 'Claude', enabled: true, pricing: { prompt: '0.000003', completion: '0.000015' }, architecture: { input_modalities: ['text', 'image'] } },
         { id: 'claude-sonnet-5', name: 'Claude 5', enabled: true, pricing: { prompt: '0.000002', completion: '0.000010' }, architecture: { input_modalities: ['text', 'image'] } },
+        { id: 'anthropic/claude-fable-5.1', name: 'Claude Fable 5.1', enabled: true, pricing: { prompt: '0.000010', completion: '0.000050' }, architecture: { input_modalities: ['text', 'image'] } },
         { id: 'z-ai/glm-5.3-flash', name: 'GLM 5.3 Flash', enabled: true, pricing: { prompt: '0.000000075', completion: '0.00000025' }, architecture: { input_modalities: ['text', 'image', 'video'] } },
         { id: 'claude-sonnet-4.6-20260101', name: 'Claude duplicate', enabled: true },
         { id: 'grok-41-fast', name: 'Grok 4.1 Fast', enabled: true, pricing: { prompt: '0.00000025', completion: '0.00000063' } },
@@ -229,10 +239,11 @@ describe('API provider runtime behavior', () => {
     const routstrModels = await fetchRoutstrModels();
 
     expect(fetch).toHaveBeenCalledWith('https://node.example.com/v1/models');
-    expect(routstrModels.map(m => m.id)).toEqual(['claude-sonnet-4.6', 'claude-sonnet-5', 'z-ai/glm-5.3-flash', 'grok-41-fast', 'x-ai/grok-4.3', 'moonshotai/kimi-k3', 'llama-3.1-8b', 'qwen/qwen3.8-27b']);
+    expect(routstrModels.map(m => m.id)).toEqual(['claude-sonnet-4.6', 'claude-sonnet-5', 'anthropic/claude-fable-5.1', 'z-ai/glm-5.3-flash', 'grok-41-fast', 'x-ai/grok-4.3', 'moonshotai/kimi-k3', 'llama-3.1-8b', 'qwen/qwen3.8-27b']);
     expect(localStorage.getItem('labcharts-routstr-model')).toBe('claude-sonnet-5');
     expect(JSON.parse(localStorage.getItem('labcharts-routstr-pricing'))['claude-sonnet-4.6']).toEqual({ input: 3, output: 15 });
     expect(JSON.parse(localStorage.getItem('labcharts-routstr-pricing'))['claude-sonnet-5']).toEqual({ input: 2, output: 10 });
+    expect(JSON.parse(localStorage.getItem('labcharts-routstr-pricing'))['anthropic/claude-fable-5.1']).toEqual({ input: 10, output: 50 });
     expect(JSON.parse(localStorage.getItem('labcharts-routstr-pricing'))['z-ai/glm-5.3-flash']).toEqual({ input: 0.075, output: 0.25 });
     expect(JSON.parse(localStorage.getItem('labcharts-routstr-pricing'))['x-ai/grok-4.3']).toEqual({ input: 3, output: 15 });
     expect(JSON.parse(localStorage.getItem('labcharts-routstr-pricing'))['moonshotai/kimi-k3']).toEqual({ input: 3, output: 15 });
@@ -240,6 +251,7 @@ describe('API provider runtime behavior', () => {
     expect(JSON.parse(localStorage.getItem('labcharts-routstr-pricing'))['qwen/qwen3.8-27b'].output).toBe(3);
     expect(JSON.parse(localStorage.getItem('labcharts-routstr-vision-models'))).toContain('claude-sonnet-4.6');
     expect(JSON.parse(localStorage.getItem('labcharts-routstr-vision-models'))).toContain('claude-sonnet-5');
+    expect(JSON.parse(localStorage.getItem('labcharts-routstr-vision-models'))).toContain('anthropic/claude-fable-5.1');
     expect(JSON.parse(localStorage.getItem('labcharts-routstr-vision-models'))).toContain('z-ai/glm-5.3-flash');
     expect(JSON.parse(localStorage.getItem('labcharts-routstr-vision-models'))).toContain('moonshotai/kimi-k3');
     expect(JSON.parse(localStorage.getItem('labcharts-routstr-vision-models'))).toContain('qwen/qwen3.8-27b');
@@ -248,6 +260,7 @@ describe('API provider runtime behavior', () => {
       data: [
         { id: 'perplexity/sonar', name: 'Sonar', pricing: { input_per_1M_tokens: '2', output_per_1M_tokens: '8' }, architecture: { modality: 'text->text' } },
         { id: 'claude-sonnet-4.6', name: 'Claude', pricing: { input_per_1M_tokens: '3', output_per_1M_tokens: '15' }, architecture: { modality: 'image->text' } },
+        { id: 'claude-fable-5.1', name: 'Claude Fable 5.1', pricing: { input_per_1M_tokens: '10', output_per_1M_tokens: '50' }, architecture: { modality: 'image->text' } },
         { id: 'claude-sonnet-5', name: 'Claude Sonnet 5', pricing: { input_per_1M_tokens: '2', output_per_1M_tokens: '10' }, architecture: { modality: 'image->text' } },
         { id: 'google/gemini-3.5-flash', name: 'Gemini 3.5 Flash', pricing: { input_per_1M_tokens: '0.7', output_per_1M_tokens: '3.75' }, architecture: { modality: 'image->text' } },
         { id: 'glm-5.3-flash', name: 'GLM 5.3 Flash', pricing: { input_per_1M_tokens: '0.08', output_per_1M_tokens: '0.26' }, architecture: { input_modalities: ['text', 'image', 'video'] } },
@@ -262,10 +275,11 @@ describe('API provider runtime behavior', () => {
 
     const ppqModels = await fetchPpqModels('sk-ppq');
 
-    expect(ppqModels.map(m => m.id)).toEqual(['claude-sonnet-4.6', 'claude-sonnet-5', 'google/gemini-3.5-flash', 'glm-5.3-flash', 'grok-4.20', 'x-ai/grok-4.3', 'moonshotai/kimi-k3', 'moonshotai/kimi-k2.7-code', 'qwen/qwen3.8-27b', 'perplexity/sonar']);
+    expect(ppqModels.map(m => m.id)).toEqual(['claude-sonnet-4.6', 'claude-fable-5.1', 'claude-sonnet-5', 'google/gemini-3.5-flash', 'glm-5.3-flash', 'grok-4.20', 'x-ai/grok-4.3', 'moonshotai/kimi-k3', 'moonshotai/kimi-k2.7-code', 'qwen/qwen3.8-27b', 'perplexity/sonar']);
     expect(localStorage.getItem('labcharts-ppq-model')).toBe('claude-sonnet-5');
     expect(JSON.parse(localStorage.getItem('labcharts-ppq-pricing'))['claude-sonnet-4.6']).toEqual({ input: 3, output: 15 });
     expect(JSON.parse(localStorage.getItem('labcharts-ppq-pricing'))['claude-sonnet-5']).toEqual({ input: 2, output: 10 });
+    expect(JSON.parse(localStorage.getItem('labcharts-ppq-pricing'))['claude-fable-5.1']).toEqual({ input: 10, output: 50 });
     expect(JSON.parse(localStorage.getItem('labcharts-ppq-pricing'))['google/gemini-3.5-flash']).toEqual({ input: 0.7, output: 3.75 });
     expect(JSON.parse(localStorage.getItem('labcharts-ppq-pricing'))['glm-5.3-flash']).toEqual({ input: 0.08, output: 0.26 });
     expect(JSON.parse(localStorage.getItem('labcharts-ppq-pricing'))['moonshotai/kimi-k2.7-code']).toEqual({ input: 0.56, output: 3.5 });
@@ -273,6 +287,7 @@ describe('API provider runtime behavior', () => {
     expect(JSON.parse(localStorage.getItem('labcharts-ppq-pricing'))['qwen/qwen3.8-27b']).toEqual({ input: 0.422, output: 3.165 });
     expect(JSON.parse(localStorage.getItem('labcharts-ppq-vision-models'))).toContain('claude-sonnet-4.6');
     expect(JSON.parse(localStorage.getItem('labcharts-ppq-vision-models'))).toContain('claude-sonnet-5');
+    expect(JSON.parse(localStorage.getItem('labcharts-ppq-vision-models'))).toContain('claude-fable-5.1');
     expect(JSON.parse(localStorage.getItem('labcharts-ppq-vision-models'))).toContain('google/gemini-3.5-flash');
     expect(JSON.parse(localStorage.getItem('labcharts-ppq-vision-models'))).toContain('glm-5.3-flash');
     expect(JSON.parse(localStorage.getItem('labcharts-ppq-vision-models'))).toContain('moonshotai/kimi-k3');
@@ -623,6 +638,8 @@ describe('API provider runtime behavior', () => {
     expect(needsMaxCompletionTokens('o3-mini')).toBe(true);
     expect(needsMaxCompletionTokens('anthropic/claude-sonnet-4.6')).toBe(false);
 
+    expect(isRecommendedModel('openrouter', 'anthropic/claude-fable-5.1')).toBe(true);
+    expect(isRecommendedModel('openrouter', 'anthropic/claude-fable-5')).toBe(false);
     expect(isRecommendedModel('openrouter', 'anthropic/claude-sonnet-5')).toBe(true);
     expect(isRecommendedModel('openrouter', 'anthropic/claude-sonnet-4.6')).toBe(true);
     expect(isRecommendedModel('openrouter', 'anthropic/claude-opus-5')).toBe(true);
@@ -641,6 +658,8 @@ describe('API provider runtime behavior', () => {
     expect(isRecommendedModel('openrouter', 'moonshotai/kimi-k2.6')).toBe(false);
     expect(isRecommendedModel('openrouter', 'moonshotai/kimi-k3')).toBe(true);
     expect(isRecommendedModel('openrouter', 'google/gemini-3.1-pro')).toBe(false);
+    expect(isRecommendedModel('venice', 'claude-fable-5-1')).toBe(true);
+    expect(isRecommendedModel('venice', 'claude-fable-5')).toBe(false);
     expect(isRecommendedModel('venice', 'claude-sonnet-5')).toBe(true);
     expect(isRecommendedModel('venice', 'claude-opus-5')).toBe(true);
     expect(isRecommendedModel('venice', 'claude-opus-4-8')).toBe(false);
@@ -661,6 +680,9 @@ describe('API provider runtime behavior', () => {
     expect(isRecommendedModel('venice', 'e2ee-qwen3-5-122b')).toBe(true);
     expect(isRecommendedModel('venice', 'e2ee-glm-5-3-flash-p')).toBe(true);
     expect(isRecommendedModel('venice', 'e2ee-glm-5-2-p')).toBe(false);
+    expect(isRecommendedModel('routstr', 'claude-fable-5.1')).toBe(true);
+    expect(isRecommendedModel('routstr', 'anthropic/claude-fable-5.1')).toBe(true);
+    expect(isRecommendedModel('routstr', 'claude-fable-5')).toBe(false);
     expect(isRecommendedModel('routstr', 'claude-sonnet-5')).toBe(true);
     expect(isRecommendedModel('routstr', 'claude-sonnet-4.6')).toBe(true);
     expect(isRecommendedModel('routstr', 'claude-opus-5')).toBe(true);
@@ -677,6 +699,9 @@ describe('API provider runtime behavior', () => {
     expect(isRecommendedModel('routstr', 'z-ai/glm-5.3')).toBe(false);
     expect(isRecommendedModel('routstr', 'moonshotai/kimi-k2.7-code')).toBe(false);
     expect(isRecommendedModel('routstr', 'moonshotai/kimi-k2.6')).toBe(false);
+    expect(isRecommendedModel('ppq', 'claude-fable-5.1')).toBe(true);
+    expect(isRecommendedModel('ppq', 'anthropic/claude-fable-5.1')).toBe(true);
+    expect(isRecommendedModel('ppq', 'claude-fable-5')).toBe(false);
     expect(isRecommendedModel('ppq', 'claude-sonnet-5')).toBe(true);
     expect(isRecommendedModel('ppq', 'claude-opus-5')).toBe(true);
     expect(isRecommendedModel('ppq', 'claude-opus-4.8')).toBe(false);
@@ -694,6 +719,9 @@ describe('API provider runtime behavior', () => {
     expect(isRecommendedModel('ppq', 'moonshotai/kimi-k2.6')).toBe(false);
     expect(isRecommendedModel('ppq', 'moonshotai/kimi-k3')).toBe(true);
     expect(isRecommendedModel('ppq', 'gemini-3-flash-preview')).toBe(true);
+    expect(isRecommendedModel('custom', 'claude-fable-5-1')).toBe(true);
+    expect(isRecommendedModel('custom', 'anthropic/claude-fable-5.1')).toBe(true);
+    expect(isRecommendedModel('custom', 'claude-fable-5')).toBe(false);
     expect(isRecommendedModel('custom', 'claude-sonnet-5')).toBe(true);
     expect(isRecommendedModel('custom', 'anthropic/claude-opus-5')).toBe(true);
     expect(isRecommendedModel('custom', 'anthropic/claude-opus-4.8')).toBe(false);
@@ -721,12 +749,15 @@ describe('API provider runtime behavior', () => {
       { id: 'openai-gpt-56-terra', name: 'GPT-5.6 Terra' },
     ]);
     expect(selectLatestRecommendedModels('openrouter', [
+      { id: 'anthropic/claude-fable-5', name: 'Claude Fable 5' },
+      { id: 'anthropic/claude-fable-5.1', name: 'Claude Fable 5.1' },
       { id: 'google/gemini-3.5-flash', name: 'Gemini 3.5 Flash' },
       { id: 'google/gemini-3.6-flash', name: 'Gemini 3.6 Flash' },
       { id: 'google/gemini-3.7-flash', name: 'Gemini 3.7 Flash' },
       { id: 'z-ai/glm-5.2', name: 'GLM 5.2' },
       { id: 'z-ai/glm-5.3-flash', name: 'GLM 5.3 Flash' },
     ])).toEqual([
+      { id: 'anthropic/claude-fable-5.1', name: 'Claude Fable 5.1' },
       { id: 'google/gemini-3.7-flash', name: 'Gemini 3.7 Flash' },
       { id: 'z-ai/glm-5.3-flash', name: 'GLM 5.3 Flash' },
     ]);

--- a/tests/playwright/provider-coverage-batch.spec.js
+++ b/tests/playwright/provider-coverage-batch.spec.js
@@ -166,6 +166,7 @@ test('provider model controls cover dropdowns custom models and delegates', asyn
       }));
       localStorage.setItem('labcharts-openrouter-model', 'anthropic/claude-sonnet-4.6');
       controls.renderOpenRouterModelDropdown([
+        { id: 'anthropic/claude-fable-5.1', name: 'Claude Fable 5.1' },
         { id: 'google/gemini-3.5-flash', name: 'Gemini 3.5 Flash' },
         { id: 'google/gemini-3.1-pro', name: 'Gemini 3.1 Pro' },
         { id: 'z-ai/glm-5.3-flash', name: 'GLM 5.3 Flash' },
@@ -180,7 +181,8 @@ test('provider model controls cover dropdowns custom models and delegates', asyn
         { id: 'qwen/qwen3.8-27b', name: 'Qwen3.8 27B' },
       ]);
       const openRouterRecommendedGroup = document.querySelector('#openrouter-model-select optgroup[label="Recommended"]');
-      const openRouterRecommended = !!openRouterRecommendedGroup?.querySelector('option[value="anthropic/claude-sonnet-5"]')
+      const openRouterRecommended = !!openRouterRecommendedGroup?.querySelector('option[value="anthropic/claude-fable-5.1"]')
+        && !!openRouterRecommendedGroup?.querySelector('option[value="anthropic/claude-sonnet-5"]')
         && !!openRouterRecommendedGroup?.querySelector('option[value="google/gemini-3.5-flash"]')
         && !!openRouterRecommendedGroup?.querySelector('option[value="z-ai/glm-5.3-flash"]')
         && !!openRouterRecommendedGroup?.querySelector('option[value="moonshotai/kimi-k3"]')
@@ -243,7 +245,13 @@ test('provider model controls cover dropdowns custom models and delegates', asyn
       localStorage.setItem('labcharts-venice-model', 'regular-a');
       localStorage.setItem('labcharts-venice-models', JSON.stringify([{ id: 'regular-a', name: 'Regular A' }]));
       localStorage.setItem('labcharts-venice-e2ee-models', JSON.stringify([{ id: 'e2ee-secure', name: 'Secure E2EE' }]));
-      controls.renderVeniceModelDropdown([{ id: 'regular-a', name: 'Regular A' }]);
+      controls.renderVeniceModelDropdown([
+        { id: 'regular-a', name: 'Regular A' },
+        { id: 'claude-fable-5-1', name: 'Claude Fable 5.1' },
+      ]);
+      const veniceFableRecommended = !!document.querySelector(
+        '#venice-model-select optgroup[label="Recommended"] option[value="claude-fable-5-1"]'
+      );
       controls.toggleVeniceE2EE(true);
       const veniceE2EEEnabled = localStorage.getItem('labcharts-venice-e2ee') === 'on'
         && localStorage.getItem('labcharts-venice-model') === 'e2ee-secure'
@@ -263,6 +271,7 @@ test('provider model controls cover dropdowns custom models and delegates', asyn
       const routstrFallback = localStorage.getItem('labcharts-routstr-model') === 'routstr-a'
         && document.getElementById('routstr-model-select')?.value === 'routstr-a';
       controls.renderRoutstrModelDropdown([
+        { id: 'anthropic/claude-fable-5.1', name: 'Claude Fable 5.1' },
         { id: 'grok-41-fast', name: 'Grok 4.1 Fast' },
         { id: 'x-ai/grok-4.3', name: 'Grok 4.3' },
         { id: 'z-ai/glm-5.3-flash', name: 'GLM 5.3 Flash' },
@@ -272,7 +281,8 @@ test('provider model controls cover dropdowns custom models and delegates', asyn
         { id: 'moonshotai/kimi-k2.7-code', name: 'Kimi K2.7 Code' },
       ]);
       const routstrRecommendedGroup = document.querySelector('#routstr-model-select optgroup[label="Recommended"]');
-      const routstrLatestGrokRecommended = !!routstrRecommendedGroup?.querySelector('option[value="x-ai/grok-4.3"]')
+      const routstrLatestGrokRecommended = !!routstrRecommendedGroup?.querySelector('option[value="anthropic/claude-fable-5.1"]')
+        && !!routstrRecommendedGroup?.querySelector('option[value="x-ai/grok-4.3"]')
         && !!routstrRecommendedGroup?.querySelector('option[value="z-ai/glm-5.3-flash"]')
         && !!routstrRecommendedGroup?.querySelector('option[value="moonshotai/kimi-k3"]')
         && !routstrRecommendedGroup?.querySelector('option[value="grok-41-fast"]')
@@ -289,6 +299,7 @@ test('provider model controls cover dropdowns custom models and delegates', asyn
       controls.renderPpqModelDropdown([
         { id: 'ppq-a', name: 'PPQ A' },
         { id: 'ppq-b', name: 'PPQ B' },
+        { id: 'claude-fable-5.1', name: 'Claude Fable 5.1' },
         { id: 'gemini-3-flash-preview', name: 'Gemini 3 Flash Preview' },
         { id: 'google/gemini-3.5-flash', name: 'Gemini 3.5 Flash' },
         { id: 'glm-5.3-flash', name: 'GLM 5.3 Flash' },
@@ -301,7 +312,8 @@ test('provider model controls cover dropdowns custom models and delegates', asyn
         { id: 'x-ai/grok-4.3', name: 'Grok 4.3' },
       ]);
       const ppqRecommendedGroup = document.querySelector('#ppq-model-select optgroup[label="Recommended"]');
-      const ppqLatestGrokRecommended = !!ppqRecommendedGroup?.querySelector('option[value="x-ai/grok-4.3"]')
+      const ppqLatestGrokRecommended = !!ppqRecommendedGroup?.querySelector('option[value="claude-fable-5.1"]')
+        && !!ppqRecommendedGroup?.querySelector('option[value="x-ai/grok-4.3"]')
         && !ppqRecommendedGroup?.querySelector('option[value="grok-4.20"]')
         && !!document.querySelector('#ppq-model-select optgroup[label="Other models"] option[value="grok-4.20"]');
       const ppqLatestGeminiRecommended = !!ppqRecommendedGroup?.querySelector('option[value="google/gemini-3.5-flash"]')
@@ -324,6 +336,7 @@ test('provider model controls cover dropdowns custom models and delegates', asyn
       localStorage.setItem('labcharts-custom-model', 'outside-model');
       controls.renderCustomApiModelDropdown([
         { id: 'model-a', name: 'Model A' },
+        { id: 'claude-fable-5-1', name: 'Claude Fable 5.1' },
         { id: 'z-ai/glm-5.3-flash', name: 'GLM 5.3 Flash' },
         { id: 'z-ai/glm-5.3', name: 'GLM 5.3' },
         { id: 'z-ai/glm-5.2', name: 'GLM 5.2' },
@@ -332,7 +345,8 @@ test('provider model controls cover dropdowns custom models and delegates', asyn
         { id: 'moonshotai/kimi-k2.6', name: 'Kimi K2.6' },
       ]);
       const customRecommendedGroup = document.querySelector('#custom-model-select optgroup[label="Recommended"]');
-      const customGlmKimiRecommended = !!customRecommendedGroup?.querySelector('option[value="z-ai/glm-5.3-flash"]')
+      const customGlmKimiRecommended = !!customRecommendedGroup?.querySelector('option[value="claude-fable-5-1"]')
+        && !!customRecommendedGroup?.querySelector('option[value="z-ai/glm-5.3-flash"]')
         && !!customRecommendedGroup?.querySelector('option[value="moonshotai/kimi-k3"]')
         && !customRecommendedGroup?.querySelector('option[value="z-ai/glm-5.3"]')
         && !customRecommendedGroup?.querySelector('option[value="z-ai/glm-5.2"]')
@@ -392,6 +406,7 @@ test('provider model controls cover dropdowns custom models and delegates', asyn
         openRouterCustomApplied,
         openRouterCustomFailure,
         openRouterDropdownReset,
+        veniceFableRecommended,
         veniceE2EEEnabled,
         veniceE2EERestored,
         routstrFallback,

--- a/tests/test-biology-scores.js
+++ b/tests/test-biology-scores.js
@@ -696,21 +696,23 @@ assert('filterDatesByRange defaults to an honest empty timeframe instead of sile
     && Object.values(defaultOldOnly.categories).every(cat =>
       Object.values(cat.markers || {}).every(marker => marker.singlePoint || marker.values.length === 0)
     ));
+const oldContextDate = new Date(Date.now() - (400 * 86400000)).toISOString().slice(0, 10);
+const recentContextDate = new Date(Date.now() - (30 * 86400000)).toISOString().slice(0, 10);
 const contextFilteredData = {
-  dates: ['2025-01-01', '2026-06-01'],
-  dateLabels: ['Jan 2025', 'Jun 2026'],
+  dates: [oldContextDate, recentContextDate],
+  dateLabels: ['Older draw', 'Recent draw'],
   entryContextByDate: {
-    '2025-01-01': { sampleTime: '23:00', cyclePhase: 'follicular' },
-    '2026-06-01': { sampleTime: '08:30', cyclePhase: 'luteal', hormoneTherapy: true },
+    [oldContextDate]: { sampleTime: '23:00', cyclePhase: 'follicular' },
+    [recentContextDate]: { sampleTime: '08:30', cyclePhase: 'luteal', hormoneTherapy: true },
   },
   categories: { hormones: { label: 'Hormones', markers: { cortisol: { name: 'Cortisol', values: [500, 320] } } } },
 };
 const contextFiltered = filterDatesByRange(contextFilteredData, { fallbackToAll: false });
 assert('filterDatesByRange preserves per-draw entry context for active timeframe scoring',
-  contextFiltered.entryContextByDate?.['2026-06-01']?.sampleTime === '08:30'
-    && contextFiltered.entryContextByDate?.['2026-06-01']?.cyclePhase === 'luteal'
-    && contextFiltered.entryContextByDate?.['2026-06-01']?.hormoneTherapy === true
-    && !contextFiltered.entryContextByDate?.['2025-01-01'],
+  contextFiltered.entryContextByDate?.[recentContextDate]?.sampleTime === '08:30'
+    && contextFiltered.entryContextByDate?.[recentContextDate]?.cyclePhase === 'luteal'
+    && contextFiltered.entryContextByDate?.[recentContextDate]?.hormoneTherapy === true
+    && !contextFiltered.entryContextByDate?.[oldContextDate],
   JSON.stringify(contextFiltered.entryContextByDate));
 state.importedData.biologyScoreContextAI = { summary: 'Context checked for filtered tests', suggestions: [], fingerprint: buildBiologyScoreContextFingerprint(strictOldOnly), range: state.dateRangeFilter, updatedAt: Date.now() };
 const timeframeLimitedHtml = renderDashboardBiologicalCoherenceWidget({ data: oldOnlyData });

--- a/tests/test-custom-api.js
+++ b/tests/test-custom-api.js
@@ -57,6 +57,7 @@ assert('hasAIProvider custom requires URL', apiProviderStorageSrc.includes("hasC
 assert('getActiveModelId handles custom', apiModelsSrc.includes("provider === 'custom') return getCustomApiModel()"));
 assert('getActiveModelDisplay handles custom', apiModelsSrc.includes("provider === 'custom') return getCustomApiModelDisplay()"));
 assert('isRecommendedModel handles custom Sonnet 5', apiModelsSrc.includes("provider === 'custom'") && apiModelsSrc.includes('isCustomRecommendedModel'));
+assert('isRecommendedModel handles custom Fable 5.1', apiModelsSrc.includes('isClaudeFable51Model'));
 assert('isRecommendedModel handles custom GLM 5.3 Flash and Kimi K3', apiModelsSrc.includes('glm-5-3-flash') && apiModelsSrc.includes('kimi-k3'));
 assert('callClaudeAPI handles custom', apiSrc.includes("provider === 'custom') return callCustomAPI("));
 assert('supportsWebSearch false for custom', apiModelsSrc.includes("provider === 'custom') return false"));

--- a/tests/test-openrouter.js
+++ b/tests/test-openrouter.js
@@ -80,6 +80,7 @@ assert('Has openrouter _default fallback', schemaSrc.includes("'_default':") && 
 assert('getModelPricing checks openrouter-pricing cache', schemaSrc.includes('labcharts-openrouter-pricing'));
 assert('OPENROUTER_CURATED whitelist exists', apiModelsSrc.includes('OPENROUTER_CURATED'));
 assert('Curated: anthropic/claude-sonnet-5 prefix', apiModelsSrc.includes("'anthropic/claude-sonnet-5'"));
+assert('Curated and recommended: Claude Fable 5.1', apiModelsSrc.includes("'anthropic/claude-fable-5'") && apiModelsSrc.includes("'anthropic/claude-fable-5.1'"));
 assert('Curated: anthropic/claude-sonnet prefix', apiModelsSrc.includes("'anthropic/claude-sonnet-4'"));
 assert('Curated: anthropic/claude-opus-5 prefix', apiModelsSrc.includes("'anthropic/claude-opus-5'"));
 assert('Curated: anthropic/claude-opus prefix', apiModelsSrc.includes("'anthropic/claude-opus-4'"));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.18.7';
+self.APP_VERSION = '1.18.8';


### PR DESCRIPTION
## Summary
- recognize Claude Fable 5.1 as recommended across OpenRouter, Venice, Routstr, PPQ, and compatible custom providers
- accept each provider's live model ID format while keeping Fable 5 out of the Recommended group
- widen routed-provider Claude catalog filters and add release notes for 1.18.8

## Verification
- npm test -- tests/api-provider-runtime.test.js
- node tests/test-openrouter.js
- node tests/test-custom-api.js
- PLAYWRIGHT_REUSE_SERVER=1 npx playwright test tests/playwright/provider-coverage-batch.spec.js --grep "provider model controls cover dropdowns" --workers=1
- npm run typecheck
- npm run typecheck:checkjs
- npm run typecheck:strict-null
- npm run production:check
- npm run quality
- node tests/test-audit.js