### PR TITLE
fix(companion): restore safe management from hosted chat

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -9,8 +9,8 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 
 | Metric | Current |
 | --- | ---: |
-| Modules | 757 |
-| Internal import edges | 3193 |
+| Modules | 758 |
+| Internal import edges | 3194 |
 | Dynamic internal edges | 105 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -1491,10 +1491,11 @@ Node-only policy and transport code shared by hosted runtimes.
 
 </details>
 
-<details><summary><code>companion</code> family — 4 modules</summary>
+<details><summary><code>companion</code> family — 5 modules</summary>
 
 - [`lib/companion-existing.js`](lib/companion-existing.js) → no in-scope imports
 - [`lib/companion-install.js`](lib/companion-install.js) → [`lib/linux-companion-install.js`](lib/linux-companion-install.js), [`lib/macos-companion-install.js`](lib/macos-companion-install.js), [`lib/windows-companion-install.js`](lib/windows-companion-install.js)
+- [`lib/companion-listener.js`](lib/companion-listener.js) → no in-scope imports
 - [`lib/companion-management.js`](lib/companion-management.js) → no in-scope imports
 - [`lib/companion-runtime-control.js`](lib/companion-runtime-control.js) → [`lib/companion-install.js`](lib/companion-install.js), [`shared/agent-host-protocol.js`](shared/agent-host-protocol.js)
 
@@ -1607,7 +1608,7 @@ Standalone loopback companion for installed CLI agents.
 
 <details><summary><code>agent</code> family — 1 module</summary>
 
-- [`server/agent-host-server.js`](server/agent-host-server.js) → [`lib/acp-agent-client.js`](lib/acp-agent-client.js), [`lib/agent-host-service.js`](lib/agent-host-service.js), [`lib/agent-host-storage.js`](lib/agent-host-storage.js), [`lib/claude-agent-client.js`](lib/claude-agent-client.js), [`lib/codex-agent-isolation.js`](lib/codex-agent-isolation.js), [`lib/codex-app-server-client.js`](lib/codex-app-server-client.js), [`lib/companion-runtime-control.js`](lib/companion-runtime-control.js), [`lib/hermes-gateway-client.js`](lib/hermes-gateway-client.js), [`lib/local-agent-registry.js`](lib/local-agent-registry.js), [`lib/openclaw-agent-client.js`](lib/openclaw-agent-client.js)
+- [`server/agent-host-server.js`](server/agent-host-server.js) → [`lib/acp-agent-client.js`](lib/acp-agent-client.js), [`lib/agent-host-service.js`](lib/agent-host-service.js), [`lib/agent-host-storage.js`](lib/agent-host-storage.js), [`lib/claude-agent-client.js`](lib/claude-agent-client.js), [`lib/codex-agent-isolation.js`](lib/codex-agent-isolation.js), [`lib/codex-app-server-client.js`](lib/codex-app-server-client.js), [`lib/companion-listener.js`](lib/companion-listener.js), [`lib/companion-runtime-control.js`](lib/companion-runtime-control.js), [`lib/hermes-gateway-client.js`](lib/hermes-gateway-client.js), [`lib/local-agent-registry.js`](lib/local-agent-registry.js), [`lib/openclaw-agent-client.js`](lib/openclaw-agent-client.js)
 
 </details>
 

--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -9,8 +9,8 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 
 | Metric | Current |
 | --- | ---: |
-| Modules | 755 |
-| Internal import edges | 3191 |
+| Modules | 757 |
+| Internal import edges | 3193 |
 | Dynamic internal edges | 105 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -1472,7 +1472,7 @@ Node-only policy and transport code shared by hosted runtimes.
 
 - [`lib/agent-host-boundary.js`](lib/agent-host-boundary.js) → [`shared/agent-tool-contract.js`](shared/agent-tool-contract.js)
 - [`lib/agent-host-external-turn.js`](lib/agent-host-external-turn.js) → no in-scope imports
-- [`lib/agent-host-service.js`](lib/agent-host-service.js) → [`lib/agent-host-boundary.js`](lib/agent-host-boundary.js), [`lib/agent-host-external-turn.js`](lib/agent-host-external-turn.js), [`shared/agent-host-protocol.js`](shared/agent-host-protocol.js)
+- [`lib/agent-host-service.js`](lib/agent-host-service.js) → [`lib/agent-host-boundary.js`](lib/agent-host-boundary.js), [`lib/agent-host-external-turn.js`](lib/agent-host-external-turn.js), [`lib/companion-management.js`](lib/companion-management.js), [`shared/agent-host-protocol.js`](shared/agent-host-protocol.js)
 - [`lib/agent-host-storage.js`](lib/agent-host-storage.js) → no in-scope imports
 - [`lib/agent-mcp-bridge.js`](lib/agent-mcp-bridge.js) → no in-scope imports
 
@@ -1491,9 +1491,11 @@ Node-only policy and transport code shared by hosted runtimes.
 
 </details>
 
-<details><summary><code>companion</code> family — 2 modules</summary>
+<details><summary><code>companion</code> family — 4 modules</summary>
 
+- [`lib/companion-existing.js`](lib/companion-existing.js) → no in-scope imports
 - [`lib/companion-install.js`](lib/companion-install.js) → [`lib/linux-companion-install.js`](lib/linux-companion-install.js), [`lib/macos-companion-install.js`](lib/macos-companion-install.js), [`lib/windows-companion-install.js`](lib/windows-companion-install.js)
+- [`lib/companion-management.js`](lib/companion-management.js) → no in-scope imports
 - [`lib/companion-runtime-control.js`](lib/companion-runtime-control.js) → [`lib/companion-install.js`](lib/companion-install.js), [`shared/agent-host-protocol.js`](shared/agent-host-protocol.js)
 
 </details>
@@ -1615,7 +1617,7 @@ Install and control the Linux user-level agent companion.
 
 <details><summary><code>getbased</code> family — 1 module</summary>
 
-- [`bin/getbased-companion.js`](bin/getbased-companion.js) → [`lib/agent-mcp-bridge.js`](lib/agent-mcp-bridge.js), [`lib/companion-install.js`](lib/companion-install.js), [`server/agent-host-server.js`](server/agent-host-server.js) *(dynamic)*
+- [`bin/getbased-companion.js`](bin/getbased-companion.js) → [`lib/agent-mcp-bridge.js`](lib/agent-mcp-bridge.js), [`lib/companion-existing.js`](lib/companion-existing.js), [`lib/companion-install.js`](lib/companion-install.js), [`server/agent-host-server.js`](server/agent-host-server.js) *(dynamic)*
 
 </details>
 

--- a/bin/getbased-companion.js
+++ b/bin/getbased-companion.js
@@ -7,6 +7,7 @@ import {
   companionPlatformName, installCompanion, runCompanionServiceCommand, uninstallCompanion,
 } from '../lib/companion-install.js';
 import { runAgentMCPBridge } from '../lib/agent-mcp-bridge.js';
