### PR TITLE
ci: test sync against relay v2.0.0

### DIFF
--- a/.github/workflows/sync-compat.yml
+++ b/.github/workflows/sync-compat.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: elkimek/getbased-relay
-          ref: 256261261c9422d803623da219820d341fbc01f0
+          ref: 6f237533344308a3032cfb996e3138216d8f454d
           path: .ci/getbased-relay
           persist-credentials: false
 


### PR DESCRIPTION
## Summary

- pin the disposable sync-compatibility relay to the released getbased-relay v2.0.0 commit (`6f237533344308a3032cfb996e3138216d8f454d`)
- exercise both the Evolu 7 rollback client and Evolu 8 default client against the exact production candidate

## Verification

The same real-relay transport scenarios were run locally against v2.0.0 before opening this PR. Both v7 and v8 passed convergence, no-op storage stability, offline recovery, relay compaction/rebuild, and mnemonic restore.