### PR TITLE
Stop inactive Routstr mint polling and repeated rejected quote checks

### DIFF
--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -10,7 +10,7 @@ The human-maintained architecture contract is in [`ARCHITECTURE.md`](ARCHITECTUR
 | Metric | Current |
 | --- | ---: |
 | Modules | 762 |
-| Internal import edges | 3216 |
+| Internal import edges | 3217 |
 | Dynamic internal edges | 107 |
 | Modules participating in cycles | 0 |
 | Cyclic components | 0 |
@@ -986,7 +986,7 @@ Native browser modules shipped with the static application.
 - [`js/provider-wallet-funding-recovery.js`](js/provider-wallet-funding-recovery.js) → [`js/cashu-funding-coordinator.js`](js/cashu-funding-coordinator.js), [`js/caught-error.js`](js/caught-error.js), [`js/provider-qr.js`](js/provider-qr.js), [`js/routstr-validation.js`](js/routstr-validation.js), [`js/utils.js`](js/utils.js)
 - [`js/provider-wallet-panel-buttons.js`](js/provider-wallet-panel-buttons.js) → [`js/utils.js`](js/utils.js)
 - [`js/provider-wallet-panel-renderers.js`](js/provider-wallet-panel-renderers.js) → [`js/utils.js`](js/utils.js)
-- [`js/provider-wallet-panels.js`](js/provider-wallet-panels.js) → [`js/api.js`](js/api.js), [`js/caught-error.js`](js/caught-error.js), [`js/provider-wallet-delegates.js`](js/provider-wallet-delegates.js), [`js/provider-wallet-funding-recovery.js`](js/provider-wallet-funding-recovery.js), [`js/provider-wallet-panel-buttons.js`](js/provider-wallet-panel-buttons.js), [`js/provider-wallet-panel-renderers.js`](js/provider-wallet-panel-renderers.js), [`js/provider-wallet-runtime.js`](js/provider-wallet-runtime.js), [`js/routstr-balance-settlement.js`](js/routstr-balance-settlement.js), [`js/routstr-model-cache.js`](js/routstr-model-cache.js), [`js/routstr-validation.js`](js/routstr-validation.js), [`js/url-safety.js`](js/url-safety.js), [`js/utils.js`](js/utils.js)
+- [`js/provider-wallet-panels.js`](js/provider-wallet-panels.js) → [`js/agent-chat-settings.js`](js/agent-chat-settings.js), [`js/api.js`](js/api.js), [`js/caught-error.js`](js/caught-error.js), [`js/provider-wallet-delegates.js`](js/provider-wallet-delegates.js), [`js/provider-wallet-funding-recovery.js`](js/provider-wallet-funding-recovery.js), [`js/provider-wallet-panel-buttons.js`](js/provider-wallet-panel-buttons.js), [`js/provider-wallet-panel-renderers.js`](js/provider-wallet-panel-renderers.js), [`js/provider-wallet-runtime.js`](js/provider-wallet-runtime.js), [`js/routstr-balance-settlement.js`](js/routstr-balance-settlement.js), [`js/routstr-model-cache.js`](js/routstr-model-cache.js), [`js/routstr-validation.js`](js/routstr-validation.js), [`js/url-safety.js`](js/url-safety.js), [`js/utils.js`](js/utils.js)
 - [`js/provider-wallet-runtime.js`](js/provider-wallet-runtime.js) → [`js/cashu-wallet.js`](js/cashu-wallet.js), [`js/nostr-discovery.js`](js/nostr-discovery.js)
 
 </details>

--- a/js/cashu-wallet.js
+++ b/js/cashu-wallet.js
@@ -487,6 +487,8 @@ export async function createFundingInvoice(amountSats) {
  */
 export async function checkFundingStatus(quoteId, quoteMint = null, options = {}) {
   return _withWalletLock(async () => {
+    const canCheck = () => !options.automatic || !options.shouldContinue || options.shouldContinue();
+    if (!canCheck()) return { paid: false, state: 'WAITING' };
     const cashuts = await _cashuLib();
     const mintUrl = _normalizeMintUrl(quoteMint || await getMintUrl());
     if (!isValidExternalUrl(mintUrl)) throw new Error('Invalid pending invoice mint');
@@ -494,16 +496,33 @@ export async function checkFundingStatus(quoteId, quoteMint = null, options = {}
     if (options.automatic) {
       const now = Date.now();
       const previous = await _getMeta(pollKey) || {};
+      if (previous.paused) return { paid: false, state: 'PAUSED' };
       const budgetKey = 'fundingNextAt:' + mintUrl;
-      const nextAt = Math.max(Number(await _getMeta(budgetKey)) || 0, options.notified ? 0 : Number(previous.nextAt) || 0);
+      const nextAt = Math.max(Number(await _getMeta(budgetKey)) || 0, Number(previous.retryAt) || 0, options.notified ? 0 : Number(previous.nextAt) || 0);
       if (nextAt > now) return { paid: false, state: 'WAITING', retryAfterMs: nextAt - now };
       const attempts = Math.min(4, (Number(previous.attempts) || 0) + 1);
       await _setMeta(budgetKey, now + 5000);
-      await _setMeta(pollKey, { attempts, nextAt: now + (options.subscribed ? 60000 : Math.min(30000, 5000 * 2 ** (attempts - 1))) });
+      await _setMeta(pollKey, { ...previous, attempts, nextAt: now + (options.subscribed ? 60000 : Math.min(30000, 5000 * 2 ** (attempts - 1))) });
     }
     const result = await _withMintRequest(mintUrl, async () => {
+      if (!canCheck()) return { paid: false, state: 'WAITING' };
       const wallet = await _getWallet(mintUrl);
-      const checked = await wallet.checkMintQuoteBolt11(quoteId);
+      if (!canCheck()) return { paid: false, state: 'WAITING' };
+      let checked;
+      try {
+        checked = await wallet.checkMintQuoteBolt11(quoteId);
+      } catch (error) {
+        const details = /** @type {{status?: number, statusCode?: number, retryAfterMs?: number}} */ (error);
+        const previous = await _getMeta(pollKey) || {};
+        const status = Number(details?.status ?? details?.statusCode);
+        const failures = Math.min(5, (Number(previous.failures) || 0) + 1);
+        const paused = status >= 400 && status < 500 && status !== 408 && status !== 429;
+        await _setMeta(pollKey, { ...previous, paused, failures, retryAt: Date.now() + Math.max(Number(details?.retryAfterMs) || 0, Math.min(900000, 60000 * 2 ** (failures - 1))) });
+        throw error;
+      }
+      // A successful explicit recheck releases a paused quote without losing it.
+      const poll = await _getMeta(pollKey);
+      if (poll?.paused || poll?.failures) await _setMeta(pollKey, { ...poll, paused: false, failures: 0, retryAt: 0 });
       // A response can be lost after the mint issued the exact journaled outputs.
       // Recover those outputs automatically instead of waiting forever for PAID.
       if (String(checked.state).toUpperCase() === 'ISSUED') {
@@ -594,6 +613,7 @@ export async function recoverPendingFunding(options = {}) {
   const entries = await _getMetaEntries(PENDING_QUOTE_PREFIX);
 
   for (const entry of entries) {
+    if (options.automatic && options.shouldContinue && !options.shouldContinue()) break;
     const details = _pendingQuoteDetails(entry, currentMint);
     const quoteId = details.quote;
     const pendingKey = entry.key;
@@ -607,6 +627,7 @@ export async function recoverPendingFunding(options = {}) {
         automatic: options.automatic,
         notified: options.notified?.some(item => item.mint === details.mint && item.quote === quoteId),
         subscribed: options.subscribedMints?.includes(details.mint),
+        shouldContinue: options.shouldContinue,
       });
       results.push({ quote: quoteId, mint: details.mint, ...result });
       if (result?.paid) {
@@ -619,11 +640,20 @@ export async function recoverPendingFunding(options = {}) {
         pending += 1;
       }
     } catch (e) {
+      if ((await _getMeta('fundingPoll:' + await _pendingQuoteKey(details.mint, quoteId)))?.paused) {
+        results.push({ quote: quoteId, mint: details.mint, paid: false, state: 'PAUSED' });
+      }
       errors.push({ quote: quoteId, mint: details.mint, message: getErrorMessage(e, String(e)), retryAfterMs: Number(/** @type {{retryAfterMs?: number}} */ (e)?.retryAfterMs) || 0 });
     }
   }
 
-  const pendingQuotes = entries.map(entry => _pendingQuoteDetails(entry, currentMint)).filter(item => item.quote && !results.some(result => result.mint === item.mint && result.quote === item.quote && (result.paid || _isTerminalMintQuoteState(result.state))));
+  const pendingQuotes = [];
+  for (const entry of entries) {
+    const item = _pendingQuoteDetails(entry, currentMint);
+    if (!item.quote || results.some(result => result.mint === item.mint && result.quote === item.quote && (result.paid || _isTerminalMintQuoteState(result.state)))) continue;
+    if ((await _getMeta('fundingPoll:' + await _pendingQuoteKey(item.mint, item.quote)))?.paused) continue;
+    pendingQuotes.push(item);
+  }
   return { mint: currentMint, checked: entries.length, recovered, pending, cleared, failed: errors.length, errors, balance, results, pendingQuotes };
 }
 

--- a/js/provider-wallet-funding-recovery.js
+++ b/js/provider-wallet-funding-recovery.js
@@ -69,7 +69,7 @@ function renderFundingPaid(status, credited) {
 }
 
 /** One wallet-wide loop, independent of the currently visible invoice/panel. */
-export function createFundingMonitor(runtime, refreshBalance, onResult = (_result) => {}) {
+export function createFundingMonitor(runtime, refreshBalance, onResult = (_result) => {}, isActive = () => true) {
   let timer = null;
   let running = false;
   let enabled = false;
@@ -78,6 +78,7 @@ export function createFundingMonitor(runtime, refreshBalance, onResult = (_resul
   let notBefore = 0;
   let recheckRequested = false;
   let refreshingBalance = false;
+  const canRun = () => enabled && leader && isActive();
   const subscriptions = new Map();
   const notified = new Map();
   const quoteKey = item => item.mint + '\n' + item.quote;
@@ -101,7 +102,9 @@ export function createFundingMonitor(runtime, refreshBalance, onResult = (_resul
       void Promise.resolve().then(() => refreshBalance()).catch(() => {}).finally(() => { refreshingBalance = false; });
     }
     const poll = document.getElementById('routstr-wfund-poll');
-    if (poll) poll.textContent = result.failed
+    if (poll) poll.textContent = displayed?.state === 'PAUSED'
+      ? 'Mint rejected this invoice check. Automatic checks paused; use Check pending deposits to retry.'
+      : result.failed
       ? 'Payment confirmation delayed. Retrying automatically…'
       : displayed?.state === 'ISSUED' ? 'Payment received. Recovering wallet balance…'
       : 'Waiting for payment… Deposits are credited automatically.';
@@ -149,16 +152,16 @@ export function createFundingMonitor(runtime, refreshBalance, onResult = (_resul
           wakeLocal();
         }
       };
-      void Promise.resolve().then(() => runtime.cashuSubscribeFundingQuotes(mint, ids, update => {
-        if (!leader || !enabled || subscriptions.get(mint) !== entry || !ids.includes(update?.quote)) return;
+      void Promise.resolve().then(() => canRun() ? runtime.cashuSubscribeFundingQuotes(mint, ids, update => {
+        if (!canRun() || subscriptions.get(mint) !== entry || !ids.includes(update?.quote)) return;
         entry.confirmed = true;
         if (/^(PAID|ISSUED|EXPIRED|CANCELLED|CANCELED)$/.test(String(update.state).toUpperCase())) {
           const item = { mint, quote: update.quote };
           // A notification never credits funds directly or bypasses HTTP limits.
           if (!notified.has(quoteKey(item))) { notified.set(quoteKey(item), item); wakeLocal(); }
         }
-      }, failed)).then(cancel => {
-        if (!leader || !enabled || subscriptions.get(mint) !== entry || entry.retryAt) { cancel?.(); return; }
+      }, failed) : null).then(cancel => {
+        if (!canRun() || subscriptions.get(mint) !== entry || entry.retryAt) { cancel?.(); return; }
         entry.connecting = false;
         entry.cancel = cancel;
         if (!cancel) entry.retryAt = Date.now() + 300000;
@@ -177,20 +180,20 @@ export function createFundingMonitor(runtime, refreshBalance, onResult = (_resul
   }, displayResult, () => wakeLocal());
 
   async function tick() {
-    if (!enabled || !leader || running) return;
+    if (!canRun() || running) return;
     if (notBefore > Date.now()) { timer = setTimeout(tick, Math.min(2147483647, notBefore - Date.now())); return; }
     running = true;
     recheckRequested = false;
     let delay = 30000;
     try {
-      if (await runtime.cashuHasWalletSeed()) {
+      if (await runtime.cashuHasWalletSeed() && canRun()) {
         const hints = [...notified.values()];
         notified.clear();
         let result;
         try {
-          result = await runtime.cashuRecoverPendingFunding({ automatic: true, notified: hints, subscribedMints: [...subscriptions].filter(([, entry]) => entry.confirmed).map(([mint]) => mint) });
+          result = await runtime.cashuRecoverPendingFunding({ automatic: true, shouldContinue: canRun, notified: hints, subscribedMints: [...subscriptions].filter(([, entry]) => entry.confirmed).map(([mint]) => mint) });
         } catch (error) { for (const hint of hints) notified.set(quoteKey(hint), hint); throw error; }
-        if (!enabled || !leader) return;
+        if (!canRun()) return;
         for (const hint of hints) {
           if (result.results?.some(item => quoteKey(item) === quoteKey(hint) && item.state === 'WAITING')) notified.set(quoteKey(hint), hint);
         }
@@ -209,7 +212,7 @@ export function createFundingMonitor(runtime, refreshBalance, onResult = (_resul
       if (poll) poll.textContent = 'Payment confirmation delayed. Retrying automatically…';
     } finally {
       running = false;
-      if (enabled && leader) timer = setTimeout(tick, Math.min(2147483647, Math.max(notBefore - Date.now(), recheckRequested ? 0 : delay, 0)));
+      if (canRun()) timer = setTimeout(tick, Math.min(2147483647, Math.max(notBefore - Date.now(), recheckRequested ? 0 : delay, 0)));
     }
   }
   function wakeLocal() {
@@ -223,6 +226,7 @@ export function createFundingMonitor(runtime, refreshBalance, onResult = (_resul
   const resume = () => { if (enabled) coordinator.start(); };
   return {
     start({ recheck = false } = {}) {
+      if (!isActive()) return;
       if (!enabled) {
         enabled = true;
         globalThis.addEventListener?.('online', wake);

--- a/js/provider-wallet-panels.js
+++ b/js/provider-wallet-panels.js
@@ -4,7 +4,8 @@
 import { canonicalRoutstrUrl, validateLightningInvoice } from './routstr-validation.js';
 import { getErrorMessage } from './caught-error.js';
 import { escapeHTML, escapeAttr, showNotification } from './utils.js';
-import { getRoutstrKey, saveRoutstrKey, touchRoutstrSession, fetchRoutstrModels, getRoutstrBalance } from './api.js';
+import { getAIProvider, getRoutstrKey, saveRoutstrKey, touchRoutstrSession, fetchRoutstrModels, getRoutstrBalance } from './api.js';
+import { getChatBackend } from './agent-chat-settings.js';
 import { isValidExternalUrl } from './url-safety.js';
 import { installRoutstrWalletDelegates } from './provider-wallet-delegates.js';
 import { createFundingMonitor, renderFundingInvoice, recoverPendingWalletFunding as recoverPendingWalletFundingImpl } from './provider-wallet-funding-recovery.js';
@@ -97,12 +98,19 @@ installRoutstrBalanceSettlementRefresh(refreshRoutstrBalance);
 
 let _fundingRequest = null;
 let _fundingInvoice = null;
+const isRoutstrActive = () => getAIProvider() === 'routstr' && getChatBackend() === 'direct';
 const fundingMonitor = createFundingMonitor(walletRuntime, () => _refreshRoutstrWalletBalance(true), result => {
   if (result.results?.some(item => item.quote === _fundingInvoice?.quote
     && (item.mint || result.mint) === _fundingInvoice?.mint
     && (item.paid || /^(EXPIRED|CANCELLED|CANCELED)$/.test(String(item.state).toUpperCase())))) _fundingInvoice = null;
-});
-export function startRoutstrFundingMonitor() { fundingMonitor.start(); }
+}, isRoutstrActive);
+export function startRoutstrFundingMonitor(options = {}) {
+  if (isRoutstrActive()) fundingMonitor.start(options);
+  else fundingMonitor.stop();
+}
+for (const event of ['labcharts-ai-settings-local-changed', 'getbased:chat-backend-changed', 'storage']) {
+  globalThis.addEventListener?.(event, () => startRoutstrFundingMonitor());
+}
 
 function _getWalletInput(id) {
   return /** @type {HTMLInputElement | HTMLTextAreaElement | null} */ (document.getElementById(id));
@@ -137,13 +145,14 @@ async function _renderWalletFundUI() {
       ${presets.map(s => `<button class="import-btn import-btn-secondary" style="flex:1;background:rgba(99,135,255,0.12);color:var(--accent);border-color:rgba(99,135,255,0.25)" data-routstr-wallet-action="fund-wallet-preset" data-sats="${s}">\u26a1 ${s.toLocaleString()}</button>`).join('')}<div id="routstr-wfund-custom-slot" style="display:flex"><button class="import-btn import-btn-secondary" style="color:var(--text-muted)" data-routstr-wallet-action="fund-wallet-custom-input">\u26a1\u2026</button></div>
     </div>
     <div style="font-size:10px;color:var(--text-muted);margin-top:5px;text-align:center">1,000 sats is enough for a few chats</div>
-    <div style="font-size:11px;color:var(--text-muted);margin-top:6px">Paid deposits are checked and credited automatically, even after closing this panel.</div>
+    <div style="font-size:11px;color:var(--text-muted);margin-top:6px">Paid deposits are checked automatically while Routstr is active, even after closing this panel.</div>
     <div style="margin-top:6px"><div class="or-oauth-divider"><span>${cashuFeeLabel}</span></div>
     <div class="routstr-wallet-input-row">
       <input type="text" class="api-key-input" id="routstr-wcashu-input" placeholder="cashuA... / cashuB... / cashu:..." style="font-size:11px;flex:1;font-family:monospace">
       <button class="import-btn import-btn-primary" style="white-space:nowrap" data-routstr-wallet-action="receive-wallet-cashu">Deposit</button>
     </div></div>
     <div id="routstr-wfund-status"></div>
+    <button class="import-btn import-btn-secondary" data-routstr-wallet-action="recover-wallet-funding">Check pending deposits</button>
   </div>`;
   startRoutstrFundingMonitor();
   const invoice = _fundingInvoice;
@@ -188,7 +197,7 @@ export async function doRoutstrWalletFund(amountSats) {
       const mint = await walletRuntime.cashuGetMintUrl();
       const result = await walletRuntime.cashuCreateFundingInvoice(amountSats);
       _fundingInvoice = { ...result, amount: amountSats, mint };
-      fundingMonitor.start({ recheck: true });
+      startRoutstrFundingMonitor({ recheck: true });
       // The quote is durable even if the user navigated away while creating it.
       if (statusEl === document.getElementById('routstr-wfund-status')) {
         await renderFundingInvoice(_fundingInvoice);

--- a/js/provider-wallet-panels.js
+++ b/js/provider-wallet-panels.js
@@ -108,7 +108,7 @@ export function startRoutstrFundingMonitor(options = {}) {
   if (isRoutstrActive()) fundingMonitor.start(options);
   else fundingMonitor.stop();
 }
-for (const event of ['labcharts-ai-settings-local-changed', 'getbased:chat-backend-changed', 'storage']) {
+for (const event of ['labcharts-ai-settings-local-changed', 'labcharts-ai-settings-synced', 'getbased:chat-backend-changed', 'storage']) {
   globalThis.addEventListener?.(event, () => startRoutstrFundingMonitor());
 }
 

--- a/js/settings-provider-bridge.js
+++ b/js/settings-provider-bridge.js
@@ -98,10 +98,20 @@ export function initSettingsProviderPanels() {
   });
 }
 
-// Resume saved wallet invoices after reload without requiring Settings to open.
-// Do not load the wallet/crypto graph for visitors who have never set one up.
-try {
-  if (localStorage.getItem('labcharts-cashu-wallet-mnemonic')) {
-    void import('./provider-wallet-panels.js').then(panels => panels.startRoutstrFundingMonitor()).catch(() => {});
-  }
-} catch {}
+// Load saved funding recovery only for the active direct Routstr provider.
+let walletPanelsLoad = null;
+function syncWalletFunding() {
+  try {
+    if (!walletPanelsLoad) {
+      if (getAIProvider() !== 'routstr' || getChatBackend() !== 'direct' || !localStorage.getItem('labcharts-cashu-wallet-mnemonic')) return;
+      walletPanelsLoad = import('./provider-wallet-panels.js');
+    }
+    void walletPanelsLoad.then(panels => panels.startRoutstrFundingMonitor()).catch(() => {});
+  } catch {}
+}
+globalThis.addEventListener?.('labcharts-ai-settings-local-changed', syncWalletFunding);
+globalThis.addEventListener?.('getbased:chat-backend-changed', syncWalletFunding);
+globalThis.addEventListener?.('storage', event => {
+  if (!event.key || ['labcharts-ai-provider', 'labcharts-chat-backend'].includes(event.key)) syncWalletFunding();
+});
+syncWalletFunding();

--- a/js/settings-provider-bridge.js
+++ b/js/settings-provider-bridge.js
@@ -110,6 +110,7 @@ function syncWalletFunding() {
   } catch {}
 }
 globalThis.addEventListener?.('labcharts-ai-settings-local-changed', syncWalletFunding);
+globalThis.addEventListener?.('labcharts-ai-settings-synced', syncWalletFunding);
 globalThis.addEventListener?.('getbased:chat-backend-changed', syncWalletFunding);
 globalThis.addEventListener?.('storage', event => {
   if (!event.key || ['labcharts-ai-provider', 'labcharts-chat-backend'].includes(event.key)) syncWalletFunding();

--- a/js/sync-apply.js
+++ b/js/sync-apply.js
@@ -169,6 +169,9 @@ async function applyAISettingsUnlocked(settings, options) {
     if (routstrSessionKey) routstrSessionChanged = true;
   }
   if (changed) {
+    // Same-tab storage writes do not emit storage events. Reconcile consumers
+    // without marking remotely applied settings as a new local edit.
+    globalThis.dispatchEvent?.(new CustomEvent('labcharts-ai-settings-synced'));
     refreshSyncedAIProviderUiRuntime();
     notifyAppExtensionSyncSettingsApplied({ settings, changedKeys });
   }

--- a/scripts/dom-sink-policy.json
+++ b/scripts/dom-sink-policy.json
@@ -749,7 +749,7 @@
     },
     "js/provider-wallet-panels.js": {
       "count": 58,
-      "digest": "efc46cf53d09aec983815ff183a998b9871c3d3ba37179716cc5f8c7e7a3658a",
+      "digest": "5bc0e7e853e5e14044a7431e0201b95f673befdbd08c5785d7bccab223a19e70",
       "kinds": {
         "innerHTML": 58
       }

--- a/tests/cashu-wallet-runtime.test.js
+++ b/tests/cashu-wallet-runtime.test.js
@@ -30,6 +30,58 @@ afterEach(() => {
 });
 
 describe('Cashu wallet runtime behavior', () => {
+  it('pauses rejected quotes across reloads and notifications without deleting recoverable deposits', async () => {
+    const wallet = await loadWallet();
+    const mint = 'https://mint.rejected.test';
+    await wallet.setMintUrl(mint);
+    await wallet.createFundingInvoice(12);
+    const check = vi.spyOn(globalThis.cashuts.Wallet.prototype, 'checkMintQuoteBolt11').mockRejectedValue(Object.assign(new Error('Quote not found'), {status:400}));
+    try {
+      const first = await wallet.recoverPendingFunding({automatic:true});
+      expect(first).toMatchObject({failed:1,pendingQuotes:[]});
+      expect(first.results[0].state).toBe('PAUSED');
+      const reloaded = await loadWallet();
+      for (let i=0;i<5;i++) await reloaded.recoverPendingFunding({automatic:true,notified:[{mint,quote:'mint-12'}]});
+      expect(check).toHaveBeenCalledTimes(1);
+      expect((await reloaded.recoverPendingFunding({automatic:true})).checked).toBe(1);
+      check.mockRestore();
+      await expect(reloaded.recoverPendingFunding()).resolves.toMatchObject({recovered:12});
+    } finally { check.mockRestore(); }
+  });
+
+  it('backs off transient quote errors even when notifications request another check', async () => {
+    const wallet = await loadWallet();
+    const mint = 'https://mint.transient.test';
+    await wallet.setMintUrl(mint); await wallet.createFundingInvoice(12);
+    const check = vi.spyOn(globalThis.cashuts.Wallet.prototype, 'checkMintQuoteBolt11').mockRejectedValue(Object.assign(new Error('Unavailable'),{status:503}));
+    let now = Date.now();
+    const clock = vi.spyOn(Date,'now').mockImplementation(()=>now);
+    try {
+      await wallet.recoverPendingFunding({automatic:true});
+      const reloaded = await loadWallet();
+      now += 59999;
+      await reloaded.recoverPendingFunding({automatic:true,notified:[{mint,quote:'mint-12'}]});
+      expect(check).toHaveBeenCalledTimes(1);
+      now += 1; await reloaded.recoverPendingFunding({automatic:true});
+      expect(check).toHaveBeenCalledTimes(2);
+      now += 119999; await reloaded.recoverPendingFunding({automatic:true,notified:[{mint,quote:'mint-12'}]});
+      expect(check).toHaveBeenCalledTimes(2);
+      now += 1; await reloaded.recoverPendingFunding({automatic:true});
+      expect(check).toHaveBeenCalledTimes(3);
+    } finally { check.mockRestore(); clock.mockRestore(); }
+  });
+
+  it('does not start queued quote requests after automatic monitoring is disabled', async () => {
+    const wallet = await loadWallet();
+    await wallet.createFundingInvoice(12);
+    const check = vi.spyOn(globalThis.cashuts.Wallet.prototype,'checkMintQuoteBolt11');
+    try {
+      await wallet.recoverPendingFunding({automatic:true,shouldContinue:()=>false});
+      await wallet.checkFundingStatus('mint-12',null,{automatic:true,shouldContinue:()=>false});
+      expect(check).not.toHaveBeenCalled();
+    } finally { check.mockRestore(); }
+  });
+
   it('shares automatic invoice pacing across reloads and caps checks per mint', async () => {
     const stub = installCashuStub();
     const wallet = await loadWallet();

--- a/tests/playwright/routstr-provider-polling.spec.js
+++ b/tests/playwright/routstr-provider-polling.spec.js
@@ -1,0 +1,52 @@
+import { expect, test } from './coverage-fixture.js';
+
+test('saved funding stays quiet on OpenRouter and stops on provider or backend changes', async ({page}) => {
+  await page.route('**/provider-polling-fixture', route => route.fulfill({contentType:'text/html',body:'<div id="routstr-wfund-poll"></div>'}));
+  const external = [];
+  await page.route(/^https:\/\//, route => { external.push(route.request().url()); return route.abort(); });
+  await page.clock.install();
+  await page.goto('/provider-polling-fixture');
+  await page.evaluate(async () => {
+    localStorage.setItem('labcharts-ai-provider','openrouter');
+    localStorage.setItem('labcharts-cashu-wallet-mnemonic','synthetic-encrypted-wallet');
+    const panels = await import('/js/provider-wallet-panels.js');
+    window.pollStats = {checks:0,subscribes:0,cancels:0};
+    panels.configureRoutstrWalletRuntime({
+      cashuHasWalletSeed: async () => true,
+      cashuGetLocalWalletBalance: async () => 0,
+      cashuRecoverPendingFunding: async () => {
+        window.pollStats.checks++;
+        return {pending:1,results:[],pendingQuotes:[{mint:'https://mint.synthetic.test',quote:'q1'}]};
+      },
+      cashuSubscribeFundingQuotes: async () => {
+        window.pollStats.subscribes++;
+        return () => { window.pollStats.cancels++; };
+      },
+    });
+    await import('/js/settings-provider-bridge.js');
+    panels.startRoutstrFundingMonitor();
+  });
+  await page.clock.runFor(120000);
+  expect(await page.evaluate(() => window.pollStats)).toEqual({checks:0,subscribes:0,cancels:0});
+  await page.evaluate(async () => (await import('/js/api.js')).setAIProvider('routstr'));
+  await expect.poll(() => page.evaluate(() => window.pollStats.checks)).toBe(1);
+  await expect.poll(() => page.evaluate(() => window.pollStats.subscribes)).toBe(1);
+  await page.evaluate(async () => (await import('/js/api.js')).setAIProvider('openrouter'));
+  await expect.poll(() => page.evaluate(() => window.pollStats.cancels)).toBe(1);
+  await page.clock.runFor(120000);
+  expect(await page.evaluate(() => window.pollStats.checks)).toBe(1);
+  await page.evaluate(async () => (await import('/js/api.js')).setAIProvider('routstr'));
+  await expect.poll(() => page.evaluate(() => window.pollStats.checks)).toBe(2);
+  await page.evaluate(async () => (await import('/js/agent-chat-settings.js')).setChatBackend('codex'));
+  await page.clock.runFor(120000);
+  expect(await page.evaluate(() => window.pollStats.checks)).toBe(2);
+  await page.evaluate(async () => (await import('/js/agent-chat-settings.js')).setChatBackend('direct'));
+  await expect.poll(() => page.evaluate(() => window.pollStats.checks)).toBe(3);
+  await page.evaluate(() => {
+    localStorage.setItem('labcharts-ai-provider','venice');
+    window.dispatchEvent(new StorageEvent('storage',{key:'labcharts-ai-provider',newValue:'venice'}));
+  });
+  await page.clock.runFor(120000);
+  expect(await page.evaluate(() => window.pollStats.checks)).toBe(3);
+  expect(external).toEqual([]);
+});

--- a/tests/playwright/routstr-provider-polling.spec.js
+++ b/tests/playwright/routstr-provider-polling.spec.js
@@ -48,5 +48,44 @@ test('saved funding stays quiet on OpenRouter and stops on provider or backend c
   });
   await page.clock.runFor(120000);
   expect(await page.evaluate(() => window.pollStats.checks)).toBe(3);
+  // Exercise the real profile-sync apply path, which writes in this same tab
+  // without firing either a local-edit event or a browser storage event.
+  const applySynced = settings => page.evaluate(async settings => {
+    await (await import('/js/sync-apply.js')).applyAISettings(settings, {preferRemote:true});
+  }, settings);
+  await applySynced({'labcharts-ai-provider':'routstr'});
+  await expect.poll(() => page.evaluate(() => window.pollStats.checks)).toBe(4);
+  await expect.poll(() => page.evaluate(() => window.pollStats.subscribes)).toBe(4);
+  await applySynced({'labcharts-ai-provider':'openrouter'});
+  await expect.poll(() => page.evaluate(() => window.pollStats.cancels)).toBe(4);
+  await page.clock.runFor(120000);
+  expect(await page.evaluate(() => window.pollStats.checks)).toBe(4);
+  await applySynced({'labcharts-ai-provider':'routstr'});
+  await expect.poll(() => page.evaluate(() => window.pollStats.checks)).toBe(5);
+  await expect.poll(() => page.evaluate(() => window.pollStats.subscribes)).toBe(5);
+  // The companion backend is device-local and is not accepted from sync.
+  await applySynced({'labcharts-chat-backend':'codex'});
+  expect(await page.evaluate(() => localStorage.getItem('labcharts-chat-backend'))).toBe('direct');
   expect(external).toEqual([]);
+});
+
+test('profile sync lazily starts saved funding when it first selects Routstr', async ({page}) => {
+  await page.route('**/provider-polling-fixture', route => route.fulfill({contentType:'text/html',body:'<div></div>'}));
+  let walletLoads = 0;
+  await page.route('**/js/provider-wallet-panels.js', route => {
+    walletLoads++;
+    return route.fulfill({contentType:'text/javascript',body:'export function startRoutstrFundingMonitor() { window.fundingStarted = true; }'});
+  });
+  await page.goto('/provider-polling-fixture');
+  await page.evaluate(async () => {
+    localStorage.setItem('labcharts-ai-provider','openrouter');
+    localStorage.setItem('labcharts-cashu-wallet-mnemonic','synthetic-encrypted-wallet');
+    await import('/js/settings-provider-bridge.js');
+  });
+  expect(walletLoads).toBe(0);
+  await page.evaluate(async () => {
+    await (await import('/js/sync-apply.js')).applyAISettings({'labcharts-ai-provider':'routstr'}, {preferRemote:true});
+  });
+  await expect.poll(() => page.evaluate(() => window.fundingStarted)).toBe(true);
+  expect(walletLoads).toBe(1);
 });

--- a/tests/playwright/routstr-security.spec.js
+++ b/tests/playwright/routstr-security.spec.js
@@ -57,6 +57,8 @@ test('a new node can be selected while old mint funds remain, with explicit mint
 test('funding recovery cannot show an old balance under a newly selected mint', async ({ page }) => {
   await page.goto('/app');
   await page.evaluate(async () => {
+    localStorage.setItem('labcharts-ai-provider', 'routstr');
+    localStorage.setItem('labcharts-chat-backend', 'direct');
     const panels = await import('/js/provider-wallet-panels.js');
     document.body.innerHTML = '<div id="routstr-wallet-balance"></div><div id="routstr-mint-label"></div>';
     let mint = 'https://mint.first.test';

--- a/tests/playwright/routstr-wallet-dom.spec.js
+++ b/tests/playwright/routstr-wallet-dom.spec.js
@@ -332,7 +332,7 @@ test('Routstr wallet DOM flows recover deposits, refunds, and seed onboarding', 
       await wait(50);
       const lightningFundingCreatesInvoice = fundingInvoiceAmount === 1000
         && (document.getElementById('routstr-wfund-status')?.textContent || '').includes('Waiting for payment');
-      await panels.recoverPendingWalletFunding();
+      document.querySelector('[data-routstr-wallet-action="recover-wallet-funding"]').click();
       await wait(50);
       const pendingFundingRecoveryReportsRecovered = pendingFundingChecked
         && (document.getElementById('routstr-wfund-status')?.textContent || '').includes('+998 sats recovered');

--- a/tests/routstr-funding-monitor.test.js
+++ b/tests/routstr-funding-monitor.test.js
@@ -10,6 +10,40 @@ const result = (extra = {}) => ({ mint: 'https://mint.test', checked: 2, pending
 const runtime = check => ({ cashuHasWalletSeed: async () => true, cashuRecoverPendingFunding: check });
 const settle = () => vi.advanceTimersByTimeAsync(0);
 
+it('does not check or subscribe when Routstr is inactive, including during async startup', async () => {
+  let active = false;
+  let seedReady;
+  const check = vi.fn().mockResolvedValue(result());
+  const subscribe = vi.fn();
+  monitor = createFundingMonitor({ ...runtime(check), cashuHasWalletSeed: () => new Promise(r => { seedReady = r; }), cashuSubscribeFundingQuotes: subscribe }, vi.fn(), () => {}, () => active);
+  monitor.start(); await settle();
+  expect(check).not.toHaveBeenCalled();
+  active = true; monitor.start(); await settle();
+  active = false; seedReady(true); await settle();
+  window.dispatchEvent(new Event('focus'));
+  await vi.advanceTimersByTimeAsync(120000);
+  expect(check).not.toHaveBeenCalled();
+  expect(subscribe).not.toHaveBeenCalled();
+});
+
+it('stops subscriptions and rejects queued checks when the provider changes', async () => {
+  let active = true;
+  let options;
+  const cancel = vi.fn();
+  const check = vi.fn(async value => { options = value; return result({pendingQuotes:[{mint:'https://mint.test',quote:'new'}]}); });
+  monitor = createFundingMonitor({ ...runtime(check), cashuSubscribeFundingQuotes: async () => cancel }, vi.fn(), () => {}, () => active);
+  monitor.start(); await settle();
+  expect(options.shouldContinue()).toBe(true);
+  active = false; monitor.stop(); await settle();
+  expect(options.shouldContinue()).toBe(false);
+  expect(cancel).toHaveBeenCalledTimes(1);
+  window.dispatchEvent(new Event('focus'));
+  await vi.advanceTimersByTimeAsync(120000);
+  expect(check).toHaveBeenCalledTimes(1);
+  active = true; monitor.start(); await settle();
+  expect(check).toHaveBeenCalledTimes(2);
+});
+
 it('automatically credits an older invoice without replacing the newer QR', async () => {
   const refresh = vi.fn();
   monitor = createFundingMonitor(runtime(vi.fn().mockResolvedValue(result({ recovered: 500, balance: 500, results: [{ quote: 'old', paid: true, minted: 500, fee: 0 }, { quote: 'new', paid: false }] }))), refresh);

--- a/tests/routstr-funding-startup.test.js
+++ b/tests/routstr-funding-startup.test.js
@@ -1,17 +1,34 @@
 import { beforeEach, expect, it, vi } from 'vitest';
-const { start } = vi.hoisted(() => ({ start: vi.fn() }));
+const { start, provider, backend } = vi.hoisted(() => ({ start: vi.fn(), provider: vi.fn(), backend: vi.fn() }));
 vi.mock('../js/provider-wallet-panels.js', () => ({ startRoutstrFundingMonitor: start }));
 vi.mock('../js/api.js', () => ({
-  clearOpenRouterOAuthSession: vi.fn(), getAIProvider: vi.fn(),
+  clearOpenRouterOAuthSession: vi.fn(), getAIProvider: provider,
   getOpenRouterKey: vi.fn(), rememberOpenRouterOAuthPreviousProvider: vi.fn(),
 }));
-vi.mock('../js/agent-chat-settings.js', () => ({ getChatBackend: vi.fn(), setChatBackend: vi.fn() }));
-beforeEach(() => { localStorage.clear(); start.mockClear(); vi.resetModules(); });
-it('resumes saved wallet funding after reload without opening settings', async () => {
+vi.mock('../js/agent-chat-settings.js', () => ({ getChatBackend: backend, setChatBackend: vi.fn() }));
+beforeEach(() => {
+  localStorage.clear(); start.mockClear(); vi.resetModules();
+  provider.mockReturnValue('routstr'); backend.mockReturnValue('direct');
+});
+it('resumes saved wallet funding after reload when Routstr is active', async () => {
   localStorage.setItem('labcharts-cashu-wallet-mnemonic', 'encrypted-test-fixture');
   await import('../js/settings-provider-bridge.js');
   await vi.dynamicImportSettled();
   expect(start).toHaveBeenCalledTimes(1);
+});
+it.each(['openrouter', 'venice', 'custom'])('does not start saved funding for %s', async selected => {
+  provider.mockReturnValue(selected);
+  localStorage.setItem('labcharts-cashu-wallet-mnemonic', 'encrypted-test-fixture');
+  await import('../js/settings-provider-bridge.js');
+  await vi.dynamicImportSettled();
+  expect(start).not.toHaveBeenCalled();
+});
+it('does not start funding while the CLI backend is active', async () => {
+  backend.mockReturnValue('codex');
+  localStorage.setItem('labcharts-cashu-wallet-mnemonic', 'encrypted-test-fixture');
+  await import('../js/settings-provider-bridge.js');
+  await vi.dynamicImportSettled();
+  expect(start).not.toHaveBeenCalled();
 });
 it('does not start the wallet monitor for visitors without a wallet', async () => {
   await import('../js/settings-provider-bridge.js');


### PR DESCRIPTION
## Summary
A saved Cashu wallet kept checking pending mint invoices even when OpenRouter or another provider was selected. Rejected quotes could then be retried repeatedly.

- Run automatic funding recovery only while direct Routstr is active, and stop subscriptions and queued checks when the provider changes locally, across tabs, or through profile sync.
- Persist a pause for rejected 4xx quotes and exponential backoff for temporary failures, including across reloads and notification hints. Existing mint-wide rate limits remain in effect.
- Preserve pending deposits and expose **Check pending deposits** for an explicit retry.

## Validation
- 113 distinct focused unit tests passed (startup, funding monitor, wallet runtime, and sync application).
- Five distinct browser tests passed, covering provider switching, same-tab sync application and lazy startup, wallet UI recovery, NUT-17, and multi-tab coordination.
- Check-JS, strict-null, quality, architecture, DOM sink audit, production budget, and diff checks passed.
- All mint interactions in these tests were mocked; no live mint or real funds were used.