+import { findExistingCompanion } from '../lib/companion-existing.js';
 
 const HELP = `getbased Companion
 
@@ -32,6 +33,13 @@ export async function main(args, options = {}) {
     return;
   }
   if (command === 'run') {
+    if (process.env.GETBASED_COMPANION_SERVICE !== '1') {
+      const existing = await findExistingCompanion();
+      if (existing) {
+        process.stdout.write(`getbased Companion is already running at ${existing.endpoint}. No second process was started.\nReturn to getbased and select Check connection.\nLocal management (current Companion versions): ${existing.endpoint}/manage\nStopping this command does not stop the existing Companion.\n`);
+        return;
+      }
+    }
     await import('../server/agent-host-server.js');
     return;
   }

--- a/docs/agent-chat-architecture.md
+++ b/docs/agent-chat-architecture.md
@@ -201,9 +201,11 @@ A hosted browser cannot start an operating-system process. The production
 build therefore emits a single dependency-free `getbased-companion.mjs`
 download. When no companion is detected, **Settings → AI → CLI agents** shows
 one bootstrap command for the detected operating system. It runs the bundle for
-the current Terminal or PowerShell session. Once that authenticated loopback
-connection exists, the page can register or remove automatic startup directly;
-there is no second installation command in the normal flow. Linux and macOS use
+the current Terminal or PowerShell session. A temporary bootstrap first checks
+for an existing Companion in the bounded port range and exits without launching
+a duplicate when one is found. Hosted discovery remains chat-only. Companion
+1.3.0 advertises `companion-management`; **Manage Companion** opens a separate
+numeric-loopback page for installation and lifecycle controls. Linux and macOS use
 a POSIX-shell command and Windows uses PowerShell. The command downloads the
 bundle from the same getbased origin the user has open, so it does not require a
 repository checkout or npm. A separate start command remains available for
@@ -232,15 +234,15 @@ standard-library APIs. A real cross-platform tray requires a GUI runtime such
 as Electron or Tauri and platform-specific icon/application packaging. That is
 an optional desktop shell, not part of the headless companion: making it the
 only distribution would reintroduce unsigned-app warnings and a much larger
-download. Companion state and lifecycle controls should first be exposed in
-getbased Settings; a tray shell can consume the same local control protocol
-later without changing the health-data or agent boundaries.
+download. Settings links to the local management page; a future tray shell
+must preserve the same health-data and management authorization boundaries.
 
 After installation, the service starts at login and the hosted PWA discovers
-it through the same origin-gated loopback protocol. Authenticated Settings
-controls can pause or resume new AI work, restart agent subprocesses,
-register automatic startup, update the installed bundle from the active
-getbased HTTPS origin, and remove automatic startup. Destructive lifecycle
+it through the same origin-gated loopback protocol. Local management and
+installation-authorized development controls can pause or resume new AI work,
+restart agent subprocesses, register automatic startup, update the installed
+bundle from the fixed official getbased HTTPS URL, and remove startup. Hosted
+discovery credentials cannot invoke those actions. Destructive lifecycle
 actions are rejected while an agent turn is active. Updates are bounded and
 validated as companion bundles before replacing the installed copy; they take
 effect on the next companion start. The CLI also supports `start`, `stop`,
@@ -270,6 +272,23 @@ origin must be explicitly listed in the comma-separated
 `GETBASED_AGENT_HOST_ALLOWED_ORIGINS` environment variable.
 
 ## Companion protocol and upgrades
+
+### Local management authorization
+
+The management page requires top-level browser navigation and rejects frames
+and cross-origin fetches. It has no CORS permission, uses a nonce CSP with
+`frame-ancestors 'none'`, checks the exact numeric-loopback Host, and issues an
+in-memory, 15-minute token (maximum eight sessions). Its status/control endpoints
+require that token and same-origin Fetch Metadata; mutation requests additionally
+require the exact Origin and JSON. No installation token is embedded or passed
+back to the hosted app. It reuses the existing action allowlist and active-turn
+guards. Opening the page performs no lifecycle mutation; each control requires
+a user action, with confirmation for installation, update, restart, and removal.
+State distinguishes an installed login configuration from the current terminal
+or background-service process. After registering startup from a terminal,
+Restart companion releases that listener before handing over to the service.
+
+### Capability negotiation
 
 The companion advertises a numeric protocol version, companion version,
 runtime mode, and named capabilities

--- a/js/settings-cli-agent-panel.js
+++ b/js/settings-cli-agent-panel.js
@@ -369,7 +369,7 @@ function renderDetectedAgent(agent) {
     </div>`;
 }
 
