### PR TITLE
Delegate edition-owned AI processing consent

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -10,7 +10,7 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | Metric | Current |
 | --- | ---: |
 | Modules | 758 |
-| Internal import edges | 3194 |
+| Internal import edges | 3195 |
 | Dynamic internal edges | 105 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -389,7 +389,7 @@ Native browser modules shipped with the static application.
 
 <details><summary><code>cloud</code> family — 1 module</summary>
 
-- [`js/cloud-ai-consent.js`](js/cloud-ai-consent.js) → [`js/ai-provider-policy.js`](js/ai-provider-policy.js), [`js/deployment-policy.js`](js/deployment-policy.js)
+- [`js/cloud-ai-consent.js`](js/cloud-ai-consent.js) → [`js/ai-provider-policy.js`](js/ai-provider-policy.js), [`js/app-extension-runtime.js`](js/app-extension-runtime.js), [`js/deployment-policy.js`](js/deployment-policy.js)
 
 </details>
 

--- a/js/app-extension-runtime.js
+++ b/js/app-extension-runtime.js
@@ -18,6 +18,7 @@
  *   getModelPolicy?: (context: Record<string, any>) => Record<string, any> | null | undefined,
  *   refresh?: (context?: Record<string, any>) => any | Promise<any>,
  *   authorizeRequest?: (context: Record<string, any>) => boolean | Promise<boolean>,
+ *   requestProcessingApproval?: (context: Record<string, any>) => boolean | Promise<boolean>,
  *   isProviderCallOwned?: (context: Record<string, any>) => boolean,
  *   callProvider?: (context: Record<string, any>) => any | Promise<any>,
  *   getRequestOptions?: (context: Record<string, any>) => Record<string, any> | null | undefined,
