### PR TITLE
Prepare PWA build updates silently before offering reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,3 +288,5 @@ See [CONTRIBUTING.md](CONTRIBUTING.md). Project board: [planned features](https:
 AGPL-3.0-or-later. See [LICENSE](LICENSE).
 
 If you run a modified version as a network service, AGPLv3 §13 requires you to offer users the corresponding source. Vendored third-party libraries are listed under their own licenses in [THIRD_PARTY_LICENSES.md](THIRD_PARTY_LICENSES.md).
+
+PWA updates use a build identity generated from the deployed commit and deployment ID. The builder embeds it in both `version.js` and the service worker; release versions remain for changelogs. Visible apps check every five minutes and on return, download new builds silently into a separate cache, and offer **Reload / Later** only after installation succeeds. Failed downloads keep the current build active. Version 1.19.3 provides the migration signal for older version-based clients; subsequent patches need no version bump.

--- a/js/changelog-current.js
+++ b/js/changelog-current.js
@@ -1,7 +1,6 @@
 // @ts-check
 // Current release kept separate so the historical archive remains bounded.
-export const CURRENT_RELEASE = { version: '1.19.2', date: '2026-09-11', title: 'Safer import review and more complete offline settings', items: [
-  '<b>Keep your import review open.</b> Escape closes the unit picker first, preserving the lab results you are reviewing.',
-  '<b>Fresh installations stay quiet.</b> The app avoids a false update prompt when the browser finishes its first offline installation.',
-  '<b>Settings artwork stays available offline.</b> Provider and wearable icons are included when the app is installed, and Fitbit uses its bundled fallback icon.',
+export const CURRENT_RELEASE = { version: '1.19.3', date: '2026-09-12', title: 'Updates ready when you are', items: [
+  '<b>Keep working while updates download.</b> The app prepares new builds in the background and offers Reload only when the update is ready.',
+  '<b>Small fixes arrive automatically.</b> Each deployed build can update the app without waiting for a new release version.',
 ] };

--- a/js/changelog-impl.js
+++ b/js/changelog-impl.js
@@ -7,6 +7,7 @@ const CHANGELOG_ACTION_ATTR = 'data-changelog-action';
 const changelogDelegateRoots = new WeakSet();
 const CHANGELOG = [
   CURRENT_RELEASE,
+  { version: '1.19.2', date: '2026-09-11', title: 'Safer import review and more complete offline settings', items: [   '<b>Keep your import review open.</b> Escape closes the unit picker first, preserving the lab results you are reviewing.',   '<b>Fresh installations stay quiet.</b> The app avoids a false update prompt when the browser finishes its first offline installation.',   '<b>Settings artwork stays available offline.</b> Provider and wearable icons are included when the app is installed, and Fitbit uses its bundled fallback icon.', ] },
   { version: '1.19.1', date: '2026-09-10', title: 'Smoother Routstr wallet payments', items: [ '<b>Lightning deposits update automatically.</b> The invoice shows a clear payment confirmation when your wallet is credited.', '<b>More reliable wallet payments.</b> Improvements to Lightning address payments and pending deposit handling make funding your wallet smoother.', ] },
   { version: '1.19.0', date: '2026-09-05', title: 'Your agents, a better chat, and a more flexible dashboard', items: [
     '<b>Use your installed AI agents.</b> Connect Codex, OpenCode, Hermes, Grok Build, or OpenClaw through the local Companion or a terminal command. Setup and connection controls live together in AI settings, and agent details can be collapsed.',
@@ -662,7 +663,6 @@ const CHANGELOG = [
     ]
   },
 ];
-
 /** Extract major.minor from a semver string (e.g. '1.0.1' → '1.0') */
 function getMajorMinor(ver) {
   const parts = String(ver).split('.');

--- a/js/service-worker-update.js
+++ b/js/service-worker-update.js
@@ -7,21 +7,14 @@ const DEV_SW_QUERY_RE = /(?:^|[?&])dev-sw=1(?:&|$)/;
 const UPDATE_CHECK_INTERVAL_MS = 5 * 60 * 1000;
 const VERSION_CHECK_URL = '/version.js?update-check=1';
 const LAST_VERSION_CHECK_KEY = 'labcharts-version-update-last-check';
-const PRECACHE_PROGRESS_MESSAGE = 'PRECACHE_PROGRESS';
+const APP_BUILD_RE = /\bAPP_BUILD_ID\s*=\s*(['"])([^'"]+)\1/;
 const APP_VERSION_RE = /\bAPP_VERSION\s*=\s*(['"])([^'"]+)\1/;
 
 let pendingRegistration = null;
 let dismissedWaitingWorker = null;
-let availableVersion = '';
-let dismissedAvailableVersion = '';
 let updateRequested = false;
-let updateInstallPending = false;
 let reloadAvailable = false;
 let lastUpdateCheckAt = 0;
-let updateProgressCompleted = 0;
-let updateProgressTotal = 0;
-let updateProgressStartedAt = 0;
-let updateProgressTimer = null;
 
 /**
  * @returns {(Window & { caches?: CacheStorage }) | null}
@@ -47,7 +40,8 @@ function getDefaultCacheStorage() {
 }
 
 export function parseAppVersionScript(source) {
-  return String(source || '').match(APP_VERSION_RE)?.[2] || '';
+  return String(source || '').match(APP_BUILD_RE)?.[2]
+    || String(source || '').match(APP_VERSION_RE)?.[2] || '';
 }
 
 export function isReloadNavigation(win = getDefaultServiceWorkerWindow()) {
@@ -59,7 +53,7 @@ export function isReloadNavigation(win = getDefaultServiceWorkerWindow()) {
 }
 
 function getCurrentAppVersion(win) {
-  return String(win?.APP_VERSION || '').trim();
+  return String(win?.APP_BUILD_ID || win?.APP_VERSION || '').trim();
 }
 
 function getStoredLastCheckAt(win) {
@@ -80,33 +74,6 @@ function storeLastCheckAt(win, checkedAt) {
 let reloadPage = () => {
   getDefaultServiceWorkerWindow()?.location.reload();
 };
-
-function stopUpdateProgressTimer() {
-  if (updateProgressTimer == null) return;
-  getDefaultServiceWorkerWindow()?.clearInterval?.(updateProgressTimer);
-  updateProgressTimer = null;
-}
-
-function resetUpdateProgress() {
-  stopUpdateProgressTimer();
-  updateProgressCompleted = 0;
-  updateProgressTotal = 0;
-  updateProgressStartedAt = 0;
-}
-
-function startUpdateProgress() {
-  resetUpdateProgress();
-  updateProgressStartedAt = Date.now();
-  const win = getDefaultServiceWorkerWindow();
-  updateProgressTimer = win?.setInterval?.(() => {
-    if (!updateInstallPending) {
-      stopUpdateProgressTimer();
-      return;
-    }
-    const banner = document.getElementById(UPDATE_BANNER_ID);
-    if (banner) renderVersionUpdateBanner(banner);
-  }, 1000) ?? null;
-}
 
 export function isDevServiceWorkerHost(hostname) {
   if (!hostname) return false;
@@ -140,15 +107,13 @@ function removeBanner() {
 
 export function hideVersionUpdateBanner() {
   reloadAvailable = false;
-  resetUpdateProgress();
   removeBanner();
 }
 
 export function showVersionUpdateBanner(registration) {
   const waitingWorker = getServiceWorker(registration);
-  const detectedUpdate = !!availableVersion && availableVersion !== dismissedAvailableVersion;
   const waitingUpdate = !!waitingWorker && waitingWorker !== dismissedWaitingWorker;
-  if (!reloadAvailable && !detectedUpdate && !waitingUpdate && !updateInstallPending) return false;
+  if (!reloadAvailable && !waitingUpdate) return false;
 
   pendingRegistration = registration || pendingRegistration;
 
@@ -163,18 +128,11 @@ export function showVersionUpdateBanner(registration) {
     banner.innerHTML = `
       <div class="version-update-body">
         <div class="version-update-copy-row">
-          <span class="version-update-copy"><strong>New version available.</strong> Update when you are ready.</span>
-          <span class="version-update-percent" hidden>0%</span>
-        </div>
-        <div class="version-update-progress" hidden>
-          <div class="version-update-progress-track" role="progressbar" aria-label="App update progress" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
-            <span class="version-update-progress-fill"></span>
-          </div>
-          <span class="version-update-progress-meta">Preparing app files…</span>
+          <span class="version-update-copy"><strong>Update ready.</strong> Reload when you are ready.</span>
         </div>
       </div>
       <div class="version-update-actions">
-        <button type="button" class="version-update-btn version-update-btn-primary" ${UPDATE_ACTION_ATTR}="apply">Update</button>
+        <button type="button" class="version-update-btn version-update-btn-primary" ${UPDATE_ACTION_ATTR}="apply">Reload</button>
         <button type="button" class="version-update-btn" ${UPDATE_ACTION_ATTR}="dismiss">Later</button>
       </div>
     `;
@@ -191,21 +149,7 @@ function renderVersionUpdateBanner(banner) {
   const copy = banner.querySelector('.version-update-copy');
   const primaryButton = banner.querySelector(`[${UPDATE_ACTION_ATTR}="apply"]`);
   const dismissButton = banner.querySelector(`[${UPDATE_ACTION_ATTR}="dismiss"]`);
-  const actions = banner.querySelector('.version-update-actions');
-  const percentCopy = banner.querySelector('.version-update-percent');
-  const progress = banner.querySelector('.version-update-progress');
-  const progressTrack = banner.querySelector('.version-update-progress-track');
-  const progressFill = banner.querySelector('.version-update-progress-fill');
-  const progressMeta = banner.querySelector('.version-update-progress-meta');
-
-  const showInstallingLayout = (visible) => {
-    if (actions instanceof HTMLElement) actions.hidden = visible;
-    if (percentCopy instanceof HTMLElement) percentCopy.hidden = !visible;
-    if (progress instanceof HTMLElement) progress.hidden = !visible;
-  };
-
   if (reloadAvailable) {
-    showInstallingLayout(false);
     banner.setAttribute('aria-live', 'polite');
     banner.setAttribute('aria-busy', 'false');
     if (copy) copy.innerHTML = '<strong>New version installed.</strong> Reload when you are ready.';
@@ -216,46 +160,10 @@ function renderVersionUpdateBanner(banner) {
     return;
   }
 
-  if (updateInstallPending) {
-    showInstallingLayout(true);
-    banner.setAttribute('aria-live', 'off');
-    banner.setAttribute('aria-busy', 'true');
-    const completed = Math.max(0, Math.min(updateProgressCompleted, updateProgressTotal || updateProgressCompleted));
-    const total = Math.max(0, updateProgressTotal);
-    const percent = total > 0 ? Math.min(100, Math.round((completed / total) * 100)) : 0;
-    const elapsedSeconds = updateProgressStartedAt
-      ? Math.max(0, Math.round((Date.now() - updateProgressStartedAt) / 1000))
-      : 0;
-    const finishedCaching = total > 0 && completed >= total;
-    if (copy) copy.innerHTML = finishedCaching
-      ? '<strong>Finalizing update…</strong> The app will reload when it is ready.'
-      : '<strong>Installing update…</strong> The app will reload when it is ready.';
-    if (percentCopy) percentCopy.textContent = `${percent}%`;
-    if (progressFill instanceof HTMLElement) progressFill.style.width = `${percent}%`;
-    if (progressTrack) {
-      progressTrack.setAttribute('aria-valuenow', String(percent));
-      progressTrack.setAttribute('aria-valuetext', total > 0
-        ? `${completed} of ${total} app files cached`
-        : 'Preparing app files');
-    }
-    if (progressMeta) {
-      const elapsedCopy = elapsedSeconds > 0 ? ` · ${elapsedSeconds}s` : '';
-      progressMeta.textContent = total > 0
-        ? `${completed} of ${total} files cached${elapsedCopy}`
-        : `Preparing app files${elapsedCopy}`;
-    }
-    if (primaryButton) primaryButton.textContent = 'Installing…';
-    if (primaryButton) primaryButton.disabled = true;
-    if (dismissButton) dismissButton.disabled = true;
-    banner.setAttribute('aria-label', 'App update installing');
-    return;
-  }
-
-  showInstallingLayout(false);
   banner.setAttribute('aria-live', 'polite');
   banner.setAttribute('aria-busy', 'false');
-  if (copy) copy.innerHTML = '<strong>New version available.</strong> Update when you are ready.';
-  if (primaryButton) primaryButton.textContent = 'Update';
+  if (copy) copy.innerHTML = '<strong>Update ready.</strong> Reload when you are ready.';
+  if (primaryButton) primaryButton.textContent = 'Reload';
   if (primaryButton) primaryButton.disabled = false;
   if (dismissButton) dismissButton.disabled = false;
   banner.setAttribute('aria-label', 'App update available');
@@ -276,7 +184,6 @@ function handleVersionUpdateActionClick(event) {
 
   if (action === 'dismiss') {
     if (!reloadAvailable) dismissedWaitingWorker = getServiceWorker(pendingRegistration);
-    if (!reloadAvailable && availableVersion) dismissedAvailableVersion = availableVersion;
     hideVersionUpdateBanner();
   }
 }
@@ -291,44 +198,12 @@ export function applyPendingServiceWorkerUpdate(registration = pendingRegistrati
   const waitingWorker = getServiceWorker(registration);
   if (waitingWorker) {
     updateRequested = true;
-    updateInstallPending = false;
     waitingWorker.postMessage({ type: 'SKIP_WAITING' });
     hideVersionUpdateBanner();
     return true;
   }
 
-  if (!availableVersion || !registration?.update) return false;
-
-  updateRequested = true;
-  updateInstallPending = true;
-  dismissedAvailableVersion = '';
-  startUpdateProgress();
-  showVersionUpdateBanner(registration);
-
-  if (registration.installing) return true;
-
-  registration.update().then(() => {
-    if (!updateInstallPending) return;
-    const installedWorker = getServiceWorker(registration);
-    if (installedWorker) {
-      updateInstallPending = false;
-      installedWorker.postMessage({ type: 'SKIP_WAITING' });
-      hideVersionUpdateBanner();
-      return;
-    }
-    if (!registration.installing) {
-      updateRequested = false;
-      updateInstallPending = false;
-      resetUpdateProgress();
-      showVersionUpdateBanner(registration);
-    }
-  }).catch(() => {
-    updateRequested = false;
-    updateInstallPending = false;
-    resetUpdateProgress();
-    showVersionUpdateBanner(registration);
-  });
-  return true;
+  return false;
 }
 
 export function watchServiceWorkerRegistration(
@@ -352,20 +227,8 @@ export function watchServiceWorkerRegistration(
       if (installingWorker.state === 'installed'
           && replacesController
           && canPromptForUpdate(registration, serviceWorkerContainer)) {
-        if (updateRequested && updateInstallPending) {
-          updateInstallPending = false;
-          installingWorker.postMessage({ type: 'SKIP_WAITING' });
-          hideVersionUpdateBanner();
-          return;
-        }
         dismissedWaitingWorker = null;
         reloadAvailable = false;
-        showVersionUpdateBanner(registration);
-      }
-      if (installingWorker.state === 'redundant' && updateInstallPending) {
-        updateRequested = false;
-        updateInstallPending = false;
-        resetUpdateProgress();
         showVersionUpdateBanner(registration);
       }
     });
@@ -403,12 +266,10 @@ export async function checkForAppVersionUpdate(
     const currentVersion = getCurrentAppVersion(win);
     if (!remoteVersion || !currentVersion || remoteVersion === currentVersion) return false;
 
-    if (availableVersion !== remoteVersion) {
-      availableVersion = remoteVersion;
-      dismissedAvailableVersion = '';
-    }
     pendingRegistration = registration || pendingRegistration;
-    if (serviceWorkerContainer?.controller) showVersionUpdateBanner(registration);
+    if (!registration?.update || registration.installing) return false;
+    await registration.update();
+    if (canPromptForUpdate(registration, serviceWorkerContainer)) showVersionUpdateBanner(registration);
     return true;
   } catch {
     return false;
@@ -434,8 +295,8 @@ function scheduleServiceWorkerUpdateChecks(registration, serviceWorkerContainer,
 
   if (isReloadNavigation(win)) {
     // An explicit reload is user intent to get current code. Let the browser
-    // perform a full worker update immediately; routine foreground checks stay
-    // lightweight and never install before the user accepts the banner.
+    // perform a full worker update immediately. Routine checks also stage new
+    // builds in the background, but never activate them in an open tab.
     requestServiceWorkerUpdateForReload(registration, serviceWorkerContainer);
   } else {
     check();
@@ -480,16 +341,6 @@ export async function registerServiceWorkerUpdates({
     reloadPage = () => win.location.reload();
     let refreshing = false;
     let controller = serviceWorkerContainer.controller;
-    serviceWorkerContainer.addEventListener('message', (event) => {
-      if (event?.data?.type !== PRECACHE_PROGRESS_MESSAGE || !updateInstallPending) return;
-      const total = Math.max(0, Math.round(Number(event.data.total) || 0));
-      const completed = Math.max(0, Math.min(total, Math.round(Number(event.data.completed) || 0)));
-      if (total <= 0) return;
-      updateProgressCompleted = completed;
-      updateProgressTotal = total;
-      const banner = document.getElementById(UPDATE_BANNER_ID);
-      if (banner) renderVersionUpdateBanner(banner);
-    });
     serviceWorkerContainer.addEventListener('controllerchange', () => {
       const nextController = serviceWorkerContainer.controller;
       if (refreshing || !nextController || nextController === controller) return;

--- a/scripts/build-production.mjs
+++ b/scripts/build-production.mjs
@@ -2,6 +2,8 @@
 
 import fs from 'node:fs/promises';
 import os from 'node:os';
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { build, RUNTIME_MODULE_ID } from 'rolldown';
@@ -162,6 +164,9 @@ async function enforceBuildBudget(summary) {
 }
 
 export async function buildProduction({ outputRoot = ROOT } = {}) {
+  const commit = process.env.VERCEL_GIT_COMMIT_SHA
+    || execFileSync('git', ['rev-parse', 'HEAD'], { cwd: ROOT, encoding: 'utf8' }).trim();
+  const buildId = createHash('sha256').update(`${commit}:${process.env.VERCEL_DEPLOYMENT_ID || ''}`).digest('hex');
   await validateBundlerLock();
   await buildCompanionBundle({ outputRoot });
 
@@ -244,12 +249,15 @@ export async function buildProduction({ outputRoot = ROOT } = {}) {
     .map(chunk => `  '/js/${chunk.fileName}',`)
     .sort();
   const builtServiceWorker = replaceMarkedSection(
-    pruneSourceModuleAppShell(serviceWorkerSource),
+    pruneSourceModuleAppShell(serviceWorkerSource).replace(/const BUILD_ID = '[^']*';/, `const BUILD_ID = '${buildId}';`),
     SW_BUNDLES_START,
     SW_BUNDLES_END,
     bundleAssetLines,
   );
+  const versionSource = (await fs.readFile(path.join(ROOT, 'version.js'), 'utf8'))
+    .replace(/\nself\.APP_BUILD_ID = '[^']*';\n?/g, '\n');
   await Promise.all([
+    fs.writeFile(path.join(outputRoot, 'version.js'), `${versionSource.trimEnd()}\nself.APP_BUILD_ID = '${buildId}';\n`),
     fs.writeFile(path.join(outputRoot, 'index.html'), builtIndex),
     fs.writeFile(path.join(outputRoot, 'service-worker.js'), builtServiceWorker),
     fs.writeFile(path.join(outputRoot, 'service-worker-runtime.js'), serviceWorkerRuntimeSource),

--- a/scripts/dom-sink-policy.json
+++ b/scripts/dom-sink-policy.json
@@ -3,7 +3,7 @@
   "scope": "Every non-generated JavaScript module under js/",
   "reviewRule": "Any added or modified HTML-writing sink requires security review and a policy refresh.",
   "scannedFiles": 713,
-  "sinkCount": 556,
+  "sinkCount": 555,
   "files": {
     "js/backup.js": {
       "count": 1,
@@ -762,10 +762,10 @@
       }
     },
     "js/service-worker-update.js": {
-      "count": 4,
-      "digest": "4c469eab2384b969913cee8b348b9168d754bac45b9964a691698c2ce6d5470e",
+      "count": 3,
+      "digest": "576de9d039003a40b833b8c810edaa7088af52ef3bdccefe3074f8bb95634bf8",
       "kinds": {
-        "innerHTML": 4
+        "innerHTML": 3
       }
     },
     "js/settings-agent-access-panel.js": {

--- a/service-worker-runtime.js
+++ b/service-worker-runtime.js
@@ -1,6 +1,7 @@
 /**
  * @typedef {Object} ServiceWorkerRuntimeConfig
  * @property {ServiceWorkerGlobalScope} scope
+ * @property {string} [buildId]
  * @property {string[]} appShell
  * @property {boolean} isProduction
  * @property {() => Promise<string>} resolveCacheName
@@ -15,6 +16,7 @@
  */
 function installServiceWorkerRuntime({
   scope,
+  buildId = '',
   appShell,
   isProduction,
   resolveCacheName,
@@ -149,13 +151,29 @@ function installServiceWorkerRuntime({
     return matchCurrentCache('/app').then((cachedApp) => cachedApp || matchCurrentCache('/index.html'));
   }
 
-  // Install: pre-cache app shell.
+  // Pin every install to its build. A deployment switch during download must
+  // not leave a partially mixed cache that a later retry could activate.
+  async function verifyDeployment() {
+    if (!buildId) return;
+    const response = await fetch('/version.js?update-check=1', { cache: 'no-store' });
+    const source = response.ok ? await response.text() : '';
+    if (source.match(/\bAPP_BUILD_ID\s*=\s*(['"])([^'"]+)\1/)?.[2] !== buildId) {
+      throw new Error('Deployment changed during app installation');
+    }
+  }
+
   scope.addEventListener('install', (event) => {
-    event.waitUntil(
-      resolveCacheName().then((name) =>
-        caches.open(name).then((cache) => precacheAppShell(cache))
-      )
-    );
+    event.waitUntil((async () => {
+      const name = await resolveCacheName();
+      try {
+        await verifyDeployment();
+        await precacheAppShell(await caches.open(name));
+        await verifyDeployment();
+      } catch (error) {
+        if (buildId) await caches.delete(name);
+        throw error;
+      }
+    })());
   });
 
   /**
@@ -231,8 +249,11 @@ function installServiceWorkerRuntime({
       }
       event.respondWith(
         matchCurrentCache(event.request).then((cached) => {
-          const fetched = fetchAndCache(event.request).catch(() => cached || cachedAppShell());
-          return cached || fetched;
+          if (cached) return cached;
+          if (url.pathname === '/app' || url.pathname === '/index.html') {
+            return cachedAppShell().then((shell) => shell || fetchAndCache(event.request));
+          }
+          return fetchAndCache(event.request).catch(() => cachedAppShell());
         })
       );
       return;

--- a/service-worker-runtime.js
+++ b/service-worker-runtime.js
@@ -250,7 +250,7 @@ function installServiceWorkerRuntime({
       event.respondWith(
         matchCurrentCache(event.request).then((cached) => {
           if (cached) return cached;
-          if (url.pathname === '/app' || url.pathname === '/index.html') {
+          if (url.pathname === '/app' || url.pathname === '/app/' || url.pathname === '/index.html') {
             return cachedAppShell().then((shell) => shell || fetchAndCache(event.request));
           }
           return fetchAndCache(event.request).catch(() => cachedAppShell());

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,6 +1,8 @@
-importScripts('/version.js'); importScripts('/service-worker-runtime.js'); // Production uses semver; previews add the deployment SHA. AI activation UX revision: 2026-08-31a.
+importScripts('/version.js'); importScripts('/service-worker-runtime.js'); // Build output pins the deployment identity.
+const BUILD_ID = ''; // Replaced by the production builder.
 const PROD_HOSTS = new Set(['app.getbased.health', 'getbased.health', 'www.getbased.health']); const IS_PROD = PROD_HOSTS.has(self.location.hostname); let _cacheNamePromise = null;
 async function resolveCacheName() {
+  if (BUILD_ID) return `labcharts-vbuild-${BUILD_ID}`;
   const base = `labcharts-v${self.APP_VERSION}`;
   if (IS_PROD) return base;
   if (!_cacheNamePromise) {
@@ -793,4 +795,4 @@ const NETWORK_ONLY_HOSTS = new Set(['openrouter.ai', 'api.venice.ai', 'nras.atte
 function isLocalOrPrivateHost(hostname) { return ['localhost', '127.0.0.1', '::1', '[::1]'].includes(hostname) || hostname.startsWith('192.168.') || hostname.startsWith('10.') || /^172\.(1[6-9]|2\d|3[01])\./.test(hostname); }
 function shouldUseNetworkOnly(url, sameOrigin) { const h = url.hostname; return NETWORK_ONLY_HOSTS.has(h) || (!sameOrigin && isLocalOrPrivateHost(h)); }
 /** @type {ServiceWorkerGlobalScope & typeof globalThis & { GetBasedServiceWorkerRuntime: { install: (config: ServiceWorkerRuntimeConfig) => void } }} */
-const serviceWorkerScope = /** @type {any} */ (self); serviceWorkerScope.GetBasedServiceWorkerRuntime.install({ scope: serviceWorkerScope, appShell: APP_SHELL, isProduction: IS_PROD, resolveCacheName, shouldUseNetworkOnly });
+const serviceWorkerScope = /** @type {any} */ (self); serviceWorkerScope.GetBasedServiceWorkerRuntime.install({ scope: serviceWorkerScope, buildId: BUILD_ID, appShell: APP_SHELL, isProduction: IS_PROD || !!BUILD_ID, resolveCacheName, shouldUseNetworkOnly });

--- a/tests/production-build.test.js
+++ b/tests/production-build.test.js
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { buildProduction, handleBuildLog } from '../scripts/build-production.mjs';
 
@@ -24,6 +24,32 @@ afterAll(async () => {
 });
 
 describe('production startup build', () => {
+  it('pins the same build identity into the app and worker without changing the release version', async () => {
+    const version = await fs.readFile(path.join(outputRoot, 'version.js'), 'utf8');
+    const source = await fs.readFile('version.js', 'utf8');
+    const worker = await fs.readFile(path.join(outputRoot, 'service-worker.js'), 'utf8');
+    const id = version.match(/APP_BUILD_ID = '([a-f0-9]{64})'/)?.[1];
+    expect(id).toBeTruthy();
+    expect(worker).toContain(`const BUILD_ID = '${id}';`);
+    expect(version).toContain(source.trim());
+  });
+  it('changes the worker and app identity for a new commit with the same version', async () => {
+    const nextRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'getbased-next-build-'));
+    const versionBefore = await fs.readFile(path.join(outputRoot, 'version.js'), 'utf8');
+    try {
+      vi.stubEnv('VERCEL_GIT_COMMIT_SHA', 'test-next-deployed-commit');
+      await buildProduction({ outputRoot: nextRoot });
+      const versionAfter = await fs.readFile(path.join(nextRoot, 'version.js'), 'utf8');
+      expect(versionAfter.match(/APP_VERSION = '[^']+'/)?.[0]).toBe(versionBefore.match(/APP_VERSION = '[^']+'/)?.[0]);
+      expect(versionAfter).not.toBe(versionBefore);
+      const id = versionAfter.match(/APP_BUILD_ID = '([^']+)'/)?.[1];
+      expect(await fs.readFile(path.join(nextRoot, 'service-worker.js'), 'utf8')).toContain(`const BUILD_ID = '${id}';`);
+    } finally {
+      vi.unstubAllEnvs();
+      await fs.rm(nextRoot, { recursive: true, force: true });
+    }
+  });
+
   it('keeps repository HTML pointed at the native development entry', async () => {
     const sourceIndex = await fs.readFile('index.html', 'utf8');
     expect(sourceIndex).toContain('<script type="module" src="js/main.js"></script>');

--- a/tests/pwa/app-server.js
+++ b/tests/pwa/app-server.js
@@ -3,8 +3,9 @@ import http from 'node:http';
 // Give each test an isolated origin and controllable releases without rewriting
 // the checkout or routing through Playwright (which cannot intercept SW updates).
 export async function startPwaServer(upstream) {
-  const state = { version: '99.0.1', offline: false, failPath: '', production: true };
+  const state = { version: '99.0.1', buildId: 'build-a', holdPath: '', held: 0, offline: false, failPath: '', production: true };
   const sockets = new Set();
+  const heldResponses = [];
   const server = http.createServer((req, res) => {
     if (state.offline) { req.socket.destroy(); return; }
     const pathname = new URL(req.url, 'http://localhost').pathname;
@@ -15,6 +16,7 @@ export async function startPwaServer(upstream) {
       return;
     }
     const target = new URL(req.url, upstream);
+    const hold = pathname === state.holdPath;
     const rewrite = pathname === '/service-worker.js' || pathname === '/version.js';
     const headers = { ...req.headers, host: target.host };
     if (rewrite) headers['accept-encoding'] = 'identity';
@@ -27,13 +29,16 @@ export async function startPwaServer(upstream) {
         incoming.setEncoding('utf8');
         incoming.on('data', chunk => { source += chunk; });
         incoming.on('end', () => {
-          if (pathname === '/version.js') source = source.replace(/self\.APP_VERSION = '[^']+'/, `self.APP_VERSION = '${state.version}'`);
+          if (pathname === '/version.js') source = source.replace(/self\.APP_VERSION = '[^']+'/, `self.APP_VERSION = '${state.version}'`) + `\nself.APP_BUILD_ID = '${state.buildId}';\n`;
           else {
             if (state.production) source = source.replace('IS_PROD = PROD_HOSTS.has(self.location.hostname)', 'IS_PROD = true');
-            source += `\n// Test release ${state.version}\n`;
+            source = source.replace("const BUILD_ID = '';", `const BUILD_ID = '${state.buildId}';`);
           }
           res.end(source);
         });
+      } else if (hold) {
+        state.held += 1;
+        heldResponses.push(() => incoming.pipe(res));
       } else incoming.pipe(res);
     });
     outgoing.on('error', () => res.destroy());
@@ -43,6 +48,7 @@ export async function startPwaServer(upstream) {
   await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
   return {
     state,
+    release() { state.holdPath = ''; for (const resume of heldResponses.splice(0)) resume(); },
     origin: `http://127.0.0.1:${server.address().port}`,
     async close() {
       for (const socket of sockets) socket.destroy();

--- a/tests/pwa/lifecycle.spec.js
+++ b/tests/pwa/lifecycle.spec.js
@@ -64,7 +64,7 @@ test('failed update preserves the installed app; retry updates two tabs without 
     });
     const other = await context.newPage();
     await openInstalledApp(other, server.origin);
-    server.state.version = '99.0.2';
+    server.state.buildId = 'build-b';
     server.state.failPath = '/css/settings.css';
     const failedState = await page.evaluate(async () => {
       const registration = await navigator.serviceWorker.getRegistration();
@@ -76,26 +76,37 @@ test('failed update preserves the installed app; retry updates two tabs without 
       return failed;
     });
     expect(failedState).toBe('redundant');
-    expect(await page.evaluate(() => window.APP_VERSION)).toBe('99.0.1');
+    expect(await page.evaluate(() => window.APP_BUILD_ID)).toBe('build-a');
     expect(await page.evaluate(() => localStorage.getItem('pwa-retained-data'))).toBe('retained');
+    await expect(page.locator('#version-update-banner')).toHaveCount(0);
+    await expect.poll(() => page.evaluate(async () => !(await navigator.serviceWorker.getRegistration()).installing)).toBe(true);
     server.state.failPath = '';
-    await page.evaluate(async () => (await navigator.serviceWorker.getRegistration()).update());
+    server.state.holdPath = '/css/settings.css';
+    await page.evaluate(async () => {
+      const updates = await import('/js/service-worker-update.js');
+      await updates.checkForAppVersionUpdate(await navigator.serviceWorker.getRegistration(), navigator.serviceWorker, window, { force: true });
+    });
+    await expect.poll(() => server.state.held).toBeGreaterThan(0);
+    await expect(page.locator('#version-update-banner')).toHaveCount(0);
+    expect(await page.evaluate(() => window.APP_BUILD_ID)).toBe('build-a');
+    server.release();
     await expect(page.locator('#version-update-banner')).toBeVisible({ timeout: 30_000 });
-    await expect(page.locator('[data-version-update-action="apply"]')).toHaveText('Update');
+    await expect(page.locator('[data-version-update-action="apply"]')).toHaveText('Reload');
     await page.locator('[data-version-update-action="dismiss"]').click();
-    expect(await page.evaluate(() => window.APP_VERSION)).toBe('99.0.1');
+    expect(await page.evaluate(() => window.APP_BUILD_ID)).toBe('build-a');
     // A later visit offers the still-pending update again.
     await page.reload({ waitUntil: 'networkidle' });
     await expect(page.locator('#version-update-banner')).toBeVisible();
+    server.state.offline = true; // Applying an already cached build needs no download.
     await page.locator('[data-version-update-action="apply"]').click();
-    await expect.poll(() => page.evaluate(() => window.APP_VERSION).catch(() => null), { timeout: 30_000 }).toBe('99.0.2');
+    await expect.poll(() => page.evaluate(() => window.APP_BUILD_ID).catch(() => null), { timeout: 30_000 }).toBe('build-b');
     await expect(other.locator('#version-update-banner')).toContainText('Reload');
-    expect(await other.evaluate(() => window.APP_VERSION)).toBe('99.0.1');
+    expect(await other.evaluate(() => window.APP_BUILD_ID)).toBe('build-a');
     await other.locator('[data-version-update-action="apply"]').click();
-    await expect.poll(() => other.evaluate(() => window.APP_VERSION).catch(() => null)).toBe('99.0.2');
+    await expect.poll(() => other.evaluate(() => window.APP_BUILD_ID).catch(() => null)).toBe('build-b');
     expect(await page.evaluate(() => localStorage.getItem('pwa-retained-data'))).toBe('retained');
     expect(await page.evaluate(async () => (await import('/js/state.js')).state.importedData.entries))
       .toEqual([{ date: '2026-09-01', markers: { 'biochemistry.glucose': 5.8 } }]);
-    await expect.poll(() => page.evaluate(() => caches.keys())).toEqual(['labcharts-v99.0.2']);
+    await expect.poll(() => page.evaluate(() => caches.keys())).toEqual(['labcharts-vbuild-build-b']);
   } finally { await server.close(); }
 });

--- a/tests/pwa/lifecycle.spec.js
+++ b/tests/pwa/lifecycle.spec.js
@@ -107,6 +107,10 @@ test('failed update preserves the installed app; retry updates two tabs without 
     expect(await page.evaluate(() => localStorage.getItem('pwa-retained-data'))).toBe('retained');
     expect(await page.evaluate(async () => (await import('/js/state.js')).state.importedData.entries))
       .toEqual([{ date: '2026-09-01', markers: { 'biochemistry.glucose': 5.8 } }]);
-    await expect.poll(() => page.evaluate(() => caches.keys())).toEqual(['labcharts-vbuild-build-b']);
+    // WebKit can transiently reject CacheStorage reads while activation settles.
+    // Retry the read, while still requiring exactly the new build's cache.
+    await expect(async () => {
+      expect(await page.evaluate(() => caches.keys())).toEqual(['labcharts-vbuild-build-b']);
+    }).toPass({ timeout: 5_000 });
   } finally { await server.close(); }
 });

--- a/tests/service-worker-runtime.test.js
+++ b/tests/service-worker-runtime.test.js
@@ -336,6 +336,40 @@ describe('service worker runtime cache behavior', () => {
     await vi.waitFor(() => expect(cache.put).toHaveBeenCalledWith(versionProbe.request, expect.any(Response)));
   });
 
+  it.each([false, true])('rejects a switched deployment and discards only its staging cache (after download=%s)', async afterDownload => {
+    const { listeners, self, caches, cache } = await loadServiceWorker({ hostname: 'app.getbased.health' });
+    self.GetBasedServiceWorkerRuntime.install({
+      scope: self, appShell: ['/app'], buildId: 'build-b', isProduction: true,
+      resolveCacheName: async () => 'labcharts-vbuild-build-b', shouldUseNetworkOnly: () => false,
+    });
+    let probes = 0;
+    globalThis.fetch = vi.fn(async url => {
+      if (url === '/version.js?update-check=1') {
+        probes += 1;
+        return new Response(`self.APP_BUILD_ID = '${afterDownload && probes === 1 ? 'build-b' : 'build-c'}';`);
+      }
+      return new Response('build-b-html');
+    });
+    const install = makeWaitEvent();
+    listeners.get('install')(install);
+    await expect(install.done()).rejects.toThrow('Deployment changed');
+    expect(cache.put).toHaveBeenCalledTimes(afterDownload ? 1 : 0);
+    expect(caches.delete).toHaveBeenCalledExactlyOnceWith('labcharts-vbuild-build-b');
+    expect(self.skipWaiting).not.toHaveBeenCalled();
+    expect(self.clients.claim).not.toHaveBeenCalled();
+  });
+
+  it('keeps the installed HTML unchanged when a new deployment is available', async () => {
+    const { listeners, matches } = await loadServiceWorker({ hostname: 'app.getbased.health' });
+    matches.set('/app', new Response('installed-html'));
+    globalThis.fetch = vi.fn(async () => new Response('new-html'));
+    const event = makeFetchEvent('https://app.getbased.health/app');
+    Object.defineProperty(event.request, 'mode', { value: 'navigate' });
+    listeners.get('fetch')(event);
+    expect(await (await event.response()).text()).toBe('installed-html');
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
   it('uses plain versioned cache names on production hosts', async () => {
     const { caches, listeners } = await loadServiceWorker({ hostname: 'app.getbased.health' });
     const install = makeWaitEvent();

--- a/tests/service-worker-runtime.test.js
+++ b/tests/service-worker-runtime.test.js
@@ -359,11 +359,11 @@ describe('service worker runtime cache behavior', () => {
     expect(self.clients.claim).not.toHaveBeenCalled();
   });
 
-  it('keeps the installed HTML unchanged when a new deployment is available', async () => {
+  it.each(['/app', '/app/', '/app?source=home', '/app/?source=home', '/index.html'])('keeps %s on the installed HTML when a new deployment is available', async entry => {
     const { listeners, matches } = await loadServiceWorker({ hostname: 'app.getbased.health' });
     matches.set('/app', new Response('installed-html'));
     globalThis.fetch = vi.fn(async () => new Response('new-html'));
-    const event = makeFetchEvent('https://app.getbased.health/app');
+    const event = makeFetchEvent(`https://app.getbased.health${entry}`);
     Object.defineProperty(event.request, 'mode', { value: 'navigate' });
     listeners.get('fetch')(event);
     expect(await (await event.response()).text()).toBe('installed-html');

--- a/tests/service-worker-update.test.js
+++ b/tests/service-worker-update.test.js
@@ -42,7 +42,7 @@ describe('service worker update prompt', () => {
     onUpdateFound();
     replacement.state = 'installed';
     onStateChange();
-    expect(document.getElementById('version-update-banner').textContent).toContain('New version available');
+    expect(document.getElementById('version-update-banner').textContent).toContain('Update ready');
   });
 
   it('delegates default browser globals through runtime helpers', () => {
@@ -300,99 +300,44 @@ describe('service worker update prompt', () => {
     expect(fetchVersion).not.toHaveBeenCalled();
   });
 
-  it('detects a new version cheaply and installs only after the update action', async () => {
-    const { checkForAppVersionUpdate } = serviceWorkerUpdate;
-    const waiting = { postMessage: vi.fn() };
+  it('stages a same-version build silently and offers reload only when ready', async () => {
+    let installed;
+    const worker = { state: 'installing', postMessage: vi.fn(), addEventListener: vi.fn((_, cb) => { installed = cb; }) };
+    let found;
     const registration = {
-      waiting: null,
-      installing: null,
-      update: vi.fn(async () => {
-        registration.waiting = waiting;
-      }),
+      waiting: null, installing: null,
+      addEventListener: vi.fn((_, cb) => { found = cb; }),
+      update: vi.fn(async () => { registration.installing = worker; found(); }),
     };
-    const serviceWorkerContainer = { controller: {} };
-    const win = {
-      APP_VERSION: '1.2.3',
-      localStorage: { getItem: vi.fn(() => null), setItem: vi.fn() },
-    };
-    const fetchImpl = vi.fn(async () => new Response("self.APP_VERSION = '1.2.4';"));
-
-    await expect(checkForAppVersionUpdate(
-      registration,
-      serviceWorkerContainer,
-      win,
-      { force: true, fetchImpl }
-    )).resolves.toBe(true);
-
-    expect(fetchImpl).toHaveBeenCalledTimes(1);
-    expect(registration.update).not.toHaveBeenCalled();
-    const banner = document.getElementById('version-update-banner');
-    expect(banner.textContent).toContain('New version available');
-
-    banner.querySelector('[data-version-update-action="apply"]').click();
-    await vi.waitFor(() => expect(registration.update).toHaveBeenCalledTimes(1));
-    await vi.waitFor(() => expect(waiting.postMessage).toHaveBeenCalledWith({ type: 'SKIP_WAITING' }));
+    const container = { controller: {} };
+    serviceWorkerUpdate.watchServiceWorkerRegistration(registration, container);
+    const win = { APP_VERSION: '1.2.3', APP_BUILD_ID: 'build-a' };
+    const fetchImpl = vi.fn(async () => new Response("self.APP_VERSION = '1.2.3'; self.APP_BUILD_ID = 'build-b';"));
+    await expect(serviceWorkerUpdate.checkForAppVersionUpdate(registration, container, win,
+      { force: true, fetchImpl })).resolves.toBe(true);
+    expect(registration.update).toHaveBeenCalledTimes(1);
     expect(document.getElementById('version-update-banner')).toBeNull();
+    expect(worker.postMessage).not.toHaveBeenCalled();
+    worker.state = 'installed'; registration.waiting = worker; installed();
+    expect(document.getElementById('version-update-banner').textContent).toContain('Update ready');
+    document.querySelector('[data-version-update-action="apply"]').click();
+    expect(worker.postMessage).toHaveBeenCalledWith({ type: 'SKIP_WAITING' });
   });
 
-  it('renders themed, accessible install progress from service-worker messages', async () => {
-    const { checkForAppVersionUpdate, registerServiceWorkerUpdates } = serviceWorkerUpdate;
-    let onMessage = null;
-    let resolveUpdate;
-    const updatePending = new Promise((resolve) => { resolveUpdate = resolve; });
-    const registration = {
-      waiting: null,
-      installing: null,
-      addEventListener: vi.fn(),
-      update: vi.fn(() => updatePending),
-    };
-    const win = {
-      APP_VERSION: '1.2.3',
-      fetch: vi.fn(async () => new Response("self.APP_VERSION = '1.2.3';")),
-      location: { hostname: 'getbased.health', search: '', reload: vi.fn() },
-      localStorage: { getItem: vi.fn(() => null), setItem: vi.fn() },
-      performance: { getEntriesByType: vi.fn(() => [{ type: 'navigate' }]) },
-      document: { visibilityState: 'visible', addEventListener: vi.fn() },
-      addEventListener: vi.fn(),
-      setInterval: vi.fn(() => 7),
-      clearInterval: vi.fn(),
-    };
-    const serviceWorkerContainer = {
-      controller: {},
-      register: vi.fn(async () => registration),
-      addEventListener: vi.fn((type, listener) => {
-        if (type === 'message') onMessage = listener;
-      }),
-    };
-
-    await registerServiceWorkerUpdates({ win, serviceWorkerContainer, cacheStorage: null });
-    await checkForAppVersionUpdate(registration, serviceWorkerContainer, win, {
-      force: true,
-      fetchImpl: vi.fn(async () => new Response("self.APP_VERSION = '1.2.4';")),
-    });
-
-    document.querySelector('[data-version-update-action="apply"]').click();
-    expect(onMessage).toEqual(expect.any(Function));
-    onMessage({ data: { type: 'PRECACHE_PROGRESS', completed: 293, total: 586 } });
-
-    const banner = document.getElementById('version-update-banner');
-    const track = banner.querySelector('.version-update-progress-track');
-    expect(banner.querySelector('.version-update-percent').textContent).toBe('50%');
-    expect(banner.querySelector('.version-update-progress-fill').style.width).toBe('50%');
-    expect(banner.querySelector('.version-update-progress-meta').textContent).toContain('293 of 586 files cached');
-    expect(track.getAttribute('role')).toBe('progressbar');
-    expect(track.getAttribute('aria-valuenow')).toBe('50');
-    expect(track.getAttribute('aria-valuetext')).toBe('293 of 586 app files cached');
-    expect(banner.getAttribute('aria-live')).toBe('off');
-    expect(banner.getAttribute('aria-busy')).toBe('true');
-    expect(banner.querySelector('.version-update-actions').hidden).toBe(true);
-
-    onMessage({ data: { type: 'PRECACHE_PROGRESS', completed: 586, total: 586 } });
-    expect(banner.textContent).toContain('Finalizing update');
-    expect(banner.querySelector('.version-update-percent').textContent).toBe('100%');
-
-    resolveUpdate();
-    await updatePending;
+  it('ignores unchanged builds and silently retries failed background updates', async () => {
+    const registration = { waiting: null, update: vi.fn().mockRejectedValueOnce(new Error('offline')).mockResolvedValue(undefined) };
+    const container = { controller: {} };
+    const win = { APP_VERSION: '1.2.3', APP_BUILD_ID: 'build-b' };
+    const same = { force: true, fetchImpl: async () => new Response("self.APP_BUILD_ID = 'build-b';") };
+    expect(await serviceWorkerUpdate.checkForAppVersionUpdate(registration, container, win, same)).toBe(false);
+    expect(registration.update).not.toHaveBeenCalled();
+    // A rollback is also a different deployed build, not a semver comparison.
+    const previous = { force: true, fetchImpl: async () => new Response("self.APP_BUILD_ID = 'build-a';") };
+    expect(await serviceWorkerUpdate.checkForAppVersionUpdate(registration, container, win, previous)).toBe(false);
+    expect(document.getElementById('version-update-banner')).toBeNull();
+    expect(await serviceWorkerUpdate.checkForAppVersionUpdate(registration, container, win, previous)).toBe(true);
+    expect(registration.update).toHaveBeenCalledTimes(2);
+    expect(document.getElementById('version-update-banner')).toBeNull();
   });
 
   it('shares the version-check throttle across tabs while allowing forced reload checks', async () => {
@@ -438,7 +383,7 @@ describe('service worker update prompt', () => {
     const banner = document.getElementById('version-update-banner');
     expect(banner).not.toBeNull();
     expect(banner.querySelector('.version-update-copy-short')).toBeNull();
-    expect(banner.textContent).toContain('New version available. Update when you are ready.');
+    expect(banner.textContent).toContain('Update ready. Reload when you are ready.');
     expect(document.body.classList.contains('version-update-visible')).toBe(true);
     expect(waiting.postMessage).not.toHaveBeenCalled();
 

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -22,6 +22,7 @@ interface Window {
   _demoLoadingProfileId?: string;
   _snpTableCache?: unknown;
   APP_VERSION?: string;
+  APP_BUILD_ID?: string;
   callClaudeAPI?: (request: {
     system?: string;
     messages: Array<{ role: string; content: string }>;

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.19.2';
+self.APP_VERSION = '1.19.3';


### PR DESCRIPTION
An open PWA previously noticed updates only when the release version changed, then downloaded the app shell after the user clicked Update. Each production build now embeds an identity derived from its deployed commit and deployment ID in both the worker and app. Changing the deployed commit updates the worker even when the release version stays the same.

Visible apps check periodically and when returning to the foreground, stage updates silently in a separate build cache, and offer **Update ready — Reload / Later** only once installation succeeds. Activation remains an explicit action in open tabs; secondary tabs receive their own reload prompt. A failed download preserves the current app. Installation checks the deployment identity before and after caching and discards the staging cache on failure. Cached app navigation no longer refreshes its HTML from a newer deployment before activation.

Release 1.19.3 supplies the one-time migration signal for existing version-based clients. Subsequent patches do not require a version bump. Built previews also use their pinned build cache; unbuilt local development keeps its existing opt-in behavior.

Validation: 47 focused unit/build checks passed, along with all 8 PWA lifecycle scenarios across Chromium, Firefox, desktop WebKit, and mobile WebKit. Browser coverage includes an unchanged release version, a failed download, a stalled background download with no premature banner, Later, offline activation in two tabs, retained imported lab data, and old-cache cleanup. CheckJs, service-worker types, strict-null, architecture, quality, build budgets, and diff checks passed. Full CI runs on this PR. Physical-device acceptance remains pending; browser emulation does not establish actual home-screen or airplane-mode behavior.