-/** @param {{status: string, paused?: boolean, runtimeMode?: string, companionVersion?: string, capabilities?: string[], controlAuthorized?: boolean}} agent */
+/** @param {{status: string, endpoint?: string, paused?: boolean, runtimeMode?: string, companionVersion?: string, capabilities?: string[], controlAuthorized?: boolean}} agent */
 function renderCompanionControls(agent) {
   const paused = agent.status === 'paused' || agent.paused === true;
   const installed = agent.runtimeMode === 'installed';
@@ -389,9 +389,18 @@ function renderCompanionControls(agent) {
   }
   const modeLabel = installed ? 'Starts automatically at login' : 'Connected for this terminal session';
   if (agent.controlAuthorized === false) {
+    const managementURL = new URL(agent.endpoint || getAgentHostEndpoint());
+    managementURL.hostname = '127.0.0.1';
+    managementURL.pathname = '/manage';
+    managementURL.search = '';
+    managementURL.hash = '';
+    const managementLink = agent.capabilities?.includes(AGENT_HOST_CAPABILITIES.COMPANION_MANAGEMENT)
+      ? `<a class="import-btn import-btn-primary settings-mini-btn" href="${escapeAttr(managementURL.href)}" target="_blank" rel="noopener noreferrer">Manage Companion</a>` : '';
     return `<div class="local-agent-list-kicker local-agent-companion-kicker">Companion</div>
     <div class="local-agent-controls"><div class="local-agent-controls-copy"><strong>Connected for chat</strong>
-    <span>Manage startup, pause, restart, or uninstall from the Companion tray or terminal. Browser discovery does not grant installation controls.</span></div>
+    <span>${escapeHTML(modeLabel)} · ${escapeHTML(managementURL.host)}${agent.companionVersion ? ` · v${escapeHTML(agent.companionVersion)}` : ''}</span>
+    <span>${managementLink ? 'Open local management for startup, pause, restart, update, or uninstall. Hosted chat does not receive installation permissions.' : 'Update Companion to enable its local management page. Until then, manage it from the terminal.'}</span></div>
+    ${managementLink}
     <button type="button" class="import-btn settings-mini-btn" data-settings-action="copy-cli-companion-update">Copy update command</button></div>`;
   }
   return `<div class="local-agent-list-kicker local-agent-companion-kicker">Companion</div>

--- a/lib/agent-host-service.js
+++ b/lib/agent-host-service.js
@@ -8,6 +8,7 @@ import {
   AGENT_HOST_CAPABILITY_LIST, AGENT_HOST_PROTOCOL_VERSION,
 } from '../shared/agent-host-protocol.js';
 import { startExternalAgentTurn } from './agent-host-external-turn.js';
+import { createCompanionManagement } from './companion-management.js';
 import {
   AGENT_BASE_INSTRUCTIONS, DEFAULT_TOOL_TIMEOUT_MS, DISCOVERY_SESSION_TTL_MS,
   IMAGE_EXTENSIONS, MAX_DISCOVERY_SESSIONS, MAX_IMAGE_BYTES, MAX_IMAGES_PER_TURN,
@@ -257,8 +258,40 @@ export function createAgentHostService(options) {
     ...(options.runtimeInfo?.() || {}),
   });
 
+  /** @param {Request} request @param {Record<string, string>} [cors] */
+  async function executeControl(request, cors = {}) {
+    let body;
+    try { body = await readJson(request); } catch (error) {
+      return jsonResponse({ error: cleanError(error) }, 400, cors);
+    }
+    const action = String(body.action || '');
+    if (!['pause', 'resume', 'install', 'restart', 'restart-companion', 'update', 'uninstall'].includes(action)) {
+      return jsonResponse({ error: 'unsupported_control_action' }, 400, cors);
+    }
+    if (['pause', 'install', 'restart', 'restart-companion', 'update', 'uninstall'].includes(action) && startingOrActiveTurns.size) {
+      return jsonResponse({ error: 'finish_the_active_response_first' }, 409, cors);
+    }
+    if (action === 'pause' || action === 'resume') {
+      paused = action === 'pause';
+      return jsonResponse(statusPayload(), 200, cors);
+    }
+    if (!options.controlHandler) return jsonResponse({ error: 'companion_control_unavailable' }, 501, cors);
+    try {
+      const result = await options.controlHandler(
+        /** @type {'install'|'restart'|'restart-companion'|'update'|'uninstall'} */ (action),
+        { origin: request.headers.get('Origin') || '' },
+      );
+      return jsonResponse({ ...statusPayload(), ...result }, 200, cors);
+    } catch (error) {
+      return jsonResponse({ error: cleanError(error) }, 500, cors);
+    }
+  }
+  const manage = createCompanionManagement({ status: statusPayload, control: executeControl });
+
   /** @param {Request} request */
   async function handleRequest(request) {
+    const managementResponse = await manage(request);
+    if (managementResponse) return managementResponse;
     const cors = corsHeaders(request, allowedOrigins);
     const origin = request.headers.get('Origin');
     if (origin && !isAllowedAgentHostOrigin(origin, allowedOrigins)) return jsonResponse({ error: 'origin_not_allowed' }, 403);
@@ -340,31 +373,7 @@ export function createAgentHostService(options) {
       if (!tokenMatches(receivedToken, token) || !isLoopbackOrigin(origin)) {
         return jsonResponse({ error: 'companion_control_requires_installation_token' }, 403, cors);
       }
-      let body;
-      try { body = await readJson(request); } catch (error) {
-        return jsonResponse({ error: cleanError(error) }, 400, cors);
-      }
-      const action = String(body.action || '');
-      if (!['pause', 'resume', 'install', 'restart', 'restart-companion', 'update', 'uninstall'].includes(action)) {
-        return jsonResponse({ error: 'unsupported_control_action' }, 400, cors);
-      }
-      if (['pause', 'restart', 'restart-companion', 'update', 'uninstall'].includes(action) && startingOrActiveTurns.size) {
-        return jsonResponse({ error: 'finish_the_active_response_first' }, 409, cors);
-      }
-      if (action === 'pause' || action === 'resume') {
-        paused = action === 'pause';
-        return jsonResponse(statusPayload(), 200, cors);
-      }
-      if (!options.controlHandler) return jsonResponse({ error: 'companion_control_unavailable' }, 501, cors);
-      try {
-        const result = await options.controlHandler(
-          /** @type {'install'|'restart'|'restart-companion'|'update'|'uninstall'} */ (action),
-          { origin: origin || '' },
-        );
-        return jsonResponse({ ...statusPayload(), ...result }, 200, cors);
-      } catch (error) {
-        return jsonResponse({ error: cleanError(error) }, 500, cors);
-      }
+      return executeControl(request, cors);
     }
     if (url.pathname === '/v1/uploads' && request.method === 'POST') {
       if (paused) return jsonResponse({ error: 'companion_paused' }, 503, cors);

--- a/lib/companion-existing.js
+++ b/lib/companion-existing.js
@@ -1,0 +1,33 @@
+// @ts-check
+// A temporary bootstrap must not create a second bridge beside a login service.
+/** @param {{env?: NodeJS.ProcessEnv, fetchImpl?: typeof fetch}} [options] */
+export async function findExistingCompanion(options = {}) {
+  const env = options.env || process.env;
+  const fetchImpl = options.fetchImpl || fetch;
+  const explicit = String(env.GETBASED_AGENT_HOST_PORT || '').trim();
+  const port = Number(explicit || 8324);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) return null;
+  const ports = explicit ? [port] : Array.from({ length: 8 }, (_, index) => 8324 + index);
+  for (const candidate of ports) {
+    const endpoint = `http://127.0.0.1:${candidate}`;
+    try {
+      const response = await fetchImpl(`${endpoint}/health`, { redirect: 'error', signal: AbortSignal.timeout(300) });
+      if (!response.ok || !response.body) continue;
+      const reader = response.body.getReader();
+      const chunks = [];
+      let size = 0;
+      try {
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          size += value.byteLength;
+          if (size > 4096) throw new Error('Unexpected health response');
+          chunks.push(value);
+        }
+      } finally { await reader.cancel(); }
+      const data = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+      if (data.ok === true && data.service === 'getbased-agent-host') return { endpoint };
+    } catch { /* An unrelated or unavailable listener is not a Companion. */ }
+  }
+  return null;
+}

--- a/lib/companion-listener.js
+++ b/lib/companion-listener.js
@@ -1,0 +1,35 @@
+// @ts-check
+/**
+ * Restore a suspended listener, with a bounded port fallback and cleanup on
+ * every completion path. The caller suspends its normal startup error handler.
+ * @param {import('node:http').Server} server
+ * @param {{host: string, port: number, lastPort: number, onPort: (port: number) => void}} options
+ */
+export function recoverCompanionListener(server, options) {
+  return new Promise((resolve, reject) => {
+    let port = options.port;
+    const cleanup = () => {
+      server.off('listening', ready);
+      server.off('error', failed);
+    };
+    const ready = () => { cleanup(); resolve(); };
+    /** @param {NodeJS.ErrnoException} error */
+    const failed = error => {
+      if (error.code === 'EADDRINUSE' && port < options.lastPort) {
+        port += 1;
+        attempt();
+        return;
+      }
+      cleanup();
+      reject(error);
+    };
+    const attempt = () => {
+      options.onPort(port);
+      try { server.listen(port, options.host); }
+      catch (error) { failed(/** @type {NodeJS.ErrnoException} */ (error)); }
+    };
+    server.once('listening', ready);
+    server.on('error', failed);
+    attempt();
+  });
+}

