### PR TITLE
Simplify CLI onboarding and Companion management

### DIFF
--- a/css/settings.css
+++ b/css/settings.css
@@ -2458,3 +2458,27 @@ label.sync-settings-toggle input:disabled + .sync-settings-toggle-slider { opaci
   .import-benchmarks-entrypoint { align-items: stretch; flex-direction: column; }
   .import-benchmarks-entrypoint .import-btn { width: 100%; }
 }
+
+.settings-modal .local-agent-management-frame {
+  display: block;
+  width: 100%;
+  height: 100px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg-secondary);
+}
+@media (max-width: 480px) {
+  .settings-modal .local-agent-management-frame { height: 120px; }
+}
+
+.settings-modal a.local-agent-management-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+.settings-modal a.local-agent-management-link:hover {
+  color: var(--text-primary);
+  text-decoration: none;
+}

--- a/js/chat-onboarding.js
+++ b/js/chat-onboarding.js
@@ -19,7 +19,7 @@ import { handleAppExtensionOnboardingAction, renderAppExtensionOnboardingSlot } 
  *   getActiveData: () => any,
  *   navigate: (route: string, data?: any) => void,
  *   openChatProviderQuiz: null | (() => void),
- *   openSettingsModal: (tab?: string) => void,
+ *   openSettingsModal: (tab?: string) => unknown,
  *   recordChange: (field: string) => void,
  *   renderChatMessages: () => void,
  *   renderMenstrualCycleSection: null | ((data: any, opts?: any) => string),