@@ -176,6 +177,22 @@ export function isAppExtensionAIProviderActive(provider) {
 /** @param {string} provider */
 export function isAppExtensionAICredentialOwned(provider) {
   return activeExtension()?.ai?.isCredentialOwned?.(provider) === true;
+}
+
+/**
+ * A credential-owning edition identifies and approves its actual recipient.
+ * Missing hooks and ownership changes fail closed; this does not replace the
+ * transport's independent request authorization.
+ * @param {Record<string, any> & { provider: string }} context
+ */
+export async function requestAppExtensionAIProcessingApproval(context) {
+  const extension = activeExtension();
+  const ai = extension?.ai;
+  if (ai?.isCredentialOwned?.(context.provider) !== true
+      || typeof ai.requestProcessingApproval !== 'function') return false;
+  const approved = await ai.requestProcessingApproval(context);
+  return approved === true && activeExtension() === extension
+    && ai.isCredentialOwned?.(context.provider) === true;
 }
 
 /** @param {string} provider */

--- a/js/cloud-ai-consent.js
+++ b/js/cloud-ai-consent.js
@@ -3,6 +3,7 @@
 
 import { getAIProcessingDestination } from './ai-provider-policy.js';
 import { getSupplementaryDeploymentPolicy } from './deployment-policy.js';
+import { isAppExtensionAICredentialOwned, requestAppExtensionAIProcessingApproval } from './app-extension-runtime.js';
 
 export const AI_TRANSPARENCY_VERSION = '2026-08-31';
 export const AI_TRANSPARENCY_KEY = 'labcharts-ai-transparency-acknowledgement';
@@ -543,6 +544,15 @@ function processingApprovalSatisfied(provider, options) {
  * route confirmation and remote sensitive-data approval records.
  */
 export function requestAIProcessingApproval(provider, { kind = 'text', endpoint = '', modelId = '' } = {}) {
+  if (isAppExtensionAICredentialOwned(provider)) {
+    return (async () => {
+      if (!hasAcknowledgedAITransparency()) {
+        if (kind === 'automatic-insight' || !await requestAITransparencyAcknowledgement()) return false;
+      }
+      return requestAppExtensionAIProcessingApproval({ provider, kind, endpoint, modelId,
+        interactive: kind !== 'automatic-insight' });
+    })();
+  }
   const options = { endpoint, modelId };
   const initialDetails = cloudAIConsentDetails(provider, options);
   const promptKey = initialDetails.boundary === 'same-device'
@@ -573,6 +583,11 @@ export function requestAIProviderActivation(provider, options = {}) {
 }
 
 export async function requireAIProcessingApproval(provider, options = {}) {
+  if (isAppExtensionAICredentialOwned(provider)) {
+    if (await requestAIProcessingApproval(provider, options)) return true;
+    if (!hasAcknowledgedAITransparency()) throw new AITransparencyDeclinedError();
+    throw new CloudAIConsentDeclinedError();
+  }
   const details = cloudAIConsentDetails(provider, options);
   const destinationApproved = details.boundary === 'same-device'
     || (details.boundary === 'private-network' && hasAIRouteConfirmation(provider, options))

--- a/scripts/cold-load-budget.json
+++ b/scripts/cold-load-budget.json
@@ -5,7 +5,7 @@
   "maximums": {
     "requests": 324,
     "transferBytes": 1193220,
-    "decodedBytes": 3320000
+    "decodedBytes": 3322000
   },
   "reference": {
     "requests": 276,
@@ -25,8 +25,9 @@
     "routeAwareAiConsentDecodedBytes": 3270632,
     "cliProviderRoutingRequests": 324,
     "cliProviderRoutingTransferBytes": 1183242,
-    "cliProviderRoutingDecodedBytes": 3319406
+    "cliProviderRoutingDecodedBytes": 3319406,
+    "ownedProcessingApprovalDecodedBytes": 3320759
   },
-  "referenceCommit": "95d13199",
-  "measuredAt": "2026-09-05"
+  "referenceCommit": "2c87ad0af840b6ca77695288eebd3467a85819ea",
+  "measuredAt": "2026-09-07"
 }

--- a/scripts/production-build-budget.json
+++ b/scripts/production-build-budget.json
@@ -4,7 +4,7 @@
     "startupJavaScriptFiles": 2,
     "startupDecodedBytes": 1198000,
     "outputJavaScriptFiles": 160,
-    "outputDecodedBytes": 5160000
+    "outputDecodedBytes": 5162000
   },
   "reference": {
     "startupJavaScriptFiles": 2,
@@ -56,8 +56,9 @@
     "openClawAndChatWorkspaceStartupDecodedBytes": 1194667,
     "openClawAndChatWorkspaceOutputDecodedBytes": 5136578,
     "directProviderReasoningStartupDecodedBytes": 1196609,
-    "directProviderReasoningOutputDecodedBytes": 5139452
+    "directProviderReasoningOutputDecodedBytes": 5139452,
+    "ownedProcessingApprovalOutputDecodedBytes": 5160463
   },
-  "referenceCommit": "331112b1",
-  "measuredAt": "2026-09-05"
+  "referenceCommit": "ee5ed1d06bd45902c04dda2680ba5d3b1b0c7391",
+  "measuredAt": "2026-09-07"
 }

--- a/tests/api-provider-contracts.test.js
+++ b/tests/api-provider-contracts.test.js
@@ -1954,6 +1954,7 @@ describe('AI provider request contracts', () => {
   });
 
   it('lets a trusted edition replace the OpenRouter transport after authorization', async () => {
+    const requestProcessingApproval = vi.fn(async () => true);
     const secret = 'sk-managed-transport-contract';
     const callProvider = vi.fn(async () => ({
       text: 'edition transport',
@@ -1964,6 +1965,7 @@ describe('AI provider request contracts', () => {
     configureAppExtension({
       id: 'managed-transport-test',
       ai: {
+        requestProcessingApproval,
         isCredentialOwned: provider => provider === 'openrouter',
         authorizeRequest: async () => true,
         isProviderCallOwned: ({ provider }) => provider === 'openrouter',
@@ -1975,6 +1977,7 @@ describe('AI provider request contracts', () => {
     updateKeyCache('labcharts-openrouter-key', secret);
 
     await expect(callClaudeAPI(baseChatOptions())).resolves.toMatchObject({ text: 'edition transport' });
+    expect(requestProcessingApproval).toHaveBeenCalledWith(expect.objectContaining({ provider: 'openrouter', interactive: true }));
     expect(callProvider).toHaveBeenCalledWith(expect.objectContaining({
       provider: 'openrouter',
       credential: secret,
@@ -1984,6 +1987,7 @@ describe('AI provider request contracts', () => {
   });
 
   it('lets a trusted edition own an OpenRouter-shaped call without a browser credential', async () => {
+    const requestProcessingApproval = vi.fn(async () => true);
     const callProvider = vi.fn(async ({ credential }) => ({
       text: credential ? 'unexpected credential' : 'credentialless edition transport',
       usage: { inputTokens: 2, outputTokens: 3 },
@@ -1993,6 +1997,7 @@ describe('AI provider request contracts', () => {
     configureAppExtension({
       id: 'credentialless-managed-transport-test',
       ai: {
+        requestProcessingApproval,
         isCredentialOwned: provider => provider === 'openrouter',
         authorizeRequest: async () => true,
         isProviderCallOwned: ({ provider }) => provider === 'openrouter',
@@ -2003,6 +2008,7 @@ describe('AI provider request contracts', () => {
     setOpenRouterModel('reviewed/model');
 
     await expect(callClaudeAPI(baseChatOptions())).resolves.toMatchObject({ text: 'credentialless edition transport' });
+    expect(requestProcessingApproval).toHaveBeenCalled();
     expect(callProvider).toHaveBeenCalledWith(expect.objectContaining({
       provider: 'openrouter',
       credential: '',
@@ -2016,6 +2022,8 @@ describe('AI provider request contracts', () => {
     configureAppExtension({
       id: 'denied-managed-transport-test',
       ai: {
+        isCredentialOwned: provider => provider === 'openrouter',
+        requestProcessingApproval: async () => true,
         authorizeRequest: async () => false,
         isProviderCallOwned: ({ provider }) => provider === 'openrouter',
         callProvider,

--- a/tests/extension-processing-consent.test.js
+++ b/tests/extension-processing-consent.test.js
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { beforeEach, afterEach, it, expect, vi } from 'vitest';
+import { configureAppExtension } from '../js/app-extension-runtime.js';
+import { AI_TRANSPARENCY_KEY, AI_TRANSPARENCY_VERSION, CLOUD_AI_CONSENT_KEY,
+  requestAIProcessingApproval, requireAIProcessingApproval,
+  withdrawAITransparencyAcknowledgement, withdrawCloudAIConsent } from '../js/cloud-ai-consent.js';
+
+beforeEach(() => {
+  document.body.innerHTML = ''; localStorage.clear();
+  withdrawAITransparencyAcknowledgement(); withdrawCloudAIConsent();
+  localStorage.setItem(AI_TRANSPARENCY_KEY, JSON.stringify({ version: AI_TRANSPARENCY_VERSION, acknowledged: true }));
+});
+afterEach(() => configureAppExtension(null));
+function edition(approve = vi.fn(async () => true)) {
+  configureAppExtension({ id: 'test-edition', ai: {
+    isCredentialOwned: provider => provider === 'openrouter', requestProcessingApproval: approve,
+  } });
+  return approve;
+}
+it('delegates owned consent without recording the built-in recipient or showing its dialog', async () => {
+  const approve = edition();
+  await expect(requestAIProcessingApproval('openrouter')).resolves.toBe(true);
+  await expect(requireAIProcessingApproval('openrouter')).resolves.toBe(true);
+  expect(approve).toHaveBeenCalledTimes(2);
+  expect(document.querySelector('#cloud-ai-consent-overlay')).toBeNull();
+  expect(localStorage.getItem(CLOUD_AI_CONSENT_KEY)).toBeNull();
+});
+it('fails closed for a missing owned hook', async () => {
+  configureAppExtension({ id: 'test-edition', ai: { isCredentialOwned: () => true } });
+  await expect(requireAIProcessingApproval('openrouter')).rejects.toThrow('approval was not granted');
+  expect(document.body.textContent).toBe('');
+});
+it('does not turn a denial or thrown error into built-in fallback', async () => {
+  edition(vi.fn(async () => false));
+  await expect(requestAIProcessingApproval('openrouter')).resolves.toBe(false);
+  edition(vi.fn(async () => { throw new Error('unavailable'); }));
+  await expect(requireAIProcessingApproval('openrouter')).rejects.toThrow('unavailable');
+  expect(document.body.textContent).toBe('');
+});
+it('rejects an edition change during approval', async () => {
+  edition(vi.fn(async () => { configureAppExtension(null); return true; }));
+  await expect(requestAIProcessingApproval('openrouter')).resolves.toBe(false);
+});
+it('keeps automatic requests noninteractive and requires transparency first', async () => {
+  const approve = edition();
+  await requireAIProcessingApproval('openrouter', { kind: 'automatic-insight' });
+  expect(approve).toHaveBeenCalledWith(expect.objectContaining({ interactive: false }));
+  approve.mockClear(); withdrawAITransparencyAcknowledgement();
+  await expect(requireAIProcessingApproval('openrouter', { kind: 'automatic-insight' })).rejects.toThrow('transparency');
+  expect(approve).not.toHaveBeenCalled(); expect(document.body.textContent).toBe('');
+});
+it('leaves unowned BYOK consent on the core path', async () => {
+  const approve = edition();
+  const pending = requestAIProcessingApproval('venice');
+  expect(document.querySelector('#cloud-ai-consent-overlay')?.textContent).toContain('Venice');
+  document.querySelector('[data-ai-processing-action="cancel"]').click();
+  await expect(pending).resolves.toBe(false); expect(approve).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
Adds a neutral processing-approval hook for credentials owned by a trusted build-time extension. Retains core AI transparency and the unowned BYOK consent path. Missing hooks, denials, errors and changed ownership fail closed; automatic insight approval is noninteractive. Transport authorization remains independent. Verification: 35 focused consent/extension tests and check-JS types passed against current main.