--- a/lib/companion-management.js
+++ b/lib/companion-management.js
@@ -1,0 +1,77 @@
+// @ts-check
+// Same-origin, user-opened management UI. Never exports installation secrets.
+import { randomUUID } from 'node:crypto';
+
+/** @param {{status: () => any, control: (request: Request) => Promise<Response>, now?: () => number}} options */
+export function createCompanionManagement(options) {
+  const now = options.now || Date.now;
+  /** @type {Map<string, {origin: string, expires: number}>} */
+  const sessions = new Map();
+  /** @param {Request} request */
+  return async function handle(request) {
+    const url = new URL(request.url);
+    if (!url.pathname.startsWith('/manage')) return null;
+    const headers = {
+      'Cache-Control': 'no-store', 'Referrer-Policy': 'no-referrer',
+      'X-Content-Type-Options': 'nosniff', 'X-Frame-Options': 'DENY',
+      'Cross-Origin-Resource-Policy': 'same-origin',
+    };
+    const deny = () => new Response('Open Companion management directly on this computer.', { status: 403, headers });
+    // The Node server preserves Host even though it constructs its Request URL
+    // from the listening address. Check both to prevent DNS-rebinding aliases.
+    if (url.hostname !== '127.0.0.1' || request.headers.get('Host') !== url.host) return deny();
+    for (const [key, session] of sessions) if (session.expires <= now()) sessions.delete(key);
+    if (url.pathname === '/manage' && request.method === 'GET') {
+      if (request.headers.get('Sec-Fetch-Mode') !== 'navigate'
+        || request.headers.get('Sec-Fetch-Dest') !== 'document') return deny();
+      while (sessions.size >= 8) sessions.delete(sessions.keys().next().value);
+      const key = randomUUID();
+      const nonce = randomUUID();
+      sessions.set(key, { origin: url.origin, expires: now() + 15 * 60_000 });
+      return new Response(managementHTML(key, nonce), { headers: {
+        ...headers, 'Content-Type': 'text/html; charset=utf-8',
+        'Content-Security-Policy': `default-src 'none'; script-src 'nonce-${nonce}'; style-src 'nonce-${nonce}'; connect-src 'self'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'`,
+      } });
+    }
+    const session = sessions.get(request.headers.get('Authorization')?.replace(/^Bearer /, '') || '');
+    if (!session || session.origin !== url.origin
+      || request.headers.get('Sec-Fetch-Site') !== 'same-origin'
+      || (request.method !== 'GET' && request.headers.get('Origin') !== url.origin)) return deny();
+    if (url.pathname === '/manage/status' && request.method === 'GET') {
+      return Response.json(options.status(), { headers });
+    }
+    if (url.pathname === '/manage/control' && request.method === 'POST') {
+      if (!request.headers.get('Content-Type')?.startsWith('application/json')) return deny();
+      const result = await options.control(request);
+      // No CORS headers, even for an allowlisted hosted application.
+      return new Response(result.body, { status: result.status, headers: { ...headers, 'Content-Type': 'application/json' } });
+    }
+    return new Response('Not found', { status: 404, headers });
+  };
+}
+
+/** @param {string} key @param {string} nonce */
+function managementHTML(key, nonce) {
+  return `<!doctype html><html lang="en"><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>getbased Companion</title><style nonce="${nonce}">
+body{font:16px system-ui,sans-serif;background:#141820;color:#eef2fa;margin:0;padding:24px}main{max-width:640px;margin:5vh auto}h1{font-size:26px}p{line-height:1.6;color:#c0cada}button{font:inherit;border:1px solid #718099;border-radius:8px;padding:12px;background:#24334a;color:inherit;cursor:pointer}button:disabled{opacity:.5;cursor:wait}button:focus-visible{outline:3px solid #80abff}nav{display:flex;flex-wrap:wrap;gap:12px;margin:24px 0}#status{padding:16px;border:1px solid #52627d;border-radius:10px}#message{min-height:3em}small{color:#a9b6c9}
+</style><main><h1>getbased Companion</h1><p>This page runs on your computer. Hosted getbased can chat through Companion, but only this local management page can use these controls.</p>
+<p id="status">Checking connection…</p><nav aria-label="Companion controls">
+<button data-action="pause">Pause</button><button data-action="restart">Reconnect CLIs</button>
+<button data-action="install">Start automatically</button><button data-action="restart-companion">Restart companion</button>
+<button data-action="update">Check for update</button><button data-action="uninstall">Uninstall</button>
+</nav><p id="message" role="status" aria-live="polite"></p><button id="refresh">Refresh status</button>
+<p><small>Reconnect CLIs resets agent connections. Restart companion reloads the installed service. Uninstall removes automatic startup and its runtime, not your agents or health data. An updated bundle takes effect after restart. This management session expires after 15 minutes; reopen the page to continue.</small></p></main>
+<script nonce="${nonce}">
+const credential=${JSON.stringify(key)};
+const status=document.getElementById('status'), message=document.getElementById('message');
+const buttons=[...document.querySelectorAll('[data-action]')];
+buttons.forEach(button=>button.disabled=true);
+let busy=false;
+async function request(path,action){const response=await fetch('/manage/'+path,{cache:'no-store',headers:{Authorization:'Bearer '+credential,...(action?{'Content-Type':'application/json'}:{})},...(action?{method:'POST',body:JSON.stringify({action})}:{})});if(response.status===403)throw Error('Session expired or access denied. Reopen this local page.');const value=await response.json();if(!response.ok)throw Error(value.error==='finish_the_active_response_first'?'Finish or stop the current AI response first.':value.error||'The operation failed.');return value;}
+function render(value){const installed=value.runtimeMode==='installed';status.textContent=(installed?'Installed · starts at login':'Temporary')+' · '+(value.processMode==='service'?'Background service':'Terminal session')+' · '+(value.paused?'Paused':'Running')+' · v'+(value.companionVersion||'unknown')+' · '+location.host;for(const button of buttons){const action=button.dataset.action;button.hidden=action==='install'?installed:['restart-companion','update','uninstall'].includes(action)&&!installed;if(action==='pause'||action==='resume'){button.dataset.action=value.paused?'resume':'pause';button.textContent=value.paused?'Resume':'Pause';}button.disabled=busy;}}
+async function refresh(){try{render(await request('status'));}catch(error){message.textContent=error.message;}}
+for(const button of buttons)button.addEventListener('click',async()=>{if(busy)return;const action=button.dataset.action;if(['install','uninstall','update','restart-companion'].includes(action)&&!confirm(button.textContent+' on this computer?'))return;busy=true;buttons.forEach(item=>item.disabled=true);message.textContent='Working…';try{const value=await request('control',action);message.textContent=value.restartRequired?'Update installed. Restart companion to use it.':value.restarting?'Restart requested. Refresh status after it starts; reopen this page if its session expired.':action==='install'?'Automatic startup configured. Choose Restart companion to hand over this terminal session to the background service.':action==='uninstall'?'Automatic startup and its runtime removed. This running instance remains available until stopped.':'Done.';render(value);}catch(error){message.textContent=error.message;}finally{busy=false;buttons.forEach(item=>item.disabled=false);}});
+document.getElementById('refresh').addEventListener('click',refresh);refresh();
+</script></html>`;
+}