@@ -78,8 +78,8 @@ function openAiSettings() {
 function openAiProviderSettings(provider) {
   clearForcedOnboardingStep();
   closeChatPanel();
-  setTimeout(() => {
-    openSettingsModal('ai');
+  setTimeout(async () => {
+    await openSettingsModal('ai');
     if (provider === 'cli') {
       const cliButton = /** @type {HTMLElement | null} */ (document.querySelector('[data-settings-action="show-cli-agent-provider"]'));
       cliButton?.click();
@@ -176,7 +176,7 @@ function openChatProviderQuiz() {
 }
 
 function openSettingsModal(tab) {
-  onboardingCallbacks.openSettingsModal?.(tab);
+  return onboardingCallbacks.openSettingsModal?.(tab);
 }
 
 function recordChange(field) {
@@ -598,7 +598,7 @@ export function _renderProviderQuiz(branch, name) {
   if (extensionQuiz) return extensionQuiz;
   if (branch === 'cli') {
     return `<div class="chat-provider-quiz"><button type="button" class="chat-quiz-back" ${chatOnboardingActionAttrs('back-to-provider-quiz')} aria-label="Back to provider options">&larr; Back</button>
-      <p><strong>Use an existing AI account &rarr; CLI agents</strong></p><p style="font-size:13px">getbased scans this computer for configured agents such as Codex, OpenCode, Hermes, Grok, and OpenClaw. There is no connection address to paste.</p><button type="button" class="chat-setup-btn" ${chatOnboardingActionAttrs('open-provider-settings', { provider: 'cli' })}>Find my installed agents &rarr;</button><p style="font-size:11px;color:var(--text-muted);margin-top:10px">Choose any ready agent, then pick its model and reasoning level directly in getbased. Health-data changes always remain reviewable drafts.</p></div>`;
+      <p><strong>Use an existing AI account &rarr; CLI agents</strong></p><p style="font-size:13px">getbased scans this computer for configured agents such as Codex, OpenCode, Hermes, Grok, and OpenClaw. You need a supported CLI installed and signed in, plus getbased Companion. We’ll check for an existing Companion connection first and guide you through any missing setup.</p><button type="button" class="chat-setup-btn" ${chatOnboardingActionAttrs('open-provider-settings', { provider: 'cli' })}>Find my installed agents &rarr;</button><p style="font-size:11px;color:var(--text-muted);margin-top:10px">Choose any ready agent, then pick its model and reasoning level directly in getbased. Health-data changes always remain reviewable drafts.</p></div>`;
   }
   if (branch === 'card') {
     return `<div class="chat-provider-quiz"><button type="button" class="chat-quiz-back" ${chatOnboardingActionAttrs('back-to-provider-quiz')} aria-label="Back to provider options">&larr; Back</button>
@@ -638,16 +638,16 @@ export function _renderProviderQuiz(branch, name) {
   // Root question
   return `<div class="chat-provider-quiz"><p>Welcome, ${safeName}! Next, pick how you want to power the AI:</p>
     <div class="chat-quiz-options">
-      <button type="button" class="chat-quiz-option chat-quiz-recommended" ${chatOnboardingActionAttrs('set-provider-branch', { 'provider-branch': 'cli' })}>
-        <span class="chat-quiz-icon" aria-hidden="true">&#9002;</span><span class="chat-quiz-body"><strong>Use an AI subscription I already have</strong><span>Detect Codex and other installed agents. <em class="chat-quiz-rec">Recommended</em></span></span><span class="chat-quiz-arrow" aria-hidden="true">&rarr;</span>
-      </button>
-      <button type="button" class="chat-quiz-option" ${chatOnboardingActionAttrs('set-provider-branch', { 'provider-branch': 'card' })}>
+      <button type="button" class="chat-quiz-option chat-quiz-recommended" ${chatOnboardingActionAttrs('set-provider-branch', { 'provider-branch': 'card' })}>
         <span class="chat-quiz-icon" aria-hidden="true">&#128179;</span>
         <span class="chat-quiz-body">
           <strong>Easiest &mdash; pay with a card</strong>
-          <span>One-click login through OpenRouter.</span>
+          <span>One-click login through OpenRouter. <em class="chat-quiz-rec">Recommended</em></span>
         </span>
         <span class="chat-quiz-arrow" aria-hidden="true">&rarr;</span>
+      </button>
+      <button type="button" class="chat-quiz-option" ${chatOnboardingActionAttrs('set-provider-branch', { 'provider-branch': 'cli' })}>
+        <span class="chat-quiz-icon" aria-hidden="true"><svg width="28" height="28" viewBox="0 0 32 32" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4.5" y="6.5" width="23" height="19" rx="4.5"/><path d="m10 12 4 4-4 4M17 20h5"/></svg></span><span class="chat-quiz-body"><strong>Use an AI subscription I already have</strong><span>Requires an installed CLI, sign-in, and getbased Companion.</span></span><span class="chat-quiz-arrow" aria-hidden="true">&rarr;</span>
       </button>
       <button type="button" class="chat-quiz-option" ${chatOnboardingActionAttrs('set-provider-branch', { 'provider-branch': 'local' })}>
         <span class="chat-quiz-icon" aria-hidden="true">&#128274;</span>

--- a/js/settings-cli-agent-panel.js
+++ b/js/settings-cli-agent-panel.js
@@ -4,7 +4,7 @@
 import { controlAgentHost, listAgentExecutionTargets, listAgentModels } from './agent-chat-client.js';
 import { cacheAgentModelCatalog } from './agent-model-catalog.js';
 import { renderCLIAgentBrandIcon } from './cli-agent-brand-assets.js';
-import { AGENT_HOST_CAPABILITIES } from '../shared/agent-host-protocol.js';
+import { AGENT_HOST_CAPABILITIES, isAllowedCompanionManagementParent } from '../shared/agent-host-protocol.js';
 import {
   connectDetectedAgent,
   discoverLocalChatAgents,
@@ -394,7 +394,8 @@ function renderCompanionControls(agent) {
     managementURL.pathname = '/manage';
     managementURL.search = '';
     managementURL.hash = '';
-    if (agent.capabilities?.includes(AGENT_HOST_CAPABILITIES.COMPANION_MANAGEMENT_EMBEDDED)) {
+    const canEmbedHere = isAllowedCompanionManagementParent(globalThis.location.origin);
+    if (canEmbedHere && agent.capabilities?.includes(AGENT_HOST_CAPABILITIES.COMPANION_MANAGEMENT_EMBEDDED)) {
       managementURL.pathname = '/manage/embed';
       managementURL.searchParams.set('parentOrigin', globalThis.location.origin);
       managementURL.searchParams.set('theme', document.documentElement.dataset.theme === 'light' ? 'light' : 'dark');
@@ -406,7 +407,7 @@ function renderCompanionControls(agent) {
     return `<div class="local-agent-list-kicker local-agent-companion-kicker">Companion</div>
     <div class="local-agent-controls"><div class="local-agent-controls-copy"><strong>Connected for chat</strong>
     <span>${escapeHTML(modeLabel)} · ${escapeHTML(managementURL.host)}${agent.companionVersion ? ` · v${escapeHTML(agent.companionVersion)}` : ''}</span>
-    <span>${managementLink ? 'Update Companion once to manage it directly in Settings. Until then, its controls open in local management.' : 'Update Companion to enable its local management page. Until then, manage it from the terminal.'}</span></div>
+    <span>${managementLink ? (canEmbedHere ? 'Update Companion once to manage it directly in Settings. Until then, its controls open in local management.' : 'Open local management to control Companion from this deployment.') : 'Update Companion to enable its local management page. Until then, manage it from the terminal.'}</span></div>
     <div class="local-agent-control-actions">${managementLink}
     <button type="button" class="import-btn import-btn-secondary settings-mini-btn" data-settings-action="copy-cli-companion-update">Copy update command</button></div></div>`;
   }

--- a/js/settings-cli-agent-panel.js
+++ b/js/settings-cli-agent-panel.js
@@ -156,7 +156,7 @@ export async function copyCLIAgentLoginCommand(agentId) {
 }
 
 export function renderCLIAgentProviderPanel() {
-  queueMicrotask(() => { void refreshDetectedAgentList(); });
+  queueMicrotask(() => { void refreshDetectedAgentList({ refresh: true }); });
   return `
     <div class="ai-provider-panel cli-agent-provider-panel" data-ai-provider-mode="cli">
       <div class="local-agent-chat-head">
@@ -388,20 +388,27 @@ function renderCompanionControls(agent) {
     </div>`;
   }
   const modeLabel = installed ? 'Starts automatically at login' : 'Connected for this terminal session';
-  if (agent.controlAuthorized === false) {
+  if (agent.controlAuthorized === false || agent.capabilities?.includes(AGENT_HOST_CAPABILITIES.COMPANION_MANAGEMENT_EMBEDDED)) {
     const managementURL = new URL(agent.endpoint || getAgentHostEndpoint());
     managementURL.hostname = '127.0.0.1';
     managementURL.pathname = '/manage';
     managementURL.search = '';
     managementURL.hash = '';
+    if (agent.capabilities?.includes(AGENT_HOST_CAPABILITIES.COMPANION_MANAGEMENT_EMBEDDED)) {
+      managementURL.pathname = '/manage/embed';
+      managementURL.searchParams.set('parentOrigin', globalThis.location.origin);
+      managementURL.searchParams.set('theme', document.documentElement.dataset.theme === 'light' ? 'light' : 'dark');
+      return `<div class="local-agent-list-kicker local-agent-companion-kicker">Companion</div>
+      <iframe class="local-agent-management-frame" title="Companion controls" src="${escapeAttr(managementURL.href)}" referrerpolicy="no-referrer" sandbox="allow-scripts allow-same-origin"></iframe>`;
+    }
     const managementLink = agent.capabilities?.includes(AGENT_HOST_CAPABILITIES.COMPANION_MANAGEMENT)
-      ? `<a class="import-btn import-btn-primary settings-mini-btn" href="${escapeAttr(managementURL.href)}" target="_blank" rel="noopener noreferrer">Manage Companion</a>` : '';
+      ? `<a class="import-btn import-btn-secondary settings-mini-btn local-agent-management-link" href="${escapeAttr(managementURL.href)}" target="_blank" rel="noopener noreferrer">Manage Companion</a>` : '';
     return `<div class="local-agent-list-kicker local-agent-companion-kicker">Companion</div>
     <div class="local-agent-controls"><div class="local-agent-controls-copy"><strong>Connected for chat</strong>
     <span>${escapeHTML(modeLabel)} · ${escapeHTML(managementURL.host)}${agent.companionVersion ? ` · v${escapeHTML(agent.companionVersion)}` : ''}</span>
-    <span>${managementLink ? 'Open local management for startup, pause, restart, update, or uninstall. Hosted chat does not receive installation permissions.' : 'Update Companion to enable its local management page. Until then, manage it from the terminal.'}</span></div>
-    ${managementLink}
-    <button type="button" class="import-btn settings-mini-btn" data-settings-action="copy-cli-companion-update">Copy update command</button></div>`;
+    <span>${managementLink ? 'Update Companion once to manage it directly in Settings. Until then, its controls open in local management.' : 'Update Companion to enable its local management page. Until then, manage it from the terminal.'}</span></div>
+    <div class="local-agent-control-actions">${managementLink}
+    <button type="button" class="import-btn import-btn-secondary settings-mini-btn" data-settings-action="copy-cli-companion-update">Copy update command</button></div></div>`;
   }
   return `<div class="local-agent-list-kicker local-agent-companion-kicker">Companion</div>
   <div class="local-agent-controls" aria-label="Companion controls">
@@ -664,7 +671,22 @@ export async function setCLIAgentEffort(effort) {
   }
 }
 
+/** @param {MessageEvent} event */
+export function resizeCLICompanionPanel(event) {
+  if (event.data?.type !== 'getbased-companion-panel-size' || !Number.isFinite(event.data.height)) return;
+  const frame = /** @type {HTMLIFrameElement | null} */ (document.querySelector('.local-agent-management-frame'));
+  if (!frame || event.source !== frame.contentWindow || event.origin !== new URL(frame.src).origin) return;
+  frame.style.height = `${Math.max(64, Math.min(800, Math.ceil(event.data.height)))}px`;
+  const styles = getComputedStyle(frame);
+  frame.contentWindow?.postMessage({
+    type: 'getbased-companion-panel-theme',
+    colors: Object.fromEntries(Object.entries({ bg: '--bg-card', text: '--text-primary', muted: '--text-muted', border: '--border', button: '--bg-card', accent: '--accent' })
+      .map(([name, variable]) => [name, styles.getPropertyValue(variable).trim()])),
+  }, event.origin);
+}
+
 if (typeof document !== 'undefined') {
+  document.defaultView?.addEventListener('message', resizeCLICompanionPanel);
   document.addEventListener('input', event => {
     const target = event.target;
     if (target instanceof HTMLInputElement && target.matches('[data-cli-agent-model-search]')) {

--- a/lib/agent-host-service.js
+++ b/lib/agent-host-service.js
@@ -8,7 +8,7 @@ import {
   AGENT_HOST_CAPABILITY_LIST, AGENT_HOST_PROTOCOL_VERSION,
 } from '../shared/agent-host-protocol.js';
 import { startExternalAgentTurn } from './agent-host-external-turn.js';
-import { createCompanionManagement } from './companion-management.js';
+import { createCompanionManagement, isAllowedCompanionManagementParent } from './companion-management.js';
 import {
   AGENT_BASE_INSTRUCTIONS, DEFAULT_TOOL_TIMEOUT_MS, DISCOVERY_SESSION_TTL_MS,
   IMAGE_EXTENSIONS, MAX_DISCOVERY_SESSIONS, MAX_IMAGE_BYTES, MAX_IMAGES_PER_TURN,
@@ -288,7 +288,7 @@ export function createAgentHostService(options) {
   }
   const manage = createCompanionManagement({
     status: statusPayload, control: executeControl,
-    allowParentOrigin: origin => isAllowedAgentHostOrigin(origin, allowedOrigins),
+    allowParentOrigin: isAllowedCompanionManagementParent,
   });
 
   /** @param {Request} request */

--- a/lib/agent-host-service.js
+++ b/lib/agent-host-service.js
@@ -5,10 +5,10 @@ import { randomUUID } from 'node:crypto';
 import { unlink, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import {
-  AGENT_HOST_CAPABILITY_LIST, AGENT_HOST_PROTOCOL_VERSION,
+  AGENT_HOST_CAPABILITY_LIST, AGENT_HOST_PROTOCOL_VERSION, isAllowedCompanionManagementParent,
 } from '../shared/agent-host-protocol.js';
 import { startExternalAgentTurn } from './agent-host-external-turn.js';
-import { createCompanionManagement, isAllowedCompanionManagementParent } from './companion-management.js';
+import { createCompanionManagement } from './companion-management.js';
 import {
   AGENT_BASE_INSTRUCTIONS, DEFAULT_TOOL_TIMEOUT_MS, DISCOVERY_SESSION_TTL_MS,
   IMAGE_EXTENSIONS, MAX_DISCOVERY_SESSIONS, MAX_IMAGE_BYTES, MAX_IMAGES_PER_TURN,

--- a/lib/agent-host-service.js
+++ b/lib/agent-host-service.js
@@ -286,7 +286,10 @@ export function createAgentHostService(options) {
       return jsonResponse({ error: cleanError(error) }, 500, cors);
     }
   }
-  const manage = createCompanionManagement({ status: statusPayload, control: executeControl });
+  const manage = createCompanionManagement({
+    status: statusPayload, control: executeControl,
+    allowParentOrigin: origin => isAllowedAgentHostOrigin(origin, allowedOrigins),
+  });
 
   /** @param {Request} request */
   async function handleRequest(request) {

--- a/lib/companion-management.js
+++ b/lib/companion-management.js
@@ -2,20 +2,6 @@
 // Local management UI, optionally framed by an approved getbased origin. Never exports installation secrets.
 import { randomUUID } from 'node:crypto';
 
-// Management has a narrower trust boundary than chat: custom chat origins and
-// arbitrary loopback ports must never receive privileged frame access.
-const MANAGEMENT_PARENT_ORIGINS = new Set([
-  'https://getbased.health', 'https://www.getbased.health',
-  'https://app.getbased.health', 'https://beta.getbased.health',
-  'https://get-based.vercel.app', 'https://get-based-managed-subscription-v2.vercel.app',
-  'http://127.0.0.1:8000', 'http://localhost:8000',
-]);
-
-/** @param {string} origin */
-export function isAllowedCompanionManagementParent(origin) {
-  return MANAGEMENT_PARENT_ORIGINS.has(origin);
-}
-
 /** @param {{status: () => any, control: (request: Request) => Promise<Response>, now?: () => number, allowParentOrigin?: (origin: string) => boolean}} options */
 export function createCompanionManagement(options) {
   const now = options.now || Date.now;

--- a/lib/companion-management.js
+++ b/lib/companion-management.js
@@ -2,6 +2,20 @@
 // Local management UI, optionally framed by an approved getbased origin. Never exports installation secrets.
 import { randomUUID } from 'node:crypto';
 
+// Management has a narrower trust boundary than chat: custom chat origins and
+// arbitrary loopback ports must never receive privileged frame access.
+const MANAGEMENT_PARENT_ORIGINS = new Set([
+  'https://getbased.health', 'https://www.getbased.health',
+  'https://app.getbased.health', 'https://beta.getbased.health',
+  'https://get-based.vercel.app', 'https://get-based-managed-subscription-v2.vercel.app',
+  'http://127.0.0.1:8000', 'http://localhost:8000',
+]);
+
+/** @param {string} origin */
+export function isAllowedCompanionManagementParent(origin) {
+  return MANAGEMENT_PARENT_ORIGINS.has(origin);
+}
+
 /** @param {{status: () => any, control: (request: Request) => Promise<Response>, now?: () => number, allowParentOrigin?: (origin: string) => boolean}} options */
 export function createCompanionManagement(options) {
   const now = options.now || Date.now;
@@ -108,7 +122,7 @@ function render(value){
   const installed=value.runtimeMode==='installed';
   restartRequired=Boolean(value.restartRequired);
   status.textContent=value.paused?'Paused':'Connected';
-  document.getElementById('startup-description').textContent=(installed?'Starts automatically at login':'Connected for this terminal session')+(value.companionVersion?' · v'+value.companionVersion:'');
+  document.getElementById('startup-description').textContent=(installed?'Starts automatically at login':value.processMode==='service'?'Automatic startup removed · service still running':'Connected for this terminal session')+(value.companionVersion?' · v'+value.companionVersion:'');
   for(const button of buttons){
     const action=button.dataset.action;
     button.hidden=button.id==='finish-update'?!restartRequired:action==='install'?installed:action==='resume'?!value.paused:action==='pause'?value.paused:['restart-companion','update','uninstall'].includes(action)&&!installed;
@@ -131,6 +145,14 @@ async function waitForRestart(){
     await new Promise(resolve=>setTimeout(resolve,600));
     try{
       const response=await fetch('/manage/status',{cache:'no-store',headers:{Authorization:'Bearer '+credential},signal:AbortSignal.timeout(1500)});
+      if(response.ok){
+        const value=await response.json();
+        if(value.restartStatus==='failed'){
+          render(value);
+          message.textContent='Restart failed. Your previous connection is still available.';
+          return;
+        }
+      }
       if(response.status===403){
         const health=await fetch('/health',{cache:'no-store',signal:AbortSignal.timeout(1500)});
         if(health.ok&&(await health.json()).service==='getbased-agent-host'){location.reload();return;}

--- a/lib/companion-management.js
+++ b/lib/companion-management.js
@@ -1,8 +1,8 @@
 // @ts-check
-// Same-origin, user-opened management UI. Never exports installation secrets.
+// Local management UI, optionally framed by an approved getbased origin. Never exports installation secrets.
 import { randomUUID } from 'node:crypto';
 
-/** @param {{status: () => any, control: (request: Request) => Promise<Response>, now?: () => number}} options */
+/** @param {{status: () => any, control: (request: Request) => Promise<Response>, now?: () => number, allowParentOrigin?: (origin: string) => boolean}} options */
 export function createCompanionManagement(options) {
   const now = options.now || Date.now;
   /** @type {Map<string, {origin: string, expires: number}>} */
@@ -21,16 +21,29 @@ export function createCompanionManagement(options) {
     // from the listening address. Check both to prevent DNS-rebinding aliases.
     if (url.hostname !== '127.0.0.1' || request.headers.get('Host') !== url.host) return deny();
     for (const [key, session] of sessions) if (session.expires <= now()) sessions.delete(key);
-    if (url.pathname === '/manage' && request.method === 'GET') {
+    const embedded = url.pathname === '/manage/embed';
+    const parentOrigin = url.searchParams.get('parentOrigin') || '';
+    if ((url.pathname === '/manage' || embedded) && request.method === 'GET') {
+      if (embedded) {
+        let normalized;
+        try { normalized = new URL(parentOrigin).origin; } catch { return deny(); }
+        if (normalized !== parentOrigin || !options.allowParentOrigin?.(parentOrigin)) return deny();
+      }
       if (request.headers.get('Sec-Fetch-Mode') !== 'navigate'
-        || request.headers.get('Sec-Fetch-Dest') !== 'document') return deny();
+        || request.headers.get('Sec-Fetch-Dest') !== (embedded ? 'iframe' : 'document')) return deny();
       while (sessions.size >= 8) sessions.delete(sessions.keys().next().value);
       const key = randomUUID();
       const nonce = randomUUID();
       sessions.set(key, { origin: url.origin, expires: now() + 15 * 60_000 });
-      return new Response(managementHTML(key, nonce), { headers: {
-        ...headers, 'Content-Type': 'text/html; charset=utf-8',
-        'Content-Security-Policy': `default-src 'none'; script-src 'nonce-${nonce}'; style-src 'nonce-${nonce}'; connect-src 'self'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'`,
+      const pageHeaders = { ...headers };
+      if (embedded) {
+        delete pageHeaders['X-Frame-Options'];
+        pageHeaders['Cross-Origin-Resource-Policy'] = 'cross-origin';
+        pageHeaders['Cross-Origin-Embedder-Policy'] = 'credentialless';
+      }
+      return new Response(managementHTML(key, nonce, embedded, url.searchParams.get('theme') === 'light', parentOrigin), { headers: {
+        ...pageHeaders, 'Content-Type': 'text/html; charset=utf-8',
+        'Content-Security-Policy': `default-src 'none'; script-src 'nonce-${nonce}'; style-src 'nonce-${nonce}'; connect-src 'self'; frame-ancestors ${embedded ? parentOrigin : "'none'"}; base-uri 'none'; form-action 'none'`,
       } });
     }
     const session = sessions.get(request.headers.get('Authorization')?.replace(/^Bearer /, '') || '');
@@ -50,28 +63,122 @@ export function createCompanionManagement(options) {
   };
 }
 
-/** @param {string} key @param {string} nonce */
-function managementHTML(key, nonce) {
-  return `<!doctype html><html lang="en"><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+/** @param {string} key @param {string} nonce @param {boolean} embedded @param {boolean} light @param {string} parentOrigin */
+function managementHTML(key, nonce, embedded, light, parentOrigin) {
+  return `<!doctype html><html lang="en" data-theme="${light ? 'light' : 'dark'}"><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>getbased Companion</title><style nonce="${nonce}">
-body{font:16px system-ui,sans-serif;background:#141820;color:#eef2fa;margin:0;padding:24px}main{max-width:640px;margin:5vh auto}h1{font-size:26px}p{line-height:1.6;color:#c0cada}button{font:inherit;border:1px solid #718099;border-radius:8px;padding:12px;background:#24334a;color:inherit;cursor:pointer}button:disabled{opacity:.5;cursor:wait}button:focus-visible{outline:3px solid #80abff}nav{display:flex;flex-wrap:wrap;gap:12px;margin:24px 0}#status{padding:16px;border:1px solid #52627d;border-radius:10px}#message{min-height:3em}small{color:#a9b6c9}
-</style><main><h1>getbased Companion</h1><p>This page runs on your computer. Hosted getbased can chat through Companion, but only this local management page can use these controls.</p>
-<p id="status">Checking connection…</p><nav aria-label="Companion controls">
-<button data-action="pause">Pause</button><button data-action="restart">Reconnect CLIs</button>
-<button data-action="install">Start automatically</button><button data-action="restart-companion">Restart companion</button>
-<button data-action="update">Check for update</button><button data-action="uninstall">Uninstall</button>
-</nav><p id="message" role="status" aria-live="polite"></p><button id="refresh">Refresh status</button>
-<p><small>Reconnect CLIs resets agent connections. Restart companion reloads the installed service. Uninstall removes automatic startup and its runtime, not your agents or health data. An updated bundle takes effect after restart. This management session expires after 15 minutes; reopen the page to continue.</small></p></main>
+*{box-sizing:border-box}
+body{font:11px system-ui,sans-serif;background:var(--bg);color:var(--text);margin:0;--bg:#232737;--text:#edf0f5;--muted:#a8b0be;--border:#363d49;--button:#252c38;--accent:#9fc5ff;color-scheme:dark}
+html[data-theme="light"] body{--bg:#f7f8fa;--text:#252b36;--muted:#606b7c;--border:#d7dce4;--button:#fff;--accent:#225ab0;color-scheme:light}
+main{max-width:680px;margin:${embedded ? '0' : '5vh auto'};padding:${embedded ? '10px 12px' : '24px'}}
+h1{font-size:20px;margin:0 0 8px}p{line-height:1.5;color:var(--muted)}
+button{font:inherit;font-weight:600;border:1px solid var(--border);border-radius:6px;padding:4px 10px;background:var(--button);color:var(--text);cursor:pointer;white-space:nowrap}
+button:hover{border-color:var(--accent)}button:disabled{opacity:.5;cursor:wait}button:focus-visible,summary:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+[hidden]{display:none!important}.overview{display:flex;align-items:center;justify-content:space-between;gap:12px}.overview strong{font-size:11px}.overview small{display:block;color:var(--muted);font-size:10px;line-height:1.5;margin-top:3px}
+.actions{display:flex;gap:6px;flex-wrap:wrap}.advanced-actions{margin-top:10px;display:flex;gap:6px;flex-wrap:wrap}details{margin-top:10px}summary{color:var(--muted);cursor:pointer;font-size:10px;width:fit-content}details p{font-size:10px;margin:8px 0 0}
+#message:empty{display:none}#message{margin:8px 0 0;font-size:10px}#confirmation{padding:10px;border:1px solid var(--border);border-radius:6px;margin-top:10px}#confirmation p{margin:0 0 8px}
+.danger{color:#ed7d85}html[data-theme="light"] .danger{color:#b32738}
+@media(max-width:380px){.overview{align-items:flex-start;flex-wrap:wrap}}
+</style><main>${embedded ? '' : '<h1>getbased Companion</h1>'}
+<div class="overview"><div><strong id="status" role="status">Checking connection…</strong><small id="startup-description"></small></div>
+<div class="actions"><button data-action="install" hidden>Start automatically</button><button data-action="update" hidden>Check for update</button><button data-action="resume" id="resume" hidden>Resume</button><button data-action="restart-companion" id="finish-update" hidden>Restart to finish update</button></div></div>
+<details id="advanced"><summary>Advanced</summary><div class="advanced-actions">
+<button data-action="pause">Pause</button><button data-action="restart">Reconnect CLIs</button><button data-action="restart-companion">Restart Companion</button><button class="danger" data-action="uninstall">Uninstall…</button>
+</div><p>Use these if an agent stops responding or you want to remove Companion.</p></details>
+<section id="confirmation" hidden aria-label="Confirm uninstall"><p>Remove Companion and automatic startup? Your CLI agents and health data will stay in place.</p><div class="actions"><button id="confirm-uninstall" class="danger">Uninstall Companion</button><button id="cancel-action">Cancel</button></div></section>
+<p id="message" role="status" aria-live="polite"></p>${embedded ? '' : '<button id="reconnect" hidden>Try again</button>'}</main>
 <script nonce="${nonce}">
 const credential=${JSON.stringify(key)};
+const embedded=${JSON.stringify(embedded)};
+const parentOrigin=${JSON.stringify(parentOrigin)};
 const status=document.getElementById('status'), message=document.getElementById('message');
 const buttons=[...document.querySelectorAll('[data-action]')];
+const confirmation=document.getElementById('confirmation');
+let busy=false, restartRequired=false;
 buttons.forEach(button=>button.disabled=true);
-let busy=false;
-async function request(path,action){const response=await fetch('/manage/'+path,{cache:'no-store',headers:{Authorization:'Bearer '+credential,...(action?{'Content-Type':'application/json'}:{})},...(action?{method:'POST',body:JSON.stringify({action})}:{})});if(response.status===403)throw Error('Session expired or access denied. Reopen this local page.');const value=await response.json();if(!response.ok)throw Error(value.error==='finish_the_active_response_first'?'Finish or stop the current AI response first.':value.error||'The operation failed.');return value;}
-function render(value){const installed=value.runtimeMode==='installed';status.textContent=(installed?'Installed · starts at login':'Temporary')+' · '+(value.processMode==='service'?'Background service':'Terminal session')+' · '+(value.paused?'Paused':'Running')+' · v'+(value.companionVersion||'unknown')+' · '+location.host;for(const button of buttons){const action=button.dataset.action;button.hidden=action==='install'?installed:['restart-companion','update','uninstall'].includes(action)&&!installed;if(action==='pause'||action==='resume'){button.dataset.action=value.paused?'resume':'pause';button.textContent=value.paused?'Resume':'Pause';}button.disabled=busy;}}
-async function refresh(){try{render(await request('status'));}catch(error){message.textContent=error.message;}}
-for(const button of buttons)button.addEventListener('click',async()=>{if(busy)return;const action=button.dataset.action;if(['install','uninstall','update','restart-companion'].includes(action)&&!confirm(button.textContent+' on this computer?'))return;busy=true;buttons.forEach(item=>item.disabled=true);message.textContent='Working…';try{const value=await request('control',action);message.textContent=value.restartRequired?'Update installed. Restart companion to use it.':value.restarting?'Restart requested. Refresh status after it starts; reopen this page if its session expired.':action==='install'?'Automatic startup configured. Choose Restart companion to hand over this terminal session to the background service.':action==='uninstall'?'Automatic startup and its runtime removed. This running instance remains available until stopped.':'Done.';render(value);}catch(error){message.textContent=error.message;}finally{busy=false;buttons.forEach(item=>item.disabled=false);}});
-document.getElementById('refresh').addEventListener('click',refresh);refresh();
+function recoveryText(){return embedded?'Select Check connection above to reconnect.':'Select Try again to reconnect.';}
+async function request(path,action){
+  const response=await fetch('/manage/'+path,{cache:'no-store',headers:{Authorization:'Bearer '+credential,...(action?{'Content-Type':'application/json'}:{})},...(action?{method:'POST',body:JSON.stringify({action})}:{})});
+  if(response.status===403)throw Error('Session expired. '+recoveryText());
+  const value=await response.json();
+  if(!response.ok)throw Error(value.error==='finish_the_active_response_first'?'Finish or stop the current AI response first.':value.error||'The operation failed.');
+  return value;
+}
+function render(value){
+  const installed=value.runtimeMode==='installed';
+  restartRequired=Boolean(value.restartRequired);
+  status.textContent=value.paused?'Paused':'Connected';
+  document.getElementById('startup-description').textContent=(installed?'Starts automatically at login':'Connected for this terminal session')+(value.companionVersion?' · v'+value.companionVersion:'');
+  for(const button of buttons){
+    const action=button.dataset.action;
+    button.hidden=button.id==='finish-update'?!restartRequired:action==='install'?installed:action==='resume'?!value.paused:action==='pause'?value.paused:['restart-companion','update','uninstall'].includes(action)&&!installed;
+    button.disabled=busy;
+  }
+}
+function showError(error){
+  message.textContent=error instanceof TypeError?'Companion is unavailable. '+recoveryText():error.message;
+  const reconnect=document.getElementById('reconnect');
+  if(reconnect)reconnect.hidden=false;
+}
+async function refresh(){try{render(await request('status'));}catch(error){showError(error);}}
+async function waitForRestart(){
+  status.textContent='Reconnecting…';
+  document.getElementById('finish-update').hidden=true;
+  // Keep this document visible during downtime. A new service rejects the old
+  // management session; reload only once that new service can answer requests.
+  const deadline=Date.now()+30000;
+  while(Date.now()<deadline){
+    await new Promise(resolve=>setTimeout(resolve,600));
+    try{
+      const response=await fetch('/manage/status',{cache:'no-store',headers:{Authorization:'Bearer '+credential},signal:AbortSignal.timeout(1500)});
+      if(response.status===403){
+        const health=await fetch('/health',{cache:'no-store',signal:AbortSignal.timeout(1500)});
+        if(health.ok&&(await health.json()).service==='getbased-agent-host'){location.reload();return;}
+      }
+    }catch{/* Companion is still restarting. */}
+  }
+  status.textContent='Connection interrupted';
+  throw Error('Companion has not reconnected yet. '+recoveryText());
+}
+async function execute(action){
+  if(busy)return;
+  busy=true;
+  confirmation.hidden=true;
+  buttons.forEach(item=>item.disabled=true);
+  message.textContent=action==='update'?'Checking for updates…':'Working…';
+  try{
+    const value=await request('control',action);
+    message.textContent=value.restarting?'Restarting Companion…':value.restartRequired?(value.updated?'Update installed. Restart when you’re ready.':'Update ready. Restart when you’re ready.'):action==='update'?'Companion is up to date.':action==='install'?'Automatic startup enabled.':action==='uninstall'?'Companion removed. This connection stays available until stopped.':action==='restart'?'CLI connections refreshed.':'';
+    if(action==='install'&&value.processMode==='terminal'){value.restartRequired=true;message.textContent='Automatic startup enabled. Restart to switch to the background service.';}
+    render(value);
+    if(value.restarting)await waitForRestart();
+  }catch(error){showError(error);}finally{
+    busy=false;
+    buttons.forEach(item=>item.disabled=false);
+  }
+}
+for(const button of buttons)button.addEventListener('click',()=>{
+  if(busy)return;
+  confirmation.hidden=true;
+  if(button.dataset.action==='uninstall'){
+    confirmation.hidden=false;
+    document.getElementById('confirm-uninstall').focus();
+  }else void execute(button.dataset.action);
+});
+document.getElementById('confirm-uninstall').addEventListener('click',()=>{if(!confirmation.hidden)void execute('uninstall');});
+document.getElementById('cancel-action').addEventListener('click',()=>{confirmation.hidden=true;});
+document.getElementById('reconnect')?.addEventListener('click',()=>location.reload());
+if(embedded){
+  // Only visual properties cross this boundary; management credentials never do.
+  window.addEventListener('message',event=>{
+    if(event.source!==parent||event.origin!==parentOrigin||event.data?.type!=='getbased-companion-panel-theme')return;
+    for(const key of ['bg','text','muted','border','button','accent']){
+      const value=event.data.colors?.[key];
+      if(typeof value==='string'&&CSS.supports('color',value))document.body.style.setProperty('--'+key,value);
+    }
+  });
+  new ResizeObserver(()=>parent.postMessage({type:'getbased-companion-panel-size',height:Math.ceil(document.querySelector('main').getBoundingClientRect().height)+2},parentOrigin)).observe(document.querySelector('main'));
+}
+refresh();
 </script></html>`;
 }

--- a/lib/companion-runtime-control.js
+++ b/lib/companion-runtime-control.js
@@ -94,8 +94,10 @@ export function createCompanionRuntimeController(options) {
   let runtimeMode = String(env.GETBASED_COMPANION_SERVICE || '').trim() === '1' ? 'installed' : 'temporary';
 
   let pendingUpdateVersion = '';
+  let restartStatus = '';
   const getInfo = () => ({
     restartRequired: Boolean(pendingUpdateVersion),
+    restartStatus,
     ...(pendingUpdateVersion ? { pendingUpdateVersion } : {}),
     companionVersion: GETBASED_COMPANION_VERSION,
     runtimeMode,
@@ -114,6 +116,7 @@ export function createCompanionRuntimeController(options) {
       if (runtimeMode !== 'installed') {
         throw new Error('Start the companion automatically before restarting it from getbased.');
       }
+      restartStatus = 'restarting';
       scheduleImpl(async () => {
         let listenerStopped = false;
         try {
@@ -128,6 +131,7 @@ export function createCompanionRuntimeController(options) {
           if (handoff) options.exitRuntime?.();
         }
         catch (error) {
+          restartStatus = 'failed';
           process.stderr.write(`getbased Companion restart failed: ${error instanceof Error ? error.message : String(error)}\n`);
           if (listenerStopped) {
             try { await options.recoverRuntime?.(); }
@@ -148,6 +152,7 @@ export function createCompanionRuntimeController(options) {
       if (runtimeMode !== 'installed') return { ...getInfo(), uninstalled: true };
       uninstallImpl({ env, platform, stopService: false });
       runtimeMode = 'temporary';
+      pendingUpdateVersion = '';
       return { ...getInfo(), uninstalled: true };
     }
     if (action === 'update') {

--- a/lib/companion-runtime-control.js
+++ b/lib/companion-runtime-control.js
@@ -50,6 +50,23 @@ async function readVerifiedBundle(response) {
   return bytes;
 }
 
+/** Read the release version as data; never evaluate downloaded code. @param {Buffer} bytes */
+function bundleVersion(bytes) {
+  const matches = [...bytes.toString('utf8').matchAll(/^\s*(?:(?:export\s+)?(?:const|let|var)\s+)?GETBASED_COMPANION_VERSION\s*=\s*["'](\d+\.\d+\.\d+)["'];?\s*$/gm)];
+  if (matches.length !== 1) throw new Error('Could not verify the Companion update version. Nothing was installed.');
+  return matches[0][1];
+}
+
+/** @param {string} candidate @param {string} current */
+function newerVersion(candidate, current) {
+  const next = candidate.split('.').map(Number);
+  const previous = current.split('.').map(Number);
+  for (let index = 0; index < 3; index++) {
+    if (next[index] !== previous[index]) return next[index] > previous[index];
+  }
+  return false;
+}
+
 /**
  * @param {{
  *   appServer: {restart: () => Promise<unknown>, initialize: () => Promise<unknown>},
@@ -76,7 +93,10 @@ export function createCompanionRuntimeController(options) {
   const scheduleImpl = options.scheduleImpl || setTimeout;
   let runtimeMode = String(env.GETBASED_COMPANION_SERVICE || '').trim() === '1' ? 'installed' : 'temporary';
 
+  let pendingUpdateVersion = '';
   const getInfo = () => ({
+    restartRequired: Boolean(pendingUpdateVersion),
+    ...(pendingUpdateVersion ? { pendingUpdateVersion } : {}),
     companionVersion: GETBASED_COMPANION_VERSION,
     runtimeMode,
     processMode: String(env.GETBASED_COMPANION_SERVICE || '').trim() === '1' ? 'service' : 'terminal',
@@ -136,6 +156,12 @@ export function createCompanionRuntimeController(options) {
         cache: 'no-store', redirect: 'error', signal: AbortSignal.timeout(30_000),
       });
       const bytes = await readVerifiedBundle(response);
+      const availableVersion = bundleVersion(bytes);
+      // A local preview or pending update must never be replaced by the same
+      // release or an older production bundle.
+      if (!newerVersion(availableVersion, pendingUpdateVersion || GETBASED_COMPANION_VERSION)) {
+        return { ...getInfo(), availableVersion, updated: false, upToDate: !pendingUpdateVersion };
+      }
       const temporaryBundle = join(tmpdir(), `getbased-companion-update-${randomUUID()}.mjs`);
       try {
         writeFileSync(temporaryBundle, bytes, { mode: 0o700, flag: 'wx' });
@@ -144,6 +170,7 @@ export function createCompanionRuntimeController(options) {
       } finally {
         rmSync(temporaryBundle, { force: true });
       }
+      pendingUpdateVersion = availableVersion;
       return { ...getInfo(), updated: true, restartRequired: true };
     }
     throw new Error('Unsupported companion control action.');

--- a/shared/agent-host-protocol.js
+++ b/shared/agent-host-protocol.js
@@ -57,4 +57,3 @@ const MANAGEMENT_PARENT_ORIGINS = new Set([
 export function isAllowedCompanionManagementParent(origin) {
   return MANAGEMENT_PARENT_ORIGINS.has(origin);
 }
-

--- a/shared/agent-host-protocol.js
+++ b/shared/agent-host-protocol.js
@@ -42,3 +42,19 @@ export function normalizeAgentHostProtocolVersion(value) {
   const version = Number(value);
   return Number.isInteger(version) && version > 0 ? version : 0;
 }
+
+// Management has a narrower trust boundary than chat: custom chat origins and
+// arbitrary loopback ports must never receive privileged frame access.
+const MANAGEMENT_PARENT_ORIGINS = new Set([
+  'https://getbased.health', 'https://www.getbased.health',
+  'https://app.getbased.health', 'https://beta.getbased.health',
+  'https://get-based.vercel.app', 'https://get-based-managed-subscription-v2.vercel.app',
+  'http://iobqafpywmncin7m2wpvbemouvulaeb7jnvtvugxnru4gpneushb5jyd.onion',
+  'http://127.0.0.1:8000', 'http://localhost:8000',
+]);
+
+/** @param {string} origin */
+export function isAllowedCompanionManagementParent(origin) {
+  return MANAGEMENT_PARENT_ORIGINS.has(origin);
+}
+

--- a/shared/agent-host-protocol.js
+++ b/shared/agent-host-protocol.js
@@ -2,13 +2,14 @@
 // Runtime-neutral version and capability contract for the loopback companion.
 
 export const AGENT_HOST_PROTOCOL_VERSION = 5;
-export const GETBASED_COMPANION_VERSION = '1.3.0';
+export const GETBASED_COMPANION_VERSION = '1.3.1';
 
 export const AGENT_HOST_CAPABILITIES = Object.freeze({
   CHAT_STREAM: 'chat-stream',
   COMPANION_CONTROL: 'companion-control',
   COMPANION_RESTART: 'companion-restart',
   COMPANION_MANAGEMENT: 'companion-management',
+  COMPANION_MANAGEMENT_EMBEDDED: 'companion-management-embedded',
   DYNAMIC_TOOLS: 'dynamic-tools',
   EXECUTION_TARGETS: 'execution-targets',
   IMAGE_UPLOAD: 'image-upload',

--- a/tests/agent-host-service.test.js
+++ b/tests/agent-host-service.test.js
@@ -40,7 +40,7 @@ it('never grants lifecycle authority to browser discovery sessions', async () =>
 it('keeps configured chat origins out of embedded management', async () => {
   const service = createAgentHostService({ appServer: new FakeAppServer(), token: TOKEN,
     workspaceRoot: '/tmp/agent-test', allowedOrigins: ['https://custom-chat.example'] });
-  for (const [origin, expected] of [['https://app.getbased.health', 200], ['http://127.0.0.1:8000', 200], ['http://localhost:9999', 403], ['https://custom-chat.example', 403]]) {
+  for (const [origin, expected] of [['https://app.getbased.health', 200], ['http://127.0.0.1:8000', 200], ['http://iobqafpywmncin7m2wpvbemouvulaeb7jnvtvugxnru4gpneushb5jyd.onion', 200], ['http://localhost:9999', 403], ['https://custom-chat.example', 403]]) {
     const response = await service.handleRequest(new Request(`http://127.0.0.1:8324/manage/embed?parentOrigin=${encodeURIComponent(origin)}`, {
       headers: { Host: '127.0.0.1:8324', 'Sec-Fetch-Mode': 'navigate', 'Sec-Fetch-Dest': 'iframe' },
     }));

--- a/tests/agent-host-service.test.js
+++ b/tests/agent-host-service.test.js
@@ -37,6 +37,17 @@ it('never grants lifecycle authority to browser discovery sessions', async () =>
   expect(controlHandler).not.toHaveBeenCalled();
 });
 
+it('keeps configured chat origins out of embedded management', async () => {
+  const service = createAgentHostService({ appServer: new FakeAppServer(), token: TOKEN,
+    workspaceRoot: '/tmp/agent-test', allowedOrigins: ['https://custom-chat.example'] });
+  for (const [origin, expected] of [['https://app.getbased.health', 200], ['http://127.0.0.1:8000', 200], ['http://localhost:9999', 403], ['https://custom-chat.example', 403]]) {
+    const response = await service.handleRequest(new Request(`http://127.0.0.1:8324/manage/embed?parentOrigin=${encodeURIComponent(origin)}`, {
+      headers: { Host: '127.0.0.1:8324', 'Sec-Fetch-Mode': 'navigate', 'Sec-Fetch-Dest': 'iframe' },
+    }));
+    expect(response.status).toBe(expected);
+  }
+});
+
 class FakeAppServer extends EventEmitter {
   constructor() {
     super();

--- a/tests/chat-onboarding-cli.test.js
+++ b/tests/chat-onboarding-cli.test.js
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import { afterEach, expect, it, vi } from 'vitest';
+import { configureChatOnboarding, _renderProviderQuiz } from '../js/chat-onboarding.js';
+
+afterEach(() => {
+  vi.useRealTimers();
+  document.body.innerHTML = '';
+  configureChatOnboarding({ openSettingsModal: () => {} });
+});
+
+it('puts card payment first and recommends it, with CLI prerequisites and a terminal icon', () => {
+  document.body.innerHTML = _renderProviderQuiz('', 'Test');
+  const choices = document.querySelectorAll('[data-chat-provider-branch]');
+  expect(choices[0].getAttribute('data-chat-provider-branch')).toBe('card');
+  expect(document.querySelectorAll('.chat-quiz-recommended')).toHaveLength(1);
+  expect(choices[0].textContent).toContain('Recommended');
+  const cli = document.querySelector('[data-chat-provider-branch="cli"]');
+  expect(cli.textContent).toContain('Requires an installed CLI, sign-in, and getbased Companion');
+  expect(cli.querySelector('svg')).not.toBeNull();
+});
+
+it('waits for lazy Settings to render before selecting CLI agents', async () => {
+  vi.useFakeTimers();
+  let finishLoading;
+  const selected = vi.fn();
+  const opening = new Promise(resolve => { finishLoading = resolve; });
+  const openSettingsModal = vi.fn(() => opening.then(() => {
+    const button = document.createElement('button');
+    button.dataset.settingsAction = 'show-cli-agent-provider';
+    button.addEventListener('click', selected);
+    document.body.append(button);
+  }));
+  configureChatOnboarding({ openSettingsModal });
+  document.body.innerHTML = _renderProviderQuiz('cli', 'Test');
+  document.querySelector('[data-chat-provider="cli"]').click();
+  await vi.advanceTimersByTimeAsync(300);
+  expect(openSettingsModal).toHaveBeenCalledWith('ai');
+  expect(selected).not.toHaveBeenCalled();
+  finishLoading();
+  await vi.advanceTimersByTimeAsync(0);
+  expect(selected).toHaveBeenCalledOnce();
+});

--- a/tests/cli-companion-ui.test.js
+++ b/tests/cli-companion-ui.test.js
@@ -155,18 +155,26 @@ describe('CLI companion setup UI', () => {
     expect(companion.querySelector('[data-settings-action="control-cli-companion"]')).toBeNull();
   });
 
-  it('shows supported local management inside Settings without putting a credential in the frame URL', async () => {
+  it.each(['http://localhost:8000', 'http://iobqafpywmncin7m2wpvbemouvulaeb7jnvtvugxnru4gpneushb5jyd.onion', 'https://custom-chat.example'])('uses embedded controls or a local fallback on %s without sharing credentials', async origin => {
+    vi.stubGlobal('location', { origin });
     vi.stubGlobal('fetch', vi.fn(async input => {
       if (String(input).startsWith('/api/local-agents')) return Response.json({ agents: [] });
       return Response.json({
         service: 'getbased-agent-host', endpoint: 'http://127.0.0.1:8325', token: '1234567890123456',
-        capabilities: ['companion-control', 'companion-restart', 'companion-management-embedded'], runtimeMode: 'installed',
+        capabilities: ['companion-control', 'companion-restart', 'companion-management', 'companion-management-embedded'], runtimeMode: 'installed',
         agents: [{ id: 'codex', status: 'available', compatible: true }],
       });
     }));
     await refreshDetectedAgentList();
     const companion = document.getElementById('local-agent-companion-section');
     const frame = companion.querySelector('iframe');
+    if (origin === 'https://custom-chat.example') {
+      expect(frame).toBeNull();
+      expect(companion.querySelector('a').href).toBe('http://127.0.0.1:8325/manage');
+      expect(companion.textContent).toContain('from this deployment');
+      expect(companion.textContent).not.toContain('Update Companion once');
+      return;
+    }
     expect(frame.title).toBe('Companion controls');
     const url = new URL(frame.src);
     expect(url.origin + url.pathname).toBe('http://127.0.0.1:8325/manage/embed');

--- a/tests/cli-companion-ui.test.js
+++ b/tests/cli-companion-ui.test.js
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { refreshDetectedAgentList, toggleCLIAgentOptions } from '../js/settings-cli-agent-panel.js';
+import { refreshDetectedAgentList, renderCLIAgentProviderPanel, resizeCLICompanionPanel, toggleCLIAgentOptions } from '../js/settings-cli-agent-panel.js';
 
 describe('CLI companion setup UI', () => {
   it('collapses agent settings without changing the selected provider or controls', () => {
@@ -73,7 +73,7 @@ describe('CLI companion setup UI', () => {
     expect(companion.querySelector('[data-value="uninstall"]')).toBeNull();
   });
 
-  it('separates CLI reconnection from an installed companion service restart', async () => {
+  it('checks an installed companion on first opening without a manual connection check', async () => {
     vi.stubGlobal('fetch', vi.fn(async input => {
       if (String(input).startsWith('/api/local-agents')) return new Response(JSON.stringify({ agents: [{
         id: 'codex', name: 'Codex CLI', status: 'available', compatible: true,
@@ -86,7 +86,14 @@ describe('CLI companion setup UI', () => {
       }), { status: 200, headers: { 'Content-Type': 'application/json' } });
     }));
 
-    await refreshDetectedAgentList();
+    document.body.innerHTML = renderCLIAgentProviderPanel();
+    expect(document.body.textContent).toContain('Scanning this computer');
+    expect(document.querySelector('.local-agent-install-card')).toBeNull();
+    await vi.waitFor(() => {
+      expect(document.querySelector('[data-value="restart-companion"]')).not.toBeNull();
+    });
+    expect(fetch).toHaveBeenCalledWith('/api/local-agents?refresh=1', expect.any(Object));
+    expect(document.querySelector('.local-agent-install-card')).toBeNull();
 
     const companion = document.getElementById('local-agent-companion-section');
     expect(companion.querySelector('[data-value="restart"]')?.textContent).toContain('Reconnect CLIs');
@@ -146,6 +153,40 @@ describe('CLI companion setup UI', () => {
     expect(companion.textContent).toContain('Starts automatically at login');
     expect(companion.innerHTML).not.toContain('1234567890123456');
     expect(companion.querySelector('[data-settings-action="control-cli-companion"]')).toBeNull();
+  });
+
+  it('shows supported local management inside Settings without putting a credential in the frame URL', async () => {
+    vi.stubGlobal('fetch', vi.fn(async input => {
+      if (String(input).startsWith('/api/local-agents')) return Response.json({ agents: [] });
+      return Response.json({
+        service: 'getbased-agent-host', endpoint: 'http://127.0.0.1:8325', token: '1234567890123456',
+        capabilities: ['companion-control', 'companion-restart', 'companion-management-embedded'], runtimeMode: 'installed',
+        agents: [{ id: 'codex', status: 'available', compatible: true }],
+      });
+    }));
+    await refreshDetectedAgentList();
+    const companion = document.getElementById('local-agent-companion-section');
+    const frame = companion.querySelector('iframe');
+    expect(frame.title).toBe('Companion controls');
+    const url = new URL(frame.src);
+    expect(url.origin + url.pathname).toBe('http://127.0.0.1:8325/manage/embed');
+    expect(url.searchParams.get('parentOrigin')).toBe(location.origin);
+    expect(frame.getAttribute('sandbox')).toBe('allow-scripts allow-same-origin');
+    expect(companion.querySelector('a')).toBeNull();
+    expect(companion.innerHTML).not.toContain('1234567890123456');
+  });
+
+  it('accepts bounded frame sizing only from its own local management panel', () => {
+    document.body.innerHTML = '<iframe class="local-agent-management-frame" src="http://127.0.0.1:8325/manage/embed"></iframe>';
+    const frame = document.querySelector('iframe');
+    const event = { data: { type: 'getbased-companion-panel-size', height: 340 }, origin: 'http://127.0.0.1:8325', source: frame.contentWindow };
+    resizeCLICompanionPanel({ ...event, origin: 'https://attacker.example' });
+    resizeCLICompanionPanel({ ...event, source: window });
+    expect(frame.style.height).toBe('');
+    resizeCLICompanionPanel(event);
+    expect(frame.style.height).toBe('340px');
+    resizeCLICompanionPanel({ ...event, data: { ...event.data, height: 100000 } });
+    expect(frame.style.height).toBe('800px');
   });
 
   it('shows a stopped companion state without attempting to load models', async () => {

--- a/tests/companion-management.test.js
+++ b/tests/companion-management.test.js
@@ -1,6 +1,8 @@
 // @vitest-environment node
 import { describe, expect, it, vi } from 'vitest';
-import { createCompanionManagement, isAllowedCompanionManagementParent } from '../lib/companion-management.js';
+import { createCompanionManagement } from '../lib/companion-management.js';
+import { isAllowedCompanionManagementParent } from '../shared/agent-host-protocol.js';
+import { readFileSync } from 'node:fs';
 import { findExistingCompanion } from '../lib/companion-existing.js';
 
 const origin = 'http://127.0.0.1:8324';
@@ -14,6 +16,9 @@ async function session(handle) {
 
 describe('local Companion management', () => {
   it('allows only exact getbased management parents, never arbitrary chat origins', () => {
+    const config = JSON.parse(readFileSync(new URL('../vercel.json', import.meta.url), 'utf8'));
+    const onion = config.routes.find(route => route.headers?.['Onion-Location']).headers['Onion-Location'];
+    expect(isAllowedCompanionManagementParent(new URL(onion).origin)).toBe(true);
     for (const origin of ['https://app.getbased.health', 'http://127.0.0.1:8000', 'http://localhost:8000']) {
       expect(isAllowedCompanionManagementParent(origin)).toBe(true);
     }

--- a/tests/companion-management.test.js
+++ b/tests/companion-management.test.js
@@ -19,7 +19,7 @@ describe('local Companion management', () => {
     const { response, html, token } = await session(handle);
     expect(response.headers.get('Content-Security-Policy')).toContain("frame-ancestors 'none'");
     expect(response.headers.has('Access-Control-Allow-Origin')).toBe(false);
-    expect(html).toContain('Start automatically');
+    expect(html).toContain('Automatic startup');
     const result = await handle(new Request(origin + '/manage/control', { method: 'POST', headers: { ...local, Authorization: `Bearer ${token}` }, body: '{"action":"pause"}' }));
     expect(result.status).toBe(200);
     expect(result.headers.has('Access-Control-Allow-Origin')).toBe(false);
@@ -32,6 +32,32 @@ describe('local Companion management', () => {
       const denied = await handle(new Request(origin + '/manage/control', { method: 'POST', headers: { Authorization: `Bearer ${token}`, ...headers }, body: '{}' }));
       expect(denied.status).toBe(403);
     }
+    expect(control).toHaveBeenCalledOnce();
+  });
+  it('embeds only for an approved exact parent origin and keeps control credentials local', async () => {
+    const parent = 'https://app.getbased.health';
+    const control = vi.fn(async () => Response.json({ ok: true }));
+    const handle = createCompanionManagement({ status: () => ({}), control, allowParentOrigin: value => value === parent });
+    const embed = (value, headers = {}) => handle(new Request(`${origin}/manage/embed?parentOrigin=${encodeURIComponent(value)}`, {
+      headers: { ...navigation, 'Sec-Fetch-Dest': 'iframe', ...headers },
+    }));
+    expect((await embed('https://attacker.example')).status).toBe(403);
+    expect((await embed(parent + '/path')).status).toBe(403);
+    expect((await embed(parent, { 'Sec-Fetch-Dest': 'document' })).status).toBe(403);
+    expect((await embed(parent, { Host: 'attacker.example:8324' })).status).toBe(403);
+    const response = await embed(parent);
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Security-Policy')).toContain(`frame-ancestors ${parent};`);
+    expect(response.headers.has('X-Frame-Options')).toBe(false);
+    expect(response.headers.has('Access-Control-Allow-Origin')).toBe(false);
+    const html = await response.text();
+    const token = html.match(/const credential="([^"]+)"/)[1];
+    const request = headers => handle(new Request(origin + '/manage/control', {
+      method: 'POST', headers: { ...local, Authorization: `Bearer ${token}`, ...headers }, body: '{"action":"pause"}',
+    }));
+    expect((await request({ Origin: parent, 'Sec-Fetch-Site': 'cross-site' })).status).toBe(403);
+    expect(control).not.toHaveBeenCalled();
+    expect((await request({})).status).toBe(200);
     expect(control).toHaveBeenCalledOnce();
   });
   it('refuses iframe, fetch, DNS aliases, expired and evicted sessions', async () => {

--- a/tests/companion-management.test.js
+++ b/tests/companion-management.test.js
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { describe, expect, it, vi } from 'vitest';
-import { createCompanionManagement } from '../lib/companion-management.js';
+import { createCompanionManagement, isAllowedCompanionManagementParent } from '../lib/companion-management.js';
 import { findExistingCompanion } from '../lib/companion-existing.js';
 
 const origin = 'http://127.0.0.1:8324';
@@ -13,6 +13,14 @@ async function session(handle) {
 }
 
 describe('local Companion management', () => {
+  it('allows only exact getbased management parents, never arbitrary chat origins', () => {
+    for (const origin of ['https://app.getbased.health', 'http://127.0.0.1:8000', 'http://localhost:8000']) {
+      expect(isAllowedCompanionManagementParent(origin)).toBe(true);
+    }
+    for (const origin of ['http://127.0.0.1:9999', 'http://localhost:8080', 'https://custom-chat.example', 'https://app.getbased.health:8443', 'https://app.getbased.health.attacker.example', 'null', '']) {
+      expect(isAllowedCompanionManagementParent(origin)).toBe(false);
+    }
+  });
   it('uses an isolated navigation-only page, not discovery or the persistent token', async () => {
     const control = vi.fn(async () => Response.json({ ok: true }));
     const handle = createCompanionManagement({ status: () => ({ runtimeMode: 'installed' }), control });

--- a/tests/companion-runtime-control.test.js
+++ b/tests/companion-runtime-control.test.js
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { createCompanionRuntimeController } from '../lib/companion-runtime-control.js';
 import { GETBASED_COMPANION_VERSION } from '../shared/agent-host-protocol.js';
 
-const VALID_BUNDLE = '#!/usr/bin/env node\nconst title = "getbased Companion"; const service = "getbased-agent-host";\n';
+const VALID_BUNDLE = '#!/usr/bin/env node\nconst title = "getbased Companion"; const service = "getbased-agent-host";\nconst GETBASED_COMPANION_VERSION = "99.0.0";\n';
 
 describe('running companion controls', () => {
   it('installs automatic startup from a temporary connection without starting a duplicate host', async () => {
@@ -117,6 +117,43 @@ describe('running companion controls', () => {
     expect(installImpl).toHaveBeenCalledWith(expect.objectContaining({ platform: 'linux', startService: false }));
     await controller.handle('update', { origin: 'http://localhost:9999' });
     expect(fetchImpl.mock.calls.every(([url]) => url === 'https://app.getbased.health/getbased-companion.mjs')).toBe(true);
+  });
+
+  it.each([GETBASED_COMPANION_VERSION, '1.0.0'])('does not install the same or an older release (%s)', async version => {
+    const installImpl = vi.fn();
+    const controller = createCompanionRuntimeController({
+      appServer: { restart: vi.fn(), initialize: vi.fn() }, bundlePath: '/tmp/getbased-companion.mjs',
+      env: { GETBASED_COMPANION_SERVICE: '1' }, installImpl,
+      fetchImpl: async () => new Response(VALID_BUNDLE.replace('99.0.0', version)),
+    });
+    await expect(controller.handle('update', { origin: 'http://localhost:8000' }))
+      .resolves.toMatchObject({ updated: false, upToDate: true, restartRequired: false });
+    expect(installImpl).not.toHaveBeenCalled();
+  });
+
+  it('installs a newer release once and preserves the pending restart across status checks', async () => {
+    const installImpl = vi.fn();
+    const controller = createCompanionRuntimeController({
+      appServer: { restart: vi.fn(), initialize: vi.fn() }, bundlePath: '/tmp/getbased-companion.mjs',
+      env: { GETBASED_COMPANION_SERVICE: '1' }, installImpl,
+      fetchImpl: async () => new Response(VALID_BUNDLE),
+    });
+    await controller.handle('update', { origin: 'http://localhost:8000' });
+    expect(controller.getInfo()).toMatchObject({ pendingUpdateVersion: '99.0.0', restartRequired: true });
+    await expect(controller.handle('update', { origin: 'http://localhost:8000' }))
+      .resolves.toMatchObject({ updated: false, upToDate: false, restartRequired: true });
+    expect(installImpl).toHaveBeenCalledOnce();
+  });
+
+  it('rejects an update without a verifiable version before installing anything', async () => {
+    const installImpl = vi.fn();
+    const controller = createCompanionRuntimeController({
+      appServer: { restart: vi.fn(), initialize: vi.fn() }, bundlePath: '/tmp/getbased-companion.mjs',
+      env: { GETBASED_COMPANION_SERVICE: '1' }, installImpl,
+      fetchImpl: async () => new Response(VALID_BUNDLE.replace('99.0.0', 'unknown')),
+    });
+    await expect(controller.handle('update', { origin: 'http://localhost:8000' })).rejects.toThrow('verify');
+    expect(installImpl).not.toHaveBeenCalled();
   });
 
   it('removes automatic startup without killing the response in flight', async () => {

--- a/tests/companion-runtime-control.test.js
+++ b/tests/companion-runtime-control.test.js
@@ -95,6 +95,7 @@ describe('running companion controls', () => {
       await controller.handle('restart-companion', { origin: 'http://127.0.0.1:8324' });
       await scheduled();
       expect(order).toEqual(['stop-listener', 'start-service', 'restore-listener']);
+      expect(controller.getInfo().restartStatus).toBe('failed');
       expect(stderr).toHaveBeenCalledWith(expect.stringContaining('Service unavailable'));
     } finally { stderr.mockRestore(); }
   });

--- a/tests/dev-agent-host.test.js
+++ b/tests/dev-agent-host.test.js
@@ -46,7 +46,7 @@ describe('development agent discovery', () => {
     expect(controller.describe().agents[0]).toMatchObject({
       status: 'available', version: 'codex-cli 0.150.1', protocolVersion: 5,
       capabilities: expect.arrayContaining(['companion-control', 'execution-targets']),
-      companionVersion: '1.3.0', runtimeMode: 'temporary',
+      companionVersion: '1.3.1', runtimeMode: 'temporary',
     });
     expect(spawnImpl).toHaveBeenCalledWith(process.execPath, [
       '--watch-preserve-output', '--watch', '/workspace/server/agent-host-server.js',

--- a/tests/playwright/companion-management.spec.js
+++ b/tests/playwright/companion-management.spec.js
@@ -13,7 +13,7 @@ test.beforeAll(async () => {
       actions.push(action);
       if (action === 'install') mode = 'installed';
       if (action === 'uninstall') mode = 'temporary';
-      return { runtimeMode: mode, restartRequired: action === 'update' };
+      return { runtimeMode: mode, restartRequired: action === 'update', updated: action === 'update' };
     },
   });
   server = createServer(async (req, res) => {
@@ -33,22 +33,25 @@ test.afterAll(async () => { server.closeAllConnections(); await new Promise(reso
 
 test('local management runs controls while hosted discovery stays chat-only', async ({ page }) => {
   await page.goto(endpoint + '/manage');
-  await expect(page.locator('#status')).toContainText('Temporary');
+  await expect(page.locator('#status')).toHaveText('Connected');
+  await expect(page.locator('#startup-description')).toContainText('Connected for this terminal session');
   await page.setViewportSize({ width: 360, height: 740 });
   expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true);
+  await page.getByText('Advanced', { exact: true }).click();
   await page.getByRole('button', { name: 'Pause', exact: true }).click();
   await expect(page.locator('#status')).toContainText('Paused');
   await page.getByRole('button', { name: 'Resume', exact: true }).click();
-  await expect(page.locator('#status')).toContainText('Running');
-  page.on('dialog', dialog => dialog.accept());
+  await expect(page.locator('#status')).toHaveText('Connected');
   await page.getByRole('button', { name: 'Start automatically', exact: true }).click();
-  await expect(page.locator('#status')).toContainText('Installed');
+  await expect(page.locator('#startup-description')).toContainText('Starts automatically at login');
   await page.getByRole('button', { name: 'Check for update', exact: true }).click();
-  await expect(page.locator('#message')).toContainText('Restart companion');
+  await expect(page.locator('#message')).toContainText('Update installed. Restart when you’re ready.');
   await page.getByRole('button', { name: 'Reconnect CLIs', exact: true }).click();
-  await page.getByRole('button', { name: 'Restart companion', exact: true }).click();
-  await page.getByRole('button', { name: 'Uninstall', exact: true }).click();
-  await expect(page.locator('#status')).toContainText('Temporary');
+  await page.getByRole('button', { name: 'Restart Companion', exact: true }).click();
+  await page.getByRole('button', { name: 'Uninstall…', exact: true }).click();
+  await page.getByRole('button', { name: 'Uninstall Companion', exact: true }).click();
+  await expect(page.locator('#status')).toHaveText('Connected');
+  await expect(page.locator('#startup-description')).toContainText('Connected for this terminal session');
   expect(actions).toEqual(['install', 'update', 'restart', 'restart-companion', 'uninstall']);
   const discovery = await page.request.get(endpoint + '/v1/discovery', { headers: { Origin: 'https://app.getbased.health' } });
   const data = await discovery.json();

--- a/tests/playwright/companion-settings-embed.spec.js
+++ b/tests/playwright/companion-settings-embed.spec.js
@@ -11,7 +11,7 @@ for (const width of [760, 360]) {
     const parent = 'https://app.getbased.health';
 
     const actions = [];
-    let updateAvailable = false, offlineUntil = 0;
+    let updateAvailable = false, offlineUntil = 0, recoverSameSession = false;
     const status = { runtimeMode: 'installed', processMode: 'service', companionVersion: '1.3.0', paused: false, restartRequired: false };
     const createManagement = () => createCompanionManagement({
       allowParentOrigin: value => value === parent,
@@ -24,6 +24,7 @@ for (const width of [760, 360]) {
           status.restartRequired = updateAvailable;
           return Response.json({ ...status, updated: updateAvailable, upToDate: !updateAvailable });
         }
+        if (action === 'uninstall') status.runtimeMode = 'temporary';
         if (action === 'restart-companion') {
           offlineUntil = Date.now() + 2600;
           return Response.json({ ...status, restarting: true });
@@ -38,7 +39,8 @@ for (const width of [760, 360]) {
         offlineUntil = 0;
         status.restartRequired = false;
         status.paused = false;
-        handle = createManagement(); // A restart invalidates management sessions.
+        if (recoverSameSession) status.restartStatus = 'failed';
+        else handle = createManagement(); // A restart invalidates management sessions.
       }
       if (req.url === '/health') {
         res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -107,6 +109,15 @@ for (const width of [760, 360]) {
     await expect(frame.locator('#status')).toHaveText('Connected', { timeout: 10000 });
     await expect(frame.getByRole('button', { name: 'Restart to finish update' })).toBeHidden();
     expect(actions).toEqual(['update', 'pause', 'update', 'restart-companion']);
+    // Failed service handoff restores the same healthy session (HTTP 200).
+    recoverSameSession = true;
+    await frame.getByText('Advanced', { exact: true }).click();
+    await frame.getByRole('button', { name: 'Restart Companion', exact: true }).click();
+    await expect(frame.locator('#message')).toContainText('previous connection is still available', { timeout: 10000 });
+    await expect(frame.locator('#status')).toHaveText('Connected');
+    await frame.getByRole('button', { name: 'Uninstall…', exact: true }).click();
+    await frame.getByRole('button', { name: 'Uninstall Companion', exact: true }).click();
+    await expect(frame.locator('#startup-description')).toContainText('Automatic startup removed · service still running');
     expect(page.url()).toBe(parent + '/companion-settings-test');
     expect(page.context().pages()).toHaveLength(1);
     const contentFrame = page.frames().find(item => item.url().startsWith(endpoint));

--- a/tests/playwright/companion-settings-embed.spec.js
+++ b/tests/playwright/companion-settings-embed.spec.js
@@ -1,0 +1,116 @@
+import { expect, test } from '@playwright/test';
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { createCompanionManagement } from '../../lib/companion-management.js';
+
+let server;
+test.afterEach(async () => { if (server) { server.closeAllConnections(); await new Promise(resolve => server.close(resolve)); } });
+
+for (const width of [760, 360]) {
+  test(`Companion controls stay inside hosted Settings at ${width}px`, async ({ page }) => {
+    const parent = 'https://app.getbased.health';
+
+    const actions = [];
+    let updateAvailable = false, offlineUntil = 0;
+    const status = { runtimeMode: 'installed', processMode: 'service', companionVersion: '1.3.0', paused: false, restartRequired: false };
+    const createManagement = () => createCompanionManagement({
+      allowParentOrigin: value => value === parent,
+      status: () => status,
+      control: async request => {
+        const { action } = await request.json();
+        actions.push(action);
+        if (action === 'pause' || action === 'resume') status.paused = action === 'pause';
+        if (action === 'update') {
+          status.restartRequired = updateAvailable;
+          return Response.json({ ...status, updated: updateAvailable, upToDate: !updateAvailable });
+        }
+        if (action === 'restart-companion') {
+          offlineUntil = Date.now() + 2600;
+          return Response.json({ ...status, restarting: true });
+        }
+        return Response.json(status);
+      },
+    });
+    let handle = createManagement();
+    server = createServer(async (req, res) => {
+      if (offlineUntil) {
+        if (Date.now() < offlineUntil) { req.socket.destroy(); return; }
+        offlineUntil = 0;
+        status.restartRequired = false;
+        status.paused = false;
+        handle = createManagement(); // A restart invalidates management sessions.
+      }
+      if (req.url === '/health') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ service: 'getbased-agent-host' }));
+        return;
+      }
+      const chunks = [];
+      for await (const chunk of req) chunks.push(chunk);
+      const body = Buffer.concat(chunks).toString();
+      const response = await handle(new Request(`http://${req.headers.host}${req.url}`, {
+        method: req.method, headers: req.headers, ...(body ? { body } : {}),
+      }));
+      res.writeHead(response.status, Object.fromEntries(response.headers));
+      res.end(await response.text());
+    });
+    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+    const endpoint = `http://127.0.0.1:${server.address().port}`;
+    await page.context().grantPermissions(['local-network-access'], { origin: parent });
+    await page.setViewportSize({ width, height: 850 });
+    const config = JSON.parse(await readFile(new URL('../../vercel.json', import.meta.url), 'utf8'));
+    const headers = config.routes.find(entry => entry.headers?.['Content-Security-Policy']).headers;
+    const css = await readFile(new URL('../../css/settings.css', import.meta.url), 'utf8');
+    await page.route(parent + '/companion-settings-test', route => route.fulfill({
+      contentType: 'text/html', headers,
+      body: `<html data-theme="light"><style>:root{--border:#d7dce4;--bg-secondary:#f7f8fa}body{margin:16px;font:14px system-ui}.settings-modal{max-width:680px;margin:auto}${css}</style><main class="settings-modal"><h2>AI settings</h2><div class="local-agent-list-kicker">Companion</div><iframe class="local-agent-management-frame" title="Companion controls" sandbox="allow-scripts allow-same-origin" src="${endpoint}/manage/embed?parentOrigin=${encodeURIComponent(parent)}&theme=light"></iframe></main></html>`,
+    }));
+    // The host's origin/source validation is covered by cli-companion-ui.test.js.
+    // Capture the embedded panel's size-only message to verify its browser layout.
+    await page.addInitScript(() => {
+      window.addEventListener('message', event => {
+        const frame = document.querySelector('iframe');
+        if (event.source === frame?.contentWindow && event.data?.type === 'getbased-companion-panel-size') {
+          frame.style.height = `${event.data.height}px`;
+        }
+      });
+    });
+    await page.goto(parent + '/companion-settings-test');
+    const frame = page.frameLocator('iframe');
+    await expect(frame.locator('#status')).toContainText('Connected');
+    await expect(frame.getByRole('button', { name: 'Pause', exact: true })).toBeHidden();
+    await expect(frame.getByRole('button', { name: 'Refresh status', exact: true })).toHaveCount(0);
+    await expect(frame.getByRole('button', { name: 'Check for update', exact: true })).toBeVisible();
+    await frame.getByRole('button', { name: 'Check for update', exact: true }).click();
+    await expect(frame.locator('#message')).toHaveText('Companion is up to date.');
+    await expect(frame.getByRole('button', { name: 'Restart to finish update' })).toBeHidden();
+    updateAvailable = true;
+    await frame.getByText('Advanced', { exact: true }).click();
+    await frame.getByRole('button', { name: 'Pause', exact: true }).click();
+    await expect(frame.getByRole('button', { name: 'Resume', exact: true })).toBeVisible();
+    expect(actions).toEqual(['update', 'pause']);
+    await frame.getByRole('button', { name: 'Uninstall…', exact: true }).click();
+    await expect(frame.getByRole('region', { name: 'Confirm uninstall' })).toBeVisible();
+    await frame.getByRole('button', { name: 'Cancel', exact: true }).click();
+    expect(actions).toEqual(['update', 'pause']);
+    // A stale uninstall prompt must never turn an update click into uninstall.
+    await frame.getByRole('button', { name: 'Uninstall…', exact: true }).click();
+    await frame.getByRole('button', { name: 'Check for update', exact: true }).click();
+    await expect(frame.getByRole('region', { name: 'Confirm uninstall' })).toBeHidden();
+    await expect(frame.locator('#message')).toContainText('Update installed');
+    expect(actions).toEqual(['update', 'pause', 'update']);
+    await frame.getByRole('button', { name: 'Restart to finish update' }).click();
+    await expect(frame.locator('#status')).toHaveText('Reconnecting…');
+    // The former 1.8-second reload navigated into a browser error page here.
+    await page.waitForTimeout(1900);
+    await expect(frame.locator('#status')).toHaveText('Reconnecting…');
+    await expect(frame.locator('#status')).toHaveText('Connected', { timeout: 10000 });
+    await expect(frame.getByRole('button', { name: 'Restart to finish update' })).toBeHidden();
+    expect(actions).toEqual(['update', 'pause', 'update', 'restart-companion']);
+    expect(page.url()).toBe(parent + '/companion-settings-test');
+    expect(page.context().pages()).toHaveLength(1);
+    const contentFrame = page.frames().find(item => item.url().startsWith(endpoint));
+    expect(await contentFrame.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true);
+    await page.screenshot({ path: `/tmp/companion-settings-${width}.png` });
+  });
+}

--- a/vercel.json
+++ b/vercel.json
@@ -32,7 +32,7 @@
     {
       "src": "/(.*)",
       "headers": {
-        "Content-Security-Policy": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' blob: https://umami-iota-olive.vercel.app https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; font-src 'self'; connect-src 'self' https: wss: http://localhost:* http://127.0.0.1:* ws://localhost:* ws://*.onion http://*.onion; img-src 'self' data: blob:; worker-src 'self' blob:; manifest-src 'self'; frame-src 'none'; object-src 'none'; base-uri 'self'",
+        "Content-Security-Policy": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' blob: https://umami-iota-olive.vercel.app https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; font-src 'self'; connect-src 'self' https: wss: http://localhost:* http://127.0.0.1:* ws://localhost:* ws://*.onion http://*.onion; img-src 'self' data: blob:; worker-src 'self' blob:; manifest-src 'self'; frame-src http://127.0.0.1:*; object-src 'none'; base-uri 'self'",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "DENY",
         "Referrer-Policy": "strict-origin-when-cross-origin",


### PR DESCRIPTION
Card payment is now the first, recommended onboarding choice. The subscription option explains its CLI, sign-in, and Companion prerequisites, and waits for lazy Settings loading before selecting CLI agents and scanning for an existing connection.

Companion controls stay inside Settings in a compact panel: connection/startup status and a one-click update check, with maintenance under Advanced. Local management credentials remain inside the loopback frame; only approved getbased origins may embed it. Updates install only newer versions, preserve pending-restart status, and cannot downgrade a local preview. Restart recovery keeps the panel visible until the new service answers instead of navigating into a broken frame.

Validation: 53 focused unit tests; focused onboarding and Companion Chromium specs; architecture, production build, quality, browser/server checkJs gates. Also verified the local installed Companion's update check and restart recovery. Companion version is 1.3.1; older installations retain a styled update fallback.