--- a/lib/companion-runtime-control.js
+++ b/lib/companion-runtime-control.js
@@ -61,6 +61,8 @@ async function readVerifiedBundle(response) {
  *   uninstallImpl?: typeof uninstallCompanion,
  *   serviceCommandImpl?: typeof runCompanionServiceCommand,
  *   scheduleImpl?: (callback: () => void, delay: number) => unknown,
+ *   stopRuntime?: () => Promise<void>,
+ *   exitRuntime?: () => void,
  * }} options
  */
 export function createCompanionRuntimeController(options) {
@@ -76,6 +78,7 @@ export function createCompanionRuntimeController(options) {
   const getInfo = () => ({
     companionVersion: GETBASED_COMPANION_VERSION,
     runtimeMode,
+    processMode: String(env.GETBASED_COMPANION_SERVICE || '').trim() === '1' ? 'service' : 'terminal',
     platform,
   });
 
@@ -90,8 +93,15 @@ export function createCompanionRuntimeController(options) {
       if (runtimeMode !== 'installed') {
         throw new Error('Start the companion automatically before restarting it from getbased.');
       }
-      scheduleImpl(() => {
-        try { serviceCommandImpl('restart', { env, platform }); }
+      scheduleImpl(async () => {
+        try {
+          // A terminal process that just installed login startup must release
+          // its listener before the installed service takes over the port.
+          const handoff = String(env.GETBASED_COMPANION_SERVICE || '').trim() !== '1' && options.stopRuntime;
+          if (handoff) await options.stopRuntime();
+          serviceCommandImpl('restart', { env, platform });
+          if (handoff) options.exitRuntime?.();
+        }
         catch (error) {
           process.stderr.write(`getbased Companion restart failed: ${error instanceof Error ? error.message : String(error)}\n`);
         }

--- a/lib/companion-runtime-control.js
+++ b/lib/companion-runtime-control.js
@@ -62,6 +62,7 @@ async function readVerifiedBundle(response) {
  *   serviceCommandImpl?: typeof runCompanionServiceCommand,
  *   scheduleImpl?: (callback: () => void, delay: number) => unknown,
  *   stopRuntime?: () => Promise<void>,
+ *   recoverRuntime?: () => Promise<void>,
  *   exitRuntime?: () => void,
  * }} options
  */
@@ -94,16 +95,26 @@ export function createCompanionRuntimeController(options) {
         throw new Error('Start the companion automatically before restarting it from getbased.');
       }
       scheduleImpl(async () => {
+        let listenerStopped = false;
         try {
           // A terminal process that just installed login startup must release
           // its listener before the installed service takes over the port.
           const handoff = String(env.GETBASED_COMPANION_SERVICE || '').trim() !== '1' && options.stopRuntime;
-          if (handoff) await options.stopRuntime();
+          if (handoff) {
+            await options.stopRuntime();
+            listenerStopped = true;
+          }
           serviceCommandImpl('restart', { env, platform });
           if (handoff) options.exitRuntime?.();
         }
         catch (error) {
           process.stderr.write(`getbased Companion restart failed: ${error instanceof Error ? error.message : String(error)}\n`);
+          if (listenerStopped) {
+            try { await options.recoverRuntime?.(); }
+            catch (recoveryError) {
+              process.stderr.write(`getbased Companion recovery failed: ${recoveryError instanceof Error ? recoveryError.message : String(recoveryError)}\n`);
+            }
+          }
         }
       }, 300);
       return { ...getInfo(), restarting: true };

--- a/server/agent-host-server.js
+++ b/server/agent-host-server.js
@@ -114,8 +114,15 @@ const runtimeController = createCompanionRuntimeController({
     async initialize() {},
   },
   bundlePath,
-  stopRuntime: () => shutdown(),
-  exitRuntime: () => process.exit(0),
+  // Keep agent clients and their workspace intact until the service starts.
+  stopRuntime: () => new Promise((resolve, reject) => {
+    server.close(error => error ? reject(error) : resolve());
+  }),
+  recoverRuntime: () => new Promise(resolve => {
+    server.once('listening', resolve);
+    listen();
+  }),
+  exitRuntime: () => { void shutdown().finally(() => process.exit(0)); },
 });
 const service = createAgentHostService({
   appServer,

--- a/server/agent-host-server.js
+++ b/server/agent-host-server.js
@@ -16,6 +16,7 @@ import {
 } from '../lib/codex-agent-isolation.js';
 import { prepareAgentHostStorage } from '../lib/agent-host-storage.js';
 import { createCompanionRuntimeController } from '../lib/companion-runtime-control.js';
+import { recoverCompanionListener } from '../lib/companion-listener.js';
 import { buildLocalAgentEnvironment, detectLocalAgents } from '../lib/local-agent-registry.js';
 import { fileURLToPath } from 'node:url';
 import { resolve } from 'node:path';
@@ -29,6 +30,7 @@ if (!Number.isInteger(port) || port < 1 || port > 65535) {
 }
 const strictPort = configuredPort !== '' || String(process.env.GETBASED_AGENT_HOST_STRICT_PORT || '').trim() === '1';
 const lastPort = strictPort ? port : Math.min(65535, port + 7);
+let recoveringListener = false;
 const maxRequestBytes = 1_200_000;
 const maxImageRequestBytes = 20 * 1024 * 1024;
 const allowedOrigins = String(process.env.GETBASED_AGENT_HOST_ALLOWED_ORIGINS || '')
@@ -118,10 +120,12 @@ const runtimeController = createCompanionRuntimeController({
   stopRuntime: () => new Promise((resolve, reject) => {
     server.close(error => error ? reject(error) : resolve());
   }),
-  recoverRuntime: () => new Promise(resolve => {
-    server.once('listening', resolve);
-    listen();
-  }),
+  recoverRuntime: async () => {
+    recoveringListener = true;
+    try {
+      await recoverCompanionListener(server, { host, port, lastPort, onPort: value => { port = value; } });
+    } finally { recoveringListener = false; }
+  },
   exitRuntime: () => { void shutdown().finally(() => process.exit(0)); },
 });
 const service = createAgentHostService({
@@ -204,6 +208,9 @@ server.on('listening', () => {
     : 'Temporary Companion: keep this terminal open. Closing it stops this instance, not other installed or development Companions.\n');
 });
 server.on('error', error => {
+  // Recovery owns its retries and error settlement; do not destroy the retained
+  // clients/workspace through the normal startup failure path.
+  if (recoveringListener) return;
   if (/** @type {NodeJS.ErrnoException} */ (error).code === 'EADDRINUSE' && port < lastPort) {
     port += 1;
     process.stderr.write(`getbased Companion port busy; trying http://${host}:${port}\n`);

--- a/server/agent-host-server.js
+++ b/server/agent-host-server.js
@@ -114,6 +114,8 @@ const runtimeController = createCompanionRuntimeController({
     async initialize() {},
   },
   bundlePath,
+  stopRuntime: () => shutdown(),
+  exitRuntime: () => process.exit(0),
 });
 const service = createAgentHostService({
   appServer,
@@ -189,7 +191,10 @@ server.on('listening', () => {
   process.stdout.write(`getbased Companion listening at http://${host}:${port}\n`);
   process.stdout.write('Automatic browser discovery enabled.\n');
   process.stdout.write(`Private agent state: ${agentStorage.dataDirectory}\n`);
-  process.stdout.write('Keep this process running while using CLI agents in getbased.\n');
+  process.stdout.write(`Local management: http://${host}:${port}/manage\n`);
+  process.stdout.write(process.env.GETBASED_COMPANION_SERVICE === '1'
+    ? 'Installed Companion service is running in the background.\n'
+    : 'Temporary Companion: keep this terminal open. Closing it stops this instance, not other installed or development Companions.\n');
 });
 server.on('error', error => {
   if (/** @type {NodeJS.ErrnoException} */ (error).code === 'EADDRINUSE' && port < lastPort) {

--- a/shared/agent-host-protocol.js
+++ b/shared/agent-host-protocol.js
@@ -2,12 +2,13 @@
 // Runtime-neutral version and capability contract for the loopback companion.
 
 export const AGENT_HOST_PROTOCOL_VERSION = 5;
-export const GETBASED_COMPANION_VERSION = '1.2.2';
+export const GETBASED_COMPANION_VERSION = '1.3.0';
 
 export const AGENT_HOST_CAPABILITIES = Object.freeze({
   CHAT_STREAM: 'chat-stream',
   COMPANION_CONTROL: 'companion-control',
   COMPANION_RESTART: 'companion-restart',
+  COMPANION_MANAGEMENT: 'companion-management',
   DYNAMIC_TOOLS: 'dynamic-tools',
   EXECUTION_TARGETS: 'execution-targets',
   IMAGE_UPLOAD: 'image-upload',

--- a/tests/agent-host-service.test.js
+++ b/tests/agent-host-service.test.js
@@ -384,10 +384,22 @@ describe('agent host service', () => {
     const turn = await service.handleRequest(turnRequest());
     const reader = turn.body.getReader();
     await nextEvent(reader, new TextDecoder(), { value: '' });
-    for (const action of ['uninstall', 'restart-companion', 'pause']) {
+    const managementPage = await service.handleRequest(new Request('http://127.0.0.1:8324/manage', {
+      headers: { Host: '127.0.0.1:8324', 'Sec-Fetch-Mode': 'navigate', 'Sec-Fetch-Dest': 'document' },
+    }));
+    const managementToken = (await managementPage.text()).match(/const credential="([^"]+)"/)[1];
+    for (const action of ['install', 'uninstall', 'restart-companion', 'pause']) {
       const blocked = await request(action);
       expect(blocked.status).toBe(409);
       expect(await blocked.json()).toEqual({ error: 'finish_the_active_response_first' });
+      const localBlocked = await service.handleRequest(new Request('http://127.0.0.1:8324/manage/control', {
+        method: 'POST', headers: {
+          Host: '127.0.0.1:8324', Origin: 'http://127.0.0.1:8324', 'Sec-Fetch-Site': 'same-origin',
+          Authorization: `Bearer ${managementToken}`, 'Content-Type': 'application/json',
+        }, body: JSON.stringify({ action }),
+      }));
+      expect(localBlocked.status).toBe(409);
+      expect(await localBlocked.json()).toEqual({ error: 'finish_the_active_response_first' });
     }
     appServer.emit('notification', {
       method: 'turn/completed', params: { threadId: 'thread-1', turn: { id: 'turn-1', status: 'completed' } },

--- a/tests/cli-companion-ui.test.js
+++ b/tests/cli-companion-ui.test.js
@@ -129,6 +129,25 @@ describe('CLI companion setup UI', () => {
     expect(companion.querySelector('[data-settings-action="copy-cli-companion-update"]')).not.toBeNull();
   });
 
+  it('links hosted discovery to management on the actual discovered port without sharing credentials', async () => {
+    vi.stubGlobal('fetch', vi.fn(async input => {
+      if (String(input).startsWith('/api/local-agents')) return new Response('{"agents":[]}');
+      return Response.json({
+        service: 'getbased-agent-host', endpoint: 'http://127.0.0.1:8325', token: '1234567890123456',
+        capabilities: ['companion-control', 'companion-restart', 'companion-management'], runtimeMode: 'installed',
+        agents: [{ id: 'codex', status: 'available', compatible: true }],
+      });
+    }));
+    await refreshDetectedAgentList();
+    const companion = document.getElementById('local-agent-companion-section');
+    const link = companion.querySelector('a');
+    expect(link?.href).toBe('http://127.0.0.1:8325/manage');
+    expect(link?.rel).toContain('noopener');
+    expect(companion.textContent).toContain('Starts automatically at login');
+    expect(companion.innerHTML).not.toContain('1234567890123456');
+    expect(companion.querySelector('[data-settings-action="control-cli-companion"]')).toBeNull();
+  });
+
   it('shows a stopped companion state without attempting to load models', async () => {
     localStorage.setItem('labcharts-chat-backend', 'codex');
     vi.stubGlobal('fetch', vi.fn(async input => {

--- a/tests/companion-listener.test.js
+++ b/tests/companion-listener.test.js
@@ -1,0 +1,34 @@
+// @vitest-environment node
+import { EventEmitter } from 'node:events';
+import { describe, expect, it, vi } from 'vitest';
+import { recoverCompanionListener } from '../lib/companion-listener.js';
+
+describe('Companion listener recovery', () => {
+  it('retries occupied ports then removes listeners on success', async () => {
+    const server = new EventEmitter();
+    server.listen = vi.fn(port => queueMicrotask(() => {
+      if (port < 8326) server.emit('error', Object.assign(new Error('busy'), { code: 'EADDRINUSE' }));
+      else server.emit('listening');
+    }));
+    const onPort = vi.fn();
+    await recoverCompanionListener(server, { host: '127.0.0.1', port: 8324, lastPort: 8326, onPort });
+    expect(onPort.mock.calls.flat()).toEqual([8324, 8325, 8326]);
+    expect(server.listenerCount('error')).toBe(0);
+    expect(server.listenerCount('listening')).toBe(0);
+  });
+
+  it.each(['EADDRINUSE', 'EACCES', 'throw'])('rejects and cleans up after %s', async code => {
+    const server = new EventEmitter();
+    const error = Object.assign(new Error('cannot listen'), { code });
+    server.listen = vi.fn(() => {
+      if (code === 'throw') throw error;
+      queueMicrotask(() => server.emit('error', error));
+    });
+    await expect(recoverCompanionListener(server, {
+      host: '127.0.0.1', port: 8324, lastPort: 8324, onPort: vi.fn(),
+    })).rejects.toBe(error);
+    expect(server.listen).toHaveBeenCalledOnce();
+    expect(server.listenerCount('error')).toBe(0);
+    expect(server.listenerCount('listening')).toBe(0);
+  });
+});

--- a/tests/companion-management.test.js
+++ b/tests/companion-management.test.js
@@ -1,0 +1,69 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from 'vitest';
+import { createCompanionManagement } from '../lib/companion-management.js';
+import { findExistingCompanion } from '../lib/companion-existing.js';
+
+const origin = 'http://127.0.0.1:8324';
+const navigation = { Host: '127.0.0.1:8324', 'Sec-Fetch-Mode': 'navigate', 'Sec-Fetch-Dest': 'document' };
+const local = { Host: '127.0.0.1:8324', Origin: origin, 'Sec-Fetch-Site': 'same-origin', 'Content-Type': 'application/json' };
+async function session(handle) {
+  const response = await handle(new Request(origin + '/manage', { headers: navigation }));
+  const html = await response.text();
+  return { response, html, token: html.match(/const credential="([^"]+)"/)[1] };
+}
+
+describe('local Companion management', () => {
+  it('uses an isolated navigation-only page, not discovery or the persistent token', async () => {
+    const control = vi.fn(async () => Response.json({ ok: true }));
+    const handle = createCompanionManagement({ status: () => ({ runtimeMode: 'installed' }), control });
+    const { response, html, token } = await session(handle);
+    expect(response.headers.get('Content-Security-Policy')).toContain("frame-ancestors 'none'");
+    expect(response.headers.has('Access-Control-Allow-Origin')).toBe(false);
+    expect(html).toContain('Start automatically');
+    const result = await handle(new Request(origin + '/manage/control', { method: 'POST', headers: { ...local, Authorization: `Bearer ${token}` }, body: '{"action":"pause"}' }));
+    expect(result.status).toBe(200);
+    expect(result.headers.has('Access-Control-Allow-Origin')).toBe(false);
+    expect(control).toHaveBeenCalledOnce();
+    for (const headers of [
+      { ...local, Origin: 'https://app.getbased.health', 'Sec-Fetch-Site': 'cross-site' },
+      { ...local, Host: 'attacker.example:8324' },
+      { ...local, Authorization: 'Bearer discovery-token' },
+    ]) {
+      const denied = await handle(new Request(origin + '/manage/control', { method: 'POST', headers: { Authorization: `Bearer ${token}`, ...headers }, body: '{}' }));
+      expect(denied.status).toBe(403);
+    }
+    expect(control).toHaveBeenCalledOnce();
+  });
+  it('refuses iframe, fetch, DNS aliases, expired and evicted sessions', async () => {
+    let time = 0;
+    const handle = createCompanionManagement({ status: () => ({}), control: vi.fn(), now: () => time });
+    for (const headers of [{}, { ...navigation, 'Sec-Fetch-Dest': 'iframe' }, { ...navigation, 'Sec-Fetch-Mode': 'cors' }, { ...navigation, Host: 'localhost:8324' }]) {
+      expect((await handle(new Request(origin + '/manage', { headers }))).status).toBe(403);
+    }
+    const first = await session(handle);
+    for (let index = 0; index < 8; index++) await session(handle);
+    const status = token => handle(new Request(origin + '/manage/status', { headers: { ...local, Authorization: `Bearer ${token}` } }));
+    expect((await status(first.token)).status).toBe(403);
+    const current = await session(handle);
+    expect((await status(current.token)).status).toBe(200);
+    time = 15 * 60_000;
+    expect((await status(current.token)).status).toBe(403);
+  });
+});
+
+describe('temporary bootstrap detection', () => {
+  it('finds an existing instance without following redirects or sending credentials', async () => {
+    const fetchImpl = vi.fn(async url => Response.json(url.includes(':8325/') ? { ok: true, service: 'getbased-agent-host' } : { ok: true, service: 'unrelated' }));
+    expect(await findExistingCompanion({ env: {}, fetchImpl })).toEqual({ endpoint: 'http://127.0.0.1:8325' });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(fetchImpl.mock.calls[0][1]).toMatchObject({ redirect: 'error' });
+    expect(fetchImpl.mock.calls[0][1].headers).toBeUndefined();
+  });
+  it('honors explicit ports and bounds untrusted responses', async () => {
+    const fetchImpl = vi.fn(async () => new Response('x'.repeat(4097)));
+    expect(await findExistingCompanion({ env: { GETBASED_AGENT_HOST_PORT: '8330' }, fetchImpl })).toBeNull();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(await findExistingCompanion({ env: { GETBASED_AGENT_HOST_PORT: 'invalid' }, fetchImpl })).toBeNull();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/companion-runtime-control.test.js
+++ b/tests/companion-runtime-control.test.js
@@ -77,6 +77,28 @@ describe('running companion controls', () => {
     expect(order).toEqual(['stop-listener', 'start-service', 'exit']);
   });
 
+  it.each(['linux', 'darwin', 'win32'])('restores the terminal listener after a failed %s service handoff', async platform => {
+    let scheduled;
+    const order = [];
+    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const controller = createCompanionRuntimeController({
+        appServer: { restart: vi.fn(), initialize: vi.fn() },
+        bundlePath: '/tmp/getbased-companion.mjs', env: {}, platform,
+        installImpl: vi.fn(), scheduleImpl: callback => { scheduled = callback; },
+        stopRuntime: async () => { order.push('stop-listener'); },
+        recoverRuntime: async () => { order.push('restore-listener'); },
+        serviceCommandImpl: () => { order.push('start-service'); throw new Error('Service unavailable'); },
+        exitRuntime: () => { order.push('exit'); },
+      });
+      await controller.handle('install', { origin: 'http://127.0.0.1:8324' });
+      await controller.handle('restart-companion', { origin: 'http://127.0.0.1:8324' });
+      await scheduled();
+      expect(order).toEqual(['stop-listener', 'start-service', 'restore-listener']);
+      expect(stderr).toHaveBeenCalledWith(expect.stringContaining('Service unavailable'));
+    } finally { stderr.mockRestore(); }
+  });
+
   it('updates only from the fixed official endpoint, never from a calling page', async () => {
     const installImpl = vi.fn(() => ({ installed: true }));
     const fetchImpl = vi.fn(async () => new Response(VALID_BUNDLE, { status: 200 }));

--- a/tests/companion-runtime-control.test.js
+++ b/tests/companion-runtime-control.test.js
@@ -59,6 +59,24 @@ describe('running companion controls', () => {
       .rejects.toThrow('Start the companion automatically');
   });
 
+  it('hands an installed terminal runtime over without two listeners', async () => {
+    const order = [];
+    let scheduled;
+    const controller = createCompanionRuntimeController({
+      appServer: { restart: vi.fn(), initialize: vi.fn() }, bundlePath: '/tmp/getbased-companion.mjs',
+      env: {}, installImpl: vi.fn(), scheduleImpl: callback => { scheduled = callback; },
+      stopRuntime: async () => { order.push('stop-listener'); },
+      serviceCommandImpl: () => { order.push('start-service'); },
+      exitRuntime: () => { order.push('exit'); },
+    });
+    await controller.handle('install', { origin: 'http://127.0.0.1:8324' });
+    expect(controller.getInfo()).toMatchObject({ runtimeMode: 'installed', processMode: 'terminal' });
+    await controller.handle('restart-companion', { origin: 'http://127.0.0.1:8324' });
+    expect(order).toEqual([]);
+    await scheduled();
+    expect(order).toEqual(['stop-listener', 'start-service', 'exit']);
+  });
+
   it('updates only from the fixed official endpoint, never from a calling page', async () => {
     const installImpl = vi.fn(() => ({ installed: true }));
     const fetchImpl = vi.fn(async () => new Response(VALID_BUNDLE, { status: 200 }));

--- a/tests/dev-agent-host.test.js
+++ b/tests/dev-agent-host.test.js
@@ -46,7 +46,7 @@ describe('development agent discovery', () => {
     expect(controller.describe().agents[0]).toMatchObject({
       status: 'available', version: 'codex-cli 0.150.1', protocolVersion: 5,
       capabilities: expect.arrayContaining(['companion-control', 'execution-targets']),
-      companionVersion: '1.2.2', runtimeMode: 'temporary',
+      companionVersion: '1.3.0', runtimeMode: 'temporary',
     });
     expect(spawnImpl).toHaveBeenCalledWith(process.execPath, [
       '--watch-preserve-output', '--watch', '/workspace/server/agent-host-server.js',

--- a/tests/playwright/companion-management.spec.js
+++ b/tests/playwright/companion-management.spec.js
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test';
+import { createServer } from 'node:http';
+import { createAgentHostService } from '../../lib/agent-host-service.js';
+
+let server, endpoint;
+let actions = [];
+test.beforeAll(async () => {
+  let mode = 'temporary';
+  const service = createAgentHostService({
+    appServer: {}, token: 'private-installation-secret', workspaceRoot: '/tmp/unused-management-test',
+    runtimeInfo: () => ({ runtimeMode: mode, companionVersion: 'test' }),
+    controlHandler: async action => {
+      actions.push(action);
+      if (action === 'install') mode = 'installed';
+      if (action === 'uninstall') mode = 'temporary';
+      return { runtimeMode: mode, restartRequired: action === 'update' };
+    },
+  });
+  server = createServer(async (req, res) => {
+    const chunks = [];
+    for await (const chunk of req) chunks.push(chunk);
+    const result = await service.handleRequest(new Request(endpoint + req.url, {
+      method: req.method, headers: req.headers,
+      body: chunks.length ? Buffer.concat(chunks) : undefined,
+    }));
+    res.writeHead(result.status, Object.fromEntries(result.headers));
+    res.end(Buffer.from(await result.arrayBuffer()));
+  });
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  endpoint = `http://127.0.0.1:${server.address().port}`;
+});
+test.afterAll(async () => { server.closeAllConnections(); await new Promise(resolve => server.close(resolve)); });
+
+test('local management runs controls while hosted discovery stays chat-only', async ({ page }) => {
+  await page.goto(endpoint + '/manage');
+  await expect(page.locator('#status')).toContainText('Temporary');
+  await page.setViewportSize({ width: 360, height: 740 });
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true);
+  await page.getByRole('button', { name: 'Pause', exact: true }).click();
+  await expect(page.locator('#status')).toContainText('Paused');
+  await page.getByRole('button', { name: 'Resume', exact: true }).click();
+  await expect(page.locator('#status')).toContainText('Running');
+  page.on('dialog', dialog => dialog.accept());
+  await page.getByRole('button', { name: 'Start automatically', exact: true }).click();
+  await expect(page.locator('#status')).toContainText('Installed');
+  await page.getByRole('button', { name: 'Check for update', exact: true }).click();
+  await expect(page.locator('#message')).toContainText('Restart companion');
+  await page.getByRole('button', { name: 'Reconnect CLIs', exact: true }).click();
+  await page.getByRole('button', { name: 'Restart companion', exact: true }).click();
+  await page.getByRole('button', { name: 'Uninstall', exact: true }).click();
+  await expect(page.locator('#status')).toContainText('Temporary');
+  expect(actions).toEqual(['install', 'update', 'restart', 'restart-companion', 'uninstall']);
+  const discovery = await page.request.get(endpoint + '/v1/discovery', { headers: { Origin: 'https://app.getbased.health' } });
+  const data = await discovery.json();
+  expect(data.controlAuthorized).toBe(false);
+  expect((await page.request.post(endpoint + '/v1/control', { headers: { Origin: 'https://app.getbased.health', Authorization: `Bearer ${data.token}` }, data: { action: 'install' } })).status()).toBe(403);
+  expect((await page.request.get(endpoint + '/manage', { headers: { Origin: 'https://app.getbased.health' } })).status()).toBe(403);
+});


### PR DESCRIPTION
## Summary
- Add a Manage Companion link for hosted users, opening a same-origin local management page for pause/resume, reconnect, automatic startup, restart, update and uninstall.
- Preserve chat-only browser discovery. Management uses short-lived independent credentials, exact loopback Host checks, Fetch Metadata, nonce CSP, no CORS and no installation-secret exposure.
- Detect an already-running Companion before starting a temporary copy and clearly distinguish terminal sessions from background services.
- Hand off a newly installed terminal instance to its service on restart. Block disruptive controls during active responses.
- Release Companion protocol-compatible version 1.3.0 and document the management boundary.

## Verification
- 48 focused unit tests passed.
- Focused Chromium management lifecycle test passed, including narrow-screen layout and hosted control rejection.
- Server and frontend type checks passed.
- Production build and Companion bundle passed.
- Quality guardrails: 17 passed; git diff --check passed.

## Deployment
Hosted controls require the updated application and Companion 1.3.0. Existing running user services were not changed. Actual OS service operations are covered with adapter tests, not executed against the user machine.